### PR TITLE
feat: add release-it + changelogs + gh release tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Superdoc Package to npm on Tag
+name: Publish Superdoc Package to npm
 
 on:
   push:
@@ -22,13 +22,14 @@ permissions:
   actions: write
 
 jobs:
-  publish:
+  release:
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           token: ${{ secrets.SUPERDOC_PAT }}
 
       - name: Setup node
@@ -37,31 +38,25 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
 
-      - name: Install dependencies
-        run: npm install
-      
-      - name: Build
-        run: npm run build
-
-      - name: Configure Git Credentials
+      - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Update versions
+      - name: Install dependencies
+        run: |
+          npm install
+          npm install -g release-it @release-it/conventional-changelog
+
+      - name: Copy README to package
         run: |
           cd packages/superdoc
           cp ../../README.md README.md
-          npm version patch
-          git add .
-          git commit -m "[skip ci] Bump version"
-          git push
-        env:
-          GIT_TOKEN: ${{ secrets.SUPERDOC_PAT }}
 
-      - name: Publish
-        run: |
-          cd packages/superdoc
-          npm publish --access public
+      - name: Release
+        working-directory: ./packages/superdoc
         env:
+          GITHUB_TOKEN: ${{ secrets.SUPERDOC_PAT }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          release-it --ci

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,31 @@
+{
+  "git": {
+    "commitMessage": "chore: release v${version}",
+    "tagName": "v${version}",
+    "tagAnnotation": "Release v${version}",
+    "push": true,
+    "requireCleanWorkingDir": false
+  },
+  "github": {
+    "release": true,
+    "releaseName": "Release v${version}",
+    "releaseNotes": null,
+    "autoGenerate": true,
+    "draft": false,
+    "tokenRef": "SUPERDOC_PAT"
+  },
+  "npm": {
+    "publish": true,
+    "skipChecks": true
+  },
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "preset": "angular",
+      "infile": "CHANGELOG.md"
+    }
+  },
+  "hooks": {
+    "before:init": ["npm run build"],
+    "after:release": "echo Successfully released ${name} v${version} to npm."
+  }
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat', // New feature
+        'fix', // Bug fix
+        'docs', // Documentation
+        'style', // Code style changes (formatting, etc)
+        'refactor', // Code refactoring
+        'perf', // Performance improvements
+        'test', // Test updates
+        'chore', // Build, tooling changes
+        'ci', // CI/CD changes
+        'revert', // Revert commits
+      ],
+    ],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:superdoc": "npm run build --workspace=packages/superdoc",
     "build:super-editor": "npm run build --workspace=packages/super-editor",
     "build": "npm run build:super-editor && npm run build:superdoc",
+    "release:superdoc": "npm run release --workspace=packages/superdoc",
     "clean:packages": "rm -rf ./packages/*/dist",
     "reset": "npm run clean:packages && rm -rf ./node_modules && rm -rf ./packages/*/node_modules && rm -rf ./package-lock.json && npm install",
     "publish": "npm run build && cd packages/superdoc && npm publish --access public",

--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "release": "release-it --ci",
     "clean": "rm -rf dist",
     "pack": "rm *.tgz 2>/dev/null || true && cd ../super-editor && npm run build && cd ../superdoc && npm run build && npm pack && mv $(ls harbour-enterprises-superdoc-*.tgz) ./superdoc.tgz"
   },
@@ -53,10 +54,12 @@
   },
   "devDependencies": {
     "@hocuspocus/provider": "^2.13.6",
+    "@release-it/conventional-changelog": "^10.0.0",
     "@vitejs/plugin-vue": "^5.0.4",
     "pdfjs-dist": "4.3.136",
     "postcss-nested": "^6.0.1",
     "postcss-nested-import": "^1.3.0",
+    "release-it": "^18.1.1",
     "vite": "^5.3.6",
     "vue-draggable-next": "^2.2.1"
   }


### PR DESCRIPTION
**Problem**: The current npm publishing workflow is manually triggered and requires several manual steps, including version bumping and README copying.  This process is error-prone and time-consuming.

**Solution**: This PR automates the release process using `release-it` and conventional commits.  It also integrates automated changelog generation and GitHub release creation.

**Changes**:
- Introduced `release-it` for automated releases with conventional changelog generation.
- Migrated from manual npm publish to automated release process triggered by pushes to the main branch.
- Automated README copying to the `superdoc` package before release.
- Added commitlint configuration for enforcing conventional commit messages.
- Updated npm scripts to include `release:superdoc`.

**Testing**: Tested the new release process locally by running `npm run release:superdoc` in the root directory and verifying the changelog generation, version bump, npm publish, and GitHub Release creation.

**Notes**: This PR requires `SUPERDOC_PAT` and `NPM_TOKEN` secrets to be configured in the repository settings. After merging, release a new version by pushing a commit with a conventional commit message to the `main` branch.
