### PR TITLE
HAR-9300 - fix: improve floating comments offset calculation and scrolling behavior

### DIFF
--- a/packages/superdoc/src/components/CommentsLayer/FloatingComments.vue
+++ b/packages/superdoc/src/components/CommentsLayer/FloatingComments.vue
@@ -58,6 +58,15 @@ const handleDialogReady = ({ commentId: dialogId, elementRef }) => {
 
   if (!activeComment.value) {
     floatingCommentsOffset.value = 0;
+  } else if (dialogId === activeComment.value) {
+    // First calculate and set the offset
+    floatingCommentsOffset.value = (dialog.floatingPosition.top - dialog.selection?.selectionBounds?.top) * -1;
+    setTimeout(() => {
+      elementRef.value?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center'
+      });
+    }, 100); // 100ms delay to ensure the offset is set before scrolling
   }
 
   nextTick(() => {
@@ -119,7 +128,7 @@ const getCommentPosition = (floatingComment) => {
 const getFloatingSidebarStyle = computed(() => {
   return {
     transform: `translateY(${floatingCommentsOffset.value}px)`,
-    transition: 'all 0.3s ease',
+    transition: 'all 0.1s ease',
   };
 });
 


### PR DESCRIPTION
**Problem**: When there are multiple comments, the selected comment might not be visible in the screen. 

**Solution**: To solve that, we are now scrolling into the element so it's on the viewport.

Note that I also changed the transition duration to `.1s` as we need to wait for the transition to complete and only then scroll to the element. Otherwise it would take `.3s` to scroll to the component.