### PR TITLE
HAR-7570 - continue list numbering after liftEmptyBlock command

### DIFF
--- a/packages/super-editor/src/extensions/list-item/list-item.js
+++ b/packages/super-editor/src/extensions/list-item/list-item.js
@@ -60,7 +60,10 @@ export const ListItem = Node.create({
   addShortcuts() {
     return {
       Enter: () => {
-        return this.editor.commands.splitListItem(this.name);
+        return this.editor.commands.first(({ commands }) => [
+          () => commands.splitListItem(this.name),
+          () => commands.continueListNumberingAfterLiftEmpty(),
+        ]);
       },
       'Shift-Enter': () => {
         return this.editor.commands.first(({ commands }) => [


### PR DESCRIPTION
Linear:
https://linear.app/harbour/issue/HAR-7570/pressing-enter-twice-inside-an-ordered-list-creates-a-new-line-but

Example 1:
<img width="733" alt="Screenshot 2024-09-13 at 19 12 20" src="https://github.com/user-attachments/assets/e920f34c-cd31-4a64-84ad-1f691ade7951">

Example 2:
<img width="670" alt="Screenshot 2024-09-13 at 19 13 17" src="https://github.com/user-attachments/assets/05443a21-827b-4aaf-b541-5dcc319ad014">

Notes:
- Numbers will not be synchronized between lists after splitting, for example when increasing the number of items in the previous list, since such implementation can be significantly more complex.
- For future needs it would be nice to be able to update the list `start` attribute in the toolbar. And also support input rules for automatic list creation when editing.

