### PR TITLE
HAR-7139 - hide marker for indented lists

### DIFF
--- a/packages/super-editor/src/core/config/style.js
+++ b/packages/super-editor/src/core/config/style.js
@@ -25,6 +25,14 @@ export const style = `.ProseMirror {
   position: relative;
 }
 
+/* 
+  Hide marker for indented lists. 
+  If a list-item contains a list but doesn't contain a "p" tag with text.
+*/
+.ProseMirror li:has(> ul:first-child, > ol:first-child):not(:has(> p)) {
+  list-style-type: none;
+}
+
 .ProseMirror-hideselection *::selection {
   background: transparent;
 }

--- a/packages/super-editor/src/extensions/list-item/list-item.js
+++ b/packages/super-editor/src/extensions/list-item/list-item.js
@@ -1,18 +1,10 @@
 import { Node } from '@core/index.js';
 import { Attribute } from '@core/index.js';
 
-const bulletTypes = {
-  111: 'circle',
-  61607: 'square',
-  61623: 'disc',
-  61656: '"\u27A2 "',
-  61558: '"\u2756 "',
-};
-
 export const ListItem = Node.create({
   name: 'listItem',
 
-  content: 'paragraph block*',
+  content: 'paragraph* block*',
 
   defining: true,
 
@@ -39,18 +31,6 @@ export const ListItem = Node.create({
       lvlText: { 
         default: null,
         rendered: false,
-        // renderDOM: (attrs) => {
-        //   let lvlText = attrs?.lvlText;
-        //   if (!lvlText) return {};
-
-        //   let code = lvlText.codePointAt(0);
-        //   let bulletType =  bulletTypes[code];
-        //   if (!bulletType) return {};
-
-        //   return {
-        //     style: `list-style-type: ${bulletType};`,
-        //   };
-        // },
       },
 
       // JC = justification. Expect left, right, center


### PR DESCRIPTION
Linear:
https://linear.app/harbour/issue/HAR-7139/%EF%B8%8F%EF%B8%8F-supereditor-viewedit-lists-editing-interactions-core-infra

Proposed solution for indented lists for now. Hide bullet on list-item if it contains nested list, but doesn't contain paragraph with text.

**In order for this to work** - need to configure the converter so that it wraps indented list into a li element.

```html
<ul>
  <li>
    <p>item</p>
    <ul>
      <li> <!-- no "p" tag -->
        <ul>
          <li><p>double indentent item</p></li>
          <li><p>double indentent item</p></li>
        </ul>
      </li>
      
      <li><p>item</p></li>
      <li><p>item</p></li>
      
      <li> <!-- no "p" tag -->
        <ul>
          <li> <!-- no "p" tag -->
            <ul>
              <li><p>triple indentent item</p></li>
              <li><p>triple indentent item</p></li>
            </ul>
          </li>
        </ul>
      </li>
    </ul>
  </li>
</ul>
```

<img width="507" alt="Screenshot 2024-07-31 at 17 49 20" src="https://github.com/user-attachments/assets/0c98ef2f-7d7d-4d5d-80cc-df3cdd727bf5">

Note:
There may be other options to solve this issue (NodeView ?), but I'm pretty sure that they will require much more effort.
