### PR TITLE
HAR-9135 Set default color for highlight icon

### DIFF
--- a/packages/super-editor/src/components/toolbar/ToolbarButtonIcon.vue
+++ b/packages/super-editor/src/components/toolbar/ToolbarButtonIcon.vue
@@ -18,7 +18,7 @@ const props = defineProps({
 
 const getBarColor = computed(() => {
   if (props.name === 'color') return { backgroundColor: props.color || '#111111' };
-  if (props.name === 'highlight') return { backgroundColor: props.color || 'transparent' };
+  if (props.name === 'highlight') return { backgroundColor: props.color || '#D6D6D6' };
 });
 
 const hasColorBar = computed(() => {

--- a/packages/super-editor/src/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/components/toolbar/super-toolbar.js
@@ -70,7 +70,7 @@ export class SuperToolbar extends EventEmitter {
     },
     
     setHighlight: ({ item, argument }) => {
-      this.#runCommandWithArgumentOnly({ item, argument });
+      this.#runCommandWithArgumentOnly({ item, argument: argument || '#D6D6D6' });
     },
 
     toggleRuler: ({ item, argument }) => {


### PR DESCRIPTION
Hi @harbournick! I did it like it's done in Word. Set default color to light grey  so when User select text and click the highlight icon it will be immediately highlighted and color picker will be offered to select a different color