### PR TITLE
handle edit and view mode for field annotations

### DIFF
--- a/packages/super-editor/src/dev/components/DeveloperPlayground.vue
+++ b/packages/super-editor/src/dev/components/DeveloperPlayground.vue
@@ -119,6 +119,7 @@ const attachAnnotationEventHandlers = () => {
     editor.commands.addFieldAnnotation(pos, {
       displayLabel: 'Enter your info',
       fieldId: `agreementinput-${Date.now()}-${Math.floor(Math.random() * 1000000000000)}`,
+      // fieldId: `111`,
       fieldType: 'TEXTINPUT',
       fieldColor: signer?.signercolor,
     });
@@ -146,18 +147,26 @@ const attachAnnotationEventHandlers = () => {
     console.log('fieldAnnotationClicked', { params });
   });
 
+  activeEditor?.on('fieldAnnotationDoubleClicked', (params) => {
+    console.log('fieldAnnotationDoubleClicked', { params });
+  });
+
+  activeEditor?.on('fieldAnnotationSelected', (params) => {
+    console.log('fieldAnnotationSelected', { params });
+  });
+
   // Update annotations by fieldId.
   // setTimeout(() => {
   //   activeEditor?.commands.updateFieldAnnotations('111', {
   //     displayLabel: 'Updated!',
   //     fieldColor: '#6943d0',
   //   });
-  // }, 3000);
+  // }, 5000);
 
   // Delete annotation by fieldId.
   // setTimeout(() => {
   //   activeEditor?.commands.deleteFieldAnnotations('111');
-  // }, 3000);
+  // }, 5000);
 
   // Get all field annotations with dom rect (to get coordinates).
   // setTimeout(() => {
