### PR TITLE
HAR-9972 - SuperDoc freezing after edit

### DIFF
--- a/packages/super-editor/src/extensions/collaboration/collaboration.js
+++ b/packages/super-editor/src/extensions/collaboration/collaboration.js
@@ -25,8 +25,6 @@ export const Collaboration = Extension.create({
     this.options.ydoc = this.editor.options.ydoc;
     const undoPlugin = createUndoPlugin();
 
-    // Listen for document lock changes
-    initDocumentLockHandler(this.options.ydoc, this.editor);
     initSyncListener(this.options.ydoc, this.editor, this);
     initDocumentListener({ ydoc: this.options.ydoc, editor: this.editor });
 


### PR DESCRIPTION
Problem: Editor becomes uneditable every time a couple seconds after you make a change. This is happening because we're locking it, even though we shouldn't.

Fix: Since this is happening with customers at the moment, we need some more time to investigate and do a proper fix. I'm proposing we release a new version at least so we can unblock our customers and have some more time to investigate how to put back the locking mechanism. 