### PR TITLE
HAR-7163 - history extension, editor focus events

### DIFF
--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -5,7 +5,7 @@ import { EventEmitter } from './EventEmitter.js';
 import { ExtensionService } from './ExtensionService.js';
 import { CommandService } from './CommandService.js';
 import { SuperConverter } from './SuperConverter.js';
-import { Commands, Keymap, Editable } from './extensions/index.js';
+import { Commands, Keymap, Editable, EditorFocus } from './extensions/index.js';
 import { createDocument } from './helpers/createDocument.js';
 import { createStyleTag } from './utilities/createStyleTag.js';
 import { initComments } from '@features/index.js';
@@ -24,6 +24,8 @@ export class Editor extends EventEmitter {
   schema;
 
   view;
+
+  isFocused = false;
 
   #css;
 
@@ -204,6 +206,7 @@ export class Editor extends EventEmitter {
     const coreExtensions = [
       Editable,
       Commands,
+      EditorFocus,
       Keymap,
     ];
     const allExtensions = [
@@ -302,6 +305,23 @@ export class Editor extends EventEmitter {
         editor: this,
         transaction
       });
+    }
+
+    const focus = transaction.getMeta('focus');
+    if (focus) {
+      this.emit('focus', {
+        editor: this,
+        event: focus.event,
+        transaction,
+      })
+    }
+    const blur = transaction.getMeta('blur');
+    if (blur) {
+      this.emit('blur', {
+        editor: this,
+        event: blur.event,
+        transaction,
+      })
     }
 
     if (!transaction.docChanged) {

--- a/packages/super-editor/src/core/ExtensionService.js
+++ b/packages/super-editor/src/core/ExtensionService.js
@@ -85,7 +85,7 @@ export class ExtensionService {
   }
 
   /**
-   * TODO: Add input and paste rules.
+   * TODO:Artem Add input and paste rules.
    * 
    * Get all PM plugins defined in the extensions.
    * And also keyboard shortcuts.

--- a/packages/super-editor/src/core/commands/enter.js
+++ b/packages/super-editor/src/core/commands/enter.js
@@ -1,4 +1,5 @@
-// TODO
+// TODO: Need to handle "enter" command properly.
+
 export const enter = () => ({ state, dispatch }) => {
   const { $from, $to } = state.selection;
 

--- a/packages/super-editor/src/core/extensions/editorFocus.js
+++ b/packages/super-editor/src/core/extensions/editorFocus.js
@@ -1,0 +1,41 @@
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { Extension } from '../Extension.js';
+
+export const EditorFocus = Extension.create({
+  name: 'editorFocus',
+
+  addPmPlugins() {
+    const editor = this.editor;
+
+    const editorFocusPlugin = new Plugin({
+      key: new PluginKey('editorFocus'),
+      props: {
+        handleDOMEvents: {
+          focus: (view, event) => {
+            editor.isFocused = true;
+
+            const tr = editor.state.tr
+              .setMeta('focus', { event })
+              // https://prosemirror.net/docs/ref/#history.history
+              .setMeta('addToHistory', false);
+
+            view.dispatch(tr);
+            return false;
+          },
+          blur: (view, event) => {
+            editor.isFocused = false;
+
+            const tr = editor.state.tr
+              .setMeta('blur', { event })
+              .setMeta('addToHistory', false);
+
+            view.dispatch(tr);
+            return false;
+          },
+        },
+      },
+    });
+
+    return [editorFocusPlugin];
+  },
+});

--- a/packages/super-editor/src/core/extensions/index.js
+++ b/packages/super-editor/src/core/extensions/index.js
@@ -1,3 +1,4 @@
 export { Commands } from './commands.js';
 export { Keymap } from './keymap.js';
 export { Editable } from './editable.js';
+export { EditorFocus } from './editorFocus.js';

--- a/packages/super-editor/src/core/extensions/keymap.js
+++ b/packages/super-editor/src/core/extensions/keymap.js
@@ -1,6 +1,6 @@
 import { Extension } from '../Extension.js';
 
-// TODO:Artem - Need to create Keymap extension from scratch.
+// TODO:Artem - Need to handle keymap properly.
 
 export const Keymap = Extension.create({
   name: 'keymap',

--- a/packages/super-editor/src/extensions/history/history.js
+++ b/packages/super-editor/src/extensions/history/history.js
@@ -1,0 +1,42 @@
+import { 
+  history, 
+  redo as originalRedo, 
+  undo as originalUndo, 
+} from 'prosemirror-history';
+import { Extension } from '@core/Extension.js';
+
+export const History = Extension.create({
+  name: 'history',
+  
+  addOptions() {
+    // https://prosemirror.net/docs/ref/#history.history
+    return {
+      depth: 100,
+      newGroupDelay: 500,
+    };
+  },
+
+  addPmPlugins() {
+    const historyPlugin = history(this.options);
+    return [historyPlugin];
+  },
+
+  addCommands() {
+    return {
+      undo: () => ({ state, dispatch }) => {
+        return originalUndo(state, dispatch);
+      },
+      redo: () => ({ state, dispatch }) => {
+        return originalRedo(state, dispatch);
+      },
+    };
+  },
+
+  addShortcuts() {
+    return {
+      'Mod-z': () => this.editor.commands.undo(),
+      'Mod-Shift-z': () => this.editor.commands.redo(),
+      'Mod-y': () => this.editor.commands.redo(),
+    };
+  },
+});

--- a/packages/super-editor/src/extensions/history/index.js
+++ b/packages/super-editor/src/extensions/history/index.js
@@ -1,0 +1,1 @@
+export * from './history.js';

--- a/packages/super-editor/src/extensions/index.js
+++ b/packages/super-editor/src/extensions/index.js
@@ -1,4 +1,5 @@
 // Extensions
+export { History } from './history/history.js';
 
 // Nodes extensions
 export { Document } from './document/index.js';


### PR DESCRIPTION
- Implemented "history" properly. Since everything is now an extension, to add "history" plugin we need to create an extension.
- Added focus events to editor with the core extension.