### PR TITLE
feat: add disableContextMenu option to SuperDoc

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -254,7 +254,7 @@ onBeforeUnmount(() => {
       @mousedown="handleMarginClick"
     >
       <div ref="editorElem" class="editor-element super-editor__element" role="presentation"></div>
-      <SlashMenu v-if="editorReady && editor" :editor="editor" :popoverControls="popoverControls" :openPopover="openPopover" :closePopover="closePopover" />
+      <SlashMenu v-if="!props.options.disableContextMenu && editorReady && editor" :editor="editor" :popoverControls="popoverControls" :openPopover="openPopover" :closePopover="closePopover" />
     </div>
 
     <div class="placeholder-editor" v-if="!editorReady">

--- a/packages/super-editor/src/extensions/slash-menu/slash-menu.js
+++ b/packages/super-editor/src/extensions/slash-menu/slash-menu.js
@@ -33,6 +33,9 @@ export const SlashMenu = Extension.create({
   name: 'slashMenu',
 
   addPmPlugins() {
+    if (this.editor.options?.disableContextMenu) {
+      return [];
+    }
     const editor = this.editor;
 
     // Cooldown flag and timeout for slash menu

--- a/packages/superdoc/src/SuperDoc.vue
+++ b/packages/superdoc/src/SuperDoc.vue
@@ -288,6 +288,7 @@ const editorOptions = (doc) => {
     telemetry: proxy.$superdoc.telemetry,
     externalExtensions: proxy.$superdoc.config.editorExtensions || [],
     suppressDefaultDocxStyles: proxy.$superdoc.config.suppressDefaultDocxStyles,
+    disableContextMenu: proxy.$superdoc.config.disableContextMenu,
     jsonOverride: proxy.$superdoc.config.jsonOverride,
   };
 

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -106,6 +106,7 @@ import { initSuperdocYdoc, initCollaborationComments, makeDocumentsCollaborative
  * @property {boolean} [rulers] Whether to show the ruler in the editor
  * @property {boolean} [suppressDefaultDocxStyles] Whether to suppress default styles in docx mode
  * @property {boolean} [jsonOverride] Whether to override content with provided JSON
+ * @property {boolean} [disableContextMenu] Whether to disable slash / right-click custom context menu
  */
 
 /**
@@ -185,6 +186,9 @@ export class SuperDoc extends EventEmitter {
     // Image upload handler
     // async (file) => url;
     handleImageUpload: null,
+
+    // Disable context menus (slash and right-click) globally
+    disableContextMenu: false,
   };
 
   /**

--- a/packages/superdoc/src/dev/components/SuperdocDev.vue
+++ b/packages/superdoc/src/dev/components/SuperdocDev.vue
@@ -56,6 +56,7 @@ const init = async () => {
     annotations: true,
     isInternal,
     telemetry: false,
+    // disableContextMenu: true,
     // format: 'docx',
     // html: '<p>Hello world</p>',
     // isDev: true,


### PR DESCRIPTION
- Do not install plugin if headless or disabled
- Do not render slash menu if disable flag exists in SuperDoc config