### PR TITLE
fix: restore focus to editor when generic popover closes

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -63,6 +63,7 @@ const closePopover = () => {
   popoverControls.visible = false;
   popoverControls.component = null;
   popoverControls.props = {};
+  editor.value.view.focus();
 };
 
 const openPopover = (component, props, position) => {


### PR DESCRIPTION
- Fix popover focus on close (return to editor)
- Fixes issue with table creation from slash menu, makes sure cursor starts in the first table cell