### PR TITLE
make link mark non-inclusive

### DIFF
--- a/packages/super-editor/src/extensions/link/link.js
+++ b/packages/super-editor/src/extensions/link/link.js
@@ -7,7 +7,7 @@ export const Link = Mark.create({
 
   keepOnSplit: false,
 
-  exitable: true,
+  inclusive: false,
 
   addOptions() {
     return {


### PR DESCRIPTION
Before:
<img width="407" alt="Screenshot 2024-12-05 at 19 16 56" src="https://github.com/user-attachments/assets/b841b6a5-7f33-4c03-93c4-e6fcbfe5ea88">

After:
<img width="381" alt="Screenshot 2024-12-05 at 19 18 36" src="https://github.com/user-attachments/assets/4c0fd8b4-2110-4339-9e6b-fa8b3fc9be9c">