### PR TITLE
feat: Add LocalStorageManager class with persistent ruler

### DIFF
--- a/packages/superdoc/src/utils/LocalStorageManager.js
+++ b/packages/superdoc/src/utils/LocalStorageManager.js
@@ -1,0 +1,82 @@
+/**
+ * Utility class to manage localStorage operations for SuperDoc
+ */
+export class LocalStorageManager {
+  static PREFIX = 'superdoc::';
+
+  /**
+   * Get a value from localStorage with the superdoc prefix
+   * @param {string} key - The key to get (without prefix)
+   * @returns {any} The parsed value or null if not found
+   */
+  static get(key) {
+    const fullKey = this.PREFIX + key;
+    const value = localStorage.getItem(fullKey);
+    try {
+      return value ? JSON.parse(value) : null;
+    } catch (e) {
+      console.error('Error parsing localStorage value:', e);
+      return null;
+    }
+  }
+
+  /**
+   * Set a value in localStorage with the superdoc prefix
+   * @param {string} key - The key to set (without prefix)
+   * @param {any} value - The value to store (will be JSON stringified)
+   */
+  static set(key, value) {
+    const fullKey = this.PREFIX + key;
+    try {
+      localStorage.setItem(fullKey, JSON.stringify(value));
+    } catch (e) {
+      console.error('Error setting localStorage value:', e);
+    }
+  }
+
+  /**
+   * Merge an object into an existing object in localStorage with the superdoc prefix
+   * Commonly used to merge settings in the settings object
+   *
+   * @param {string} key - The key to merge into (without prefix)
+   * @param {Record<string, any>} value - The object to merge (will be JSON stringified)
+   */
+  static merge(key, value) {
+    const fullKey = this.PREFIX + key;
+    const existingObject = this.get(key);
+    const mergedValue = { ...existingObject, ...value };
+    try {
+      localStorage.setItem(fullKey, JSON.stringify(mergedValue));
+    } catch (e) {
+      console.error('Error merging localStorage value:', e);
+    }
+  }
+
+  /**
+   * Remove a value from localStorage with the superdoc prefix
+   * @param {string} key - The key to remove (without prefix)
+   */
+  static remove(key) {
+    const fullKey = this.PREFIX + key;
+    localStorage.removeItem(fullKey);
+  }
+
+  /**
+   * Get all superdoc keys from localStorage
+   * @returns {string[]} Array of keys without prefix
+   */
+  static getAllKeys() {
+    return Object.keys(localStorage)
+      .filter((key) => key.startsWith(this.PREFIX))
+      .map((key) => key.replace(this.PREFIX, ''));
+  }
+
+  /**
+   * Get all superdoc settings as an object
+   * @returns {Object} Settings object
+   */
+  static getSetting(key) {
+    const value = this.get('settings') || {};
+    return value[key];
+  }
+}

--- a/packages/superdoc/src/utils/LocalStorageManager.js
+++ b/packages/superdoc/src/utils/LocalStorageManager.js
@@ -78,6 +78,6 @@ export class LocalStorageManager {
    */
   static getSetting(key) {
     const value = this.get('settings') || {};
-    return value[key];
+    return key in value ? value[key] : null;
   }
 }

--- a/packages/superdoc/src/utils/LocalStorageManager.js
+++ b/packages/superdoc/src/utils/LocalStorageManager.js
@@ -72,8 +72,9 @@ export class LocalStorageManager {
   }
 
   /**
-   * Get all superdoc settings as an object
-   * @returns {Object} Settings object
+   * Get a setting from the settings object
+   * @param {string} key - The key to get (without prefix)
+   * @returns {any} The parsed value or null if not found
    */
   static getSetting(key) {
     const value = this.get('settings') || {};


### PR DESCRIPTION
- Added a LocalStorageManager class to interact with localStorage
- Complete with get, set, merge, getSetting functions 

Example usage:
```LocalStorageManager.getSetting('rulers')``` -> ```true```

Stored as:
```superdoc::settings | { rulers: true } ```

To update rulers: 
```LocalStorageManager.merge('settings', { rulers: this.config.rulers });```