### PR TITLE
Fix editor type exports when rolling into SuperDoc, add annotate() types

### DIFF
--- a/examples/typescript-example/src/components/DocumentEditor.tsx
+++ b/examples/typescript-example/src/components/DocumentEditor.tsx
@@ -1,5 +1,6 @@
 import { SuperDoc, Config } from '@harbour-enterprises/superdoc';
 import { Editor } from '@harbour-enterprises/superdoc/super-editor'
+
 import '@harbour-enterprises/superdoc/style.css';
 import { useEffect, useRef } from 'react';
 
@@ -24,15 +25,9 @@ const DocumentEditor = ({
       selector: '#superdoc',
       toolbar: 'superdoc-toolbar',
       documentMode: readOnly ? 'viewing' : 'editing',
-      documents: [{
-        id: documentId,
-        type: documentType,
-        data: initialData
-      }],
-      onReady: (editor: { superdoc: SuperDoc }) => {
-        if (onEditorReady) {
-          onEditorReady(editor);
-        }
+      onReady: (activeSuperDoc: SuperDoc) => {
+        const superEditor = activeSuperDoc.activeEditor;
+        console.debug('SuperDoc editor is ready', superEditor);
       },
       onEditorCreate: (editor: Editor) => {
         console.log('Editor created', editor);

--- a/packages/super-editor/package.json
+++ b/packages/super-editor/package.json
@@ -8,7 +8,8 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/super-editor.es.js"
+      "import": "./dist/super-editor.es.js",
+      "types": "./dist/index.d.ts"
     },
     "./converter": {
       "import": "./dist/converter.es.js"

--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -21,7 +21,7 @@
     },
     "./super-editor": {
       "import": "./dist/super-editor.es.js",
-      "types": "./dist/super-editor/src/index.d.ts"
+      "types": "./dist/super-editor/index.d.ts"
     },
     "./super-editor/style.css": {
       "import": "./dist/super-editor/style.css"


### PR DESCRIPTION
- Fixes types export in super-editor package
- Adds initial types for new annotate() function in super-editor
- Fixes super-editor type defs roll up in SuperDoc