### PR TITLE
HAR-8873 - fix: prevent duplicate editor initialization on collaboration sync

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -60,6 +60,10 @@ const pollForMetaMapData = (ydoc, retries = 10, interval = 500) => {
     if (docx) {
       stopPolling();
       initEditor({ content: docx });
+      // Remove the synced event listener.
+      // Avoids re-initializing the editor in case the connection is lost and reconnected
+      const provider = props.options.collaborationProvider;
+      provider.off('synced');
     } else if (retries > 0) {
       console.debug(`Waiting for 'docx' data... retries left: ${retries}`);
       dataPollTimeout = setTimeout(checkData, interval); // Retry after the interval

--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -60,10 +60,6 @@ const pollForMetaMapData = (ydoc, retries = 10, interval = 500) => {
     if (docx) {
       stopPolling();
       initEditor({ content: docx });
-      // Remove the synced event listener.
-      // Avoids re-initializing the editor in case the connection is lost and reconnected
-      const provider = props.options.collaborationProvider;
-      provider.off('synced');
     } else if (retries > 0) {
       console.debug(`Waiting for 'docx' data... retries left: ${retries}`);
       dataPollTimeout = setTimeout(checkData, interval); // Retry after the interval
@@ -99,6 +95,9 @@ const initializeData = async () => {
     const provider = props.options.collaborationProvider;
     provider.on('synced', () => {
       pollForMetaMapData(ydoc);
+      // Remove the synced event listener.
+      // Avoids re-initializing the editor in case the connection is lost and reconnected
+      provider.off('synced');
     });
   }
 };


### PR DESCRIPTION
### Issue

Collaboration cursor starts to flick from time to time. 

![unnamed](https://github.com/user-attachments/assets/c017532c-6201-46b2-8efe-7e9528df1149)


### How to reproduce:

1. Open a SuperDoc and share it with someone
2. Leave the page open for ~5 minutes.
3. Come back to the page and try to make any edits. You will see the cursor will start to flick.

The reason this happens is because we use Cloud Run for the collaboration service, and by default it times out after 5 minutes. When it times out, the connection will be lost, but our provider (hocus pocus)  will reconnect automatically.

When that happens: 

1. The `synced` event will be triggered again
2. It will call the `pollForMetaMapData` function. 
3. The `pollForMetaMapData` function will call `initEditor` again.
4. When that happens, internally we are reinitializing  `Editor.js`, and hence the error starts to happen.

### Solution

Remove the listener to the `synced` event once it's triggered for the first time.