### PR TITLE
HAR-8946 - Standardize how params are passed around importer functions

### DIFF
--- a/packages/super-editor/src/core/super-converter/v2/importer/annotationImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/annotationImporter.js
@@ -4,7 +4,8 @@ import { parseMarks } from './markImporter.js';
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-export const handleAnnotationNode = (nodes, docx, nodeListHandler, insideTrackChange) => {
+export const handleAnnotationNode = (params) => {
+  const { nodes, docx, nodeListHandler, insideTrackChange } = params;
   if (nodes.length === 0 || nodes[0].name !== 'w:sdt') {
     return { nodes: [], consumed: 0 };
   }

--- a/packages/super-editor/src/core/super-converter/v2/importer/bookmarkNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/bookmarkNodeImporter.js
@@ -1,7 +1,8 @@
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-export const handleBookmarkNode = (nodes, docx, nodeListHandler, insideTrackChange) => {
+export const handleBookmarkNode = (params) => {
+  const { nodes, nodeListHandler } = params;
   if (nodes.length === 0 || nodes[0].name !== 'w:bookmarkStart') {
     return { nodes: [], consumed: 0 };
   }
@@ -13,8 +14,10 @@ export const handleBookmarkNode = (nodes, docx, nodeListHandler, insideTrackChan
   if (!handleStandardNode) {
     console.error('Standard node handler not found');
     return { nodes: [], consumed: 0 };
-  }
-  const result = handleStandardNode([node], docx, nodeListHandler, insideTrackChange);
+  };
+
+  const updatedParams = {...params, nodes: [node]};
+  const result = handleStandardNode(updatedParams);
   if (result.nodes.length === 1) {
     result.nodes[0].attrs.name = node.attributes['w:name'];
     result.nodes[0].attrs.id = node.attributes['w:id'];

--- a/packages/super-editor/src/core/super-converter/v2/importer/docPartGalleryImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/docPartGalleryImporter.js
@@ -6,6 +6,6 @@
  * @param {*} insideTrackChange
  * @returns {Array} The processed nodes
  */
-export const tableOfContentsHandler = (node, docx, nodeListHandler, insideTrackChange = false) => {
-  return nodeListHandler.handler(node.elements, docx, false);
+export const tableOfContentsHandler = (params) => {
+  return nodeListHandler.handler({ ...params, nodes: node.elements });
 };

--- a/packages/super-editor/src/core/super-converter/v2/importer/docPartObjImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/docPartObjImporter.js
@@ -1,6 +1,7 @@
 import { tableOfContentsHandler } from './docPartGalleryImporter.js';
 
-export const handleDocPartObj = (nodes, docx, nodeListHandler, insideTrackChange) => {
+export const handleDocPartObj = (params) => {
+  const { nodes } = params;
   if (nodes.length === 0 || nodes[0].name !== 'w:sdt') {
     return { nodes: [], consumed: 0 };
   }
@@ -22,7 +23,7 @@ export const handleDocPartObj = (nodes, docx, nodeListHandler, insideTrackChange
 
   const content = node?.elements.find((el) => el.name === 'w:sdtContent');
   const handler = validGalleryTypeMap[docPartGalleryType];
-  const result = handler(content, docx, nodeListHandler, insideTrackChange);
+  const result = handler({ ...params, nodes: [content] });
 
   return {
     nodes: result,

--- a/packages/super-editor/src/core/super-converter/v2/importer/hyperlinkImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/hyperlinkImporter.js
@@ -1,7 +1,8 @@
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-export const handleHyperlinkNode = (nodes, docx, nodeListHandler, insideTrackChange) => {
+export const handleHyperlinkNode = (params) => {
+  const { nodes, docx, nodeListHandler } = params;
   if (nodes.length === 0 || nodes[0].name !== 'w:hyperlink') {
     return { nodes: [], consumed: 0 };
   }
@@ -47,7 +48,7 @@ export const handleHyperlinkNode = (nodes, docx, nodeListHandler, insideTrackCha
     }
   }
 
-  const updatedNode = nodeListHandler.handler(runNodes, docx, insideTrackChange);
+  const updatedNode = nodeListHandler.handler({ ...params, nodes: runNodes });
   return { nodes: updatedNode, consumed: 1 };
 };
 

--- a/packages/super-editor/src/core/super-converter/v2/importer/imageImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/imageImporter.js
@@ -3,7 +3,8 @@ import { emuToPixels } from '../../helpers.js';
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-export const handleDrawingNode = (nodes, docx, nodeListHandler, insideTrackChange, converter, editor, filename) => {
+export const handleDrawingNode = (params) => {
+  const { nodes, filename } = params;
   if (nodes.length === 0 || nodes[0].name !== 'w:drawing') {
     return { nodes: [], consumed: 0 };
   }
@@ -16,15 +17,16 @@ export const handleDrawingNode = (nodes, docx, nodeListHandler, insideTrackChang
 
   // Some images are identified by wp:anchor
   const isAnchor = elements.find((el) => el.name === 'wp:anchor');
-  if (isAnchor) result = handleImageImport(elements[0], currentFileName, docx);
+  if (isAnchor) result = handleImageImport(elements[0], currentFileName, params);
 
   // Others, wp:inline
   const inlineImage = elements.find((el) => el.name === 'wp:inline');
-  if (inlineImage) result = handleImageImport(inlineImage, currentFileName, docx);
+  if (inlineImage) result = handleImageImport(inlineImage, currentFileName, params);
   return { nodes: result ? [result] : [], consumed: 1 };
 };
 
-export function handleImageImport(node, currentFileName, docx) {
+export function handleImageImport(node, currentFileName, params) {
+  const { docx } = params;
   const { attributes } = node;
   const padding = {
     top: emuToPixels(attributes['distT']),

--- a/packages/super-editor/src/core/super-converter/v2/importer/lineBreakImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/lineBreakImporter.js
@@ -1,7 +1,8 @@
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-export const handleLineBreakNode = (nodes, docx, nodeListHandler, insideTrackChange) => {
+export const handleLineBreakNode = (params) => {
+  const { nodes } = params;
   if (nodes.length === 0 || nodes[0].name !== 'w:br') {
     return { nodes: [], consumed: 0 };
   }

--- a/packages/super-editor/src/core/super-converter/v2/importer/paragraphNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/paragraphNodeImporter.js
@@ -11,7 +11,8 @@ import { mergeTextNodes } from './mergeTextNodes.js';
  *
  * @type {import("docxImporter").NodeHandler}
  */
-export const handleParagraphNode = (nodes, docx, nodeListHandler, insideTrackChange, converter, editor, filename) => {
+export const handleParagraphNode = (params) => {
+  const { nodes, docx, nodeListHandler, filename } = params;
   if (nodes.length === 0 || nodes[0].name !== 'w:p') {
     return { nodes: [], consumed: 0 };
   }
@@ -38,7 +39,8 @@ export const handleParagraphNode = (nodes, docx, nodeListHandler, insideTrackCha
     return { nodes: [], consumed: 0 };
   }
 
-  const result = handleStandardNode([node], docx, nodeListHandler, insideTrackChange, converter, editor, filename);
+  const updatedParams = {...params, nodes: [node]};
+  const result = handleStandardNode(updatedParams);
   if (result.nodes.length === 1) {
     schemaNode = result.nodes[0];
   }

--- a/packages/super-editor/src/core/super-converter/v2/importer/runNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/runNodeImporter.js
@@ -4,13 +4,15 @@ import { createImportMarks } from './markImporter.js';
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-const handleRunNode = (nodes, docx, nodeListHandler, insideTrackChange = false, converter, editor, filename) => {
+const handleRunNode = (params) => {
+  const { nodes, nodeListHandler } = params;
   if (nodes.length === 0 || nodes[0].name !== 'w:r') {
     return { nodes: [], consumed: 0 };
   }
   
   const node = nodes[0];
-  let processedRun = nodeListHandler.handler(node.elements, docx, insideTrackChange, filename)?.filter((n) => n) || [];
+  const childParams = { ...params, nodes: node.elements };
+  let processedRun = nodeListHandler.handler(childParams)?.filter((n) => n) || [];
   const hasRunProperties = node.elements.some((el) => el.name === 'w:rPr');
   if (hasRunProperties) {
     const { marks = [], attributes = {} } = parseProperties(node);

--- a/packages/super-editor/src/core/super-converter/v2/importer/standardNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/standardNodeImporter.js
@@ -3,13 +3,15 @@ import { getElementName, parseProperties } from './importerHelpers.js';
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-export const handleStandardNode = (nodes, docx, nodeListHandler, insideTrackChange = false, converter, editor, filename) => {
+export const handleStandardNode = (params) => {
+  const { nodes, docx, nodeListHandler } = params;
   if (!nodes || nodes.length === 0) {
     return { nodes: [], consumed: 0 };
   }
-  const node = nodes[0];
+
   // Parse properties
-  const { name, type } = node;
+  const node = nodes[0];
+  const { name } = node;
   const { attributes, elements, marks = [] } = parseProperties(node, docx);
   
   if (!getElementName(node)) {
@@ -34,7 +36,10 @@ export const handleStandardNode = (nodes, docx, nodeListHandler, insideTrackChan
       el.marks.push(...marks);
       return el;
     });
-    content.push(...nodeListHandler.handler(updatedElements, docx, insideTrackChange, converter, editor, filename));
+
+    const childParams = { ...params, nodes: updatedElements };
+    const childContent = nodeListHandler.handler(childParams);
+    content.push(...childContent);
   }
 
   const resultNode = {

--- a/packages/super-editor/src/core/super-converter/v2/importer/tabImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/tabImporter.js
@@ -3,7 +3,8 @@ import { parseProperties } from './importerHelpers.js';
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-const handleTabNode = (nodes, docx, nodeListHandler, insideTrackChange = false) => {
+const handleTabNode = (params) => {
+  const { nodes } = params;
   if (nodes.length === 0 || nodes[0].name !== 'w:tab') {
     return { nodes: [], consumed: 0 };
   }

--- a/packages/super-editor/src/core/super-converter/v2/importer/textNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/textNodeImporter.js
@@ -3,7 +3,8 @@ import { getElementName, parseProperties } from './importerHelpers.js';
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-export const handleTextNode = (nodes, docx, nodeListHandler, insideTrackChange = false) => {
+export const handleTextNode = (params) => {
+  const { nodes, insideTrackChange } = params;
   if (nodes.length === 0 || !(nodes[0].name === 'w:t' || (insideTrackChange && nodes[0].name === 'w:delText'))) {
     return { nodes: [], consumed: 0 };
   }

--- a/packages/super-editor/src/core/super-converter/v2/importer/trackChangesImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/trackChangesImporter.js
@@ -4,7 +4,8 @@ import { parseProperties } from './importerHelpers.js';
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-export const handleTrackChangeNode = (nodes, docx, nodeListHandler, insideTrackChange = false) => {
+export const handleTrackChangeNode = (params) => {
+  const { nodes, nodeListHandler } = params;
   if (nodes.length === 0 || !(nodes[0].name === 'w:del' || nodes[0].name === 'w:ins')) {
     return { nodes: [], consumed: 0 };
   }
@@ -12,7 +13,7 @@ export const handleTrackChangeNode = (nodes, docx, nodeListHandler, insideTrackC
   const { name } = node;
   const { attributes, elements } = parseProperties(node);
 
-  const subs = nodeListHandler.handler(elements, docx, true);
+  const subs = nodeListHandler.handler({ ...params, insideTrackChange: true, nodes: elements });
   const changeType = name === 'w:del' ? TrackDeleteMarkName : TrackInsertMarkName;
 
   const mappedAttributes = {

--- a/packages/super-editor/src/dev/components/DeveloperPlayground.vue
+++ b/packages/super-editor/src/dev/components/DeveloperPlayground.vue
@@ -2,7 +2,7 @@
 import '@/style.css';
 import '@harbour-enterprises/common/styles/common-styles.css';
 
-import { ref, computed, onMounted } from 'vue';
+import { ref, shallowRef, computed, onMounted } from 'vue';
 import { SuperEditor } from '@/index.js';
 import { getFileObject } from '@harbour-enterprises/common/helpers/get-file-object';
 import { DOCX } from '@harbour-enterprises/common';
@@ -17,7 +17,7 @@ let activeEditor;
 const currentFile = ref(null);
 const pageStyles = ref(null);
 const isDebuggingPagination = ref(false);
-const telemetry = ref(null);
+const telemetry = shallowRef(null);
 
 const handleNewFile = async (file) => {
   currentFile.value = null;

--- a/packages/super-editor/src/tests/export/lists/miscOrderedListExport.test.js
+++ b/packages/super-editor/src/tests/export/lists/miscOrderedListExport.test.js
@@ -38,7 +38,7 @@ describe('[orderedlist_interrupted1.docx] interrupted ordered list tests', async
 
     // Check if pPr is correct
     const firstListPprList = firstList.elements.filter((n) => n.name = 'w:pPr');
-    expect(firstListPprList.length).toBe(1);
+    expect(firstListPprList.length).toBe(3);
 
     const firstListPpr = firstListPprList[0];
     expect(firstListPpr.elements.length).toBe(1);

--- a/packages/super-editor/src/tests/import/annotationImporter.test.js
+++ b/packages/super-editor/src/tests/import/annotationImporter.test.js
@@ -14,7 +14,9 @@ describe('paragraph tests to check spacing', () => {
     const body = doc.elements[0];
     const content = body.elements;
     const paragraphWithField = content[0].elements[2];
-    const { nodes } = handleAnnotationNode([paragraphWithField], docx, defaultNodeListHandler(), false);
+    const { nodes } = handleAnnotationNode({
+      nodes: [paragraphWithField], docx, nodeListHandler: defaultNodeListHandler()
+    });
 
     const node = nodes[0];
     expect(node.type).toBe('fieldAnnotation');
@@ -37,7 +39,11 @@ describe('paragraph tests to check spacing', () => {
     const body = doc.elements[0];
     const content = body.elements;
     const paragraphWithField = content[0].elements[3];
-    const { nodes } = handleAnnotationNode([paragraphWithField], docx, defaultNodeListHandler(), false);
+    const { nodes } = handleAnnotationNode({
+      nodes: [paragraphWithField],
+      docx,
+      nodeListHandler: defaultNodeListHandler()
+    });
 
     const node = nodes[0];
     expect(node.type).toBe('fieldAnnotation');

--- a/packages/super-editor/src/tests/import/boomarkNodeImporter.test.js
+++ b/packages/super-editor/src/tests/import/boomarkNodeImporter.test.js
@@ -7,14 +7,14 @@ describe('BookmarkNodeImporter', () => {
     const names = Object.keys(SuperConverter.allowedElements).filter((name) => name !== 'w:bookmarkStart');
     const nodesOfNodes = names.map((name) => [{ name }]);
     for (const nodes of nodesOfNodes) {
-      const result = handleBookmarkNode(nodes, null, null, false);
+      const result = handleBookmarkNode({ nodes });
       expect(result.nodes.length).toBe(0);
       expect(result.consumed).toBe(0);
     }
   });
   it('parses bookmark nodes and w:name attributes', () => {
     const nodes = [{ name: 'w:bookmarkStart', attributes: { 'w:name': 'bookmarkName' } }];
-    const result = handleBookmarkNode(nodes, null, createNodeListHandlerMock(), false);
+    const result = handleBookmarkNode({ nodes, nodeListHandler: createNodeListHandlerMock() });
     expect(result.nodes.length).toBe(1);
     expect(result.consumed).toBe(1);
     expect(result.nodes[0].type).toBe('standardNodeHandler');
@@ -24,7 +24,7 @@ describe('BookmarkNodeImporter', () => {
     const consoleMock = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     const nodes = [{ name: 'w:bookmarkStart', attributes: { 'w:name': 'bookmarkName' } }];
-    const result = handleBookmarkNode(nodes, null, { handlerEntities: [] }, false);
+    const result = handleBookmarkNode({ nodes, nodeListHandler: { handlerEntities: [] } });
     expect(result.nodes.length).toBe(0);
     expect(result.consumed).toBe(0);
     expect(consoleMock).toHaveBeenCalledOnce();

--- a/packages/super-editor/src/tests/import/hyperlinkImporter.test.js
+++ b/packages/super-editor/src/tests/import/hyperlinkImporter.test.js
@@ -11,7 +11,7 @@ describe('HyperlinkNodeImporter', () => {
     const doc = documentXml.elements[0];
     const body = doc.elements[0];
     const content = body.elements;
-    const { nodes } = handleHyperlinkNode([content[1].elements[1]], docx, defaultNodeListHandler(), false);
+    const { nodes } = handleHyperlinkNode({ nodes: [content[1].elements[1]], docx, nodeListHandler: defaultNodeListHandler() });
     
     const { marks } = nodes[0];
     expect(marks.length).toBe(3);

--- a/packages/super-editor/src/tests/import/imageImporter.test.js
+++ b/packages/super-editor/src/tests/import/imageImporter.test.js
@@ -1,6 +1,7 @@
 import { getTestDataByFileName } from '../helpers/helpers.js';
 import { defaultNodeListHandler } from '@converter/v2/importer/docxImporter.js';
 import { handleDrawingNode } from '../../core/super-converter/v2/importer/imageImporter.js';
+import { handleParagraphNode } from '../../core/super-converter/v2/importer/paragraphNodeImporter.js';
 
 describe('ImageNodeImporter', () => {
   it('imports image node correctly', async() => {
@@ -11,12 +12,16 @@ describe('ImageNodeImporter', () => {
     const doc = documentXml.elements[0];
     const body = doc.elements[0];
     const content = body.elements;
-    const drawingNode = content[0].elements[1].elements[1];
-    const { nodes } = handleDrawingNode([drawingNode], docx, defaultNodeListHandler(), false);
+    const { nodes } = handleParagraphNode({ nodes: [content[0]], docx, nodeListHandler: defaultNodeListHandler() });
 
-    const { attrs } = nodes[0];
+    const paragraphNode = nodes[0];
+    const drawingNode = paragraphNode.content[0];
+    const { attrs } = drawingNode;
     const { padding, marginOffset, size } = attrs;
     
+    expect(paragraphNode.type).toBe('paragraph');
+    expect(drawingNode.type).toBe('image');
+
     expect(attrs).toHaveProperty('rId', 'rId4');
     expect(attrs).toHaveProperty('src', 'word/media/image1.jpeg');
     

--- a/packages/super-editor/src/tests/import/lineBreakImporter.test.js
+++ b/packages/super-editor/src/tests/import/lineBreakImporter.test.js
@@ -7,7 +7,7 @@ describe('LineBreakNodeImporter', () => {
     const names = Object.keys(SuperConverter.allowedElements).filter((name) => name !== 'w:br');
     const nodesOfNodes = names.map((name) => [{ name }]);
     for (const nodes of nodesOfNodes) {
-      const result = handleLineBreakNode(nodes, null, null, false);
+      const result = handleLineBreakNode({ nodes });
       expect(result.nodes.length).toBe(0);
       expect(result.consumed).toBe(0);
     }
@@ -15,7 +15,7 @@ describe('LineBreakNodeImporter', () => {
 
   it('parses line break nodes and w:br attributes', () => {
     const nodes = [{ name: 'w:br' }];
-    const result = handleLineBreakNode(nodes, null, createNodeListHandlerMock(), false);
+    const result = handleLineBreakNode({ nodes, nodeListHandler: createNodeListHandlerMock() });
     expect(result.nodes.length).toBe(1);
     expect(result.consumed).toBe(1);
     expect(result.nodes[0].type).toBe('lineBreak');

--- a/packages/super-editor/src/tests/import/listImporter.test.js
+++ b/packages/super-editor/src/tests/import/listImporter.test.js
@@ -25,7 +25,7 @@ describe('table live xml test', () => {
       'word/numbering.xml': numbering,
     };
 
-    const result = handleListNode(nodes, docx, defaultNodeListHandler(), false);
+    const result = handleListNode({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
     expect(result.nodes.length).toBe(1);
     expect(result.nodes[0].type).toBe('bulletList');
     expect(result.nodes[0].content.length).toBe(1);
@@ -59,7 +59,7 @@ describe('table live xml test', () => {
       'word/numbering.xml': numbering,
     };
 
-    const result = handleListNode(nodes, docx, defaultNodeListHandler(), false);
+    const result = handleListNode({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
     expect(result.nodes.length).toBe(1);
     expect(result.nodes[0].type).toBe('orderedList');
     expect(result.nodes[0].content.length).toBe(1);
@@ -165,7 +165,7 @@ describe('table live xml test', () => {
       'word/numbering.xml': numbering,
     };
 
-    const result = handleListNode(nodes, docx, defaultNodeListHandler(), false);
+    const result = handleListNode({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
     expect(result.nodes.length).toBe(1);
     expect(result.nodes[0].type).toBe('bulletList');
     expect(result.nodes[0].content.length).toBe(3);
@@ -291,7 +291,7 @@ describe('custom nested list tests', () => {
     const docx = {
       'word/numbering.xml': numbering,
     };
-    const result = handleListNode(nodes, docx, defaultNodeListHandler(), false);
+    const result = handleListNode({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
 
     expect(result.nodes.length).toBe(1);
     const expectedResult = {
@@ -1116,7 +1116,7 @@ describe('custom nested list tests', () => {
     const docx = {
       'word/numbering.xml': numbering,
     };
-    const result = handleListNode(nodes, docx, defaultNodeListHandler(), false);
+    const result = handleListNode({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
     const expectedResult = {
       type: 'orderedList',
       content: [
@@ -2070,7 +2070,7 @@ describe('custom nested list tests', () => {
     const docx = {
       'word/numbering.xml': numbering,
     };
-    const result = handleListNode(nodes, docx, defaultNodeListHandler(), false);
+    const result = handleListNode({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
 
     const expectedResult = {
       type: 'orderedList',

--- a/packages/super-editor/src/tests/import/paragraphNodeImporter.test.js
+++ b/packages/super-editor/src/tests/import/paragraphNodeImporter.test.js
@@ -14,7 +14,7 @@ describe('paragraph tests to check spacing', () => {
     const doc = documentXml.elements[0];
     const body = doc.elements[0];
     const content = body.elements;
-    const { nodes } = handleParagraphNode([content[0]], docx, defaultNodeListHandler(), false);
+    const { nodes } = handleParagraphNode({ nodes: [content[0]], docx, nodeListHandler: defaultNodeListHandler() });
 
     const node = nodes[0];
     expect(node.type).toBe('paragraph');
@@ -41,7 +41,7 @@ describe('paragraph tests to check spacing', () => {
     const tcNode = trNode.elements[1];
 
     // Check all nodes after the known tcPr
-    const { nodes } = handleParagraphNode(tcNode.elements.slice(1), docx, defaultNodeListHandler(), false);
+    const { nodes } = handleParagraphNode({ nodes: tcNode.elements.slice(1), docx, nodeListHandler: defaultNodeListHandler() });
     const node = nodes[0];
 
     expect(node.type).toBe('paragraph');
@@ -64,7 +64,7 @@ describe('paragraph tests to check spacing', () => {
     const body = doc.elements[0];
     const content = body.elements;
 
-    const { nodes } = handleParagraphNode([content[0]], docx, defaultNodeListHandler(), false);
+    const { nodes } = handleParagraphNode({ nodes: [content[0]], docx, nodeListHandler: defaultNodeListHandler() });
 
     const node = nodes[0];
     expect(node.type).toBe('paragraph');
@@ -91,6 +91,6 @@ describe('paragraph tests to check spacing', () => {
     const content = body.elements;
 
     const firstListItem = content[0];
-    const { nodes } = handleListNode([content[0]], docx, defaultNodeListHandler(), false);
+    const { nodes } = handleListNode({ nodes: [content[0]], docx, nodeListHandler: defaultNodeListHandler() });
   });
 });

--- a/packages/super-editor/src/tests/import/standardNodeImporter.test.js
+++ b/packages/super-editor/src/tests/import/standardNodeImporter.test.js
@@ -1,0 +1,25 @@
+import { defaultNodeListHandler } from '@converter/v2/importer/docxImporter.js';
+import { handleStandardNode } from '@converter/v2/importer/standardNodeImporter.js';
+import { getTestDataByFileName } from '@tests/helpers/helpers.js';
+
+describe('StandardNodeImporter', () => {
+  it('parses basic standard node', async () => {
+    const dataName = 'paragraph_spacing_missing.docx';
+    const docx = await getTestDataByFileName(dataName);
+    const documentXml = docx['word/document.xml'];
+
+    const doc = documentXml.elements[0];
+    const body = doc.elements[0];
+    const content = body.elements;
+    const { nodes } = handleStandardNode({ nodes: [content[0]], docx, nodeListHandler: defaultNodeListHandler() });
+    expect(nodes.length).toBe(1);
+    expect(nodes[0].content[0].type).toBe('text');
+    expect(nodes[0].content[0].text).toBe('First paragraph');
+
+    const { marks } = nodes[0].content[0];
+    expect(marks[0].type).toBe('textStyle');
+    expect(marks[0].attrs).toHaveProperty('fontFamily', 'Arial');
+    expect(marks[0].attrs).toHaveProperty('lineHeight', '0.19in');
+  });
+
+});

--- a/packages/super-editor/src/tests/import/tableImporter.test.js
+++ b/packages/super-editor/src/tests/import/tableImporter.test.js
@@ -141,7 +141,7 @@ describe('table live xml test', () => {
       'word/styles.xml': styles,
     };
 
-    const result = handleAllTableNodes(nodes, docx, defaultNodeListHandler(), false);
+    const result = handleAllTableNodes({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
     expect(result.nodes.length).toBe(1);
 
     expect(result.nodes[0].type).toBe('table');
@@ -165,6 +165,7 @@ describe('table live xml test', () => {
     expect(result.nodes[0].content[0].type).toBe('tableRow');
     expect(result.nodes[0].content[0].content.length).toBe(2);
     expect(result.nodes[0].content[0].content[0].content[0].type).toBe('paragraph');
+
     expect(result.nodes[0].content[0].content[0].content[0].content[0].type).toBe('text');
     expect(result.nodes[0].content[0].content[0].content[0].content[0].text).toBe('COL 1 ROW 1');
     expect(result.nodes[0].content[0].content[1].content[0].type).toBe('paragraph');
@@ -189,7 +190,7 @@ describe('table live xml test', () => {
     const docx = {
       'word/styles.xml': styles,
     };
-    const result = handleAllTableNodes(nodes, docx, defaultNodeListHandler(), false);
+    const result = handleAllTableNodes({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
     expect(result.nodes[0].content[0].content[0].attrs.borders).toBeDefined();
     expect(result.nodes[0].content[0].content[1].attrs.borders).toBeDefined();
     expect(result.nodes[0].content[0].content[0].attrs.borders.right.val).toBe('none');

--- a/packages/super-editor/src/tests/import/textNodeImporter.test.js
+++ b/packages/super-editor/src/tests/import/textNodeImporter.test.js
@@ -7,7 +7,7 @@ describe('TextNodeImporter', () => {
     const names = Object.keys(SuperConverter.allowedElements).filter((name) => name !== 'w:t');
     const nodesOfNodes = names.map((name) => [{ name }]);
     for (const nodes of nodesOfNodes) {
-      const result = handleTextNode(nodes, null, null, false);
+      const result = handleTextNode({ nodes });
       expect(result.nodes.length).toBe(0);
       expect(result.consumed).toBe(0);
     }
@@ -15,7 +15,7 @@ describe('TextNodeImporter', () => {
 
   it('parses text nodes with xml:space attribute', () => {
     const nodes = [{ name: 'w:t', attributes: { 'xml:space': 'preserve' }, elements: [] }];
-    const result = handleTextNode(nodes, null, createNodeListHandlerMock(), false);
+    const result = handleTextNode({ nodes, nodeListHandler: createNodeListHandlerMock() });
     expect(result.nodes.length).toBe(1);
     expect(result.consumed).toBe(1);
     expect(result.nodes[0].type).toBe('text');
@@ -24,7 +24,7 @@ describe('TextNodeImporter', () => {
 
   it('parses text nodes', () => {
     const nodes = [{ name: 'w:t', attributes: {}, elements: [{ text: 'This is a test text!' }] }];
-    const result = handleTextNode(nodes, null, createNodeListHandlerMock(), false);
+    const result = handleTextNode({ nodes, nodeListHandler: createNodeListHandlerMock() });
     expect(result.nodes.length).toBe(1);
     expect(result.consumed).toBe(1);
     expect(result.nodes[0].type).toBe('text');

--- a/packages/super-editor/src/tests/import/trackChangesImporter.test.js
+++ b/packages/super-editor/src/tests/import/trackChangesImporter.test.js
@@ -10,7 +10,7 @@ describe('TrackChangesImporter', () => {
     const names = Object.keys(SuperConverter.allowedElements).filter((name) => name !== 'w:del' && name !== 'w:ins');
     const nodesOfNodes = names.map((name) => [{ name }]);
     for (const nodes of nodesOfNodes) {
-      const result = handleTrackChangeNode(nodes, null, null, false);
+      const result = handleTrackChangeNode({ nodes });
       expect(result.nodes.length).toBe(0);
       expect(result.consumed).toBe(0);
     }
@@ -24,7 +24,7 @@ describe('TrackChangesImporter', () => {
         elements: [{ name: 'w:t', attributes: {}, elements: [{ text: 'This is a test text!' }] }],
       },
     ];
-    const result = handleTrackChangeNode(nodes, null, createNodeListHandlerMock(), false);
+    const result = handleTrackChangeNode({ nodes, nodeListHandler: defaultNodeListHandler() });
     expect(result.nodes.length).toBe(1);
     expect(result.consumed).toBe(1);
     expect(result.nodes[0].marks[0].type).toBe(TrackDeleteMarkName);
@@ -43,7 +43,7 @@ describe('TrackChangesImporter', () => {
         elements: [{ name: 'w:t', attributes: {}, elements: [{ text: 'This is a test text!' }] }],
       },
     ];
-    const result = handleTrackChangeNode(nodes, null, createNodeListHandlerMock(), false);
+    const result = handleTrackChangeNode({ nodes, nodeListHandler: defaultNodeListHandler() });
     expect(result.nodes.length).toBe(1);
     expect(result.consumed).toBe(1);
     expect(result.nodes[0].marks[0].type).toBe(TrackInsertMarkName);
@@ -90,7 +90,7 @@ describe('trackChanges live xml test', () => {
 
   it('parses insert xml', () => {
     const nodes = parseXmlToJson(inserXml).elements;
-    const result = handleTrackChangeNode(nodes, null, defaultNodeListHandler(), false);
+    const result = handleTrackChangeNode({ nodes, nodeListHandler: defaultNodeListHandler() });
     expect(result.nodes.length).toBe(1);
     const insertionMark = result.nodes[0].marks.find((mark) => mark.type === TrackInsertMarkName);
     expect(insertionMark).toBeDefined();
@@ -103,7 +103,7 @@ describe('trackChanges live xml test', () => {
   });
   it('parses delete xml', () => {
     const nodes = parseXmlToJson(deleteXml).elements;
-    const result = handleTrackChangeNode(nodes, null, defaultNodeListHandler(), false);
+    const result = handleTrackChangeNode({ nodes, nodeListHandler: defaultNodeListHandler() });
     expect(result.nodes.length).toBe(1);
     const deletionMark = result.nodes[0].marks.find((mark) => mark.type === TrackDeleteMarkName);
     expect(deletionMark).toBeDefined();
@@ -117,7 +117,7 @@ describe('trackChanges live xml test', () => {
   it('parses mark change xml', () => {
     const nodes = parseXmlToJson(markChangeXml).elements;
     const handler = defaultNodeListHandler();
-    const result = handler.handler(nodes, null, false);
+    const result = handler.handler({ nodes });
     expect(result.length).toBe(1);
     expect(result[0].type).toBe('paragraph');
     expect(result[0].content.length).toBe(1);


### PR DESCRIPTION
- Since the importer has grown so much, the params that handlers require were getting very confusing. This cleans up how params are passed around the recursive importer handlers.
- Fixes issue with images not importing into headers/footers