### PR TITLE
Fix: wp anchor image export and content types main

### DIFF
--- a/packages/super-editor/src/core/DocxZipper.js
+++ b/packages/super-editor/src/core/DocxZipper.js
@@ -149,6 +149,8 @@ class DocxZipper {
     }
 
     Object.keys(docx.files).forEach((name) => {
+      // Important: We need to filter out .rels files - they should not be included in content types
+      // Otherwise this generates MS word validation error
       if (name.includes('.rels') || (!name.includes('header') && !name.includes('footer'))) return;
       const hasExtensible = types.elements?.some(
         (el) => el.name === 'Override' && el.attributes.PartName === `/${name}`,

--- a/packages/super-editor/src/core/DocxZipper.js
+++ b/packages/super-editor/src/core/DocxZipper.js
@@ -149,7 +149,7 @@ class DocxZipper {
     }
 
     Object.keys(docx.files).forEach((name) => {
-      if (!name.includes('header') && !name.includes('footer')) return;
+      if (name.includes('.rels') || (!name.includes('header') && !name.includes('footer'))) return;
       const hasExtensible = types.elements?.some(
         (el) => el.name === 'Override' && el.attributes.PartName === `/${name}`,
       );

--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -1922,6 +1922,13 @@ function translateImageNode(params, imageSize) {
         name: 'wp:wrapTopAndBottom',
       });
     }
+
+    // Important: wp:anchor will break if no wrapping is specified. We need to use wrapNone.
+    if (attrs.isAnchor && !wrapProp.length) {
+      wrapProp.push({
+        name: 'wp:wrapNone',
+      });
+    }
   }
 
   const drawingXmlns = 'http://schemas.openxmlformats.org/drawingml/2006/main';
@@ -2070,7 +2077,7 @@ function translateImageNode(params, imageSize) {
     },
     [],
   );
-
+  
   return textNode;
 }
 


### PR DESCRIPTION
- wp:anchor images require wrapNone if no other type of wrapping is specified
- .rels files for headers/footers should not be included in Content_types file