### PR TITLE
HAR-9905 - Fix html paste turning empty spans into page breaks

### DIFF
--- a/packages/super-editor/src/extensions/line-break/line-break.js
+++ b/packages/super-editor/src/extensions/line-break/line-break.js
@@ -51,7 +51,16 @@ export const HardBreak = Node.create({
   },
 
   parseDOM() {
-    return [{ tag: 'span' }];
+    return [{
+      tag: 'span[linebreaktype="page"]',
+      getAttrs: dom => {
+        if (!(dom instanceof HTMLElement)) return false;
+        return {
+          pageBreakSource: dom.getAttribute('pagebreaksource') || null,
+          pageBreakType: dom.getAttribute('linebreaktype') || null,
+        };
+      },
+    }];
   },
 
   renderDOM({ htmlAttributes }) {


### PR DESCRIPTION
- Remove unnecessary / forbidden tags when pasting HTML into the editor
- remove tags with linebreaktype in HTML as they are not used here and cause issues
- Make DOM parsing definition for hard break more strict