### PR TITLE
feat: prevent custom menu from opening when user holds control

### DIFF
--- a/packages/super-editor/src/components/slash-menu/SlashMenu.vue
+++ b/packages/super-editor/src/components/slash-menu/SlashMenu.vue
@@ -132,6 +132,11 @@ const handleGlobalOutsideClick = (event) => {
 };
 
 const handleRightClick = async (event) => {
+  // If user is also holding control, don't open the menu
+  if (event.ctrlKey) {
+    return;
+  }
+
   event.preventDefault();
   props.editor.view.dispatch(
     props.editor.view.state.tr.setMeta(SlashMenuPluginKey, {


### PR DESCRIPTION
- prevents our custom menu from opening on right click if control key is also held 