### PR TITLE
HAR-9663 - add zero width text when create a table

### DIFF
--- a/packages/super-editor/src/extensions/table/table.js
+++ b/packages/super-editor/src/extensions/table/table.js
@@ -13,6 +13,7 @@ import { createCellBorders } from '../table-cell/helpers/createCellBorders.js';
 import { findParentNode } from '@helpers/findParentNode.js';
 import { TextSelection } from 'prosemirror-state';
 import { getFieldAttrs } from '@helpers/annotator.js';
+import { getNodeType } from '@core/helpers/getNodeType.js';
 import {
   addColumnBefore,
   addColumnAfter,
@@ -151,7 +152,9 @@ export const Table = Node.create({
     return {
       insertTable:
         ({ rows = 3, cols = 3, withHeaderRow = false } = {}) => ({ tr, dispatch, editor }) => {
-          const node = createTable(editor.schema, rows, cols, withHeaderRow);
+          const zeroWidthText = editor.schema.text('\u200B');
+          const emptyPar = getNodeType('paragraph', editor.schema).create(null, zeroWidthText);
+          const node = createTable(editor.schema, rows, cols, withHeaderRow, emptyPar);
 
           if (dispatch) {
             const offset = tr.selection.from + 1;


### PR DESCRIPTION
Add zero width text to empty cell when create a table in order to apply marks to the text.

Note: please check my comment in the ticket before merging.