### PR TITLE
HAR-8199 Fix issue with wrong selection displayed after comment was added

### DIFF
--- a/packages/superdoc/src/components/CommentsLayer/CommentDialog.vue
+++ b/packages/superdoc/src/components/CommentsLayer/CommentDialog.vue
@@ -14,7 +14,7 @@ import falCheckIcon from '@/assets/fontawesome/light/check.svg?raw';
 const superdocStore = useSuperdocStore();
 const commentsStore = useCommentsStore();
 const { COMMENT_EVENTS } = commentsStore;
-const { getConfig, activeComment, pendingComment, floatingCommentsOffset, suppressInternalExternal } = storeToRefs(commentsStore);
+const { getConfig, activeComment, pendingComment, floatingCommentsOffset, suppressInternalExternal, skipSelectionUpdate } = storeToRefs(commentsStore);
 const { areDocumentsReady, getDocument } = superdocStore;
 const { selectionPosition, activeZoom, documentScroll } = storeToRefs(superdocStore);
 const { proxy } = getCurrentInstance();
@@ -93,6 +93,7 @@ const addComment = () => {
 
     // Remove the pending comment
     pendingComment.value = null;
+    skipSelectionUpdate.value = true;
 
     const editor = proxy.$superdoc.activeEditor;
     if (editor) createNewEditorComment({ conversation: newConversation, editor });
@@ -104,7 +105,7 @@ const addComment = () => {
     props.data.comments.push(comment);
     proxy.$superdoc.broadcastComments(COMMENT_EVENTS.ADD, props.data.getValues());
   }
-
+  
   currentComment.value = '';
   emit('dialog-exit');
   activeComment.value = null;

--- a/packages/superdoc/src/stores/comments-store.js
+++ b/packages/superdoc/src/stores/comments-store.js
@@ -25,6 +25,7 @@ export const useCommentsStore = defineStore('comments', () => {
   const floatingCommentsOffset = ref(0);
   const sortedConversations = ref([]);
   const visibleConversations = ref([]);
+  const skipSelectionUpdate = ref(false);
 
   const pendingComment = ref(null);
   const getPendingComment = (selection) => {
@@ -177,6 +178,7 @@ export const useCommentsStore = defineStore('comments', () => {
     floatingCommentsOffset,
     sortedConversations,
     visibleConversations,
+    skipSelectionUpdate,
 
     // Getters
     getConfig,


### PR DESCRIPTION
@harbournick This fix is for issue Elliot reported here: https://linear.app/harbour/issue/HAR-8199/1-superdoc-preview-in-approver-appapproval-trail-comments-not#comment-6f235fca

The problem is that when we add a comment there is selection bounds recalculation happen but selection is changed to the comment box value