### PR TITLE
feat: add code examples

### DIFF
--- a/examples/react-example/index.html
+++ b/examples/react-example/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SuperDoc React Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/examples/react-example/package.json
+++ b/examples/react-example/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "react-superdoc-example",
+    "private": true,
+    "version": "0.0.1",
+    "type": "module",
+    "scripts": {
+        "dev": "vite"
+    },
+    "dependencies": {
+        "@harbour-enterprises/superdoc": "^0.2.26",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+    },
+    "devDependencies": {
+        "@vitejs/plugin-react": "^4.0.4",
+        "vite": "^4.4.6"
+    }
+}

--- a/examples/react-example/src/App.jsx
+++ b/examples/react-example/src/App.jsx
@@ -1,0 +1,79 @@
+import { useRef, useState } from 'react';
+import DocumentEditor from './components/DocumentEditor';
+
+function App() {
+  const [documentFile, setDocumentFile] = useState(null);
+  const [documentId, setDocumentId] = useState('example-doc');
+  const fileInputRef = useRef(null);
+
+  const handleFileChange = (event) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      setDocumentFile(file);
+      // Optional: Generate new document ID when file changes
+      setDocumentId(`doc-${Date.now()}`);
+    }
+  };
+
+  const handleEditorReady = (editor) => {
+    console.log('SuperDoc editor is ready', editor);
+  };
+
+  return (
+    <div className="app">
+      <header>
+        <h1>SuperDoc Example</h1>
+        <button onClick={() => fileInputRef.current?.click()}>
+          Load Document
+        </button>
+        <input
+          type="file"
+          ref={fileInputRef}
+          accept=".docx,.pdf,.html"
+          onChange={handleFileChange}
+          style={{ display: 'none' }}
+        />
+      </header>
+
+      <main>
+        <DocumentEditor
+          documentId={documentId}
+          initialData={documentFile}
+          onEditorReady={handleEditorReady}
+        />
+      </main>
+
+      <style jsx>{`
+        .app {
+          height: 100vh;
+          display: flex;
+          flex-direction: column;
+        }
+        header {
+          padding: 1rem;
+          background: #f5f5f5;
+          display: flex;
+          align-items: center;
+          gap: 1rem;
+        }
+        header button {
+          padding: 0.5rem 1rem;
+          background: #1355ff;
+          color: white;
+          border: none;
+          border-radius: 4px;
+          cursor: pointer;
+        }
+        header button:hover {
+          background: #0044ff;
+        }
+        main {
+          flex: 1;
+          padding: 1rem;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+export default App;

--- a/examples/react-example/src/components/DocumentEditor.jsx
+++ b/examples/react-example/src/components/DocumentEditor.jsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react';
+import { Superdoc } from '@harbour-enterprises/superdoc';
+import '@harbour-enterprises/superdoc/style.css';
+
+const DocumentEditor = ({ 
+  documentId, 
+  documentType = 'docx', 
+  initialData = null,
+  readOnly = false,
+  onEditorReady 
+}) => {
+  const editorRef = useRef(null);
+
+  useEffect(() => {
+    const editor = new Superdoc({
+      selector: '#superdoc',
+      toolbar: 'superdoc-toolbar',
+      documentMode: readOnly ? 'viewing' : 'editing',
+      documents: [{
+        id: documentId,
+        type: documentType,
+        data: initialData
+      }],
+      onReady: () => {
+        if (onEditorReady) {
+          onEditorReady(editor);
+        }
+      },
+      onEditorCreate: () => {
+        console.log('Editor created');
+      },
+      onEditorDestroy: () => {
+        console.log('Editor destroyed');
+      }
+    });
+
+    editorRef.current = editor;
+
+    // Cleanup on unmount
+    return () => {
+      if (editorRef.current) {
+        editorRef.current = null;
+      }
+    };
+  }, [documentId, documentType, initialData, readOnly, onEditorReady]);
+
+  return (
+    <div className="document-editor">
+      <div id="superdoc-toolbar" className="toolbar" />
+      <div id="superdoc" className="editor" />
+      <style jsx>{`
+        .document-editor {
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          width: 100%;
+        }
+        .toolbar {
+          flex: 0 0 auto;
+          border-bottom: 1px solid #eee;
+        }
+        .editor {
+          flex: 1 1 auto;
+          overflow: auto;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default DocumentEditor;

--- a/examples/react-example/src/main.jsx
+++ b/examples/react-example/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/examples/react-example/vite.config.js
+++ b/examples/react-example/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  optimizeDeps: {
+    include: ['@harbour-enterprises/superdoc']
+  }
+});

--- a/examples/vanilla-example/index.html
+++ b/examples/vanilla-example/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SuperDoc Vanilla Example</title>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>SuperDoc Example</h1>
+            <button id="loadButton">Load Document</button>
+            <input 
+                type="file" 
+                id="fileInput" 
+                accept=".docx,.pdf,.html" 
+                style="display: none"
+            >
+        </header>
+        <main>
+            <div id="superdoc-toolbar"></div>
+            <div id="superdoc"></div>
+        </main>
+    </div>
+    <script type="module" src="/src/main.js"></script>
+</body>
+</html>

--- a/examples/vanilla-example/package.json
+++ b/examples/vanilla-example/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "vanilla-superdoc-example",
+    "private": true,
+    "version": "0.0.1",
+    "type": "module",
+    "scripts": {
+        "dev": "vite"
+    },
+    "dependencies": {
+        "@harbour-enterprises/superdoc": "^0.2.26"
+    },
+    "devDependencies": {
+        "vite": "^4.4.6"
+    }
+}

