### PR TITLE
HAR-9353 - Force generateRandom32BitHex to only positive values

### DIFF
--- a/packages/super-editor/src/core/helpers/generateDocxRandomId.js
+++ b/packages/super-editor/src/core/helpers/generateDocxRandomId.js
@@ -15,5 +15,6 @@ export function generateDocxRandomId(length = 8) {
 }
 
 export function generateRandom32BitHex() {
-  return Math.floor(Math.random() * 0xFFFFFFFF).toString(16).toUpperCase().padStart(8, '0');
+  const val = Math.floor(Math.random() * 0x7FFFFFFF);
+  return val.toString(16).toUpperCase().padStart(8, '0');
 };


### PR DESCRIPTION
It appears that MS word will reject ID values in w16cex:durableId that are larger than 2^31 despite this not being documented anywhere. Initial tests with this PR (keeping the 32-bit hex ID under 2^31 aka positive values) seem to solve the issue.