### PR TITLE
update field annotations

### DIFF
--- a/packages/super-editor/src/dev/components/DeveloperPlayground.vue
+++ b/packages/super-editor/src/dev/components/DeveloperPlayground.vue
@@ -148,7 +148,7 @@ const attachAnnotationEventHandlers = () => {
 
   // Update annotations by fieldId.
   // setTimeout(() => {
-  //   activeEditor?.commands.updateFieldAnnotations('agreementinput-1723720330834-228771403177', {
+  //   activeEditor?.commands.updateFieldAnnotations('111', {
   //     displayLabel: 'Updated!',
   //     fieldColor: '#6943d0',
   //   });
@@ -156,19 +156,38 @@ const attachAnnotationEventHandlers = () => {
 
   // Delete annotation by fieldId.
   // setTimeout(() => {
-  //   activeEditor?.commands.deleteFieldAnnotations('agreementinput-1723720330834-228771403177');
+  //   activeEditor?.commands.deleteFieldAnnotations('111');
   // }, 3000);
 
   // Get all field annotations with dom rect (to get coordinates).
   // setTimeout(() => {
   //   let fieldAnnotationsWithRect = fieldAnnotationHelpers.getAllFieldAnnotationsWithRect(
-  //     'fieldAnnotation', 
   //     activeEditor.view,
   //     activeEditor.state
   //   );
 
   //   console.log({ fieldAnnotationsWithRect });
   // }, 3000);
+
+  // Find field annotations by field id.
+  // setTimeout(() => {
+  //   let fieldAnnotationsByFieldId = fieldAnnotationHelpers.findFieldAnnotationsByFieldId(
+  //     'test-id',
+  //     activeEditor.state,
+  //   );
+
+  //   console.log({ fieldAnnotationsByFieldId });
+  // }, 4000);
+
+  // Find first field annotation by field id.
+  // setTimeout(() => {
+  //   let firstFieldAnnotation = fieldAnnotationHelpers.findFirstFieldAnnotationByFieldId(
+  //     'test-id',
+  //     activeEditor.state,
+  //   );
+
+  //   console.log({ firstFieldAnnotation });
+  // }, 4000);
 };
 /* Inputs pane and field annotations */
 

--- a/packages/super-editor/src/extensions/field-annotation/FieldAnnotationView.js
+++ b/packages/super-editor/src/extensions/field-annotation/FieldAnnotationView.js
@@ -45,6 +45,7 @@ export class FieldAnnotationView {
       text: (...args) => this.buildTextView(...args),
       image: (...args) => this.buildImageView(...args),
       signature: (...args) => this.buildSignatureView(...args),
+      checkbox: (...args) => this.buildCheckboxView(...args),
       default: (...args) => this.buildTextView(...args),
     };
 
@@ -109,6 +110,16 @@ export class FieldAnnotationView {
       content.innerHTML = displayLabel;
     }
 
+    this.dom = annotation;
+  }
+
+  buildCheckboxView() {
+    let { displayLabel } = this.node.attrs;
+    
+    let { annotation } = this.#createAnnotation({
+      displayLabel
+    });
+    
     this.dom = annotation;
   }
 

--- a/packages/super-editor/src/extensions/field-annotation/field-annotation.js
+++ b/packages/super-editor/src/extensions/field-annotation/field-annotation.js
@@ -5,6 +5,7 @@ import { toHex } from 'color2k';
 
 const { findChildren } = helpers;
 
+export const fieldAnnotationName = 'fieldAnnotation';
 export const annotationClass = 'annotation';
 export const annotationContentClass = 'annotation-content';
 
