### PR TITLE
set annotations hidden conditionally, handle visibility

### DIFF
--- a/packages/super-editor/src/core/CommandService.js
+++ b/packages/super-editor/src/core/CommandService.js
@@ -66,7 +66,7 @@ export class CommandService {
    * Check if a command or a chain of commands can be executed. Without executing it.
    */
   get can() {
-    return () => this.createChain();
+    return () => this.createCan();
   }
 
   /**

--- a/packages/super-editor/src/dev/components/DeveloperPlayground.vue
+++ b/packages/super-editor/src/dev/components/DeveloperPlayground.vue
@@ -123,80 +123,15 @@ const attachAnnotationEventHandlers = () => {
       fieldType: 'TEXTINPUT',
       fieldColor: signer?.signercolor,
     });
-
-    // editor.commands.addFieldAnnotation(pos, {
-    //   displayLabel: 'Upload your image',
-    //   fieldId: `agreementinput-${Date.now()}-${Math.floor(Math.random() * 1000000000000)}`,
-    //   fieldType: 'IMAGEINPUT',
-    //   fieldColor: signer?.signercolor,
-    //   imageSrc: 'https://placehold.co/200x200?text=Image',
-    //   type: 'image',
-    // });
-
-    // editor.commands.addFieldAnnotation(pos, {
-    //   displayLabel: 'Signature',
-    //   fieldId: `agreementinput-${Date.now()}-${Math.floor(Math.random() * 1000000000000)}`,
-    //   fieldType: 'SIGNATUREINPUT',
-    //   fieldColor: signer?.signercolor,
-    //   imageSrc: 'https://placehold.co/85x25?text=Signature',
-    //   type: 'signature',
-    // });
   });
 
   activeEditor?.on('fieldAnnotationClicked', (params) => {
     console.log('fieldAnnotationClicked', { params });
   });
 
-  activeEditor?.on('fieldAnnotationDoubleClicked', (params) => {
-    console.log('fieldAnnotationDoubleClicked', { params });
-  });
-
   activeEditor?.on('fieldAnnotationSelected', (params) => {
     console.log('fieldAnnotationSelected', { params });
   });
-
-  // Update annotations by fieldId.
-  // setTimeout(() => {
-  //   activeEditor?.commands.updateFieldAnnotations('111', {
-  //     displayLabel: 'Updated!',
-  //     fieldColor: '#6943d0',
-  //   });
-  // }, 5000);
-
-  // Delete annotation by fieldId.
-  // setTimeout(() => {
-  //   activeEditor?.commands.deleteFieldAnnotations('111');
-  // }, 5000);
-
-  // Get all field annotations with dom rect (to get coordinates).
-  // setTimeout(() => {
-  //   let fieldAnnotationsWithRect = fieldAnnotationHelpers.getAllFieldAnnotationsWithRect(
-  //     activeEditor.view,
-  //     activeEditor.state
-  //   );
-
-  //   console.log({ fieldAnnotationsWithRect });
-  // }, 3000);
-
-  // Find field annotations by field id.
-  // setTimeout(() => {
-  //   let fieldAnnotationsByFieldId = fieldAnnotationHelpers.findFieldAnnotationsByFieldId(
-  //     'test-id',
-  //     activeEditor.state,
-  //   );
-
-  //   console.log({ fieldAnnotationsByFieldId });
-  // }, 4000);
-
-  // Find first field annotation by field id.
-  // setTimeout(() => {
-  //   let firstFieldAnnotation = fieldAnnotationHelpers.findFirstFieldAnnotationByFieldId(
-  //     'test-id',
-  //     activeEditor.state,
-  //   );
-
-  //   console.log({ firstFieldAnnotation });
-  // }, 4000);
 };
 /* Inputs pane and field annotations */
 

--- a/packages/super-editor/src/extensions/field-annotation/field-annotation.js
+++ b/packages/super-editor/src/extensions/field-annotation/field-annotation.js
@@ -1,10 +1,8 @@
 import { Node, Attribute, helpers } from '@core/index.js';
 import { FieldAnnotationView } from './FieldAnnotationView.js';
 import { FieldAnnotationPlugin } from './FieldAnnotationPlugin.js';
-import { findFieldAnnotationsByFieldId } from './fieldAnnotationHelpers/index.js';
+import { findFieldAnnotationsByFieldId, getAllFieldAnnotations } from './fieldAnnotationHelpers/index.js';
 import { toHex } from 'color2k';
-
-const { findChildren } = helpers;
 
 export const fieldAnnotationName = 'fieldAnnotation';
 export const annotationClass = 'annotation';
@@ -33,6 +31,7 @@ export const FieldAnnotation = Node.create({
       types: ['text', 'image', 'signature', 'checkbox'], // annotation types
       defaultType: 'text',
       borderColor: '#b015b3',
+      visibilityOptions: ['visible', 'hidden'],
       handleDropOutside: true,
     }
   },
@@ -110,6 +109,28 @@ export const FieldAnnotation = Node.create({
           };
         },
       },
