### PR TITLE
HAR-9430 - fix paragraph text indentation

### DIFF
--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -167,7 +167,7 @@ function generateParagraphProperties(node) {
   const { styleId } = attrs;
   if (styleId) pPrElements.push({ name: 'w:pStyle', attributes: { 'w:val': styleId } });
 
-  const { spacing, indent, textAlign } = attrs;
+  const { spacing, indent, textAlign, textIndent } = attrs;
   if (spacing) {
     const { lineSpaceBefore, lineSpaceAfter, line, lineRule } = spacing;
 
@@ -185,7 +185,7 @@ function generateParagraphProperties(node) {
     };
     pPrElements.push(spacingElement);
   }
-
+  
   if (indent) {
     const { left, right, firstLine } = indent;
     const attributes = {};
@@ -193,9 +193,21 @@ function generateParagraphProperties(node) {
     if (right || right === 0) attributes['w:right'] = pixelsToTwips(right);
     if (firstLine || firstLine === 0) attributes['w:firstLine'] = pixelsToTwips(firstLine);
 
+    if (textIndent && !attributes['w:left']) {
+      attributes['w:left'] = inchesToTwips(textIndent);
+    }
+    
     const indentElement = {
       name: 'w:ind',
       attributes,
+    };
+    pPrElements.push(indentElement);
+  } else if (textIndent) {
+    const indentElement = {
+      name: 'w:ind',
+      attributes: { 
+        'w:left': inchesToTwips(textIndent), 
+      },
     };
     pPrElements.push(indentElement);
   }

--- a/packages/super-editor/src/core/super-converter/v2/importer/markImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/markImporter.js
@@ -167,7 +167,7 @@ function getFontFamilyValue(attributes, docx) {
 
 function getIndentValue(attributes) {
   let value = attributes['w:left'];
-  if (!value) value = attributes['w:firstLine'];
+  if (!value) return null;
   return `${twipsToInches(value)}in`;
 }
 

--- a/packages/super-editor/src/core/super-converter/v2/importer/paragraphNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/paragraphNodeImporter.js
@@ -64,8 +64,11 @@ export const handleParagraphNode = (params) => {
       if (firstLine) schemaNode.attrs['indent'].firstLine = twipsToPixels(firstLine);
     }
 
-    const textIndentVal = left || firstLine || 0;
-    schemaNode.attrs['textIndent'] = `${twipsToInches(textIndentVal)}in`;
+    const textIndentValue = left || 0;
+
+    if (textIndentValue) {
+      schemaNode.attrs['textIndent'] = `${twipsToInches(textIndentValue)}in`;
+    }    
   }
 
   const justify = pPr?.elements?.find((el) => el.name === 'w:jc');

--- a/packages/super-editor/src/extensions/text-indent/text-indent.js
+++ b/packages/super-editor/src/extensions/text-indent/text-indent.js
@@ -1,13 +1,6 @@
 import { Extension } from '@core/index.js';
 import { parseSizeUnit } from '@core/utilities/index.js';
 
-/**
- * Do we need a unit conversion system?
- *
- * For reference.
- * https://remirror.vercel.app/?path=/story/extensions-nodeformatting--basic
- * https://github.com/remirror/remirror/tree/HEAD/packages/remirror__extension-node-formatting
- */
 export const TextIndent = Extension.create({
   name: 'textIndent',
 
@@ -32,7 +25,7 @@ export const TextIndent = Extension.create({
             renderDOM: (attrs) => {
               if (!attrs.textIndent) return {};
               let [value, unit] = parseSizeUnit(attrs.textIndent);
-              if (Number.isNaN(value)) return {};
+              if (Number.isNaN(value) || !value) return {};
               unit = unit ? unit : this.options.defaults.unit;
               return { style: `margin-left: ${value}${unit}` };
             },

--- a/packages/super-editor/src/tests/import/listImporter.test.js
+++ b/packages/super-editor/src/tests/import/listImporter.test.js
@@ -351,6 +351,7 @@ describe('custom nested list tests', () => {
                         'w:rsidR': '00F20DE4',
                         'w:rsidRDefault': '00F20DE4',
                         'w:rsidP': '00F20DE4',
+                        textAlign: 'both',
                         paragraphProperties: {
                           type: 'element',
                           name: 'w:pPr',
@@ -411,8 +412,7 @@ describe('custom nested list tests', () => {
                               },
                             },
                           ],
-                        },
-                        textIndent: 'undefinedin',
+                        }
                       },
                       marks: [],
                     },
@@ -428,7 +428,6 @@ describe('custom nested list tests', () => {
                     textStyle: {
                       type: 'textStyle',
                       attrs: {
-                        textIndent: 'undefinedin',
                         textAlign: 'both',
                       },
                     },
@@ -450,6 +449,7 @@ describe('custom nested list tests', () => {
                         'w:rsidR': '00F20DE4',
                         'w:rsidRDefault': '007B64C8',
                         'w:rsidP': '00F20DE4',
+                        textAlign: 'both',
                         paragraphProperties: {
                           type: 'element',
                           name: 'w:pPr',
@@ -489,8 +489,7 @@ describe('custom nested list tests', () => {
                               },
                             },
                           ],
-                        },
-                        textIndent: 'undefinedin',
+                        }
                       },
                     },
                     numId: '2',
@@ -507,6 +506,7 @@ describe('custom nested list tests', () => {
                     'w:rsidR': '00F20DE4',
                     'w:rsidRDefault': '007B64C8',
                     'w:rsidP': '00F20DE4',
+                    textAlign: 'both',
                     paragraphProperties: {
                       type: 'element',
                       name: 'w:pPr',
@@ -546,8 +546,7 @@ describe('custom nested list tests', () => {
                           },
                         },
                       ],
-                    },
-                    textIndent: 'undefinedin',
+                    }
                   },
                 },
               },
@@ -564,7 +563,6 @@ describe('custom nested list tests', () => {
             textStyle: {
               type: 'textStyle',
               attrs: {
-                textIndent: 'undefinedin',
                 textAlign: 'both',
               },
             },
@@ -586,6 +584,7 @@ describe('custom nested list tests', () => {
                 'w:rsidR': '00F20DE4',
                 'w:rsidRDefault': '007B64C8',
                 'w:rsidP': '00F20DE4',
+                textAlign: 'both',
                 paragraphProperties: {
                   type: 'element',
                   name: 'w:pPr',
@@ -625,8 +624,7 @@ describe('custom nested list tests', () => {
                       },
                     },
                   ],
-                },
-                textIndent: 'undefinedin',
+                }
               },
             },
             numId: '1',
@@ -689,9 +687,7 @@ describe('custom nested list tests', () => {
                     },
                     textStyle: {
                       type: 'textStyle',
-                      attrs: {
-                        textIndent: 'undefinedin',
-                      },
+                      attrs: {},
                     },
                     order: '1',
                     lvlText: '○',
@@ -761,8 +757,7 @@ describe('custom nested list tests', () => {
                               },
                             },
                           ],
-                        },
-                        textIndent: 'undefinedin',
+                        }
                       },
                     },
                     numId: '2',
