### PR TITLE
HAR-8693 - unitless line-height value

### DIFF
--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -609,8 +609,9 @@ export class Editor extends EventEmitter {
     this.element.style.webkitOverflowScrolling = 'touch';
 
     // Calculate line height
-    const defaultLineHeight = (fontSizePt * 1.3333) * 1.15;
-    proseMirror.style.lineHeight = defaultLineHeight + 'px';
+    // const defaultLineHeight = (fontSizePt * 1.3333) * 1.15;
+    const defaultLineHeight = 1.2;
+    proseMirror.style.lineHeight = defaultLineHeight;
 
     // If we are not using pagination, we still need to add some padding for header/footer
     if (!this.options.extensions.find((e) => e.name === 'pagination')) {

--- a/packages/super-editor/src/core/config/style.js
+++ b/packages/super-editor/src/core/config/style.js
@@ -206,8 +206,8 @@ img.ProseMirror-separator {
   position: relative;
   display: block;
   height: 18px;
-  minHeight: 18px;
-  minWidth: 100%;
+  min-height: 18px;
+  min-width: 100%;
   width: 100%;
   border-top: 1px solid #DBDBDB;
   border-bottom: 1px solid #DBDBDB;


### PR DESCRIPTION
We should use a unitless value for the default `line-height` so that it is automatically calculated for elements with different font sizes. In most cases this is the preferred way.

https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#number

Before:
<img width="519" alt="Screenshot 2025-01-07 at 18 19 55" src="https://github.com/user-attachments/assets/8dcf6726-85d1-4f41-a974-b43143d4bc3a" />

After:
<img width="665" alt="Screenshot 2025-01-07 at 18 15 57" src="https://github.com/user-attachments/assets/1d821526-3dfc-4881-906a-2fa94956f238" />