--- a/examples/vanilla-example/src/main.js
+++ b/examples/vanilla-example/src/main.js
@@ -1,0 +1,44 @@
+import { Superdoc } from '@harbour-enterprises/superdoc';
+import '@harbour-enterprises/superdoc/style.css';
+
+// Initialize SuperDoc
+let editor = null;
+
+function initializeEditor(file = null) {
+  // Cleanup previous instance if it exists
+  if (editor) {
+    editor = null;
+  }
+
+  editor = new Superdoc({
+    selector: '#superdoc',
+    toolbar: 'superdoc-toolbar',
+    documentMode: 'editing',
+    documents: [{
+      id: `doc-${Date.now()}`,
+      type: 'docx',
+      data: file
+    }],
+    onReady: () => {
+      console.log('Editor is ready');
+    }
+  });
+}
+
+// Setup file input handling
+const fileInput = document.getElementById('fileInput');
+const loadButton = document.getElementById('loadButton');
+
+loadButton.addEventListener('click', () => {
+  fileInput.click();
+});
+
+fileInput.addEventListener('change', (event) => {
+  const file = event.target.files?.[0];
+  if (file) {
+    initializeEditor(file);
+  }
+});
+
+// Initialize empty editor on page load
+initializeEditor();

--- a/examples/vanilla-example/src/style.css
+++ b/examples/vanilla-example/src/style.css
@@ -1,0 +1,42 @@
+.container {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  header {
+    padding: 1rem;
+    background: #f5f5f5;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  
+  button {
+    padding: 0.5rem 1rem;
+    background: #1355ff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  
+  button:hover {
+    background: #0044ff;
+  }
+  
+  main {
+    flex: 1;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  #superdoc-toolbar {
+    border-bottom: 1px solid #eee;
+  }
+  
+  #superdoc {
+    flex: 1;
+    overflow: auto;
+  }

--- a/examples/vanilla-example/vite.config.js
+++ b/examples/vanilla-example/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  optimizeDeps: {
+    include: ['@harbour-enterprises/superdoc']
+  }
+});

--- a/examples/vue-example/index.html
+++ b/examples/vue-example/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SuperDoc Vue Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/examples/vue-example/package.json
+++ b/examples/vue-example/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "vue-superdoc-example",
+    "private": true,
+    "version": "0.0.1",
+    "type": "module",
+    "scripts": {
+        "dev": "vite"
+    },
+    "dependencies": {
+        "@harbour-enterprises/superdoc": "^0.2.25",
+        "vue": "^3.5.13"
+    },
+    "devDependencies": {
+        "@vitejs/plugin-vue": "^4.2.3",
+        "vite": "^4.4.6"
+    }
+}

--- a/examples/vue-example/src/App.vue
+++ b/examples/vue-example/src/App.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="app">
+    <header>
+      <h1>SuperDoc Example</h1>
+      <button @click="fileInput?.click()">Load Document</button>
+      <input 
+        type="file" 
+        ref="fileInput" 
+        accept=".docx,.pdf" 
+        class="hidden"
+        @change="handleFileChange"
+      >
+    </header>
+    
+    <main>
+      <DocumentEditor
+        :document-id="documentId"
+        :initial-data="documentFile"
+        @editor-ready="handleEditorReady"
+      />
+    </main>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import DocumentEditor from './components/DocumentEditor.vue';
+
+const documentId = ref('example-doc');
+const documentFile = ref(null);
+const fileInput = ref(null);
+
+const handleFileChange = (event) => {
+  const file = event.target.files?.[0];
+  if (file) {
+    documentFile.value = file;
+    documentId.value = `doc-${Date.now()}`;
+  }
+};
+
+const handleEditorReady = (editor) => {
+  console.log('SuperDoc editor is ready', editor);
+};
+</script>
+
+<style>
+.app {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  padding: 1rem;
+  background: #f5f5f5;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+header button {
+  padding: 0.5rem 1rem;
+  background: #1355ff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+header button:hover {
+  background: #0044ff;
+}
+
+.hidden {
+  display: none;
+}
+
+main {
+  flex: 1;
+  padding: 1rem;
+}
+</style>

