### PR TITLE
HAR-7572 - update ordered list style when sink or lift list item

### DIFF
--- a/packages/super-editor/src/extensions/list-item/list-item.js
+++ b/packages/super-editor/src/extensions/list-item/list-item.js
@@ -69,10 +69,16 @@ export const ListItem = Node.create({
         ]);
       },
       Tab: () => {
-        return this.editor.commands.sinkListItem(this.name);
+        return this.editor.chain()
+          .sinkListItem(this.name)
+          .updateOrderedListStyleType()
+          .run();
       },
       'Shift-Tab': () => {
-        return this.editor.commands.liftListItem(this.name);
+        return this.editor.chain()
+          .liftListItem(this.name)
+          .updateOrderedListStyleType()
+          .run();
       },
     };
   },


### PR DESCRIPTION
Linear:
https://linear.app/harbour/issue/HAR-7572/sub-lists-in-an-ordered-list-use-specific-rules-for-ordering-type

When sink list item:
<img width="682" alt="Screenshot 2024-09-12 at 22 11 41" src="https://github.com/user-attachments/assets/84d7b661-ecc3-4a4e-bd04-2d5cbfc2d887">

When lift list item:
<img width="608" alt="Screenshot 2024-09-12 at 22 14 54" src="https://github.com/user-attachments/assets/22de9466-ff50-4f5f-b797-12af8faca01f">