### PR TITLE
[Bugfix] Remove white background from `.pagination-inner`

### DIFF
--- a/packages/super-editor/src/assets/styles/extensions/pagination.css
+++ b/packages/super-editor/src/assets/styles/extensions/pagination.css
@@ -54,7 +54,6 @@
   left: 0;
   display: flex;
   flex-direction: column;
-  background-color: white;
 }
 
 /**


### PR DESCRIPTION
The header / footer of the pages have a white background set in the `.pagination-inner` class. The "body" of the pages however have no background color set and are transparent.

This results in the document looking "broken" if SuperDoc is used on anything but a white background. Hence this commit removing the explicit white background to leave the whole page transparent.

*Illustration of the issue:*
<img width="910" alt="Screenshot 2025-06-14 at 12 21 10 PM" src="https://github.com/user-attachments/assets/87fbda71-20ad-4813-bd62-11bdc2a34e55" />