@@ -829,8 +824,7 @@ describe('custom nested list tests', () => {
                           },
                         },
                       ],
-                    },
-                    textIndent: 'undefinedin',
+                    }
                   },
                 },
               },
@@ -847,7 +841,6 @@ describe('custom nested list tests', () => {
             textStyle: {
               type: 'textStyle',
               attrs: {
-                textIndent: 'undefinedin',
                 textAlign: 'both',
               },
             },
@@ -869,6 +862,7 @@ describe('custom nested list tests', () => {
                 'w:rsidR': '00F20DE4',
                 'w:rsidRDefault': '007B64C8',
                 'w:rsidP': '00F20DE4',
+                textAlign: 'both',
                 paragraphProperties: {
                   type: 'element',
                   name: 'w:pPr',
@@ -908,8 +902,7 @@ describe('custom nested list tests', () => {
                       },
                     },
                   ],
-                },
-                textIndent: 'undefinedin',
+                }
               },
             },
             numId: '1',
@@ -926,6 +919,7 @@ describe('custom nested list tests', () => {
             'w:rsidR': '00F20DE4',
             'w:rsidRDefault': '007B64C8',
             'w:rsidP': '00F20DE4',
+            textAlign: 'both',
             paragraphProperties: {
               type: 'element',
               name: 'w:pPr',
@@ -965,8 +959,7 @@ describe('custom nested list tests', () => {
                   },
                 },
               ],
-            },
-            textIndent: 'undefinedin',
+            }
           },
         },
       },


### PR DESCRIPTION
The first line indent should not be mixed and used for the overall indentation of the entire paragraph.