### PR TITLE
Add isFinalDoc flag in SuperDoc export

### DIFF
--- a/examples/vue-fields-example/src/App.vue
+++ b/examples/vue-fields-example/src/App.vue
@@ -115,7 +115,11 @@ const addField = (field) => {
 }
 
 const exportDocx = () => {
-  superdoc.value?.export();
+  superdoc.value?.export({ isFinalDoc: true });
+
+  // Or use superdoc.value?.export({ isFinalDoc: true }); 
+  // If you want to fully remove all fields and replace them with their values
+
 };
 
 const onDragStart = (event) => {

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -567,11 +567,12 @@ export class SuperDoc extends EventEmitter {
     commentsType,
     exportedName,
     additionalFiles = [],
-    additionalFileNames = []
+    additionalFileNames = [],
+    isFinalDoc = false,
   } = {}) {
     // Get the docx files first
     const baseFileName = exportedName ? cleanName(exportedName) : cleanName(this.config.title);
-    const docxFiles = await this.exportEditorsToDOCX({ commentsType });
+    const docxFiles = await this.exportEditorsToDOCX({ commentsType, isFinalDoc });
     const blobsToZip = [...additionalFiles];
     const filenames = [...additionalFileNames];
 
@@ -592,7 +593,7 @@ export class SuperDoc extends EventEmitter {
     }
   };
 
-  async exportEditorsToDOCX({ commentsType } = {}) {    
+  async exportEditorsToDOCX({ commentsType, isFinalDoc } = {}) {    
     const comments = [];
     if (commentsType !== 'clean') {
       comments.push(...this.commentsStore?.translateCommentsForExport());
@@ -602,7 +603,7 @@ export class SuperDoc extends EventEmitter {
     this.superdocStore.documents.forEach((doc) => {
       const editor = doc.getEditor();
       if (editor) {
-        docxPromises.push(editor.exportDocx({ comments, commentsType }));
+        docxPromises.push(editor.exportDocx({ isFinalDoc, comments, commentsType }));
       }
     });
     return await Promise.all(docxPromises);


### PR DESCRIPTION
- Adds isFinalDoc to superdoc's export() and passes it down to the existing editor.exportDocx()
- updates example