--- a/examples/vue-example/src/components/DocumentEditor.vue
+++ b/examples/vue-example/src/components/DocumentEditor.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="document-editor">
+    <div :key="documentKey">
+      <div id="superdoc-toolbar" class="toolbar"></div>
+      <div id="superdoc" class="editor"></div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, onUnmounted, ref, watch } from 'vue';
+import { Superdoc } from '@harbour-enterprises/superdoc';
+import '@harbour-enterprises/superdoc/style.css';
+
+const props = defineProps({
+  documentId: {
+    type: String,
+    required: true
+  },
+  initialData: {
+    type: File,
+    default: null
+  },
+  readOnly: {
+    type: Boolean,
+    default: false
+  }
+});
+
+const emit = defineEmits(['editor-ready', 'editor-error']);
+
+// Use ref to track the editor instance
+const editor = ref(null);
+const documentKey = ref(0);
+
+// Function to safely destroy editor
+const destroyEditor = () => {
+  if (editor.value) {
+    editor.value = null;
+  }
+};
+
+// Function to initialize editor
+const initializeEditor = async () => {
+  try {
+    // Ensure cleanup of previous instance
+    destroyEditor();
+    
+    // Increment key to force re-render
+    documentKey.value++;
+
+    // Create new editor instance
+    editor.value = new Superdoc({
+      selector: '#superdoc',
+      toolbar: 'superdoc-toolbar',
+      documentMode: props.readOnly ? 'viewing' : 'editing',
+      documents: [{
+        id: props.documentId,
+        type: 'docx',
+        data: props.initialData
+      }],
+      // Handle focus events
+      onFocus: () => {
+        console.log('Editor focused');
+      },
+      onBlur: () => {
+        console.log('Editor lost focus');
+      },
+      onReady: () => {
+        emit('editor-ready', editor.value);
+      },
+      onError: (error) => {
+        emit('editor-error', error);
+      }
+    });
+  } catch (error) {
+    console.error('Failed to initialize editor:', error);
+    emit('editor-error', error);
+  }
+};
+
+// Watch for changes in props that should trigger re-initialization
+watch(
+  () => [props.documentId, props.initialData, props.readOnly],
+  () => {
+    initializeEditor();
+  }
+);
+
+onMounted(() => {
+  initializeEditor();
+});
+
+onUnmounted(() => {
+  destroyEditor();
+});
+</script>
+
+<style scoped>
+.document-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
+.toolbar {
+  flex: 0 0 auto;
+  border-bottom: 1px solid #eee;
+  min-height: 40px; /* Ensure toolbar has minimum height */
+}
+
+.editor {
+  flex: 1 1 auto;
+  overflow: auto;
+  min-height: 400px; /* Ensure editor has minimum height */
+}
+</style>

--- a/examples/vue-example/src/main.js
+++ b/examples/vue-example/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/examples/vue-example/vite.config.js
+++ b/examples/vue-example/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  optimizeDeps: {
+    include: ['@harbour-enterprises/superdoc']
+  }
+});


### PR DESCRIPTION
**Problem**:  There were no examples showing how to integrate Superdoc with popular frontend frameworks like React, Vue, and Vanilla JS. This made it difficult for developers to quickly get started using the library in their projects.

**Solution**: This PR adds new example projects for React, Vue, and Vanilla JS, demonstrating how to initialize Superdoc, load documents, and handle basic events.  These examples provide clear and concise starting points for developers using these frameworks.

**Changes**:
- Added a React example application (`examples/react-example`).
- Added a Vue example application (`examples/vue-example`).
- Added a Vanilla JS example application (`examples/vanilla-example`).
- Included basic styling for each example.
- Added file input functionality to load documents in each example.

**Testing**:  Each example application was manually tested by running the development server (`npm run dev`) and verifying the Superdoc editor initialized correctly and loaded documents as expected.

**Notes**: These examples provide a basic integration and can be further extended to showcase more advanced Superdoc features. Consider adding more complex examples demonstrating collaborative editing, custom toolbar configurations, and other advanced use cases in future PRs.
