### PR TITLE
fix: wrong anchor image position in header (HAR-9893)

### DIFF
--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -250,6 +250,8 @@ export class Editor extends EventEmitter {
     isCustomXmlChanged: false,
 
     focusTarget: null,
+
+    parentEditor: null,
   };
 
   /**

--- a/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
@@ -1,6 +1,6 @@
 import { getInitialJSON } from '../docxHelper.js';
 import { carbonCopy } from '../../../utilities/carbonCopy.js';
-import { twipsToInches } from '../../helpers.js';
+import { twipsToInches, twipsToPixels } from '../../helpers.js';
 import { DEFAULT_LINKED_STYLES } from '../../exporter-docx-defs.js';
 import { tableNodeHandlerEntity } from './tableImporter.js';
 import { drawingNodeHandlerEntity } from './imageImporter.js';
@@ -189,6 +189,7 @@ const createNodeListHandler = (nodeHandlers) => {
     filename,
     parentStyleId,
     lists,
+    mainParent,
   }) => {
     if (!elements || !elements.length) return [];
 
@@ -216,6 +217,7 @@ const createNodeListHandler = (nodeHandlers) => {
                 filename,
                 parentStyleId,
                 lists,
+                mainParent,
               });
             },
             { nodes: [], consumed: 0 },
@@ -324,6 +326,8 @@ function getDocumentStyles(node, docx, converter, editor) {
           header: twipsToInches(attributes['w:header']),
           footer: twipsToInches(attributes['w:footer']),
           gutter: twipsToInches(attributes['w:gutter']),
+          topPx: twipsToPixels(attributes['w:top']),
+          leftPx: twipsToPixels(attributes['w:left']),
         };
         break;
       case 'w:cols':

--- a/packages/super-editor/src/core/super-converter/v2/importer/imageImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/imageImporter.js
@@ -93,6 +93,7 @@ export function handleImageImport(node, currentFileName, params) {
       vRelativeFrom,
       alignH,
       alignV,
+      parent: params.mainParent?.name,
     };
   }
 

--- a/packages/super-editor/src/core/super-converter/v2/importer/tableImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/tableImporter.js
@@ -231,7 +231,7 @@ export function handleTableCellNode(node, row, table, rowBorders, columnWidth = 
 
   return {
     type: 'tableCell',
-    content: nodeListHandler.handler({ ...params, nodes: node.elements }),
+    content: nodeListHandler.handler({ ...params, nodes: node.elements, mainParent: node }),
     attrs: attributes,
   };
 }


### PR DESCRIPTION
Hi @harbournick!. Vivienne experienced issues with header anchor images which are placed outside of the table structure. 
The main issue is that Word treats those images like ones which are attached to the document not header. I did some fix but it's still not ideal since image is cut and plugin applied only when header is activated. Let's talk about this one once you're back. Attaching video of how it works

https://github.com/user-attachments/assets/5565610b-c05b-4e06-9617-cd5c5054dd98

