### PR TITLE
HAR-7940 - ordered list marker plugin

### DIFF
--- a/packages/super-editor/src/core/commands/index.js
+++ b/packages/super-editor/src/core/commands/index.js
@@ -1,6 +1,7 @@
 export * from './first.js';
 export * from './command.js';
 export * from './insertTabChar.js';
+export * from './setMeta.js';
 
 export * from './splitBlock.js';
 export * from './liftEmptyBlock.js';

--- a/packages/super-editor/src/core/commands/setMeta.js
+++ b/packages/super-editor/src/core/commands/setMeta.js
@@ -1,0 +1,4 @@
+export const setMeta = (key, value) => ({ tr }) => {
+  tr.setMeta(key, value);
+  return true;
+};

--- a/packages/super-editor/src/core/config/style.js
+++ b/packages/super-editor/src/core/config/style.js
@@ -32,6 +32,9 @@ export const style = `.ProseMirror {
 .ProseMirror li:has(> ul:first-child, > ol:first-child):not(:has(> p)) {
   list-style-type: none;
 }
+.ProseMirror li:has(> ul:first-child, > ol:first-child):not(:has(> p))::marker {
+  content: '';
+}
 
 .ProseMirror-hideselection *::selection {
   background: transparent;
@@ -103,4 +106,13 @@ img.ProseMirror-separator {
   display: inline !important;
   border: none !important;
   margin: 0 !important;
-}`;
+}
+  
+.ProseMirror li[data-marker-type] {
+  list-style-type: none;
+}
+
+.ProseMirror li[data-marker-type]::marker {
+  content: attr(data-marker-type) ' ';
+}
+`;

--- a/packages/super-editor/src/extensions/list-item/list-item.js
+++ b/packages/super-editor/src/extensions/list-item/list-item.js
@@ -28,31 +28,45 @@ export const ListItem = Node.create({
   
   addAttributes() {
     return {
+      // Virtual attribute.
+      markerType: {
+        default: null,
+        renderDOM: (attrs) => {
+          let { listLevel, listNumberingType, lvlText } = attrs;
+          let hasListLevel = !!listLevel?.length;
+          
+          if (!hasListLevel || !lvlText) {
+            return {};
+          }
 
-      // lvlText: { 
-      //   default: null,
-      //   renderDOM: (attrs) => {
-      //     const { listLevel, listNumberingType, lvlText } = attrs;
-      //     if (!listLevel) return {};
-        
-      //     // MS Word has many custom ordered list options. We need to generate the correct index here.
-      //     const numbering = generateOrderedListIndex({ listLevel, lvlText, listNumberingType });
-      //     if (!numbering) return {};
+          // MS Word has many custom ordered list options. 
+          // We need to generate the correct index here.
+          let orderMarker = generateOrderedListIndex({ 
+            listLevel, 
+            lvlText, 
+            listNumberingType, 
+          });
+          
+          if (!orderMarker) return {};
 
-      //     return {
-      //       'data-bullet-type': numbering,
-      //       class: 'custom-list-item',
-      //     }
-      //   },
-      // },
+          return {
+            'data-marker-type': orderMarker,
+          };
+        },
+      },
+
+      lvlText: { 
+        default: null,
+        rendered: false,
+      },
 
       listNumberingType: {
-        default: 'decimal',
+        default: null,
         rendered: false,
       },
 
       listLevel: {
-        default: 0,
+        default: null,
         rendered: false,
       },
 

--- a/packages/super-editor/src/extensions/ordered-list/helpers/orderedListMarkerPlugin.js
+++ b/packages/super-editor/src/extensions/ordered-list/helpers/orderedListMarkerPlugin.js
@@ -1,0 +1,209 @@
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { findChildren, findParentNodeClosestToPos } from '@core/helpers/index.js';
+
+export function orderedListMarker(options = {}) {
+  return new Plugin({
+    key: new PluginKey('orderedListMarker'),
+
+    appendTransaction: (transactions, oldState, newState) => {
+      let docChanges = transactions.some((tr) => tr.docChanged) 
+        && !oldState.doc.eq(newState.doc);
+
+      if (!docChanges) {
+        return;
+      }
+
+      let { doc, tr } = newState;
+      let listItemsByList = getOrderedListItemsByList(newState);
+
+      if (!listItemsByList.size) {
+        return;
+      }
+
+      let changed = false;
+      Array.from(listItemsByList).forEach(([list, items]) => {
+        let listItems = items;
+        let isBulletList = list.type.name === 'bulletList';
+        let listHasSyncId = !!list.attrs.syncId; // Lists with syncId?
+        let listHasItemsWithoutAttrs = list.childCount !== listItems.length;
+
+        // If the list was toggled to a bullet list,
+        // then remove ordered marker attrs from list items.
+        if (isBulletList) {
+          listItems.forEach((item) => removeListItemMarkerAttrs(tr, item));
+          changed = true;
+          return;
+        }
+
+        // If the current list has items without the marker attrs, 
+        // then get all items and update listItems.
+        if (listHasItemsWithoutAttrs) {
+          let allItems = getAllChildListItemsOfList({ state: newState, list });
+          if (allItems.length) listItems = allItems;
+        }
+
+        let firstItem = listItems[0];
+        let firstItemAttrs = buildFirstListItemAttrs({ state: newState, listItems });
+
+        let defaultAttrs = createMarkerAttrs();
+        let currentAttrs = {
+          lvlText: firstItem.node.attrs.lvlText ?? defaultAttrs.lvlText,
+          listLevel: firstItem.node.attrs.listLevel ?? defaultAttrs.listLevel,
+          listNumberingType: firstItem.node.attrs.listNumberingType ?? defaultAttrs.listNumberingType,
+        };
+
+        let equalFirstItemAttrs = currentAttrs.lvlText === firstItemAttrs.lvlText &&
+          currentAttrs.listNumberingType === firstItemAttrs.listNumberingType &&
+          compare(currentAttrs.listLevel, firstItemAttrs.listLevel);
+
+        if (!equalFirstItemAttrs) {
+          tr.setNodeMarkup(firstItem.pos, undefined, {
+            ...firstItem.node.attrs,
+            ...firstItemAttrs,
+          });
+          changed = true;
+          currentAttrs = firstItemAttrs;
+        }
+
+        listItems.forEach((listItem, index) => {
+          // Skip the first list item.
+          if (index === 0) {
+            return;
+          }
+
+          let { node, pos } = listItem;
+          let { lvlText, listLevel, listNumberingType } = node.attrs;
+
+          let newListLevel = [
+            ...currentAttrs.listLevel.slice(0, -1), 
+            currentAttrs.listLevel.at(-1) + 1,
+          ];
+
+          let equalMarkerAttrs = lvlText === currentAttrs.lvlText &&
+            listNumberingType === currentAttrs.listNumberingType &&
+            compare(listLevel, newListLevel);
+
+          if (!equalMarkerAttrs) {
+            tr.setNodeMarkup(pos, undefined, {
+              ...node.attrs,
+              listLevel: newListLevel,
+              lvlText: currentAttrs.lvlText,
+              listNumberingType: currentAttrs.listNumberingType,
+            });
+            changed = true;
+          }
+          
+          currentAttrs = { 
+            ...currentAttrs, 
+            listLevel: newListLevel,
+          };
+        });
+      });
+
+      return changed ? tr : null;
+    },
+  });
+};
+
+function getOrderedListItemsByList(state) {
+  let { doc } = state;
+  let map = new Map();
+  doc.descendants((node, pos) => {
+    let { attrs } = node;
+    let isListItem = node.type.name === 'listItem';
+    let hasListLevel = !!attrs.listLevel?.length;
+    let hasLvlText = !!attrs.lvlText;
+    let orderedType = attrs.listNumberingType && attrs.listNumberingType !== 'bullet';
+    if (isListItem && hasListLevel && hasLvlText && orderedType) {
+      let $pos = doc.resolve(pos);
+      let list = $pos.parent;
+      if (!map.get(list)) map.set(list, []);
+      let items = map.get(list);
+      items.push({ node, pos });
+    }
+  });
+  return map;
+}
+
+function getAllChildListItemsOfList({ state, list }) {
+  let { doc } = state;
+  let allItems = [];
+  doc.descendants((node, pos) => {
+    let isListItem = node.type.name === 'listItem';
+    let $pos = doc.resolve(pos);
+    if (isListItem && $pos.parent === list) {
+      allItems.push({ node, pos });
+    }
+  });
+  return allItems;
+}
+
+function createMarkerAttrs({
+  lvlText = '',
+  listLevel = [],
+  listNumberingType = 'decimal',
+} = {}) {
+  return {
+    lvlText,
+    listLevel,
+    listNumberingType,
+  };
+}
+
+function removeListItemMarkerAttrs(tr, listItem) {
+  let { pos, node } = listItem;
+  tr.setNodeMarkup(pos, undefined, {
+    ...node.attrs,
+    lvlText: null,
+    listLevel: null,
+    listNumberingType: null,
+  });
+}
+
+function compare(a1, a2) {
+  return a1.length === a2.length &&
+    a1.every((item, index) => item === a2[index]);
+}
+
+// This is the place where we can check 
+// the first item attributes and patch them as needed.
+function buildFirstListItemAttrs({ state, listItems }) {
+  let { doc } = state;
+  let firstItem = listItems[0];
+  let { lvlText, listLevel, listNumberingType } = firstItem.node.attrs;
+
+  let defaultAttrs = createMarkerAttrs({
+    lvlText: '%1.',
+    listLevel: [1],
+    listNumberingType: 'decimal',
+  });
+
+  let $itemPos = doc.resolve(firstItem.pos);
+  let listDepth = $itemPos.depth - 1; // listItem depth - 1
+  let listLevelValue = listDepth / 2;
+
+  let itemHasAllAttrs = lvlText && listLevel?.length && listNumberingType;
+  
+  if (!itemHasAllAttrs) {
+    // Set default attributes.
+    ({ lvlText, listLevel, listNumberingType } = defaultAttrs);
+  } else {
+    let firstLevel = listLevelValue === 0;
+    let nestedList = listLevelValue > 0;
+
+    if (nestedList && listLevelValue >= 3) {
+      // Set default attributes.
+      ({ lvlText, listLevel, listNumberingType } = defaultAttrs);
+    } else if (nestedList && listLevelValue < 3) {
+      // Update listLevel to always start at 1.
+      // [6] -> [1], [3, 3] -> [3, 1], etc.
+      listLevel = [...listLevel.slice(0, -1), 1];
+    }
+  }
+
+  return {
+    lvlText,
+    listLevel,
+    listNumberingType,
+  };
+}

--- a/packages/super-editor/src/extensions/ordered-list/ordered-list.js
+++ b/packages/super-editor/src/extensions/ordered-list/ordered-list.js
@@ -2,6 +2,7 @@ import { Node, Attribute } from '@core/index.js';
 import { toKebabCase } from '@harbour-enterprises/common';
 import { generateDocxListAttributes, findParentNode } from '@helpers/index.js';
 import { orderedListSync as orderedListSyncPlugin } from './helpers/orderedListSyncPlugin.js';
+import { orderedListMarker as orderedListMarkerPlugin } from './helpers/orderedListMarkerPlugin.js';
 
 export const OrderedList = Node.create({
   name: 'orderedList',
@@ -228,6 +229,7 @@ export const OrderedList = Node.create({
 
   addPmPlugins() {
     return [
+      orderedListMarkerPlugin(),
       orderedListSyncPlugin(),
     ];
   },

--- a/packages/super-editor/src/style.css
+++ b/packages/super-editor/src/style.css
@@ -67,13 +67,3 @@
   margin: 0;
   padding: 0;
 } */
-.custom-list-item {
-  list-style-type: none;
-}
-.custom-list-item::before {
-  margin-right: 0.5em;
-  content: attr(data-bullet-type);
-}
-.custom-list-item p {
-  display: inline;
-}


### PR DESCRIPTION
Linear:
https://linear.app/harbour/issue/HAR-7940/superdoc-lists-v2-custom-numbering

Screenshot 1:
<img width="511" alt="Screenshot 2024-10-15 at 21 01 06" src="https://github.com/user-attachments/assets/edd90bf4-dca5-4c18-8216-0238fdf418c8">

Screenshot 2:
<img width="401" alt="Screenshot 2024-10-15 at 20 54 07" src="https://github.com/user-attachments/assets/a04a7811-f3a4-4a29-a427-6cc1b17bd530">

Note:
- In some cases there may be inconsistency when editing lists with custom markers, but it seems to me that if we standardize the approach to lists, then in most cases we can patch the first item based on some rules (`buildFirstListItemAttrs` function) and update the rest of the items accordingly.

FYI @harbournick 