### PR TITLE
disable csp in dev env

### DIFF
--- a/packages/superdoc/index.html
+++ b/packages/superdoc/index.html
@@ -4,13 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="csp-nonce" content="testnonce123" />
-    <meta
+    <!-- <meta
       http-equiv="Content-Security-Policy"
       content="
         style-src 'self' 'nonce-testnonce123';
         style-src-attr 'unsafe-inline';
       "
-    />
+    /> -->
     <title>SuperDoc</title>
   </head>
   <body>

--- a/packages/superdoc/src/dev/components/SuperdocDev.vue
+++ b/packages/superdoc/src/dev/components/SuperdocDev.vue
@@ -77,7 +77,7 @@ const init = async () => {
     //     isNewFile: true,
     //   },
     // ],
-    cspNonce: 'testnonce123',
+    // cspNonce: 'testnonce123',
     modules: {
       comments: {
         // comments: sampleComments,


### PR DESCRIPTION
Vite can't load styles into dev env because of this.

<img width="610" alt="Screenshot 2025-06-05 at 11 33 56" src="https://github.com/user-attachments/assets/aa97c560-240d-4abc-ae6e-0bf4db5e9d1a" />
