### PR TITLE
Remove DOM observer in pagination, use transaction only, add header m…

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -4,7 +4,7 @@ import { NSkeleton } from 'naive-ui';
 import { ref, onMounted, onBeforeUnmount, computed, shallowRef, reactive, nextTick } from 'vue';
 import { Editor } from '@/index.js';
 import { getStarterExtensions } from '@extensions/index.js';
-import { observeDomChanges, adjustPaginationBreaks } from './pagination-helpers.js';
+import { adjustPaginationBreaks } from './pagination-helpers.js';
 import { onMarginClickCursorChange } from './cursor-helpers.js';
 import Ruler from './rulers/Ruler.vue';
 
@@ -152,11 +152,7 @@ const handleSuperEditorClick = (event) => {
   }
 };
 
-let paginationObserver;
 onMounted(() => {
-  // Initialize pagination observer if pagination is enabled
-  if (props.options?.pagination) paginationObserver = observeDomChanges(editorWrapper, editor);
-
   initializeData();
   if (props.options?.suppressSkeletonLoader || !props.options?.collaborationProvider) editorReady.value = true;
 });
@@ -185,7 +181,6 @@ const handleMarginChange = ({ side, value }) => {
 };
 
 onBeforeUnmount(() => {
-  paginationObserver?.disconnect();
   stopPolling();
   editor.value?.destroy();
   editor.value = null;

--- a/packages/super-editor/src/components/pagination-helpers.js
+++ b/packages/super-editor/src/components/pagination-helpers.js
@@ -18,30 +18,15 @@ export function adjustPaginationBreaks(editorElem, editor) {
 
   breakNodes.forEach((node) => {
     const nodeBounds = node.getBoundingClientRect();
-    if (nodeBounds.left === bounds.left) return;
     const left = ((nodeBounds.left - bounds.left) / zoom) * -1 + 1;
     const minLeft = Math.min(marginLeft * -96, left)
+
+    const inner = node.firstChild;
+    if (inner.children.length >= 2) {
+      const pm = inner.children[2];
+      pm.style.paddingLeft = pageMargins.left * 96 + 'px';
+      pm.style.paddingRight = pageMargins.right * 96 + 'px';
+    };
     node.style.transform = `translateX(${minLeft}px)`;
   });
-}
-
-/**
- * Pagination helper to ensure that breaks are always aligned to the editor container
- * @param {HTMLElement} editorElem The editor container element
- * @param {Object} editor The editor instance
- * @returns {MutationObserver} The observer instance
- */
-export const observeDomChanges = (editorElem, editor) => {
-  if (!editorElem.value || !editor) return;
-
-  const observer = new MutationObserver((mutationsList) => {
-    adjustPaginationBreaks(editorElem, editor);
-  });
-
-  observer.observe(editorElem.value, {
-    childList: true,
-    subtree: true,
-  });
-
-  return observer;
 };


### PR DESCRIPTION
- removes to DOM observer that recalculated pagination
- uses transaction to trigger recalculation of left margins
- Adds header/footer margin change detection