### PR TITLE
HAR-9516, HAR-9571 - add default spacing to paragraph

### DIFF
--- a/packages/super-editor/src/core/super-converter/v2/importer/paragraphNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/paragraphNodeImporter.js
@@ -197,7 +197,7 @@ export const getParagraphSpacing = (node, docx, styleId = '', marks = []) => {
     lineSpaceBefore: 0,
     line: 0,
     lineRule: null,
-  }
+  };
   
   const { spacing: pDefaultSpacing = {} } = getDefaultParagraphStyle(docx, styleId);
   let lineSpaceAfter, lineSpaceBefore, line, lineRuleStyle;

--- a/packages/super-editor/src/extensions/paragraph/helpers/getDefaultSpacing.js
+++ b/packages/super-editor/src/extensions/paragraph/helpers/getDefaultSpacing.js
@@ -1,0 +1,6 @@
+export const getDefaultSpacing = () => ({
+  lineSpaceAfter: 0,
+  lineSpaceBefore: 0,
+  line: 0,
+  lineRule: null,
+});

--- a/packages/super-editor/src/extensions/paragraph/paragraph.js
+++ b/packages/super-editor/src/extensions/paragraph/paragraph.js
@@ -2,6 +2,7 @@ import { Plugin, PluginKey } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
 import { Node, Attribute, Schema } from '@core/index.js';
 import { getSpacingStyleString, getMarksStyle } from '@extensions/linked-styles/index.js';
+import { getDefaultSpacing } from './helpers/getDefaultSpacing.js';
 
 export const Paragraph = Node.create({
   name: 'paragraph',
@@ -23,6 +24,7 @@ export const Paragraph = Node.create({
   addAttributes() {
     return {
       spacing: {
+        default: getDefaultSpacing(),
         renderDOM: (attrs) => {
           const { spacing } = attrs;
           if (!spacing) return {};


### PR DESCRIPTION
Paragraphs must have default spacing with zero margin, otherwise there may be spacing issues on the next import.

Here are some cases where this can happen:
1. We import a docx file that has a default margin for paragraphs (in default styles). When creating a table, paragraphs inside have no margins. During the next import, we go through the style chain - inline attributes (margin not found), but it is found in default styles and will be applied to the paragraph.

2. We import a docx file in which formatting styles are defined by id (heading1, heading2, etc). Next, we create new paragraphs (they don’t have margins) and apply formatting styles to them, for example Heading 2. On the next import we go through the style chain - inline margins are not found, but they are found by the formatting style ID in this file and will be applied (although there were no margins in the editor).

Note:
- Also, when exporting, we save the current spacing in inline attributes, so that the next time we import it, it will be taken from the attributes (and not from default styles or by id).