### PR TITLE
feat: add paths to ignore during npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,8 +5,16 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'README.md'
+      - '*.md'
+      - 'LICENSE'      
       - '.github/**'
+      - '.vscode/**'
+      - '.gitignore'
+      - '*.toml'
+      - '*.yml'
+      - '*.yaml'
+      - '.prettierrc'
+
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
**Problem**: The npm publish workflow was triggering unnecessarily for changes to documentation and configuration files.

**Solution**: This PR updates the `paths-ignore` list in the npm publish workflow to prevent it from running when changes are made to files that don't affect the package itself.

**Changes**:
- Added several file types and directories to the `paths-ignore` list, including `*.md`, `LICENSE`, `.github/**`, `.vscode/**`, `.gitignore`, `*.toml`, `*.yml`, `*.yaml`, and `.prettierrc`.
- Consolidated the existing `README.md` ignore into the broader `*.md` pattern.

**Testing**: N/A - This change affects the CI workflow itself; its functionality is implicitly tested by observing the workflow trigger behavior on subsequent pushes.

**Notes**: This should reduce the number of unnecessary workflow runs, saving resources and reducing noise in the CI logs.
