### PR TITLE
Refactor header/footer import logic

### DIFF
--- a/packages/super-editor/src/extensions/pagination/pagination.js
+++ b/packages/super-editor/src/extensions/pagination/pagination.js
@@ -290,7 +290,6 @@ function generateInternalPageBreaks(doc, view, editor, sectionData) {
   let pageHeightThreshold = pageHeight;
   let hardBreakOffsets = 0;
   let footer = null, header = null;
-  const { headerIds, footerIds } = editor.converter;
 
   const firstHeaderId = getHeaderFooterId(currentPageNumber, 'headerIds', editor);
   const firstHeader = createHeader(pageMargins, pageSize, sectionData, firstHeaderId);


### PR DESCRIPTION
Refactor header/footer import logic to account for documents that have multiple <w:sectPr> tags across document.xml