### PR TITLE
Paragraph lists v2 migrations, copy paste handling of lists from html…

### DIFF
--- a/packages/super-editor/src/core/InputRule.js
+++ b/packages/super-editor/src/core/InputRule.js
@@ -1,11 +1,12 @@
 import { Plugin, PluginKey } from 'prosemirror-state';
-import { Fragment, DOMParser } from 'prosemirror-model';
+import { Fragment, DOMParser as PMDOMParser } from 'prosemirror-model';
 import { CommandService } from './CommandService.js';
 import { chainableEditorState } from './helpers/chainableEditorState.js';
 import { getHTMLFromFragment } from './helpers/getHTMLFromFragment.js';
 import { getTextContentFromNodes } from './helpers/getTextContentFromNodes.js';
 import { isRegExp } from './utilities/isRegExp.js';
 import { handleDocxPaste } from './inputRules/docx-paste/docx-paste.js';
+import { flattenListsInHtml } from './inputRules/html/html-helpers.js';
 
 
 export class InputRule {
@@ -244,9 +245,11 @@ export function isWordHtml(html) {
  * @returns {Boolean} Returns true if the paste was handled.
  */
 export function handleHtmlPaste(html, editor) {
-  const htmlWithPtSizing = convertEmToPt(html);
+  const flatHtml = flattenListsInHtml(html, editor);
+
+  const htmlWithPtSizing = convertEmToPt(flatHtml);
   const cleanedHtml = sanitizeHtml(htmlWithPtSizing);
-  const doc = DOMParser.fromSchema(editor.schema).parse(cleanedHtml);
+  const doc = PMDOMParser.fromSchema(editor.schema).parse(cleanedHtml);
 
   const { dispatch, state } = editor.view;
   if (!dispatch) return false;

--- a/packages/super-editor/src/core/child-editor/child-editor.js
+++ b/packages/super-editor/src/core/child-editor/child-editor.js
@@ -1,0 +1,63 @@
+import { Editor } from '../Editor.js';
+
+/**
+ * Creates a linked child editor based on the current editor.
+ * This function checks if the current editor is already a child editor,
+ * and if not, it creates a new editor instance with the specified options.
+ * The new editor will have pagination disabled and will link to the parent editor's list definitions change handler.
+ * @param {Editor} currentEditor - The current editor instance to link to.
+ * @param {Object} [options={}] - Additional options to override the default editor options.
+ * @returns {Editor} A new child editor instance linked to the current editor.
+ */
+export const createLinkedChildEditor = (currentEditor, options = {}) => {
+  if (currentEditor.options.isChildEditor) {
+    return null;
+  }
+
+  const editor = new Editor({
+    ...currentEditor.options,
+    pagination: false,
+    suppressDefaultDocxStyles: true,
+    ydoc: null,
+    collaborationProvider: null,
+    fileSource: null,
+    initialState: null,
+    documentId: null,
+    isCommentsEnabled: false,
+    isNewFile: false,
+    fragment: false,
+    onCreate: () => null,
+    onListDefinitionsChange: linkListDefinitionsChange,
+
+    // Options overrides
+    ...options,
+    isChildEditor: true,
+    parentEditor: currentEditor,
+  });
+
+  return editor;
+}
+
+/**
+ * Default handler for when the list definitions change in a linked child editor.
+ * This function updates the parent editor's converter with the new numbering definitions
+ * and dispatches a transaction to update the list item node views.
+ * @param {Object} options - The options object containing the editor, change, and numbering.
+ * @param {Editor} options.editor - The parent editor instance.
+ * @param {Object} options.change - The change object containing the new numbering definitions.
+ * @param {Object} options.numbering - The new numbering definitions to be applied.
+ * @returns {void}
+ */
+const linkListDefinitionsChange = (options) => {
+  const { editor, numbering } = options;
+  const { parentEditor = {} } = editor.options;
+  const { converter: parentConverter } = parentEditor;
+  if (!parentConverter) return;
+
+  parentConverter.numbering = numbering;
+
+  const { tr } = parentEditor.state;
+  const { dispatch } = parentEditor.view;
+  tr.setMeta('updatedListItemNodeViews', true);
+  dispatch(tr);
+};

--- a/packages/super-editor/src/core/child-editor/index.js
+++ b/packages/super-editor/src/core/child-editor/index.js
@@ -1,0 +1,1 @@
+export * from './child-editor.js';

--- a/packages/super-editor/src/core/helpers/list-numbering-helpers.js
+++ b/packages/super-editor/src/core/helpers/list-numbering-helpers.js
@@ -43,6 +43,10 @@ export const generateNewListDefinition = ({ numId, listType, editor }) => {
   // Update the editor's numbering with the new definition
   editor.converter.numbering = newNumbering;
 
+  // Emit a change to numbering event
+  const change = { numDef: newNumDef, abstractDef: newAbstractDef, editor }
+  editor.emit('list-definitions-change', { change, numbering: newNumbering, editor });
+
   return { abstract: newAbstractDef, definition: newNumDef };
 };
 
@@ -355,6 +359,10 @@ export const insertNewList = (tr, replaceFrom, replaceTo, listNode, marks = []) 
  */
 export const getListItemStyleDefinitions = ({ styleId, node, numId, level, editor, tries }) => {  
   if (tries) return {};
+
+  if (typeof numId === 'string') numId = Number(numId);
+  if (typeof level === 'string') level = Number(level);
+
   const docx = { ...editor?.converter?.convertedXml };
   const newNumbering = { ...editor?.converter?.numbering };
 

--- a/packages/super-editor/src/core/inputRules/html/html-helpers.js
+++ b/packages/super-editor/src/core/inputRules/html/html-helpers.js
@@ -1,0 +1,208 @@
+import { ListHelpers } from '@helpers/list-numbering-helpers.js';
+import { generateOrderedListIndex } from '@helpers/orderedListUtils.js';
+
+/**
+ * Flattens ALL lists to ensure each list contains exactly ONE list item.
+ * Handles both multi-item lists and nested lists.
+ */
+export function flattenListsInHtml(html, editor) {  
+  // pick the right parser & Node interface
+  let parser, NodeInterface;
+  if (editor.options.mockDocument) {
+    const win = editor.options.mockDocument.defaultView;
+    parser = new win.DOMParser();
+    NodeInterface = win.Node;
+  } else {
+    parser = new DOMParser();
+    NodeInterface = window.Node;
+  }
+
+  const doc = parser.parseFromString(html, 'text/html');
+
+  // Keep processing until all lists are flattened
+  let foundList;
+  while ((foundList = findListToFlatten(doc))) {
+    flattenFoundList(foundList, editor, NodeInterface);
+  }
+
+  return doc.body.innerHTML;
+}
+
+/**
+ * Finds the first list that needs flattening:
+ * 1. Lists without data-list-id (completely unprocessed)
+ * 2. Lists with more than one <li> child
+ * 3. Lists with nested lists inside them
+ */
+function findListToFlatten(doc) {
+  // First priority: unprocessed lists
+  let list = doc.querySelector('ol:not([data-list-id]), ul:not([data-list-id])');
+  if (list) return list;
+  
+  // Second priority: lists with multiple items
+  const allLists = doc.querySelectorAll('ol[data-list-id], ul[data-list-id]');
+  for (const list of allLists) {
+    const liChildren = Array.from(list.children).filter(c => c.tagName.toLowerCase() === 'li');
+    if (liChildren.length > 1) {
+      return list;
+    }
+    
+    // Third priority: lists with nested lists
+    const nestedLists = list.querySelectorAll('ol, ul');
+    if (nestedLists.length > 0) {
+      return list;
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Flattens a single list by:
+ * 1. Ensuring it has proper data-list-id
+ * 2. Splitting multi-item lists into single-item lists
+ * 3. Extracting nested lists and processing them recursively
+ */
+function flattenFoundList(listElem, editor, NodeInterface) {
+  const localDoc = listElem.ownerDocument;
+  const tag = listElem.tagName.toLowerCase();
+  
+  // Ensure the list has a data-list-id
+  let rootNumId = listElem.getAttribute('data-list-id');
+  if (!rootNumId) {
+    rootNumId = ListHelpers.getNewListId(editor);
+    ListHelpers.generateNewListDefinition({
+      numId: rootNumId,
+      listType: tag === 'ol' ? 'orderedList' : 'bulletList',
+      editor,
+    });
+  }
+  
+  // Calculate the level of this list
+  let level = 0;
+  let ancestor = listElem.parentElement;
+  while (ancestor && ancestor !== localDoc.body) {
+    if (ancestor.tagName && ancestor.tagName.toLowerCase() === 'li') {
+      level++;
+    }
+    ancestor = ancestor.parentElement;
+  }
+  
+  // Get all direct <li> children
+  const items = Array.from(listElem.children).filter(
+    c => c.tagName.toLowerCase() === 'li'
+  );
+  
+  // Create single-item lists for each item
+  const newLists = [];
+  
+  items.forEach((li, index) => {
+    // Extract any nested lists first
+    const nestedLists = Array.from(li.querySelectorAll('ol, ul'));
+    const nestedListsData = nestedLists.map(nl => ({
+      element: nl.cloneNode(true),
+      parent: nl.parentNode
+    }));
+    
+    // Remove nested lists from the li
+    nestedLists.forEach(nl => nl.parentNode.removeChild(nl));
+    
+    // Create a new single-item list for this li
+    const newList = createSingleItemList(li, tag, rootNumId, level, editor, NodeInterface);
+    newLists.push(newList);
+    
+    // Add the nested lists (they'll be processed in the next iteration)
+    nestedListsData.forEach(data => {
+      newLists.push(data.element);
+    });
+  });
+  
+  // Replace the original list with the new single-item lists
+  const parent = listElem.parentNode;
+  const nextSibling = listElem.nextSibling;
+  parent.removeChild(listElem);
+  
+  newLists.forEach(list => {
+    parent.insertBefore(list, nextSibling);
+  });
+}
+
+/**
+ * Creates a single-item list from an <li> element
+ */
+function createSingleItemList(li, tag, rootNumId, level, editor, NodeInterface) {
+  const localDoc = li.ownerDocument;
+  const ELEMENT_NODE = NodeInterface.ELEMENT_NODE;
+  const TEXT_NODE = NodeInterface.TEXT_NODE;
+  
+  // Create new list and list item
+  const newList = localDoc.createElement(tag);
+  const newLi = localDoc.createElement('li');
+  
+  // Copy attributes from original li (except the ones we'll set ourselves)
+  Array.from(li.attributes).forEach(attr => {
+    if (!attr.name.startsWith('data-num-') && !attr.name.startsWith('data-level') && !attr.name.startsWith('data-list-')) {
+      newLi.setAttribute(attr.name, attr.value);
+    }
+  });
+  
+  // Set list attributes
+  newList.setAttribute('data-list-id', rootNumId);
+  
+  // Set list item attributes
+  newLi.setAttribute('data-num-id', rootNumId);
+  newLi.setAttribute('data-level', String(level));
+  
+  // Get numbering info
+  const { listNumberingType, lvlText } = ListHelpers.getListDefinitionDetails({
+    numId: rootNumId,
+    level,
+    editor,
+  });
+  
+  newLi.setAttribute('data-num-fmt', listNumberingType);
+  newLi.setAttribute('data-lvl-text', lvlText || '');
+  newLi.setAttribute('data-list-level', JSON.stringify([level + 1]));
+  
+  // Copy content from original li
+  Array.from(li.childNodes).forEach(node => {
+    if (node.nodeType === ELEMENT_NODE || 
+        (node.nodeType === TEXT_NODE && node.textContent.trim())) {
+      newLi.appendChild(node.cloneNode(true));
+    }
+  });
+  
+  // Handle case where li only contains text
+  if (newLi.childNodes.length === 0 || 
+      (newLi.childNodes.length === 1 && newLi.childNodes[0].nodeType === TEXT_NODE)) {
+    const textContent = newLi.textContent.trim();
+    if (textContent) {
+      newLi.innerHTML = '';
+      const p = localDoc.createElement('p');
+      p.textContent = textContent;
+      newLi.appendChild(p);
+    }
+  }
+  
+  newList.appendChild(newLi);
+  return newList;
+}
+
+// Keep the original function signature for backwards compatibility
+export function flattenSingleList(listElem, editor, level = 0, parentNumId, NodeInterface) {
+  // This function is now just a wrapper that calls the main flattening logic
+  const results = [];
+  const tempDiv = listElem.ownerDocument.createElement('div');
+  tempDiv.appendChild(listElem.cloneNode(true));
+  
+  const flattened = flattenListsInHtml(tempDiv.innerHTML, editor);
+  const tempDoc = new DOMParser().parseFromString(flattened, 'text/html');
+  
+  Array.from(tempDoc.body.children).forEach(child => {
+    if (child.tagName && (child.tagName.toLowerCase() === 'ol' || child.tagName.toLowerCase() === 'ul')) {
+      results.push(child);
+    }
+  });
+  
+  return results;
+}

--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -21,6 +21,9 @@ import { baseBulletList, baseOrderedListDef } from './v2/exporter/helpers/base-l
 import { translateCommentNode } from './v2/exporter/commentsExporter.js';
 import { createColGroup } from '@extensions/table/tableHelpers/createColGroup.js';
 import { sanitizeHtml } from '../InputRule.js';
+import { ListHelpers } from '@helpers/list-numbering-helpers.js';
+import { flattenListsInHtml } from '@core/inputRules/html/html-helpers.js';
+
 
 /**
  * @typedef {Object} ExportParams
@@ -776,10 +779,19 @@ function addNewImageRelationship(params, imagePath) {
  * @returns {XmlReadyNode} The translated list node
  */
 function translateList(params) {
-  const { node } = params;
+  const { node, editor } = params;
 
   const listItem = node.content[0];
   const { numId, level } = listItem.attrs;
+  const listType = node.type.name;
+  const listDef = ListHelpers.getListDefinitionDetails({ numId, level, listType, editor });
+  if (!listDef) {
+    ListHelpers.generateNewListDefinition({
+      numId,
+      listType,
+      editor,
+    })
+  }
 
   let numPrTag;
 

--- a/packages/super-editor/src/extensions/field-annotation/FieldAnnotationView.js
+++ b/packages/super-editor/src/extensions/field-annotation/FieldAnnotationView.js
@@ -134,6 +134,19 @@ export class FieldAnnotationView {
 
   buildHTMLView() {
     let { displayLabel, rawHtml } = this.node.attrs;
+  
+    if (!this.editor.options.isHeadless && !!rawHtml) {
+      try {
+        const tempDiv = document.createElement('div');
+        const childEditor = this.editor.createChildEditor({
+          element: tempDiv,
+          html: rawHtml,
+        });
+        rawHtml = childEditor.view.dom.innerHTML;
+      } catch (error) {
+        console.warn('Error parsing HTML in FieldAnnotationView:', error);
+      }
+    }
 
     let { annotation, content } = this.#createAnnotation();
 
@@ -304,3 +317,4 @@ export class FieldAnnotationView {
     });
   }
 }
+

--- a/packages/super-editor/src/extensions/list-item/list-item.js
+++ b/packages/super-editor/src/extensions/list-item/list-item.js
@@ -140,25 +140,28 @@ export const ListItem = Node.create({
         keepOnSplit: true,
         default: null,
         parseDOM: (elem) => elem.getAttribute('data-num-id'),
+        renderDOM: (attrs) => {
+          if (!attrs.numId) return {};
+          return {
+            'data-num-id': attrs.numId,
+          };
+        }
       },
 
       numPrType: {
         rendered: false,
-        default: null,
+        default: 'inline',
         keepOnSplit: true,
       },
 
       level: {
-        default: null,
-        rendered: false,
-        keepOnSplit: true,
         parseDOM: (elem) => {
-          return elem.getAttribute('data-item-level');
+          return elem.getAttribute('data-level');
         },
         renderDOM: (attrs) => {
-          if (!attrs.level) return {};
+          if (attrs.level === undefined || attrs.level === null) return {};
           return {
-            'data-item-level': JSON.stringify(attrs.level),
+            'data-level': JSON.stringify(attrs.level),
           };
         },
       },
@@ -223,7 +226,7 @@ export const ListItem = Node.create({
 
   addShortcuts() {
     return {
-
+ 
       Enter: () => {
         return this.editor.commands.splitListItem();
       },

--- a/packages/super-editor/src/extensions/ordered-list/helpers/orderedListSyncPlugin.js
+++ b/packages/super-editor/src/extensions/ordered-list/helpers/orderedListSyncPlugin.js
@@ -1,19 +1,26 @@
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { docxNumberigHelpers } from '@core/super-converter/v2/importer/listImporter.js';
 import { ListHelpers } from '@helpers/list-numbering-helpers.js';
+import { refreshAllListItemNodeViews } from '@extensions/list-item/ListItemNodeView.js';
 
 export const orderedListSyncPluginKey = new PluginKey('orderedListSync');
 
 export function orderedListSync(editor) {
+  let hasInitialized = false;
   const docx = editor.converter.convertedXml;
   return new Plugin({
     key: orderedListSyncPluginKey,
 
     appendTransaction(transactions, oldState, newState) {
-      const isFromPlugin = transactions.some(tr => tr.getMeta('orderedListSync'));
-      if (isFromPlugin || !transactions.some(tr => tr.docChanged)) {
+      const updateNodeViews = transactions.some((tr) => tr.getMeta('updatedListItemNodeViews'));
+      if (updateNodeViews || !hasInitialized) refreshAllListItemNodeViews();
+
+      const isFromPlugin = transactions.some((tr) => tr.getMeta('orderedListSync'));
+      if (isFromPlugin || !transactions.some((tr) => tr.docChanged)) {
         return null;
       };
+
+      hasInitialized = true;
 
       const tr = newState.tr;
       tr.setMeta('orderedListSync', true);

--- a/packages/superdoc/src/SuperDoc.vue
+++ b/packages/superdoc/src/SuperDoc.vue
@@ -253,6 +253,10 @@ const onEditorException = ({ error, editor }) => {
   proxy.$superdoc.emit('exception', { error, editor });
 };
 
+const onEditorListdefinitionsChange = (params) => {
+  proxy.$superdoc.emit('list-definitions-change', params);
+};
+
 const editorOptions = (doc) => {
   const options = {
     pagination: proxy.$superdoc.config.pagination,
@@ -281,6 +285,7 @@ const editorOptions = (doc) => {
     onCommentsLoaded,
     onCommentsUpdate: onEditorCommentsUpdate,
     onCommentLocationsUpdate: onEditorCommentLocationsUpdate,
+    onListDefinitionsChange: onEditorListdefinitionsChange,
     ydoc: doc.ydoc,
     collaborationProvider: doc.provider || null,
     isNewFile: doc.isNewFile || false,

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -94,6 +94,7 @@ import { initSuperdocYdoc, initCollaborationComments, makeDocumentsCollaborative
  * @property {(params: { editor: Editor }) => void} [onEditorUpdate] Callback when document is updated
  * @property {(params: { error: Error }) => void} [onException] Callback when an exception is thrown
  * @property {(params: { isRendered: boolean }) => void} [onCommentsListChange] Callback when the comments list is rendered
+ * @property {(params: {})} [onListDefinitionsChange] Callback when the list definitions change
  * @property {string} [format] The format of the document (docx, pdf, html)
  * @property {Object[]} [editorExtensions] The extensions to load for the editor
  * @property {boolean} [isInternal] Whether the SuperDoc is internal
@@ -182,6 +183,7 @@ export class SuperDoc extends EventEmitter {
     onEditorUpdate: () => null,
     onCommentsListChange: () => null,
     onException: () => null,
+    onListDefinitionsChange: () => null,
 
     // Image upload handler
     // async (file) => url;
@@ -340,6 +342,7 @@ export class SuperDoc extends EventEmitter {
     this.on('editor-update', this.config.onEditorUpdate);
     this.on('content-error', this.onContentError);
     this.on('exception', this.config.onException);
+    this.on('list-definitions-change', this.config.onListDefinitionsChange);
   }
 
   /**


### PR DESCRIPTION
- Adds migration tool for lists in html fields
- HTML must be migrated before being previewed in fields, if necessary
- Adds "child editor" concept of linked editors
- Migration tweaks
- List item node view tweaks, field annotation view change for html view