+
+      hidden: {
+        default: false,
+        parseDOM: (elem) => elem.hasAttribute('hidden') ? true : null,
+        renderDOM: (attrs) => {
+          if (!attrs.hidden) return {};
+          return { hidden: '' };
+        },
+      },
+
+      visibility: {
+        default: 'visible',
+        parseDOM: (el) => {
+          let visibility = el.style.visibility || 'visible';
+          let containsVisibility = this.options.visibilityOptions.includes(visibility);
+          return containsVisibility ? visibility : 'visible';
+        },
+        renderDOM: (attrs) => {
+          if (!attrs.visibility || attrs.visibility === 'visible') return {};
+          return { style: `visibility: ${attrs.visibility}` };
+        },
+      },
     };
   },
 
@@ -174,7 +195,7 @@ export const FieldAnnotation = Node.create({
        *  fieldId: `123`,
        *  fieldType: 'TEXTINPUT',
        *  fieldColor: '#980043',
-       * });
+       * })
        */
       addFieldAnnotation: (pos, attrs = {}) => ({ 
         editor,
@@ -205,35 +226,52 @@ export const FieldAnnotation = Node.create({
        * @example
        * editor.commands.updateFieldAnnotations('123', {
        *  displayLabel: 'Updated!',
-       * });
+       * })
+       * @example
        * editor.commands.updateFieldAnnotations(['123', '456'], {
        *  displayLabel: 'Updated!',
-       * });
+       * })
        */
       updateFieldAnnotations: (fieldIdOrArray, attrs = {}) => ({
         dispatch,
         state,
-        tr,
+        commands,
       }) => {
         let annotations = findFieldAnnotationsByFieldId(fieldIdOrArray, state);
 
         if (!annotations.length) return false;
 
         if (dispatch) {
-          annotations
-            .forEach((annotation) => {
-              let { pos, node } = annotation;
-              let newPos = tr.mapping.map(pos);
-
-              let currentNode = tr.doc.nodeAt(newPos);
-              if (node.eq(currentNode)) {
-                tr.setNodeMarkup(newPos, undefined, {
-                  ...node.attrs,
-                  ...attrs,
-                });
-              }
-            });
+          return commands.updateFieldAnnotationsAttributes(annotations, attrs);
         }
+
+        return true;
+      },
+      
+      /**
+       * Update the attributes of annotations.
+       * @param annotations The annotations array [{pos, node}].
+       * @param attrs The attributes object.
+       */
+      updateFieldAnnotationsAttributes: (annotations, attrs = {}) => ({
+        dispatch,
+        tr,
+      }) => {
+        if (!dispatch) return true;
+
+        annotations
+          .forEach((annotation) => {
+            let { pos, node } = annotation;
+            let newPos = tr.mapping.map(pos);
+            let currentNode = tr.doc.nodeAt(pos);
+
+            if (node.eq(currentNode)) {
+              tr.setNodeMarkup(newPos, undefined, {
+                ...node.attrs,
+                ...attrs,
+              });
+            }
+          });
 
         return true;
       },
