### PR TITLE
HAR-9825 - fix paste event for fieldAnnotation node

### DIFF
--- a/packages/super-editor/src/core/InputRule.js
+++ b/packages/super-editor/src/core/InputRule.js
@@ -214,6 +214,13 @@ export const inputRulesPlugin = ({ editor, rules }) => {
         const clipboard = event.clipboardData;
         const html = clipboard.getData("text/html");
         const text = clipboard.getData("text/plain");
+        const fieldAnnotationContent = slice.content.content.filter((item) => item.type.name === 'fieldAnnotation');
+
+        if (fieldAnnotationContent.length) {
+          // The paste event will be handled here.
+          // packages/super-editor/src/extensions/field-annotation/FieldAnnotationPlugin.js
+          return false;
+        }
 
         let source;
         if (!html) {


### PR DESCRIPTION
Notes:
- Affected by these changes.
https://github.com/Harbour-Enterprises/SuperDoc/pull/477/files#diff-70aae1b44e67a2fa8645128978e8e7701cbb71ed76f5e73d83399fdec0a6cd3fR211
- Also paste rules should not be in input rules.