### PR TITLE
fix toolbar item z-index

### DIFF
--- a/packages/super-editor/src/components/toolbar/ToolbarButton.vue
+++ b/packages/super-editor/src/components/toolbar/ToolbarButton.vue
@@ -133,7 +133,7 @@ const onFontSizeInput = (event) => {
 <style scoped>
 .toolbar-item {
   position: relative;
-  z-index: 100;
+  z-index: 1;
   min-width: 30px;
   margin: 0 1px;
 }


### PR DESCRIPTION
Not sure why z-index is so big, but the fix doesn't seem to break anything.

<img width="749" alt="Screenshot 2024-12-16 at 14 07 34" src="https://github.com/user-attachments/assets/802affa7-f49c-411b-9628-7c68053fd060" />
