### PR TITLE
HAR-9854 - fix: text mark font family precedes linked style

### DIFF
--- a/packages/super-editor/src/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/components/toolbar/super-toolbar.js
@@ -709,8 +709,7 @@ export class SuperToolbar extends EventEmitter {
           const linkedStylesItem = linkedStyles?.definition.styles[markToStyleMap[item.name.value]];
 
           const value = {
-            [item.name.value]:
-              activeMarkItem || linkedStylesItem,
+            [item.name.value]: activeMarkItem || linkedStylesItem,
           };
 
           item.activate(value);

--- a/packages/super-editor/src/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/components/toolbar/super-toolbar.js
@@ -687,16 +687,15 @@ export class SuperToolbar extends EventEmitter {
       }
 
       const activeMark = marks.find((mark) => mark.name === item.name.value);
-
       if (activeMark) {
         item.activate(activeMark.attrs);
       } else {
         item.deactivate();
       }
 
-      // Activate toolbar items based on linked styles
+      // Activate toolbar items based on linked styles (if there's no active mark to avoid overriding  it)
       const styleIdMark = marks.find((mark) => mark.name === 'styleId');
-      if (styleIdMark?.attrs.styleId) {
+      if (!activeMark && styleIdMark?.attrs.styleId) {
         const markToStyleMap = {
           fontSize: 'font-size',
           fontFamily: 'font-family',
@@ -705,13 +704,10 @@ export class SuperToolbar extends EventEmitter {
         };
         const linkedStyles = this.activeEditor.converter?.linkedStyles.find((style) => style.id === styleIdMark.attrs.styleId);
         if (linkedStyles && markToStyleMap[item.name.value] in linkedStyles?.definition.styles) {
-          const activeMarkItem = activeMark?.attrs?.[item.name.value];
           const linkedStylesItem = linkedStyles?.definition.styles[markToStyleMap[item.name.value]];
-
           const value = {
-            [item.name.value]: activeMarkItem || linkedStylesItem,
+            [item.name.value]: linkedStylesItem,
           };
-
           item.activate(value);
         }
       }

--- a/packages/super-editor/src/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/components/toolbar/super-toolbar.js
@@ -705,10 +705,14 @@ export class SuperToolbar extends EventEmitter {
         };
         const linkedStyles = this.activeEditor.converter?.linkedStyles.find((style) => style.id === styleIdMark.attrs.styleId);
         if (linkedStyles && markToStyleMap[item.name.value] in linkedStyles?.definition.styles) {
+          const activeMarkItem = activeMark?.attrs?.[item.name.value];
+          const linkedStylesItem = linkedStyles?.definition.styles[markToStyleMap[item.name.value]];
+
           const value = {
             [item.name.value]:
-              activeMark?.attrs[item.name.value] || linkedStyles?.definition.styles[markToStyleMap[item.name.value]],
+              activeMarkItem || linkedStylesItem,
           };
+
           item.activate(value);
         }
       }

--- a/packages/super-editor/src/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/components/toolbar/super-toolbar.js
@@ -663,7 +663,7 @@ export class SuperToolbar extends EventEmitter {
     this.#initDefaultFonts();
     this.#updateHighlightColors();
 
-    // Decativate toolbar items if no active editor
+    // Deactivate toolbar items if no active editor
     // This will skip buttons that are marked as allowWithoutEditor
     if (!this.activeEditor || this.documentMode === 'viewing') {
       this.#deactivateAll();
@@ -706,7 +706,8 @@ export class SuperToolbar extends EventEmitter {
         const linkedStyles = this.activeEditor.converter?.linkedStyles.find((style) => style.id === styleIdMark.attrs.styleId);
         if (linkedStyles && markToStyleMap[item.name.value] in linkedStyles?.definition.styles) {
           const value = {
-            [item.name.value]: linkedStyles?.definition.styles[markToStyleMap[item.name.value]]
+            [item.name.value]:
+              activeMark?.attrs[item.name.value] || linkedStyles?.definition.styles[markToStyleMap[item.name.value]],
           };
           item.activate(value);
         }

--- a/packages/super-editor/src/tests/toolbar/updateToolbarState.test.js
+++ b/packages/super-editor/src/tests/toolbar/updateToolbarState.test.js
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SuperToolbar } from '../../components/toolbar/super-toolbar.js';
+
+// Mock the dependencies
+vi.mock('@core/helpers/getActiveFormatting.js', () => ({
+  getActiveFormatting: vi.fn(),
+}));
+
+vi.mock('@helpers/isInTable.js', () => ({
+  isInTable: vi.fn().mockImplementation(() => false),
+}));
+
+vi.mock('@extensions/linked-styles/linked-styles.js', () => ({
+  getQuickFormatList: vi.fn(),
+}));
+
+describe('updateToolbarState', () => {
+  let toolbar;
+  let mockEditor;
+  let mockGetActiveFormatting;
+  let mockIsInTable;
+  let mockGetQuickFormatList;
+
+  beforeEach(async () => {
+    // Reset all mocks
+    vi.clearAllMocks();
+
+    // Setup mock editor
+    mockEditor = {
+      state: {},
+      commands: {
+        setFieldAnnotationsFontSize: vi.fn(),
+        setFieldAnnotationsFontFamily: vi.fn(),
+        setFieldAnnotationsTextColor: vi.fn(),
+        setFieldAnnotationsTextHighlight: vi.fn(),
+        setCellBackground: vi.fn(),
+        toggleFieldAnnotationsFormat: vi.fn(),
+      },
+      converter: {
+        getDocumentDefaultStyles: vi.fn(() => ({ typeface: 'Arial', fontSizePt: 12 })),
+        linkedStyles: [],
+        docHiglightColors: new Set(['#ff0000', '#00ff00']),
+      },
+      options: {
+        mode: 'docx',
+        isHeaderOrFooter: false,
+      },
+      focus: vi.fn(),
+      on: vi.fn(),
+    };
+
+    // Setup mock functions
+    mockGetActiveFormatting = vi.fn();
+    mockIsInTable = vi.fn();
+    mockGetQuickFormatList = vi.fn().mockReturnValue([]);
+
+    // Import the mocked functions
+    const { getActiveFormatting } = await import('@core/helpers/getActiveFormatting.js');
+    const { isInTable } = await import('@helpers/isInTable.js');
+    const { getQuickFormatList } = await import('@extensions/linked-styles/linked-styles.js');
+
+    getActiveFormatting.mockImplementation(mockGetActiveFormatting);
+    isInTable.mockImplementation(mockIsInTable);
+    getQuickFormatList.mockImplementation(mockGetQuickFormatList);
+
+    // Create toolbar instance
+    toolbar = new SuperToolbar({
+      selector: '#test-toolbar',
+      editor: mockEditor,
+      role: 'editor',
+    });
+
+    
+    // Mock toolbar items
+    toolbar.toolbarItems = [
+      {
+        name: { value: 'bold' },
+        resetDisabled: vi.fn(),
+        activate: vi.fn(),
+        deactivate: vi.fn(),
+        setDisabled: vi.fn(),
+        allowWithoutEditor: { value: false },
+      },
+      {
+        name: { value: 'italic' },
+        resetDisabled: vi.fn(),
+        activate: vi.fn(),
+        deactivate: vi.fn(),
+        setDisabled: vi.fn(),
+        allowWithoutEditor: { value: false },
+      },
+      {
+        name: { value: 'linkedStyles' },
+        resetDisabled: vi.fn(),
+        activate: vi.fn(),
+        deactivate: vi.fn(),
+        setDisabled: vi.fn(),
+        allowWithoutEditor: { value: false },
+      },
+      {
+        name: { value: 'tableActions' },
+        resetDisabled: vi.fn(),
+        activate: vi.fn(),
+        deactivate: vi.fn(),
+        setDisabled: vi.fn(),
+        disabled: { value: false },
+        allowWithoutEditor: { value: false },
+      },
+      {
+        name: { value: 'fontSize' },
+        resetDisabled: vi.fn(),
+        activate: vi.fn(),
+        deactivate: vi.fn(),
+        setDisabled: vi.fn(),
+        defaultLabel: { value: '' },
+        allowWithoutEditor: { value: false },
+      },
+      {
+        name: { value: 'fontFamily' },
+        resetDisabled: vi.fn(),
+        activate: vi.fn(),
+        deactivate: vi.fn(),
+        setDisabled: vi.fn(),
+        defaultLabel: { value: '' },
+        allowWithoutEditor: { value: false },
+      },
+      {
+        name: { value: 'lineHeight' },
+        resetDisabled: vi.fn(),
+        activate: vi.fn(),
+        deactivate: vi.fn(),
+        setDisabled: vi.fn(),
+        selectedValue: { value: '' },
+        allowWithoutEditor: { value: false },
+      },
+      {
+        name: { value: 'highlight' },
+        resetDisabled: vi.fn(),
+        activate: vi.fn(),
+        deactivate: vi.fn(),
+        setDisabled: vi.fn(),
+        nestedOptions: { value: [] },
+        allowWithoutEditor: { value: false },
+      },
+    ];
+
+    // Set active editor
+    toolbar.activeEditor = mockEditor;
+    toolbar.documentMode = 'editing';
+  });
+
+  it.skip('should update toolbar state with active formatting marks', () => {
+    // Setup mock active formatting
+    mockGetActiveFormatting.mockReturnValue([
+      { name: 'bold', attrs: {} },
+      { name: 'italic', attrs: { } },
+    ]);
+
+    mockIsInTable.mockReturnValue(false);
+    mockGetQuickFormatList.mockReturnValue(['style1', 'style2']);
+
+    // Call the method
+    toolbar.updateToolbarState();
+
+    // Verify that toolbar items were updated correctly
+    expect(toolbar.toolbarItems[0].resetDisabled).toHaveBeenCalled(); 
+    expect(toolbar.toolbarItems[0].activate).toHaveBeenCalledWith({}); // bold
+    expect(toolbar.toolbarItems[1].resetDisabled).toHaveBeenCalled(); 
+    expect(toolbar.toolbarItems[1].activate).toHaveBeenCalledWith({}); // italic
+
+    // Verify that getActiveFormatting was called
+    expect(mockGetActiveFormatting).toHaveBeenCalledWith(mockEditor);
+  });
+
+  it.skip('should deactivate toolbar items when no active editor', () => {
+    // Set no active editor
+    toolbar.activeEditor = null;
+
+    // Call the method
+    toolbar.updateToolbarState();
+
+    // Verify that all toolbar items are disabled
+    toolbar.toolbarItems.forEach(item => {
+      expect(item.setDisabled).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it.skip('should deactivate toolbar items when in viewing mode', () => {
+    // Set viewing mode
+    toolbar.documentMode = 'viewing';
+
+    // Call the method
+    toolbar.updateToolbarState();
+
+
+    // Verify that all toolbar items are disabled
+    toolbar.toolbarItems.forEach(item => {
+      expect(item.setDisabled).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('should prioritize active mark over linked styles (font family)', () => {
+    // Setup mock active formatting (font family)
+    mockGetActiveFormatting.mockReturnValue([
+      { name: 'fontFamily', attrs: { fontFamily: 'Roboto' } },
+      { name: 'styleId', attrs: { styleId: 'test-style' } },
+    ]);
+
+    // Setup mock linked styles
+    mockEditor.converter.linkedStyles = [
+      {
+        id: 'test-style',
+        definition: { styles: { 'font-family': 'Arial' } },
+      },
+    ];
+
+    // Call the method
+    toolbar.updateToolbarState();
+
+    // Verify that the active mark was prioritized
+    const fontFamilyItem = toolbar.toolbarItems.find(item => item.name.value === 'fontFamily');
+    expect(fontFamilyItem.activate).toHaveBeenCalledWith({ fontFamily: 'Roboto' });
+    expect(fontFamilyItem.activate).not.toHaveBeenCalledWith({ fontFamily: 'Arial' });
+  });
+
+  it('should prioritize active mark over linked styles (font size)', () => {
+    // Setup mock active formatting (font size)
+    mockGetActiveFormatting.mockReturnValue([
+      { name: 'fontSize', attrs: { fontSize: '20pt' } },
+      { name: 'styleId', attrs: { styleId: 'test-style' } },
+    ]);
+
+    // Setup mock linked styles
+    mockEditor.converter.linkedStyles = [
+      {
+        id: 'test-style',
+        definition: { styles: { 'font-size': '14pt' } },
+      },
+    ];
+
+    // Call the method
+    toolbar.updateToolbarState();
+
+    // Verify that the active mark was prioritized
+    const fontSizeItem = toolbar.toolbarItems.find(item => item.name.value === 'fontSize'); 
+    expect(fontSizeItem.activate).toHaveBeenCalledWith({ fontSize: '20pt' });
+    expect(fontSizeItem.activate).not.toHaveBeenCalledWith({ fontSize: '14pt' });
+  });
+});

--- a/packages/super-editor/src/tests/toolbar/updateToolbarState.test.js
+++ b/packages/super-editor/src/tests/toolbar/updateToolbarState.test.js
@@ -149,7 +149,7 @@ describe('updateToolbarState', () => {
     toolbar.documentMode = 'editing';
   });
 
-  it.skip('should update toolbar state with active formatting marks', () => {
+  it('should update toolbar state with active formatting marks', () => {
     // Setup mock active formatting
     mockGetActiveFormatting.mockReturnValue([
       { name: 'bold', attrs: {} },
@@ -172,7 +172,7 @@ describe('updateToolbarState', () => {
     expect(mockGetActiveFormatting).toHaveBeenCalledWith(mockEditor);
   });
 
-  it.skip('should deactivate toolbar items when no active editor', () => {
+  it('should deactivate toolbar items when no active editor', () => {
     // Set no active editor
     toolbar.activeEditor = null;
 
@@ -185,7 +185,7 @@ describe('updateToolbarState', () => {
     });
   });
 
-  it.skip('should deactivate toolbar items when in viewing mode', () => {
+  it('should deactivate toolbar items when in viewing mode', () => {
     // Set viewing mode
     toolbar.documentMode = 'viewing';
 

--- a/packages/super-editor/src/tests/toolbar/updateToolbarState.test.js
+++ b/packages/super-editor/src/tests/toolbar/updateToolbarState.test.js
@@ -22,10 +22,8 @@ describe('updateToolbarState', () => {
   let mockGetQuickFormatList;
 
   beforeEach(async () => {
-    // Reset all mocks
     vi.clearAllMocks();
 
-    // Setup mock editor
     mockEditor = {
       state: {},
       commands: {
@@ -49,12 +47,10 @@ describe('updateToolbarState', () => {
       on: vi.fn(),
     };
 
-    // Setup mock functions
     mockGetActiveFormatting = vi.fn();
     mockIsInTable = vi.fn();
     mockGetQuickFormatList = vi.fn().mockReturnValue([]);
 
-    // Import the mocked functions
     const { getActiveFormatting } = await import('@core/helpers/getActiveFormatting.js');
     const { isInTable } = await import('@helpers/isInTable.js');
     const { getQuickFormatList } = await import('@extensions/linked-styles/linked-styles.js');
@@ -63,7 +59,6 @@ describe('updateToolbarState', () => {
     isInTable.mockImplementation(mockIsInTable);
     getQuickFormatList.mockImplementation(mockGetQuickFormatList);
 
-    // Create toolbar instance
     toolbar = new SuperToolbar({
       selector: '#test-toolbar',
       editor: mockEditor,
@@ -71,7 +66,6 @@ describe('updateToolbarState', () => {
     });
 
     
-    // Mock toolbar items
     toolbar.toolbarItems = [
       {
         name: { value: 'bold' },
@@ -144,13 +138,11 @@ describe('updateToolbarState', () => {
       },
     ];
 
-    // Set active editor
     toolbar.activeEditor = mockEditor;
     toolbar.documentMode = 'editing';
   });
 
   it('should update toolbar state with active formatting marks', () => {
-    // Setup mock active formatting
     mockGetActiveFormatting.mockReturnValue([
       { name: 'bold', attrs: {} },
       { name: 'italic', attrs: { } },
@@ -159,54 +151,42 @@ describe('updateToolbarState', () => {
     mockIsInTable.mockReturnValue(false);
     mockGetQuickFormatList.mockReturnValue(['style1', 'style2']);
 
-    // Call the method
     toolbar.updateToolbarState();
 
-    // Verify that toolbar items were updated correctly
     expect(toolbar.toolbarItems[0].resetDisabled).toHaveBeenCalled(); 
     expect(toolbar.toolbarItems[0].activate).toHaveBeenCalledWith({}); // bold
     expect(toolbar.toolbarItems[1].resetDisabled).toHaveBeenCalled(); 
     expect(toolbar.toolbarItems[1].activate).toHaveBeenCalledWith({}); // italic
 
-    // Verify that getActiveFormatting was called
     expect(mockGetActiveFormatting).toHaveBeenCalledWith(mockEditor);
   });
 
   it('should deactivate toolbar items when no active editor', () => {
-    // Set no active editor
     toolbar.activeEditor = null;
 
-    // Call the method
     toolbar.updateToolbarState();
 
-    // Verify that all toolbar items are disabled
     toolbar.toolbarItems.forEach(item => {
       expect(item.setDisabled).toHaveBeenCalledWith(true);
     });
   });
 
   it('should deactivate toolbar items when in viewing mode', () => {
-    // Set viewing mode
     toolbar.documentMode = 'viewing';
 
-    // Call the method
     toolbar.updateToolbarState();
 
-
-    // Verify that all toolbar items are disabled
     toolbar.toolbarItems.forEach(item => {
       expect(item.setDisabled).toHaveBeenCalledWith(true);
     });
   });
 
   it('should prioritize active mark over linked styles (font family)', () => {
-    // Setup mock active formatting (font family)
     mockGetActiveFormatting.mockReturnValue([
       { name: 'fontFamily', attrs: { fontFamily: 'Roboto' } },
       { name: 'styleId', attrs: { styleId: 'test-style' } },
     ]);
 
-    // Setup mock linked styles
     mockEditor.converter.linkedStyles = [
       {
         id: 'test-style',
@@ -214,23 +194,19 @@ describe('updateToolbarState', () => {
       },
     ];
 
-    // Call the method
     toolbar.updateToolbarState();
 
-    // Verify that the active mark was prioritized
     const fontFamilyItem = toolbar.toolbarItems.find(item => item.name.value === 'fontFamily');
     expect(fontFamilyItem.activate).toHaveBeenCalledWith({ fontFamily: 'Roboto' });
     expect(fontFamilyItem.activate).not.toHaveBeenCalledWith({ fontFamily: 'Arial' });
   });
 
   it('should prioritize active mark over linked styles (font size)', () => {
-    // Setup mock active formatting (font size)
     mockGetActiveFormatting.mockReturnValue([
       { name: 'fontSize', attrs: { fontSize: '20pt' } },
       { name: 'styleId', attrs: { styleId: 'test-style' } },
     ]);
 
-    // Setup mock linked styles
     mockEditor.converter.linkedStyles = [
       {
         id: 'test-style',
@@ -238,10 +214,8 @@ describe('updateToolbarState', () => {
       },
     ];
 
-    // Call the method
     toolbar.updateToolbarState();
 
-    // Verify that the active mark was prioritized
     const fontSizeItem = toolbar.toolbarItems.find(item => item.name.value === 'fontSize'); 
     expect(fontSizeItem.activate).toHaveBeenCalledWith({ fontSize: '20pt' });
     expect(fontSizeItem.activate).not.toHaveBeenCalledWith({ fontSize: '14pt' });


### PR DESCRIPTION
- Ensure linked styles doesn't override the active mark
- Add initial tests for the toolbar