### PR TITLE
HAR-7139 - document code, little refactoring

### DIFF
--- a/packages/super-editor/src/core/CommandService.js
+++ b/packages/super-editor/src/core/CommandService.js
@@ -55,16 +55,22 @@ export class CommandService {
     return Object.fromEntries(transformed);
   }
 
+  /**
+   * Create a chain of commands to call multiple commands at once.
+   */
   get chain() {
     return () => this.createChain();
   }
 
+  /**
+   * Check if a command or a chain of commands can be executed. Without executing it.
+   */
   get can() {
     return () => this.createChain();
   }
 
   /**
-   * Creates "chain".
+   * Creates a chain of commands.
    * @param startTr Start transaction.
    * @param shouldDispatch Should dispatch or not.
    */
@@ -106,7 +112,7 @@ export class CommandService {
   }
 
   /**
-   * Creates "can".
+   * Creates a can check for commands.
    * @param startTr Start transaction.
    */
   createCan(startTr) {

--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -138,14 +138,14 @@ export class Editor extends EventEmitter {
   }
 
   /**
-   * Create "chain".
+   * Create a chain of commands to call multiple commands at once.
    */
   chain() {
     return this.#commandService.chain();
   }
 
   /**
-   * Create "can".
+   * Check if a command or a chain of commands can be executed. Without executing it.
    */
   can() {
     return this.#commandService.can();

--- a/packages/super-editor/src/core/commands/clearNodes.js
+++ b/packages/super-editor/src/core/commands/clearNodes.js
@@ -1,7 +1,11 @@
 import { liftTarget } from 'prosemirror-transform';
 
 /**
- * Normalize nodes to a simple paragraph.
+ * Normalize nodes to the default node (paragraph by default). 
+ * This may be helpful before applying a new node type.
+ * 
+ * The paragraph is the default node because 
+ * it has the highest priority (priority: 1000) and it's loaded first.
  */
 export const clearNodes = () => ({ state, tr, dispatch }) => {
   const { selection } = tr;

--- a/packages/super-editor/src/core/commands/first.js
+++ b/packages/super-editor/src/core/commands/first.js
@@ -1,6 +1,13 @@
 /**
  * Runs commands and stops at the first one that returns true.
  * @param commands Commands to run.
+ * 
+ * Example:
+ * editor.commands.first(({ commands }) => [
+ *  () => commands.deleteSelection(),
+ *  () => commands.joinBackward(),
+ *  () => commands.selectNodeBackward(),
+ * ]);
  */
 export const first = (commands) => (props) => {
   const items = typeof commands === 'function' 

--- a/packages/super-editor/src/core/commands/joinBackward.js
+++ b/packages/super-editor/src/core/commands/joinBackward.js
@@ -1,6 +1,8 @@
 import { joinBackward as originalJoinBackward } from 'prosemirror-commands';
 
 /**
+ * Join two nodes backward.
+ * 
  * If the selection is empty and at the start of a textblock, try to
  * reduce the distance between that block and the one before it—if
  * there's a block directly before it that can be joined, join them.
@@ -8,6 +10,8 @@ import { joinBackward as originalJoinBackward } from 'prosemirror-commands';
  * the document structure by lifting it out of its parent or moving it
  * into a parent of the previous block. Will use the view for accurate
  * (bidi-aware) start-of-textblock detection if given.
+ * 
+ * https://prosemirror.net/docs/ref/#commands.joinBackward
  */
 export const joinBackward = () => ({ state, dispatch }) => {
   return originalJoinBackward(state, dispatch);

--- a/packages/super-editor/src/core/commands/joinDown.js
+++ b/packages/super-editor/src/core/commands/joinDown.js
@@ -3,6 +3,8 @@ import { joinDown as originalJoinDown } from 'prosemirror-commands';
 /**
  * Join the selected block, or the closest ancestor of the selection
  * that can be joined, with the sibling after it.
+ * 
+ * https://prosemirror.net/docs/ref/#commands.joinDown
  */
 export const joinDown = () => ({ state, dispatch }) => {
   return originalJoinDown(state, dispatch);

--- a/packages/super-editor/src/core/commands/joinForward.js
+++ b/packages/super-editor/src/core/commands/joinForward.js
@@ -1,11 +1,15 @@
 import { joinForward as originalJoinForward } from 'prosemirror-commands';
 
 /**
+ * Join two nodes forward.
+ * 
  * If the selection is empty and the cursor is at the end of a
  * textblock, try to reduce or remove the boundary between that block
  * and the one after it, either by joining them or by moving the other
  * block closer to this one in the tree structure. Will use the view
  * for accurate start-of-textblock detection if given.
+ * 
+ * https://prosemirror.net/docs/ref/#commands.joinForward
  */
 export const joinForward = () => ({ state, dispatch }) => {
   return originalJoinForward(state, dispatch);

--- a/packages/super-editor/src/core/commands/joinUp.js
+++ b/packages/super-editor/src/core/commands/joinUp.js
@@ -4,6 +4,8 @@ import { joinUp as originalJoinUp } from 'prosemirror-commands';
  * Join the selected block or, if there is a text selection, the
  * closest ancestor block of the selection that can be joined, with
  * the sibling above it.
+ * 
+ * https://prosemirror.net/docs/ref/#commands.joinUp
  */
 export const joinUp = () => ({ state, dispatch }) => {
   return originalJoinUp(state, dispatch);

--- a/packages/super-editor/src/core/commands/liftEmptyBlock.js
+++ b/packages/super-editor/src/core/commands/liftEmptyBlock.js
@@ -2,6 +2,8 @@ import { liftEmptyBlock as originalLiftEmptyBlock } from 'prosemirror-commands';
 
 /**
  * If the cursor is in an empty textblock that can be lifted, lift the block.
+ * 
+ * https://prosemirror.net/docs/ref/#commands.liftEmptyBlock
  */
 export const liftEmptyBlock = () => ({ state, dispatch }) => {
   return originalLiftEmptyBlock(state, dispatch);

--- a/packages/super-editor/src/core/commands/liftListItem.js
+++ b/packages/super-editor/src/core/commands/liftListItem.js
@@ -4,6 +4,8 @@ import { getNodeType } from '../helpers/getNodeType.js';
 /**
  * Lift the list item around the selection up into a wrapping list.
  * @param typeOrName Type/name of the node.
+ * 
+ * https://prosemirror.net/docs/ref/#schema-list.liftListItem
  */
 export const liftListItem = (typeOrName) => ({ state, dispatch }) => {
   const type = getNodeType(typeOrName, state.schema);

--- a/packages/super-editor/src/core/commands/newlineInCode.js
+++ b/packages/super-editor/src/core/commands/newlineInCode.js
@@ -2,6 +2,8 @@ import { newlineInCode as originalNewlineInCode } from 'prosemirror-commands';
 
 /**
  * Add a newline character in code.
+ * 
+ * https://prosemirror.net/docs/ref/#commands.newlineInCode
  */
 export const newlineInCode = () => ({ state, dispatch }) => {
   return originalNewlineInCode(state, dispatch);

--- a/packages/super-editor/src/core/commands/selectAll.js
+++ b/packages/super-editor/src/core/commands/selectAll.js
@@ -2,6 +2,8 @@ import { selectAll as originalSelectAll } from 'prosemirror-commands';
 
 /**
  * Select the whole document.
+ * 
+ * https://prosemirror.net/docs/ref/#commands.selectAll
  */
 export const selectAll = () => ({ state, dispatch }) => {
   return originalSelectAll(state, dispatch);

--- a/packages/super-editor/src/core/commands/selectNodeBackward.js
+++ b/packages/super-editor/src/core/commands/selectNodeBackward.js
@@ -2,6 +2,8 @@ import { selectNodeBackward as originalSelectNodeBackward } from 'prosemirror-co
 
 /**
  * Select a node backward.
+ * 
+ * https://prosemirror.net/docs/ref/#commands.selectNodeBackward
  */
 export const selectNodeBackward = () => ({ state, dispatch }) => {
   return originalSelectNodeBackward(state, dispatch);

--- a/packages/super-editor/src/core/commands/selectNodeForward.js
+++ b/packages/super-editor/src/core/commands/selectNodeForward.js
@@ -2,6 +2,8 @@ import { selectNodeForward as originalSelectNodeForward } from 'prosemirror-comm
 
 /**
  * Select a node forward.
+ * 
+ * https://prosemirror.net/docs/ref/#commands.selectNodeForward
  */
 export const selectNodeForward = () => ({ state, dispatch }) => {
   return originalSelectNodeForward(state, dispatch);

--- a/packages/super-editor/src/core/commands/selectTextblockEnd.js
+++ b/packages/super-editor/src/core/commands/selectTextblockEnd.js
@@ -2,6 +2,8 @@ import { selectTextblockEnd as originalSelectTextblockEnd } from 'prosemirror-co
 
 /**
  * Moves the cursor to the end of current text block.
+ * 
+ * https://prosemirror.net/docs/ref/#commands.selectTextblockEnd
  */
 export const selectTextblockEnd = () => ({ state, dispatch }) => {
   return originalSelectTextblockEnd(state, dispatch);

--- a/packages/super-editor/src/core/commands/selectTextblockStart.js
+++ b/packages/super-editor/src/core/commands/selectTextblockStart.js
@@ -2,6 +2,8 @@ import { selectTextblockStart as originalSelectTextblockStart } from 'prosemirro
 
 /**
  * Moves the cursor to the start of current text block.
+ * 
+ * https://prosemirror.net/docs/ref/#commands.selectTextblockStart
  */
 export const selectTextblockStart = () => ({ state, dispatch }) => {
   return originalSelectTextblockStart(state, dispatch);

--- a/packages/super-editor/src/core/commands/sinkListItem.js
+++ b/packages/super-editor/src/core/commands/sinkListItem.js
@@ -4,6 +4,8 @@ import { getNodeType } from '../helpers/getNodeType.js';
 /**
  * Sink list item down into an inner list.
  * @param typeOrName Type/name of the node.
+ * 
+ * https://prosemirror.net/docs/ref/#schema-list.sinkListItem
  */
 export const sinkListItem = (typeOrName) => ({ state, dispatch }) => {
   const type = getNodeType(typeOrName, state.schema);

--- a/packages/super-editor/src/core/commands/splitBlock.js
+++ b/packages/super-editor/src/core/commands/splitBlock.js
@@ -13,11 +13,13 @@ const ensureMarks = (state, splittableMarks) => {
 };
 
 /**
- * Creates a new node from an existing node.
- * 
- * For reference.
- * https://github.com/ProseMirror/prosemirror-commands/blob/master/src/commands.ts#L357
+ * Will split the current node into two nodes. If the selection is not
+ * splittable, the command will be ignored.
  * @param options.keepMarks Keep marks from prev node.
+ * 
+ * The command is a slightly modified version of the original 
+ * `splitBlockAs` command to better manage attributes and marks.
+ * https://github.com/ProseMirror/prosemirror-commands/blob/master/src/commands.ts#L357
  */
 export const splitBlock = ({ keepMarks = true } = {}) => (props) => {
   const { tr, state, dispatch, editor } = props;

--- a/packages/super-editor/src/core/commands/splitListItem.js
+++ b/packages/super-editor/src/core/commands/splitListItem.js
@@ -5,11 +5,12 @@ import { Attribute } from '../Attribute.js';
 import { getNodeType } from '../helpers/getNodeType.js';
 
 /**
- * Splits one list item into two list items.
- * 
- * For reference.
- * https://github.com/ProseMirror/prosemirror-schema-list/blob/master/src/schema-list.ts#L114
+ * Splits one list item into two separate list items.
  * @param typeOrName The type or name of the node.
+ * 
+ * The command is a slightly modified version of the original 
+ * `splitListItem` command to better manage attributes and marks.
+ * https://github.com/ProseMirror/prosemirror-schema-list/blob/master/src/schema-list.ts#L114
  */
 export const splitListItem = (typeOrName) => (props) => {
   const { tr, state, dispatch, editor } = props;

--- a/packages/super-editor/src/core/commands/toggleList.js
+++ b/packages/super-editor/src/core/commands/toggleList.js
@@ -28,27 +28,26 @@ export const toggleList = (listTypeOrName, itemTypeOrName, keepMarks, attributes
   const { selection, storedMarks } = state;
   const { $from, $to } = selection;
   const range = $from.blockRange($to);
-  
-  const marks = storedMarks || (selection.$to.parentOffset && selection.$from.marks())
+
+  const marks = storedMarks || (selection.$to.parentOffset && selection.$from.marks());
 
   if (!range) return false;
 
-  const parentList = findParentNode(
-    (node) => isList(node.type.name, extensions),
-    selection,
-  );
+  const parentList = findParentNode((node) => isList(node.type.name, extensions))(selection);
 
+  // This is the case when we toggle an existing list.
   if (range.depth >= 1 && parentList && range.depth - parentList.depth <= 1) {
-    // remove list
+    // If we toggle to the same list type, 
+    // then execute `liftListItem` command.
     if (parentList.node.type === listType) {
       return commands.liftListItem(itemType);
     }
 
-    // change list type
+    // When we switch between different list types.
     if (
       isList(parentList.node.type.name, extensions)
-        && listType.validContent(parentList.node.content)
-        && dispatch
+      && listType.validContent(parentList.node.content)
+      && dispatch
     ) {
       const result = chain()
         .command(() => {
@@ -75,8 +74,11 @@ export const toggleList = (listTypeOrName, itemTypeOrName, keepMarks, attributes
     };
   };
 
+  // This is the case when there is no need to ensureMarks.
   if (!keepMarks || !marks || !dispatch) {
     const result = chain()
+      // First check if it's possible to wrap node in a list 
+      // and if not then try to convert it into a default node (paragraph).
       .command(createTryConvertNodeToDefault({ ensureMarks: false }))
       .wrapInList(listType, attributes)
       .command(() => joinListBackwards(tr, listType))
@@ -85,8 +87,10 @@ export const toggleList = (listTypeOrName, itemTypeOrName, keepMarks, attributes
 
     return result;
   }
-
+  
   const result = chain()
+    // First check if it's possible to wrap node in a list 
+    // and if not then try to convert it into a default node (paragraph).
     .command(createTryConvertNodeToDefault({ ensureMarks: true }))
     .wrapInList(listType, attributes)
     .command(() => joinListBackwards(tr, listType))

--- a/packages/super-editor/src/core/commands/toggleMark.js
+++ b/packages/super-editor/src/core/commands/toggleMark.js
@@ -5,7 +5,8 @@ import { getMarkType } from '../helpers/getMarkType.js';
  * Toggle mark.
  * @param typeOrName Mark type or name.
  * @param attrs Mark attributes.
- * @returns 
+ * 
+ * https://prosemirror.net/docs/ref/#commands.toggleMark
  */
 export const toggleMark = (typeOrName, attrs = {}) => ({ state, dispatch }) => {
   const type = getMarkType(typeOrName, state.schema);

--- a/packages/super-editor/src/core/commands/wrapInList.js
+++ b/packages/super-editor/src/core/commands/wrapInList.js
@@ -5,6 +5,8 @@ import { getNodeType } from '../helpers/getNodeType.js';
  * Wrap a node in a list.
  * @param typeOrName Type/name of the node.
  * @param attrs Attributes of the node.
+ * 
+ * https://prosemirror.net/docs/ref/#schema-list.wrapInList
  */
 export const wrapInList = (typeOrName, attrs = {}) => ({ state, dispatch }) => {
   const type = getNodeType(typeOrName, state.schema);

--- a/packages/super-editor/src/core/extensions/keymap.js
+++ b/packages/super-editor/src/core/extensions/keymap.js
@@ -4,7 +4,7 @@ import { isMacOS } from '../utilities/isMacOS.js';
 
 /**
  * For reference.
- * https://github.com/ProseMirror/prosemirror-commands/blob/master/src/commands.ts
+ * https://github.com/ProseMirror/prosemirror-commands/blob/master/src/commands.ts#L736
  */
 export const Keymap = Extension.create({
   name: 'keymap',

--- a/packages/super-editor/src/core/helpers/defaultBlockAt.js
+++ b/packages/super-editor/src/core/helpers/defaultBlockAt.js
@@ -1,8 +1,9 @@
 /**
  * Gets the default block type at a given match.
- * https://github.com/ProseMirror/prosemirror-commands/blob/master/src/commands.ts#L297
  * @param match Content match.
  * @returns Default block type or null.
+ * 
+ * https://github.com/ProseMirror/prosemirror-commands/blob/master/src/commands.ts#L297
  */
 export function defaultBlockAt(match) {
   for (let i = 0; i < match.edgeCount; i++) {

--- a/packages/super-editor/src/core/helpers/findParentNode.js
+++ b/packages/super-editor/src/core/helpers/findParentNode.js
@@ -1,22 +1,12 @@
+import { findParentNodeClosestToPos } from './findParentNodeClosestToPos';
+
 /**
  * Find the closest parent node to the current selection that matches a predicate.
  * @param predicate Predicate to match.
- * @param selection Selection.
- * @returns Closest parent node that matches the predicate.
+ * @returns Command that finds the closest parent node.
+ * 
+ * https://github.com/atlassian/prosemirror-utils/blob/master/src/selection.ts#L17
  */
-export const findParentNode = (predicate, selection) => {
-  const { $from: $pos } = selection;
-
-  for (let i = $pos.depth; i > 0; i--) {
-    const node = $pos.node(i)
-
-    if (predicate(node)) {
-      return {
-        pos: i > 0 ? $pos.before(i) : 0,
-        start: $pos.start(i),
-        depth: i,
-        node,
-      };
-    }
-  }
+export const findParentNode = (predicate) => {
+  return ({ $from }) => findParentNodeClosestToPos($from, predicate);
 };

--- a/packages/super-editor/src/core/helpers/findParentNodeClosestToPos.js
+++ b/packages/super-editor/src/core/helpers/findParentNodeClosestToPos.js
@@ -1,0 +1,22 @@
+
+/**
+ * Finds the closest parent node to a resolved position that matches a predicate.
+ * @param $pos Resolved position.
+ * @param predicate Predicate to match.
+ * @returns Closest parent node to the resolved position that matches the predicate.
+ * 
+ * https://github.com/atlassian/prosemirror-utils/blob/master/src/selection.ts#L57
+ */
+export const findParentNodeClosestToPos = ($pos, predicate) => {
+  for (let i = $pos.depth; i > 0; i--) {
+    const node = $pos.node(i);
+    if (predicate(node)) {
+      return {
+        pos: i > 0 ? $pos.before(i) : 0,
+        start: $pos.start(i),
+        depth: i,
+        node,
+      };
+    }
+  }
+};

--- a/packages/super-editor/src/core/helpers/index.js
+++ b/packages/super-editor/src/core/helpers/index.js
@@ -6,6 +6,7 @@ export * from './chainableEditorState.js';
 export * from './getNodeType.js';
 export * from './getMarkType.js';
 export * from './defaultBlockAt.js';
+export * from './findParentNodeClosestToPos.js';
 export * from './findParentNode.js';
 export * from './isList.js';
 export * from './joinListBackwards.js';

--- a/packages/super-editor/src/core/helpers/isList.js
+++ b/packages/super-editor/src/core/helpers/isList.js
@@ -5,7 +5,6 @@ import { callOrGet } from '../utilities/callOrGet.js';
  * Check if node is a list.
  * @param name Node name.
  * @param extensions Array of extensions.
- * @returns 
  */
 export const isList = (name, extensions) => {
   const nodeExtensions = extensions.filter((e) => e.type === 'node');

--- a/packages/super-editor/src/core/helpers/joinListBackwards.js
+++ b/packages/super-editor/src/core/helpers/joinListBackwards.js
@@ -7,10 +7,7 @@ import { findParentNode } from './findParentNode.js';
  * @param listType List type.
  */
 export const joinListBackwards = (tr, listType) => {
-  const list = findParentNode(
-    (node) => node.type === listType,
-    tr.selection,
-  );
+  const list = findParentNode((node) => node.type === listType)(tr.selection);
   if (!list) return true;
 
   const before = tr.doc.resolve(Math.max(0, list.pos - 1)).before(list.depth);

--- a/packages/super-editor/src/core/helpers/joinListForwards.js
+++ b/packages/super-editor/src/core/helpers/joinListForwards.js
@@ -7,10 +7,7 @@ import { findParentNode } from './findParentNode.js';
  * @param listType List type.
  */
 export const joinListForwards = (tr, listType) => {
-  const list = findParentNode(
-    (node) => node.type === listType,
-    tr.selection,
-  );
+  const list = findParentNode((node) => node.type === listType)(tr.selection);
   if (!list) return true;
 
   const after = tr.doc.resolve(list.start).after(list.depth)

--- a/packages/super-editor/src/extensions/bullet-list/bullet-list.js
+++ b/packages/super-editor/src/extensions/bullet-list/bullet-list.js
@@ -14,8 +14,7 @@ export const BulletList = Node.create({
     return {
       itemTypeName: 'listItem',
       htmlAttributes: {},
-      keepMarks: false,
-      keepAttributes: false,
+      keepMarks: true,
     };
   },
 

--- a/packages/super-editor/src/extensions/list-item/list-item.js
+++ b/packages/super-editor/src/extensions/list-item/list-item.js
@@ -38,18 +38,19 @@ export const ListItem = Node.create({
       // The DOCX character for this list item (ie: ●, ▪)
       lvlText: { 
         default: null,
-        renderDOM: (attrs) => {
-          let lvlText = attrs?.lvlText;
-          if (!lvlText) return {};
+        rendered: false,
+        // renderDOM: (attrs) => {
+        //   let lvlText = attrs?.lvlText;
+        //   if (!lvlText) return {};
 
-          let code = lvlText.codePointAt(0);
-          let bulletType =  bulletTypes[code];
-          if (!bulletType) return {};
+        //   let code = lvlText.codePointAt(0);
+        //   let bulletType =  bulletTypes[code];
+        //   if (!bulletType) return {};
 
-          return {
-            style: `list-style-type: ${bulletType};`,
-          };
-        },
+        //   return {
+        //     style: `list-style-type: ${bulletType};`,
+        //   };
+        // },
       },
 
       // JC = justification. Expect left, right, center

--- a/packages/super-editor/src/extensions/ordered-list/ordered-list.js
+++ b/packages/super-editor/src/extensions/ordered-list/ordered-list.js
@@ -15,8 +15,7 @@ export const OrderedList = Node.create({
     return {
       itemTypeName: 'listItem',
       htmlAttributes: {},
-      keepMarks: false,
-      keepAttributes: false,
+      keepMarks: true,
     };
   },
 


### PR DESCRIPTION
Linear:
https://linear.app/harbour/issue/HAR-7139/%EF%B8%8F%EF%B8%8F-supereditor-viewedit-lists-editing-interactions-core-infra

- Documented the code.
- Minor refactoring.
- Disable `lvlText` handling/rendering inside list-item for now. Using a `list-style-type` style for each list-item that overrides the `list-style-type` on the list - this breaks list toggling a bit. I think it will be good to come back to this issue when there are many real use cases with custom markes, since rendering all marker types for list items can be a complex task.