@@ -242,8 +280,9 @@ export const FieldAnnotation = Node.create({
        * Delete annotations associated with a field.
        * @param fieldIdOrArray The field ID or array of field IDs.
        * @example 
-       * editor.commands.deleteFieldAnnotations('123');
-       * editor.commands.deleteFieldAnnotations(['123', '456']);
+       * editor.commands.deleteFieldAnnotations('123')
+       * @example
+       * editor.commands.deleteFieldAnnotations(['123', '456'])
        */
       deleteFieldAnnotations: (fieldIdOrArray) => ({
         dispatch,
@@ -270,6 +309,95 @@ export const FieldAnnotation = Node.create({
         
         return true;
       },
+
+      /**
+       * Set `hidden` for annotations matching predicate.
+       * Other annotations become unhidden.
+       * @param predicate The predicate function.
+       * @example 
+       * editor.commands.setFieldAnnotationsHiddenByCondition((node) => {
+       *   let ids = ['111', '222', '333'];
+       *   return ids.includes(node.attrs.fieldId);
+       * })
+       */
+      setFieldAnnotationsHiddenByCondition: (
+        predicate = () => false,
+      ) => ({
+        dispatch,
+        state,
+        chain,
+      }) => {
+        let annotations = getAllFieldAnnotations(state);
+
+        if (!annotations.length) return false;
+
+        if (dispatch) {
+          let otherAnnotations = [];
+          let matchedAnnotations = annotations.filter((annotation) => {
+            if (predicate(annotation.node)) return annotation;
+            else otherAnnotations.push(annotation);
+          });
+
+          return chain()
+            .updateFieldAnnotationsAttributes(matchedAnnotations, { hidden: true })
+            .updateFieldAnnotationsAttributes(otherAnnotations, { hidden: false })
+            .run();
+        }
+
+        return true;
+      },
+
+      /**
+       * Unset `hidden` for all annotations.
+       * @example 
+       * editor.commands.unsetFieldAnnotationsHidden()
+       */
+      unsetFieldAnnotationsHidden: () => ({
+        dispatch,
+        state,
+        commands,
+      }) => {
+        let annotations = getAllFieldAnnotations(state);
+
+        if (!annotations.length) return false;
+
+        if (dispatch) {
+          return commands
+            .updateFieldAnnotationsAttributes(annotations, { hidden: false })
+        }
+
+        return true;
+      },
+
+      /**
+       * Set `visibility` for all annotations (without changing the layout).
+       * @param visibility The visibility value (visible, hidden).
+       * @example
+       * editor.commands.setFieldAnnotationsVisibility('visible');
+       * @example
+       * editor.commands.setFieldAnnotationsVisibility('hidden');
+       */
+      setFieldAnnotationsVisibility: (visibility = 'visible') => ({
+        dispatch,
+        state,
+        commands,
+      }) => {
+        let annotations = getAllFieldAnnotations(state);
+
+        if (!annotations.length) return false;
+
+        let containsVisibility = this.options.visibilityOptions.includes(visibility);
+        
+        if (!containsVisibility) return false;
+
+        if (dispatch) {
+          return commands.updateFieldAnnotationsAttributes(annotations, {
+            visibility,
+          });
+        }
+
+        return true;
+      },
     };
   },
 
@@ -294,12 +422,3 @@ export const FieldAnnotation = Node.create({
     ];
   },
 });
-
-function findNode(node, predicate) {
-  let found;
-  node.descendants((node, pos) => {
-    if (found) return false;
-    if (predicate(node)) found = { node, pos };
-  });
-  return found;
-};

--- a/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/getAllFieldAnnotations.js
+++ b/packages/super-editor/src/extensions/field-annotation/fieldAnnotationHelpers/getAllFieldAnnotations.js
@@ -1,6 +1,6 @@
 import { helpers } from '@core/index.js';
 
-const { findChildren, getNodeType } = helpers;
+const { findChildren } = helpers;
 
 /**
  * Get all field annotations in the doc.

--- a/packages/superdoc/src/dev/components/SuperdocDev.vue
+++ b/packages/superdoc/src/dev/components/SuperdocDev.vue
@@ -120,28 +120,6 @@ const attachEditorEventsHandlers = () => {
     editor.on('fieldAnnotationSelected', (params) => {
       console.log('fieldAnnotationSelected', { params });
     });
-
-    // Update annotations by fieldId.
-    // setTimeout(() => {
-    //   editor.commands.updateFieldAnnotations('111', {
-    //     displayLabel: 'Updated!',
-    //     fieldColor: '#6943d0',
-    //   });
-    // }, 3000);
-
-    // Delete annotation by fieldId.
-    // setTimeout(() => {
-    //   editor.commands.deleteFieldAnnotations('111');
-    // }, 3000);
-
-    // Get all field annotations with dom rect (to get coordinates).
-    // setTimeout(() => {
-    //   let fieldAnnotationsWithRect = fieldAnnotationHelpers.getAllFieldAnnotationsWithRect(
-    //     editor.view,
-    //     editor.state
-    //   );
-    //   console.log({ fieldAnnotationsWithRect });
-    // }, 3000);
   };
 
   superdoc.value?.on('editorCreate', onEditorCreate);


### PR DESCRIPTION
- Added `hidden`, `visibility` attributes for field annotations and their processing.
- Added the following commands for field annotations.

`updateFieldAnnotationsAttributes` - Used to reduce code duplication.

`setFieldAnnotationsHiddenByCondition` - Can be used to conditionally hide annotations that match a predicate. Other annotations become unhidden.

Example:
<img width="529" alt="Screenshot 2024-09-10 at 10 11 08" src="https://github.com/user-attachments/assets/e73d3de7-fbc1-4eff-bd01-d295a428b7dc">

<img width="450" alt="Screenshot 2024-09-10 at 10 11 17" src="https://github.com/user-attachments/assets/8487ea10-1c9d-4d90-9298-2f8f8cd06ed6">

<img width="415" alt="Screenshot 2024-09-10 at 10 11 25" src="https://github.com/user-attachments/assets/b76c9543-c9a4-4d26-b56d-4ecce46f0393">

`unsetFieldAnnotationsHidden` - Can be used to make all annotations unhidden.

`setFieldAnnotationsVisibility` - Can be used to set visibility for all annotations (without changing the layout). For example, if need to show annotations on another layer or something like that.

Example:
<img width="598" alt="Screenshot 2024-09-10 at 08 00 16" src="https://github.com/user-attachments/assets/8a0d62f4-8ddf-48dd-8462-a1578b94d5dd">

<img width="558" alt="Screenshot 2024-09-10 at 08 00 28" src="https://github.com/user-attachments/assets/738f01ea-1311-4699-a5ee-ac0990cf4c2b">


- Refactoring, minor fixes.
- Code cleanup.