### PR TITLE
HAR-9299 - Fix: improve selection bounds calculation for floating comments

### DIFF
--- a/packages/superdoc/src/SuperDoc.vue
+++ b/packages/superdoc/src/SuperDoc.vue
@@ -159,13 +159,15 @@ const onEditorSelectionChange = ({ editor, transaction }) => {
   const { pageMargins } = editor.getPageStyles();
 
   const layerBounds = layers.value.getBoundingClientRect();
-  let top = fromCoords.top - layerBounds.top;
-  top = Math.max(96, (top - 100));
+  const HEADER_HEIGHT = 96;
+  // Ensure the selection is not placed at the top of the page
+  const top = Math.max(HEADER_HEIGHT, fromCoords.top - layerBounds.top);
+  const bottom = toCoords.bottom - layerBounds.top;
   const selectionBounds = {
     top,
     left: fromCoords.left,
     right: toCoords.left,
-    bottom: toCoords.bottom - layerBounds.top,
+    bottom,
   };
 
   const selection = useSelection({


### PR DESCRIPTION
**Problem**: Floating comments are not correctly aligned with the selected text. There was some code in place to determine  `Math.max(96, (top - 100))`. This ensures that the floating comment won't be too close to the header, but the `-100` part was causing the misalignment. 

**Before:**

<img width="1086" alt="Screenshot 2025-03-18 at 18 59 53" src="https://github.com/user-attachments/assets/6ce3413b-f406-4dcf-97fc-67cd54b61083" />

**After:** 

<img width="1914" alt="Screenshot 2025-03-18 at 19 01 14" src="https://github.com/user-attachments/assets/2893c327-c3ba-4e19-92eb-35398ecd7aa6" />

