### PR TITLE
HAR-9669 - fix header and footer for first page

### DIFF
--- a/packages/super-editor/src/extensions/pagination/pagination.js
+++ b/packages/super-editor/src/extensions/pagination/pagination.js
@@ -195,7 +195,9 @@ const getHeaderFooterId = (currentPageNumber, sectionType, editor, node = null) 
   if (sectionIds?.titlePg && first && currentPageNumber === 1) return first;
 
   let sectionId = sectionIds.default;
-  if (currentPageNumber === 1) sectionId = first || defaultHeader;
+  // this causes issue and displays incorrect header/footer for first page
+  // if (currentPageNumber === 1) sectionId = first || defaultHeader;
+  if (currentPageNumber === 1) sectionId = defaultHeader;
 
   if (alternateHeaders) {
     if (currentPageNumber === 1) sectionId = first;


### PR DESCRIPTION
Show default header/footer for the first page.

Previous changes probably addressed some specific document issue, related to compatibility for example. But these changes raise header/footer issue for many other docs.

For reference.
https://github.com/Harbour-Enterprises/SuperDoc/pull/492/files.