### PR TITLE
HAR-8016 - create styled list marker plugin

### DIFF
--- a/packages/super-editor/src/core/config/style.js
+++ b/packages/super-editor/src/core/config/style.js
@@ -36,6 +36,19 @@ export const style = `.ProseMirror {
   content: '';
 }
 
+.ProseMirror li::marker {
+  font-size: var(--marker-font-size);
+  font-family: var(--marker-font-family);
+}
+
+.ProseMirror li[data-marker-type] {
+  list-style-type: none;
+}
+
+.ProseMirror li[data-marker-type]::marker {
+  content: attr(data-marker-type) ' ';
+}
+
 .ProseMirror-hideselection *::selection {
   background: transparent;
 }
@@ -106,13 +119,5 @@ img.ProseMirror-separator {
   display: inline !important;
   border: none !important;
   margin: 0 !important;
-}
-  
-.ProseMirror li[data-marker-type] {
-  list-style-type: none;
-}
-
-.ProseMirror li[data-marker-type]::marker {
-  content: attr(data-marker-type) ' ';
 }
 `;

--- a/packages/super-editor/src/extensions/list-item/helpers/styledListMarkerPlugin.js
+++ b/packages/super-editor/src/extensions/list-item/helpers/styledListMarkerPlugin.js
@@ -1,0 +1,115 @@
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { Decoration, DecorationSet } from 'prosemirror-view';
+import { Attribute } from '@core/index.js';
+import { findChildren, getMarkType } from '@core/helpers/index.js';
+import { parseSizeUnit } from '@core/utilities/index.js';
+
+export function styledListMarker(options = {}) {
+  return new Plugin({
+    key: new PluginKey('styledListMarker'),
+
+    state: {
+      init(_, state) {
+        let decorations = getListMarkerDecorations(state);
+        return DecorationSet.create(state.doc, decorations);
+      },
+
+      apply(tr, oldDecorationSet, oldState, newState) {
+        if (!tr.docChanged) return oldDecorationSet;
+        const decorations = getListMarkerDecorations(newState);
+        return DecorationSet.create(newState.doc, decorations);
+      },
+    },
+
+    props: {
+      decorations(state) {
+        return this.getState(state);
+      },
+    },
+  });
+}
+
+function getListMarkerDecorations(state) {
+  let { doc, storedMarks } = state;
+  let decorations = [];
+
+  let listItems = findChildren(doc, (node) => node.type.name === 'listItem');
+
+  if (!listItems.length) {
+    return decorations;
+  }
+
+  listItems.forEach(({ node, pos }) => {
+    let textStyleMarks = [];
+    let textStyleType = getMarkType('textStyle', doc.type.schema);
+    let isEmptyListItem = checkListItemEmpty(node);
+
+    if (isEmptyListItem && storedMarks) {
+      let marks = storedMarks.filter((mark) => mark.type === textStyleType);
+      textStyleMarks.push(...marks);
+    } else {
+      let marks = getListItemTextStyleMarks(node, doc, textStyleType);
+      textStyleMarks.push(...marks);
+    }
+
+    let fontSize = null;
+    let fontFamily = null;
+
+    // We iterate over all found textStyle marks 
+    // and take the first style found.
+    textStyleMarks.forEach((mark) => {
+      let { attrs } = mark;
+
+      if (attrs.fontSize && !fontSize) {
+        let [value, unit] = parseSizeUnit(attrs.fontSize);
+        if (!Number.isNaN(value)) {
+          unit = unit ?? 'pt';
+          fontSize = `${value}${unit}`;
+        }
+      }
+
+      if (attrs.fontFamily && !fontFamily) {
+        fontFamily = attrs.fontFamily;
+      }
+    });
+
+    let fontSizeAttrs = { 
+      style: `--marker-font-size: ${fontSize ?? 'initial'}`, 
+    };
+    let fontFamilyAttrs = { 
+      style: `--marker-font-family: ${fontFamily ?? 'initial'}`, 
+    };
+
+    let attrs = Attribute.mergeAttributes(
+      fontSizeAttrs,
+      fontFamilyAttrs,
+    );
+
+    let dec = Decoration.node(pos, pos + node.nodeSize, attrs);
+    decorations.push(dec);
+  });
+
+  return decorations;
+}
+
+function getListItemTextStyleMarks(listItem, doc, markType) {
+  let textStyleMarks = [];
+  listItem.forEach((childNode) => {
+    if (childNode.type.name !== 'paragraph') return;
+    childNode.forEach((textNode) => {
+      let isTextNode = textNode.type.name === 'text';
+      let hasTextStyleMarks = markType.isInSet(textNode.marks);
+      if (isTextNode && hasTextStyleMarks) {
+        let marks = textNode.marks.filter((mark) => mark.type === markType);
+        textStyleMarks.push(...marks);
+      }
+    });
+  });
+  return textStyleMarks;
+}
+
+function checkListItemEmpty(listItem) {
+  return listItem.childCount === 1 && 
+    listItem.firstChild?.type.name === 'paragraph' && 
+    listItem.firstChild?.content.size === 0;
+}

--- a/packages/super-editor/src/extensions/list-item/list-item.js
+++ b/packages/super-editor/src/extensions/list-item/list-item.js
@@ -1,5 +1,6 @@
 import { Node, Attribute } from '@core/index.js';
 import { generateOrderedListIndex } from '@helpers/orderedListUtils.js';
+import { styledListMarker as styledListMarkerPlugin } from './helpers/styledListMarkerPlugin.js';
 
 export const ListItem = Node.create({
   name: 'listItem',
@@ -119,5 +120,11 @@ export const ListItem = Node.create({
           .run();
       },
     };
+  },
+
+  addPmPlugins() {
+    return [
+      styledListMarkerPlugin(),
+    ];
   },
 });

--- a/packages/super-editor/src/extensions/ordered-list/helpers/orderedListMarkerPlugin.js
+++ b/packages/super-editor/src/extensions/ordered-list/helpers/orderedListMarkerPlugin.js
@@ -83,12 +83,20 @@ export function orderedListMarker(options = {}) {
             compare(listLevel, newListLevel);
 
           if (!equalMarkerAttrs) {
+            let { selection, storedMarks } = newState;
+            let marks = storedMarks || (selection.$to.parentOffset && selection.$from.marks());
+            
             tr.setNodeMarkup(pos, undefined, {
               ...node.attrs,
               listLevel: newListLevel,
               lvlText: currentAttrs.lvlText,
               listNumberingType: currentAttrs.listNumberingType,
             });
+
+            if (marks) {
+              tr.ensureMarks(marks);
+            }
+            
             changed = true;
           }
           


### PR DESCRIPTION
Linear:
https://linear.app/harbour/issue/HAR-8016/custom-list-markers-font-doesnt-match

**Merge this PR first** - https://github.com/Harbour-Enterprises/SuperDoc/pull/133

For each `listItem` we find all `textStyle` marks and apply the first found font-family and font-size (`listItem` may contain different font-size and font-family in the text) to the marker if defined there.

Note:
- Color is excluded from this list because it would lead to undesirable behavior.

Screenshot:
<img width="545" alt="Screenshot 2024-10-18 at 14 46 03" src="https://github.com/user-attachments/assets/d1444b89-889c-42e5-a64c-f35f79a9e103">