### PR TITLE
HAR-8434 - Fix docx default font and font size, show defaults in toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "shared/*"
   ],
   "scripts": {
+    "dev": "npm run build:super-editor && npm run dev:superdoc",
     "dev:superdoc": "npm run dev --workspace=packages/superdoc",
     "dev:super-editor": "npm run dev --workspace=packages/super-editor",
     "build:superdoc": "npm run build --workspace=packages/superdoc",

--- a/packages/super-editor/src/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/components/toolbar/super-toolbar.js
@@ -118,6 +118,9 @@ export class SuperToolbar extends EventEmitter {
     this.app.config.globalProperties.$toolbar = this;
     if (el) this.toolbar = this.app.mount(el);
     this.activeEditor = config.editor || null;
+
+    this.#initDefaultFonts();
+
     this.#updateToolbarState();
   }
 
@@ -151,6 +154,15 @@ export class SuperToolbar extends EventEmitter {
     this.toolbarItems = defaultItems;
     this.overflowItems = overflowItems;
     this.#updateToolbarState();
+  }
+
+  #initDefaultFonts() {
+    const { typeface = 'Arial', fontSizePt = 12 } = this.activeEditor.converter.getDocumentDefaultStyles() ?? {};
+    const fontSizeItem = this.toolbarItems.find(item => item.name.value === 'fontSize');
+    fontSizeItem.defaultLabel.value = fontSizePt;
+
+    const fontFamilyItem = this.toolbarItems.find(item => item.name.value === 'fontFamily');
+    fontFamilyItem.defaultLabel.value = typeface;
   }
 
   /**

--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -599,9 +599,8 @@ export class Editor extends EventEmitter {
     proseMirror.style.paddingBottom = pageMargins.bottom + 'in';
 
     const { typeface, fontSizePt } = this.converter.getDocumentDefaultStyles() ?? {};
-
     typeface && (this.element.style.fontFamily = typeface);
-    fontSizePt && (this.element.style.fontSize = fontSizePt);
+    fontSizePt && (this.element.style.fontSize = fontSizePt + 'pt');
 
   }
 

--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -129,11 +129,11 @@ class SuperConverter {
 
     const defaults = styles.elements[0].elements.find((el) => el.name === 'w:docDefaults');
 
-    // TODO: Check if we need this
     // const pDefault = defaults.elements.find((el) => el.name === 'w:pPrDefault');
 
     // Get the run defaults for this document - this will include font, theme etc.
     const rDefault = defaults.elements.find((el) => el.name === 'w:rPrDefault');
+
     if ('elements' in rDefault) {
       const rElements = rDefault.elements[0].elements
       const fontThemeName = rElements.find((el) => el.name === 'w:rFonts')?.attributes['w:asciiTheme'];
@@ -142,6 +142,9 @@ class SuperConverter {
         const fontInfo = this.getThemeInfo(fontThemeName);
         typeface = fontInfo.typeface;
         panose = fontInfo.panose;
+      } else {
+        const rFonts = rElements.find((el) => el.name === 'w:rFonts');
+        typeface = rFonts.attributes['w:ascii'];
       }
 
       const fontSizePt = Number(rElements.find((el) => el.name === 'w:sz')?.attributes['w:val']) / 2;


### PR DESCRIPTION
- Fix default font and font size when xml is inline and not from style definition
- Show document default font and size in toolbar
- add 'npm run dev' for superdoc from main folder (per request)