### PR TITLE
refactor default properties

### DIFF
--- a/packages/super-editor/src/extensions/comment/comment.js
+++ b/packages/super-editor/src/extensions/comment/comment.js
@@ -20,7 +20,9 @@ export const CommentRangeStart = Node.create({
 
   addAttributes() {
     return {
-      'w:id': { default: uuidv4() },
+      'w:id': { 
+        default: () => uuidv4(), 
+      },
     };
   },
 });
@@ -44,7 +46,9 @@ export const CommentRangeEnd = Node.create({
 
   addAttributes() {
     return {
-      'w:id': { default: uuidv4() },
+      'w:id': { 
+        default: () => uuidv4(),
+      },
     };
   },
 });

--- a/packages/super-editor/src/extensions/table/table.js
+++ b/packages/super-editor/src/extensions/table/table.js
@@ -29,7 +29,10 @@ export const Table = Node.create({
           return { style: `min-width: ${width}px;` }
         }
       },
-      gridColumnWidths: { rendered: false, default: [], },
+      gridColumnWidths: { 
+        rendered: false, 
+        default: () => [], 
+      },
       tableStyleId: { rendered: false, },
       tableIndent: {
         renderDOM: ({ tableIndent }) => {
@@ -43,7 +46,7 @@ export const Table = Node.create({
       },
       tableLayout: { rendered: false, },
       borders: {
-        default: {},
+        default: () => ({}),
         renderDOM({ borders = {} }) {
           if (!borders) return {};
           const style = Object.entries(borders).reduce((acc, [key, { size, color }]) => {

--- a/packages/super-editor/src/extensions/track-changes/track-delete.js
+++ b/packages/super-editor/src/extensions/track-changes/track-delete.js
@@ -39,7 +39,7 @@ export const TrackDelete = Mark.create({
                 },
             },
             date: {
-                default: (new Date()).toISOString(),
+                default: () => (new Date()).toISOString(),
                 parseHTML: element => element.getAttribute('date'),
                 renderHTML: attributes => {
                     return {

--- a/packages/super-editor/src/extensions/track-changes/track-insert.js
+++ b/packages/super-editor/src/extensions/track-changes/track-insert.js
@@ -39,7 +39,7 @@ export const TrackInsert = Mark.create({
                 },
             },
             date: {
-                default: (new Date()).toISOString(),
+                default: () => (new Date()).toISOString(),
                 parseHTML: element => element.getAttribute('date'),
                 renderHTML: attributes => {
                     return {

--- a/packages/super-editor/src/extensions/track-changes/track-marks.js
+++ b/packages/super-editor/src/extensions/track-changes/track-marks.js
@@ -37,7 +37,7 @@ export const TrackMarks = Mark.create({
                 },
             },
             date: {
-                default: (new Date()).toISOString(),
+                default: () => (new Date()).toISOString(),
                 parseHTML: element => element.getAttribute('date'),
                 renderHTML: attributes => {
                     return {
@@ -46,7 +46,7 @@ export const TrackMarks = Mark.create({
                 },
             },
             before: {
-                default: [],
+                default: () => [],
                 parseHTML: element => {
                     try {
                         return JSON.parse(element.getAttribute('before'))
@@ -62,7 +62,7 @@ export const TrackMarks = Mark.create({
                 },
             },
             after: {
-                default: [],
+                default: () => [],
                 parseHTML: element => {
                     try {
                         return JSON.parse(element.getAttribute('after'))


### PR DESCRIPTION
Default values ​​that are dynamically generated must be functions. I also think this is needed for values ​​that are passed by reference (array, object, etc).

This is handled here
https://github.com/Harbour-Enterprises/SuperDoc/blob/main/packages/super-editor/src/core/Attribute.js#L126