### PR TITLE
HAR-9211 - fix content types and hex

### DIFF
--- a/packages/super-editor/src/core/DocxZipper.js
+++ b/packages/super-editor/src/core/DocxZipper.js
@@ -106,26 +106,26 @@ class DocxZipper {
       typesString += newContentType;
       seenTypes.add(type);
     }
-
+  
     // Update for comments
     if (docx.files['word/comments.xml']) {
       const commentsDef = `<Override PartName="/word/comments.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml" />`;
-      typesString += commentsDef;
+      if (!contentTypesXml.includes(commentsDef)) typesString += commentsDef;
     };
 
     if (docx.files['word/commentsExtended.xml']) {
       const commentsExtendedDef = `<Override PartName="/word/commentsExtended.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtended+xml" />`;
-      typesString += commentsExtendedDef;
+      if (!contentTypesXml.includes(commentsExtendedDef)) typesString += commentsExtendedDef;
     };
 
     if (docx.files['word/commentsIds.xml']) {
       const commentsIdsDef = `<Override PartName="/word/commentsIds.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.commentsIds+xml" />`;
-      typesString += commentsIdsDef;
+      if (!contentTypesXml.includes(commentsIdsDef)) typesString += commentsIdsDef;
     };
 
     if (docx.files['word/commentsExtensible.xml']) {
       const commentsExtendedDef = `<Override PartName="/word/commentsExtensible.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtensible+xml" />`;
-      typesString += commentsExtendedDef;
+      if (!contentTypesXml.includes(commentsExtendedDef)) typesString += commentsExtendedDef;
     };
   
     const beginningString = '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">';

--- a/packages/super-editor/src/core/helpers/generateDocxListAttributes.js
+++ b/packages/super-editor/src/core/helpers/generateDocxListAttributes.js
@@ -1,4 +1,4 @@
-import { generateDocxRandomId } from './generateDocxRandomId';
+import { generateDocxRandomId, generateRandom32BitHex } from './generateDocxRandomId';
 
 export function generateDocxListAttributes(listType) {
   // Our default blank doc definition has the following list types:

--- a/packages/super-editor/src/core/helpers/generateDocxRandomId.js
+++ b/packages/super-editor/src/core/helpers/generateDocxRandomId.js
@@ -13,3 +13,7 @@ export function generateDocxRandomId(length = 8) {
 
   return id.join('');
 }
+
+export function generateRandom32BitHex() {
+  return Math.floor(Math.random() * 0xFFFFFFFF).toString(16).toUpperCase().padStart(8, '0');
+};

--- a/packages/super-editor/src/core/super-converter/v2/exporter/commentsExporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/exporter/commentsExporter.js
@@ -1,7 +1,7 @@
 import { translateParagraphNode } from '../../exporter.js';
 import { carbonCopy } from '../../../utilities/carbonCopy.js';
 import { COMMENT_REF, COMMENTS_XML_DEFINITIONS } from '../../exporter-docx-defs.js';
-
+import { generateRandom32BitHex } from '../../../helpers/generateDocxRandomId.js';
 
 /**
  * Generate the end node for a comment
@@ -71,7 +71,7 @@ const getCommentSchema = (type, commentId) => {
 export const prepareCommentParaIds = (comment) => {
   const newComment = {
     ...comment,
-    commentParaId: generateCommentId(),
+    commentParaId: generateRandom32BitHex(),
   };
   return newComment;
 };
@@ -223,7 +223,7 @@ export const updateCommentsIdsAndExtensible = (comments = [], commentsIds, exten
   extensibleUpdated.elements[0].elements = [];
   comments.forEach((comment) => {
 
-    const newDurableId = generateCommentId();
+    const newDurableId = generateRandom32BitHex();
     const newCommentIdDef = {
       "type": "element",
       "name": "w16cid:commentId",
@@ -259,24 +259,6 @@ export const updateCommentsIdsAndExtensible = (comments = [], commentsIds, exten
  */
 export const updateDocumentRels = () => {
   return COMMENTS_XML_DEFINITIONS.DOCUMENT_RELS_XML_DEF;
-};
-
-
-/**
- * Generate a random comment paragraph ID
- * 
- * @returns {string} The generated ID
- */
-export const generateCommentId = () => {
-  const digits = "0123456789";
-  const alphaNum = "ABCDEF0123456789";
-
-  let id = digits[Math.floor(Math.random() * digits.length)];
-  for (let i = 0; i < 7; i++) {
-    id += alphaNum[Math.floor(Math.random() * alphaNum.length)];
-  }
-  
-  return id;
 };
 
 

--- a/packages/super-editor/src/tests/export/lists/commentExport.test.js
+++ b/packages/super-editor/src/tests/export/lists/commentExport.test.js
@@ -6,7 +6,6 @@ import basicResolvedCommentData from '../data/comments/basic-resolved-comment';
 import {
   getInitials,
   toIsoNoFractional,
-  generateCommentId,
   removeCommentsFilesFromConvertedXml,
 } from '@converter/v2/exporter/commentsExporter';
 
@@ -88,28 +87,6 @@ describe('test toIsoNoFractional function', () => {
     const date = Date.now();
     const isoDate = toIsoNoFractional(date);
     expect(isoDate).toBe(new Date(date).toISOString().replace(/\.\d{3}Z$/, 'Z'));
-  });
-});
-
-describe('generateCommentId', () => {
-  it('should return an 8-character string', () => {
-    const id = generateCommentId();
-    expect(id).to.be.a('string');
-    expect(id).to.have.lengthOf(8);
-  });
-
-  it('should start with a digit', () => {
-    const id = generateCommentId();
-    const firstChar = id[0];
-    expect('0123456789').to.include(firstChar);
-  });
-
-  it('should only contain digits and uppercase letters', () => {
-    const id = generateCommentId();
-    const validChars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    for (let char of id) {
-      expect(validChars).to.include(char);
-    }
   });
 });
 


### PR DESCRIPTION
- Fix issue with content types becoming corrupted if any comments type is double (ie: if imported file already had it)
- Fix paraId generator to use correct 32-bit hex