### PR TITLE
Fix parsing error in Ideals doc

### DIFF
--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -204,6 +204,8 @@ class SuperConverter {
 
     // Get the run defaults for this document - this will include font, theme etc.
     const rDefault = defaults.elements.find((el) => el.name === 'w:rPrDefault');
+    if (!rDefault.elements) return {};
+    
     const rElements = rDefault.elements[0].elements;
     const rFonts = rElements?.find((el) => el.name === 'w:rFonts');
     if ('elements' in rDefault) {


### PR DESCRIPTION
@harbournick This document from Ideals has font inconsistencies but document itself has no font definitions. SD renders Arial but Word has Times new roman. As far as I understood it uses 'Normal' styles for paragraphs and 'Heading 1'. Probably this document was created in older version of Word which had Times new roman as default font but I didn't find any signs of it in xml