### PR TITLE
HAR-8703 - update active link mark behavior

### DIFF
--- a/packages/super-editor/src/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/components/toolbar/super-toolbar.js
@@ -169,13 +169,18 @@ export class SuperToolbar extends EventEmitter {
 
     // Decativate toolbar items if no active editor
     // This will skip buttons that are marked as allowWithoutEditor
-    if (!this.activeEditor || this.documentMode === 'viewing') return this.#deactivateAll();
+    if (!this.activeEditor || this.documentMode === 'viewing') {
+      this.#deactivateAll();
+      return;
+    }
 
     const marks = getActiveFormatting(this.activeEditor);
+
     this.toolbarItems.forEach((item) => {
       item.resetDisabled();
 
       const activeMark = marks.find((mark) => mark.name === item.name.value);
+      
       if (activeMark) {
         item.activate(activeMark.attrs);
       } else {

--- a/packages/super-editor/src/core/helpers/findMark.js
+++ b/packages/super-editor/src/core/helpers/findMark.js
@@ -1,0 +1,31 @@
+export const findMark = (state, markType, toArr = false) => {
+  const { selection, doc } = state;
+  const { $from, $to } = selection;
+
+  const fromMark = $from.marks().find((mark) => mark.type === markType);
+  const toMark = $to.marks().find((mark) => mark.type === markType);
+
+  let markFound;
+  const marksFound = [];
+
+  doc.nodesBetween($from.pos, $to.pos, (node, from) => {
+    if (node.marks) {
+      const actualMark = node.marks.find((mark) => mark.type === markType);
+      if (actualMark) {
+        markFound = {
+          from,
+          to: from + node.nodeSize,
+          attrs: actualMark.attrs,
+          contained: !fromMark || !toMark || fromMark === toMark,
+        };
+        marksFound.push(markFound);
+      }
+    }
+  });
+
+  if (toArr) {
+    return marksFound;
+  }
+
+  return markFound;
+};

--- a/packages/super-editor/src/core/helpers/index.js
+++ b/packages/super-editor/src/core/helpers/index.js
@@ -22,3 +22,4 @@ export * from './getMarksFromSelection.js';
 export * from './getActiveFormatting.js';
 export * from './findChildren.js';
 export * from './posToDOMRect.js';
+export * from './findMark.js';

--- a/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/documentHelpers.js
+++ b/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/documentHelpers.js
@@ -1,35 +1,3 @@
-export const findMark = (state, markType, toArr = false) => {
-  const { selection, doc } = state;
-  const { $from, $to } = selection;
-
-  const fromMark = $from.marks().find((mark) => mark.type === markType);
-  const toMark = $to.marks().find((mark) => mark.type === markType);
-
-  let markFound;
-  const marksFound = [];
-
-  doc.nodesBetween($from.pos, $to.pos, (node, from) => {
-    if (node.marks) {
-      const actualMark = node.marks.find((mark) => mark.type === markType);
-      if (actualMark) {
-        markFound = {
-          from,
-          to: from + node.nodeSize,
-          attrs: actualMark.attrs,
-          contained: !fromMark || !toMark || fromMark === toMark,
-        };
-        marksFound.push(markFound);
-      }
-    }
-  });
-
-  if (toArr) {
-    return marksFound;
-  }
-
-  return markFound;
-};
-
 // https://discuss.prosemirror.net/t/expanding-the-selection-to-the-active-mark/
 export const findMarkPosition = (doc, pos, markName) => {
   const $pos = doc.resolve(pos);

--- a/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/replaceStep.js
+++ b/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/replaceStep.js
@@ -3,7 +3,7 @@ import { Transaction, EditorState } from 'prosemirror-state';
 import { Node } from 'prosemirror-model';
 import { markInsertion } from './markInsertion.js';
 import { markDeletion } from './markDeletion.js';
-import { findMark } from './documentHelpers.js';
+import { findMark } from '@core/helpers/index.js';
 import { TrackDeleteMarkName } from '../constants.js';
 
 /**

--- a/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/trackedTransaction.js
+++ b/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/trackedTransaction.js
@@ -5,7 +5,7 @@ import { replaceAroundStep } from './replaceAroundStep.js';
 import { addMarkStep } from './addMarkStep.js';
 import { removeMarkStep } from './removeMarkStep.js';
 import { TrackDeleteMarkName } from '../constants.js';
-import { findMark } from './documentHelpers.js';
+import { findMark } from '@core/helpers/index.js';
 
 /**
  * Tracked transaction to track changes.


### PR DESCRIPTION
Handling of active link marks should be separate from handling of active formatting marks.

The link will be considered active and the popup will open only in the following cases:
- the selection matches the bounds of the link mark.
- the selection is inside the link's bounds.

True cases for active link mark.
```
{
    "link.from": 18,
    "link.to": 22,
    "selection.from": 18,
    "selection.to": 22
}
{
    "link.from": 18,
    "link.to": 22,
    "selection.from": 20,
    "selection.to": 20
}
{
    "link.from": 18,
    "link.to": 22,
    "selection.from": 20,
    "selection.to": 22
}
```
