### PR TITLE
HAR-9857, HAR-9832 - field annotation commands

### DIFF
--- a/packages/super-editor/src/core/helpers/annotator.js
+++ b/packages/super-editor/src/core/helpers/annotator.js
@@ -380,7 +380,23 @@ const deleteHeaderFooterFieldAnnotations = ({ editor, fieldIdOrArray }) => {
       type,
     );
   });
+};
 
+const resetHeaderFooterFieldAnnotations = ({ editor }) => {
+  if (!editor) return;
+
+  const sectionEditors = getAllHeaderFooterEditors(editor);
+
+  sectionEditors.forEach(({ editor: sectionEditor, sectionId, type }) => {
+    sectionEditor.commands.resetFieldAnnotations();
+
+    onHeaderFooterDataUpdate(
+      { editor: sectionEditor },
+      editor,
+      sectionId,
+      type,
+    );
+  });
 };
 
 export const cleanUpListsWithAnnotations = (fieldsToDelete = [], editor) => {
@@ -475,5 +491,6 @@ export const AnnotatorHelpers = {
   getAllHeaderFooterEditors,
   updateHeaderFooterFieldAnnotations,
   deleteHeaderFooterFieldAnnotations,
+  resetHeaderFooterFieldAnnotations,
   cleanUpListsWithAnnotations,
 };


### PR DESCRIPTION
Extended schema, added `defaultDisplayLabel` attribute, which will be filled with `displayLabel` attr value when the annotation is added.

Commands added:
- `replaceFieldAnnotationsWithLabel` - Convert annotations back to text node.
- `replaceFieldAnnotationsWithLabelInSelection` - Convert annotations back to text node (In selection).
- `resetFieldAnnotations` - Reset all annotations to default value.

Helpers added:
- `resetHeaderFooterFieldAnnotations` - Reset all annotations to default value (in header/footer).