### PR TITLE
HAR-7139 - improvements for extensions

### DIFF
--- a/packages/super-editor/src/extensions/font-size/font-size.js
+++ b/packages/super-editor/src/extensions/font-size/font-size.js
@@ -15,6 +15,7 @@ export const FontSize = Extension.create({
     return {
       types: ['textStyle'],
       defaults: {
+        value: 12,
         unit: 'pt',
       },
     }
@@ -30,9 +31,10 @@ export const FontSize = Extension.create({
             parseDOM: (el) => el.style.fontSize,
             renderDOM: (attrs) => {
               if (!attrs.fontSize) return {};
-              const [value, unit] = parseSizeUnit(attrs.fontSize);
-              const fontSize = `${value}${unit ? unit : this.options.defaults.unit}`;
-              return { style: `font-size: ${fontSize}` };
+              let [value, unit] = parseSizeUnit(attrs.fontSize);
+              if (Number.isNaN(value)) return {};
+              unit = unit ? unit : this.options.defaults.unit;
+              return { style: `font-size: ${value}${unit}` };
             },
           },
         },

--- a/packages/super-editor/src/extensions/line-height/line-height.js
+++ b/packages/super-editor/src/extensions/line-height/line-height.js
@@ -1,4 +1,5 @@
 import { Extension } from '@core/index.js';
+import { parseSizeUnit } from '@core/utilities/index.js';
 
 export const LineHeight = Extension.create({
   name: 'lineHeight',
@@ -6,6 +7,9 @@ export const LineHeight = Extension.create({
   addOptions() {
     return {
       types: ['heading', 'paragraph'],
+      defaults: {
+        unit: 'in',
+      },
     };
   },
 
@@ -19,7 +23,10 @@ export const LineHeight = Extension.create({
             parseDOM: (el) => el.style.lineHeight,
             renderDOM: (attrs) => {
               if (!attrs.lineHeight) return {};
-              return { style: `line-height: ${attrs.lineHeight}` };
+              let [value, unit] = parseSizeUnit(attrs.lineHeight);
+              if (Number.isNaN(value)) return {};
+              unit = unit ? unit : this.options.defaults.unit;
+              return { style: `line-height: ${value}${unit}` };
             },
           },
         },


### PR DESCRIPTION
Improvements for `font-size`, `line-height`, `text-indent` extensions.

Also for `text-indent` extension we need to use `margin-left` style (instead of `text-indent`)  so that it behaves like in Word. `text-indent` style works differently and moves only the first line.

Screenshot 1:
<img width="1048" alt="Screenshot 2024-08-06 at 18 28 11" src="https://github.com/user-attachments/assets/c267d476-82b8-4ce0-87aa-c0f7b955b5d9">

Screenshot 2:
<img width="877" alt="Screenshot 2024-08-06 at 18 30 06" src="https://github.com/user-attachments/assets/ed8ff965-2ee3-4597-acca-79ecc07d8aba">

One more example:
https://remirror.vercel.app/?path=/story/extensions-nodeformatting--basic
