### PR TITLE
HAR-7635 - add basic support for html/paragraph field

### DIFF
--- a/packages/super-editor/src/extensions/field-annotation/FieldAnnotationView.js
+++ b/packages/super-editor/src/extensions/field-annotation/FieldAnnotationView.js
@@ -47,6 +47,7 @@ export class FieldAnnotationView {
       image: (...args) => this.buildImageView(...args),
       signature: (...args) => this.buildSignatureView(...args),
       checkbox: (...args) => this.buildCheckboxView(...args),
+      html: (...args) => this.buildHTMLView(...args),
       default: (...args) => this.buildTextView(...args),
     };
 
@@ -59,7 +60,7 @@ export class FieldAnnotationView {
     let { displayLabel } = this.node.attrs;
 
     let { annotation } = this.#createAnnotation({
-      displayLabel
+      displayLabel,
     });
     
     this.dom = annotation;
@@ -82,7 +83,7 @@ export class FieldAnnotationView {
       annotation.style.display = 'inline-block';
       content.style.display = 'inline-block';
     } else {
-      content.innerHTML = displayLabel;
+      content.textContent = displayLabel;
     }
 
     this.dom = annotation;
@@ -108,7 +109,7 @@ export class FieldAnnotationView {
       annotation.style.display = 'inline-block';
       content.style.display = 'inline-block';
     } else {
-      content.innerHTML = displayLabel;
+      content.textContent = displayLabel;
     }
 
     this.dom = annotation;
@@ -118,9 +119,26 @@ export class FieldAnnotationView {
     let { displayLabel } = this.node.attrs;
     
     let { annotation } = this.#createAnnotation({
-      displayLabel
+      displayLabel,
     });
     
+    this.dom = annotation;
+  }
+
+  buildHTMLView() {
+    let { displayLabel, rawHtml } = this.node.attrs;
+
+    let { annotation, content } = this.#createAnnotation();
+
+    if (rawHtml) {
+      content.innerHTML = rawHtml.trim();
+
+      annotation.style.display = 'inline-block';
+      content.style.display = 'inline-block';
+    } else {
+      content.textContent = displayLabel;
+    }
+
     this.dom = annotation;
   }
 
@@ -136,7 +154,7 @@ export class FieldAnnotationView {
     content.contentEditable = 'false';
 
     if (displayLabel) {
-      content.innerHTML = displayLabel;
+      content.textContent = displayLabel;
     }
     
     annotation.append(content);


### PR DESCRIPTION
So we support the following field types:
- text - text fields, default type.
- image, signature - if there is a value in the `imageSrc` attribute, then renders the image instead of the `displayLabel`.
- checkbox - works exactly the same as the `text` type, but we assign `checkbox` type in case the behavior needs to be extended later.
- html - renders raw html  if there is a value in the `rawHtml`attribute or `displayLabel` instead (to support paragraph field).

Note:
- There are two more field types in the webapp that I'm not entirely sure about, but they seem to work just like `text` fields -`YESNOINPUT`, `DROPDOWNINPUT`.

If needed we can add separate field types (in `field-annotation`) for them in case we need to extend their behavior later or handle them differently. For example - `yesno` and `dropdown` types.