### PR TITLE
fix editor focus when pressing tab for bullet list

### DIFF
--- a/packages/super-editor/src/extensions/ordered-list/ordered-list.js
+++ b/packages/super-editor/src/extensions/ordered-list/ordered-list.js
@@ -109,7 +109,7 @@ export const OrderedList = Node.create({
         let list = findParentNode((node) => node.type.name === this.name)(state.selection);
 
         if (!list) {
-          return false;
+          return true; 
         }
 
         if (dispatch) {


### PR DESCRIPTION
Probably in cases like this, when the element for which the command is intended is not found (or something like that), it is better to return `true`. That means that the command worked in a specific case anyway.