### PR TITLE
HAR-6913 - super-editor: strikethrough and underline

### DIFF
--- a/packages/super-editor/package.json
+++ b/packages/super-editor/package.json
@@ -27,6 +27,7 @@
     "prosemirror-schema-basic": "^1.2.2",
     "prosemirror-schema-list": "^1.3.0",
     "prosemirror-view": "^1.33.6",
+    "uuidv4": "^6.2.13",
     "vue": "^3.4.21",
     "xml-js": "^1.6.11"
   },

--- a/packages/super-editor/src/core/schema/DocxSchema.js
+++ b/packages/super-editor/src/core/schema/DocxSchema.js
@@ -138,6 +138,22 @@ const DocxSchema = new Schema({
         { style: "font-style=normal", clearMark: m => m.type.name == "em" }
       ],
       toDOM() { return ["em", 0]; }
+    },
+    underline: {
+      parseDOM: [
+        { tag: "u" },
+        { style: "text-decoration=underline" },
+        { style: "text-decoration=auto", clearMark: m => m.type.name == "u" }
+      ],
+      toDOM() { return ["u", 0]; }
+    },
+    strikethrough: {
+      parseDOM: [
+        { tag: "s" },
+        { style: "text-decoration=line-through" },
+        { style: "text-decoration=auto", clearMark: m => m.type.name == "s" }
+      ],
+      toDOM() { return ["s", 0]; }
     }
   }
 });

--- a/packages/super-editor/src/core/shortcuts/buildKeymap.js
+++ b/packages/super-editor/src/core/shortcuts/buildKeymap.js
@@ -13,6 +13,8 @@ export function buildKeymap() {
       "Mod-y": redo,
       "Mod-b": toggleMark(DocxSchema.marks.strong),
       "Mod-i": toggleMark(DocxSchema.marks.em),
+      "Mod-u": toggleMark(DocxSchema.marks.underline),
+      "Mod-Shift-S": toggleMark(DocxSchema.marks.strikethrough),
       "Enter": chainCommands(Commands.enter),
 
       // Just as an example


### PR DESCRIPTION
Thanks for teeing this up :)
This branch comes from Artem's branch, so I'm using his as the trunk.

fyi: I had some issues with this line in `packages/super-editor/src/extensions/Comments/comments.js` :
`import { v4 as uuidv4 } from 'uuid';`
I think we might need to change it to `uuidv4`? But I see this is imported as `uuid` everywhere else so maybe it's just a problem for me?
