### PR TITLE
HAR-9218 - fix: do not reposition floating comments when selected

### DIFF
--- a/packages/superdoc/src/components/CommentsLayer/FloatingComments.vue
+++ b/packages/superdoc/src/components/CommentsLayer/FloatingComments.vue
@@ -58,8 +58,6 @@ const handleDialogReady = ({ commentId: dialogId, elementRef }) => {
 
   if (!activeComment.value) {
     floatingCommentsOffset.value = 0;
-  } else if (dialogId === activeComment.value) {
-    floatingCommentsOffset.value = (dialog.floatingPosition.top - dialog.selection?.selectionBounds?.top) * -1;
   }
 
   nextTick(() => {


### PR DESCRIPTION
**Problem**: When you select a floating comment it recalculates the position of them so it's aligned with the linked text. However, if you have many comments, this might cause the comment to be moved away from your current view port. 

**Solution**: We decided to stick with a quick fix and just do not recalculate the position.