### PR TITLE
HAR-7815, HAR-7822 - run toolbar font-size and color commands with args only

### DIFF
--- a/packages/super-editor/src/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/components/toolbar/super-toolbar.js
@@ -35,13 +35,15 @@ export class SuperToolbar extends EventEmitter {
     },
 
     setFontSize: ({ item, argument }) => {
-      if (!argument || !this.activeEditor) return;
-      
-      let command = item.command;
-      if (command in this.activeEditor.commands) {
-        this.activeEditor.commands[command](argument);
-        this.#updateToolbarState();
-      }
+      this.#runCommandWithArgumentOnly({ item, argument });
+    },
+
+    setFontFamily: ({ item, argument }) => {
+      this.#runCommandWithArgumentOnly({ item, argument });
+    },
+
+    setColor: ({ item, argument }) => {
+      this.#runCommandWithArgumentOnly({ item, argument });
     },
   }
 
@@ -182,6 +184,16 @@ export class SuperToolbar extends EventEmitter {
       this.#updateToolbarState();
     } else {
       throw new Error(`[super-toolbar 🎨] Command not found: ${command}`);
+    }
+  }
+
+  #runCommandWithArgumentOnly({ item, argument }) {
+    if (!argument || !this.activeEditor) return;
+      
+    let command = item.command;
+    if (command in this.activeEditor.commands) {
+      this.activeEditor.commands[command](argument);
+      this.#updateToolbarState();
     }
   }
 }


### PR DESCRIPTION
Linear:
https://linear.app/harbour/issue/HAR-7815/font-text-defaults-to-arial-even-when-user-didnt-select-the-font
https://linear.app/harbour/issue/HAR-7822/font-color-is-defaulting-to-black