@@ -198,22 +199,29 @@ export const FieldAnnotation = Node.create({
 
       /**
        * Update annotations associated with a field.
-       * @param fieldId The field ID.
+       * @param fieldIdOrArray The field ID or array of field IDs.
        * @param attrs The attributes.
        * @example
        * editor.commands.updateFieldAnnotations('123', {
        *  displayLabel: 'Updated!',
        * });
+       * editor.commands.updateFieldAnnotations(['123', '456'], {
+       *  displayLabel: 'Updated!',
+       * });
        */
-      updateFieldAnnotations: (fieldId, attrs = {}) => ({
+      updateFieldAnnotations: (fieldIdOrArray, attrs = {}) => ({
         dispatch,
         state,
         tr,
       }) => {
-        let annotations = findChildren(state.doc, (node) => (
-          node.type.name === this.name
-          && node.attrs.fieldId === fieldId
-        ));
+        let annotations = findChildren(state.doc, (node) => {
+          let isFieldAnnotation = node.type.name === this.name;
+          if (Array.isArray(fieldIdOrArray)) {
+            return isFieldAnnotation && fieldIdOrArray.includes(node.attrs.fieldId);
+          } else {
+            return isFieldAnnotation && node.attrs.fieldId === fieldIdOrArray;
+          }
+        });
 
         if (!annotations.length) return false;
 
@@ -238,18 +246,24 @@ export const FieldAnnotation = Node.create({
 
       /**
        * Delete annotations associated with a field.
-       * @param fieldId The field ID.
-       * @example editor.commands.deleteFieldAnnotations('123');
+       * @param fieldIdOrArray The field ID or array of field IDs.
+       * @example 
+       * editor.commands.deleteFieldAnnotations('123');
+       * editor.commands.deleteFieldAnnotations(['123', '456']);
        */
-      deleteFieldAnnotations: (fieldId) => ({
+      deleteFieldAnnotations: (fieldIdOrArray) => ({
         dispatch,
         state,
         tr,
       }) => {
-        let annotations = findChildren(state.doc, (node) => (
-          node.type.name === this.name
-          && node.attrs.fieldId === fieldId
-        ));
+        let annotations = findChildren(state.doc, (node) => {
+          let isFieldAnnotation = node.type.name === this.name;
+          if (Array.isArray(fieldIdOrArray)) {
+            return isFieldAnnotation && fieldIdOrArray.includes(node.attrs.fieldId);
+          } else {
+            return isFieldAnnotation && node.attrs.fieldId === fieldIdOrArray;
+          }
+        });
 
         if (!annotations.length) return false;
 

--- a/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/findFieldAnnotationsByFieldId.js
+++ b/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/findFieldAnnotationsByFieldId.js
@@ -1,0 +1,14 @@
+import { helpers } from '@core/index.js';
+
+const { findChildren } = helpers;
+
+export function findFieldAnnotationsByFieldId(fieldId, state) {
+  let fieldAnnotations = findChildren(state.doc, (node) => {
+    return (
+      node.type.name === 'fieldAnnotation'
+      && node.attrs.fieldId === fieldId
+    );
+  });
+
+  return fieldAnnotations;
+}

--- a/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/findFirstFieldAnnotationByFieldId.js
+++ b/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/findFirstFieldAnnotationByFieldId.js
@@ -1,0 +1,20 @@
+
+export function findFirstFieldAnnotationByFieldId(fieldId, state) {
+  let fieldAnnotation = findNode(state.doc, (node) => {
+    return (
+      node.type.name === 'fieldAnnotation'
+      && node.attrs.fieldId === fieldId
+    );
+  });
+
+  return fieldAnnotation;
+}
+
+function findNode(node, predicate) {
+  let found = null;
+  node.descendants((node, pos) => {
+    if (predicate(node)) found = { node, pos };
+    if (found) return false;
+  })
+  return found;
+}

--- a/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/getAllFieldAnnotations.js
+++ b/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/getAllFieldAnnotations.js
@@ -4,15 +4,12 @@ const { findChildren, getNodeType } = helpers;
 
 /**
  * Get all field annotations in the doc.
- * @param typeOrName The node type or name.
  * @param state The editor state.
  * @returns The array of field annotations.
  */
-export function getAllFieldAnnotations(typeOrName, state) {
-  let nodeType = getNodeType(typeOrName, state.schema);
-
+export function getAllFieldAnnotations(state) {
   let fieldAnnotations = findChildren(state.doc, (node) => (
-    node.type.name === nodeType.name
+    node.type.name === 'fieldAnnotation'
   ));
 
   return fieldAnnotations;

--- a/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/getAllFieldAnnotationsWithRect.js
+++ b/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/getAllFieldAnnotationsWithRect.js
@@ -3,15 +3,12 @@ import { getAllFieldAnnotations } from './getAllFieldAnnotations.js';
 
 /**
  * Get all field annotations with rects in the doc.
- * @param typeOrName The node type or name.
  * @param view The editor view.
  * @param state The editor state.
  * @returns The array of field annotations with rects.
  */
-export function getAllFieldAnnotationsWithRect(typeOrName, view, state) {
-  let nodeType = getNodeType(typeOrName, state.schema);
-
-  let fieldAnnotations = getAllFieldAnnotations(nodeType.name, state)
+export function getAllFieldAnnotationsWithRect(view, state) {
+  let fieldAnnotations = getAllFieldAnnotations(state)
     .map(({ node, pos }) => {
       let rect = posToDOMRect(view, pos, pos + node.nodeSize);
       return {

--- a/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/index.js
+++ b/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/index.js
@@ -1,2 +1,4 @@
 export * from './getAllFieldAnnotations.js';
 export * from './getAllFieldAnnotationsWithRect.js'
+export * from './findFieldAnnotationsByFieldId.js';
+export * from './findFirstFieldAnnotationByFieldId.js';

--- a/packages/superdoc/src/dev/components/SuperdocDev.vue
+++ b/packages/superdoc/src/dev/components/SuperdocDev.vue
@@ -137,7 +137,6 @@ const attachEditorEventsHandlers = () => {
     // Get all field annotations with dom rect (to get coordinates).
     // setTimeout(() => {
     //   let fieldAnnotationsWithRect = fieldAnnotationHelpers.getAllFieldAnnotationsWithRect(
-    //     'fieldAnnotation', 
     //     editor.view,
     //     editor.state
     //   );

--- a/packages/superdoc/src/index.js
+++ b/packages/superdoc/src/index.js
@@ -1,5 +1,9 @@
 import { Superdoc } from './core/index.js';
-import { SuperInput } from '@harbour-enterprises/super-editor';
+import { 
+  SuperInput, 
+  helpers as superEditorHelpers, 
+  fieldAnnotationHelpers 
+} from '@harbour-enterprises/super-editor';
 import { DOCX, PDF, HTML } from '@harbour-enterprises/common';
 import BlankDOCX from '@harbour-enterprises/common/data/blank.docx?url';
 
@@ -14,4 +18,8 @@ export {
 
   // Components
   SuperInput,
+
+  // Helpers
+  superEditorHelpers,
+  fieldAnnotationHelpers,
 }


### PR DESCRIPTION
- Added `Checkbox View` for field annotations. Works as a text view, but can always be modified for further needs.
- Updated `updateFieldAnnotations` and `deleteFieldAnnotations` method signatures. Can accept either one `fieldId` or an array of `fieldIds`.
- Added `findFieldAnnotationsByFieldId`, `findFirstFieldAnnotationByFieldId` helpers.
- Minor refactoring.