### PR TITLE
Prevent trying to connect the global superdoc ydoc connection if there is no superdocId

### DIFF
--- a/packages/superdoc/src/core/collaboration/helpers.js
+++ b/packages/superdoc/src/core/collaboration/helpers.js
@@ -55,8 +55,9 @@ export const initCollaborationComments = (superdoc) => {
 export const initSuperdocYdoc = (superdoc) => {
   const { isInternal } = superdoc.config;
   const baseName = `${superdoc.config.superdocId}-superdoc`;
-  const documentId = isInternal ? baseName : `${baseName}-external`;
+  if (!superdoc.config.superdocId) return;
 
+  const documentId = isInternal ? baseName : `${baseName}-external`;
   const superdocCollaborationOptions = {
     config: superdoc.config.modules.collaboration,
     user: superdoc.config.user,


### PR DESCRIPTION
Prevent trying to connect the global superdoc ydoc connection if there is no superdocId