### PR TITLE
fix: select whole doc

### DIFF
--- a/packages/super-editor/src/assets/styles/elements/prosemirror.css
+++ b/packages/super-editor/src/assets/styles/elements/prosemirror.css
@@ -354,6 +354,6 @@ https://github.com/ProseMirror/prosemirror-tables/blob/master/demo/index.html
   background-color: #ff6a0054;
 }
 
-.ProseMirror ::selection {
+.ProseMirror span::selection {
   background: transparent;
 }

--- a/packages/super-editor/src/extensions/custom-selection/custom-selection.js
+++ b/packages/super-editor/src/extensions/custom-selection/custom-selection.js
@@ -1,5 +1,5 @@
 import { Extension } from '@core/Extension.js';
-import { Plugin, PluginKey, TextSelection } from 'prosemirror-state';
+import { AllSelection, Plugin, PluginKey, TextSelection } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
 
 export const CustomSelectionPluginKey = new PluginKey('CustomSelection');
@@ -12,15 +12,15 @@ export const CustomSelection = Extension.create({
       key: CustomSelectionPluginKey,
 
       state: {
-        init(_, { doc }) {
+        init() {
           return DecorationSet.empty;
         },
         apply(tr, oldDecorationSet, oldState, newState) {
           const sel = tr.selection;
           let newDecos = [];
 
-          // Only apply to text selections
-          if (sel.from !== sel.to && tr.doc.resolve(sel.from).parent.isTextblock) {
+          // Only apply to text selections or whole doc selections
+          if (sel.from !== sel.to && (tr.doc.resolve(sel.from).parent.isTextblock || sel instanceof AllSelection)) {
             newDecos.push(
               Decoration.inline(sel.from, sel.to, {
                 class: 'sd-custom-selection',
@@ -34,7 +34,7 @@ export const CustomSelection = Extension.create({
       props: {
         handleDOMEvents: {
           focusout: (view, event) => {
-            const isDropDownOption = this.editor.options.focusTarget.getAttribute('data-dropdown-option');
+            const isDropDownOption = this.editor.options.focusTarget?.getAttribute('data-dropdown-option');
             if (document.activeElement && !event.relatedTarget && !view.state.selection.empty && !isDropDownOption) {
               this.editor.setOptions({
                 lastSelection: view.state.selection,


### PR DESCRIPTION
Hi @harbournick! There are a lot of issues caused by custom selection implemented because of this https://linear.app/harbour/issue/HAR-10078/superdoc-visual-bug-document-text-visual-highlightselection-disappears(native selection is lost when toolbar item with focusable element inside is opened). I tested all toolbar items with custom selection and it seems to work now but can we ask Priya to test this somehow in order to find corner cases I could potentially miss.