### PR TITLE
fix editor initialization

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -99,17 +99,15 @@ const initEditor = async (content, media = {}) => {
     media,
     users: [], // For comment @-mentions, only users that have access to the document
     ...props.options,
-    onCollaborationReady,
-    onCreate,
   });
-};
 
-const onCreate = () => {
-  editorReady.value = true; 
-};
+  editor.on('create', () => {
+    editorReady.value = true;
+  });
 
-const onCollaborationReady = (data) => {
-  editorReady.value = true; 
+  editor.on('collaborationUpdate', () => {
+    editorReady.value = true;
+  });
 };
 
 onMounted(() => {


### PR DESCRIPTION
These callbacks override those that are in the `props.options` and break a lot of functionality (for example, drag&drop in AE).

Here need to either subscribe to the events or combine callbacks.