@@ -243,6 +252,10 @@ onMounted(async () => {
                 />
               </div>
             </div>
+        </div>
+
+        <div>
+          <!-- -->
         </div>
       </div>
 

--- a/packages/super-editor/src/extensions/field-annotation/FieldAnnotationPlugin.js
+++ b/packages/super-editor/src/extensions/field-annotation/FieldAnnotationPlugin.js
@@ -1,7 +1,10 @@
 import { Plugin, PluginKey } from 'prosemirror-state';
 
 export const FieldAnnotationPlugin = (options = {}) => {
-  let { editor, annotationClass } = options;
+  let { 
+    editor, 
+    annotationClass, 
+  } = options;
 
   return new Plugin({
     key: new PluginKey('fieldAnnotation'),

--- a/packages/super-editor/src/extensions/field-annotation/FieldAnnotationView.js
+++ b/packages/super-editor/src/extensions/field-annotation/FieldAnnotationView.js
@@ -32,6 +32,7 @@ export class FieldAnnotationView {
     this.borderColor = options.borderColor;
 
     this.handleAnnotationClick = this.handleAnnotationClick.bind(this);
+    this.handleAnnotationDoubleClick = this.handleAnnotationDoubleClick.bind(this);
     this.handleSelectionUpdate = this.handleSelectionUpdate.bind(this);
     
     this.buildView();
@@ -162,15 +163,21 @@ export class FieldAnnotationView {
 
   attachEventListeners() {
     this.dom.addEventListener('click', this.handleAnnotationClick);
+    this.dom.addEventListener('dblclick', this.handleAnnotationDoubleClick);
     this.editor.on('selectionUpdate', this.handleSelectionUpdate);
   }
 
   removeEventListeners() {
     this.dom.removeEventListener('click', this.handleAnnotationClick);
+    this.dom.removeEventListener('dblclick', this.handleAnnotationDoubleClick);
     this.editor.off('selectionUpdate', this.handleSelectionUpdate);
   }
 
   handleSelectionUpdate({ editor, transaction }) {
+    if (!this.editor.isEditable) {
+      return;
+    }
+
     let { selection } = editor.state;
     
     if (selection instanceof NodeSelection) {
@@ -188,7 +195,25 @@ export class FieldAnnotationView {
   }
 
   handleAnnotationClick(event) {
+    if (!this.editor.isEditable) {
+      return;
+    }
+
     this.editor.emit('fieldAnnotationClicked', {
+      editor: this.editor,
+      node: this.node,
+      nodePos: this.getPos(),
+      event,
+      currentTarget: event.currentTarget,
+    });
+  }
+  
+  handleAnnotationDoubleClick(event) {
+    if (!this.editor.isEditable) {
+      return;
+    }
+
+    this.editor.emit('fieldAnnotationDoubleClicked', {
       editor: this.editor,
       node: this.node,
       nodePos: this.getPos(),
@@ -198,6 +223,11 @@ export class FieldAnnotationView {
   }
 
   stopEvent(event) {
+    if (!this.editor.isEditable) {
+      event.preventDefault();
+      return true;
+    }
+
     return false;
   }
 

--- a/packages/super-editor/src/extensions/field-annotation/field-annotation.js
+++ b/packages/super-editor/src/extensions/field-annotation/field-annotation.js
@@ -1,6 +1,7 @@
 import { Node, Attribute, helpers } from '@core/index.js';
 import { FieldAnnotationView } from './FieldAnnotationView.js';
 import { FieldAnnotationPlugin } from './FieldAnnotationPlugin.js';
+import { findFieldAnnotationsByFieldId } from './fieldAnnotationHelpers/index.js';
 import { toHex } from 'color2k';
 
 const { findChildren } = helpers;
@@ -214,14 +215,7 @@ export const FieldAnnotation = Node.create({
         state,
         tr,
       }) => {
-        let annotations = findChildren(state.doc, (node) => {
-          let isFieldAnnotation = node.type.name === this.name;
-          if (Array.isArray(fieldIdOrArray)) {
-            return isFieldAnnotation && fieldIdOrArray.includes(node.attrs.fieldId);
-          } else {
-            return isFieldAnnotation && node.attrs.fieldId === fieldIdOrArray;
-          }
-        });
+        let annotations = findFieldAnnotationsByFieldId(fieldIdOrArray, state);
 
         if (!annotations.length) return false;
 
@@ -256,14 +250,7 @@ export const FieldAnnotation = Node.create({
         state,
         tr,
       }) => {
-        let annotations = findChildren(state.doc, (node) => {
-          let isFieldAnnotation = node.type.name === this.name;
-          if (Array.isArray(fieldIdOrArray)) {
-            return isFieldAnnotation && fieldIdOrArray.includes(node.attrs.fieldId);
-          } else {
-            return isFieldAnnotation && node.attrs.fieldId === fieldIdOrArray;
-          }
-        });
+        let annotations = findFieldAnnotationsByFieldId(fieldIdOrArray, state);
 
         if (!annotations.length) return false;
 

--- a/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/findFieldAnnotationsByFieldId.js
+++ b/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/findFieldAnnotationsByFieldId.js
@@ -2,12 +2,20 @@ import { helpers } from '@core/index.js';
 
 const { findChildren } = helpers;
 
-export function findFieldAnnotationsByFieldId(fieldId, state) {
+/**
+ * Find field annotations by field ID or array of field IDs.
+ * @param fieldIdOrArray The field ID or array of field IDs.
+ * @param state The editor state.
+ * @returns The field annotations array.
+ */
+export function findFieldAnnotationsByFieldId(fieldIdOrArray, state) {
   let fieldAnnotations = findChildren(state.doc, (node) => {
-    return (
-      node.type.name === 'fieldAnnotation'
-      && node.attrs.fieldId === fieldId
-    );
+    let isFieldAnnotation = node.type.name === 'fieldAnnotation';
+    if (Array.isArray(fieldIdOrArray)) {
+      return isFieldAnnotation && fieldIdOrArray.includes(node.attrs.fieldId);
+    } else {
+      return isFieldAnnotation && node.attrs.fieldId === fieldIdOrArray;
+    }
   });
 
   return fieldAnnotations;

--- a/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/findFirstFieldAnnotationByFieldId.js
+++ b/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/findFirstFieldAnnotationByFieldId.js
@@ -1,4 +1,9 @@
-
+/**
+ * Find first field annotation by field ID.
+ * @param fieldId The field ID.
+ * @param state The editor state.
+ * @returns The field annotation or null.
+ */
 export function findFirstFieldAnnotationByFieldId(fieldId, state) {
   let fieldAnnotation = findNode(state.doc, (node) => {
     return (


### PR DESCRIPTION
- Handled double click for field annotation.
- Added checks if the editor is not editable (to avoid emitting events and annotation selection).
- Minor refactoring, removing duplicate code.
- Documenting functions.

Note:
If the editor is not editable, these annotation commands will still work and ignore the flag. I'm not sure it's a good idea to add a check there (my opinion may change though).
`addFieldAnnotation`, `updateFieldAnnotations`, `deleteFieldAnnotations`

But it seems to me that the commands should be independent of these checks, and we should prevent the execution of the commands from the outside (in AE code for example).

I found that other commands don't rely on this flag either. Also, I found confirmation that this can be useful.