### PR TITLE
HAR-8731 Cannot read properties of undefined (reading 'contains')

### DIFF
--- a/packages/super-editor/src/extensions/field-annotation/FieldAnnotationPlugin.js
+++ b/packages/super-editor/src/extensions/field-annotation/FieldAnnotationPlugin.js
@@ -78,7 +78,7 @@ export const FieldAnnotationPlugin = (options = {}) => {
           if (!event.target) return false;
 
           let { target } = event;
-          let isAnnotationField = target.classList.contains(annotationClass);
+          let isAnnotationField = target.classList?.contains(annotationClass);
 
           if (isAnnotationField) {
             event.dataTransfer?.setDragImage(target, 0, 0);


### PR DESCRIPTION
@harbournick I wasn't able to reproduce this issue by myself and it's not likely to happen when we have event target element defined(classList will always be defined for element even if there is no class set) but it could happen if event target is a collection. Anyway, I added this additional check to make sure we have classList defined

https://linear.app/harbour/issue/HAR-8731/typeerror-cannot-read-properties-of-undefined-reading-contains