### PR TITLE
fix: remove only handleSynced listener after it's triggered

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -93,12 +93,13 @@ const initializeData = async () => {
     delete props.options.content;
     const ydoc = props.options.ydoc;
     const provider = props.options.collaborationProvider;
-    provider.on('synced', () => {
+    const handleSynced = () => {
       pollForMetaMapData(ydoc);
       // Remove the synced event listener.
       // Avoids re-initializing the editor in case the connection is lost and reconnected
-      provider.off('synced');
-    });
+      provider.off('synced', handleSynced);
+    }
+    provider.on('synced', handleSynced);
   }
 };
 


### PR DESCRIPTION
After the `synced` event is triggered, we need to ensure only the same event listener is unbind as we have other listeners for the `synced` event.