### PR TITLE
fix: improve null handling and clean up code in translateList

### DIFF
--- a/packages/super-editor/src/core/super-converter/v2/importer/listImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/listImporter.js
@@ -74,11 +74,11 @@ function handleListNodes(params, node) {
   if (!Object.keys(numberingDefinition).length) {
     const { definition, ilvl } = getNodeNumberingDefinitionByStyle(node, docx);
     if (definition) numberingDefinition = definition;
-    if (Number.isNaN(iLvl)) iLvl = ilvl;    
+    if (Number.isNaN(iLvl)) iLvl = ilvl;
   }
 
   const { listType, listOrderingType, listrPrs, listpPrs, start, lvlText, lvlJc, customFormat } = numberingDefinition;
-      
+
   // Fallback if the list definition is not found or is invalid
   // See invalid-list-def-fallback.docx for example and
   if (!listType) {
@@ -201,7 +201,7 @@ export function testForList(node, docx) {
   let outlinelvl;
 
   const styleId = paragraphStyle?.attributes['w:val'];
-  
+
   const styleTag = getStyleTagFromStyleId(styleId, docx);
   if (styleTag && !numId) {
     const { numPr: numPrRecursve, type } = getNumPrRecursive({ node, styleId, docx });
@@ -544,7 +544,7 @@ export function getNodeNumberingDefinitionByStyle(item, docx) {
   const styleId = styleTag?.attributes['w:val'];
   const styleDef = getStyleTagFromStyleId(styleId, docx);
   if (!styleDef) return {};
-  
+
   const pPr = styleDef.elements?.find((el) => el.name === 'w:pPr');
   const numPr = pPr?.elements?.find((el) => el.name === 'w:numPr');
   const numIdTag = numPr?.elements?.find((el) => el.name === 'w:numId');
@@ -573,10 +573,7 @@ function getAbstractNumIdByNumId(numId, docx) {
   const listData = elements[0];
   const numberingElements = listData.elements || [];
 
-  const numDef = numberingElements.find((el) => 
-    el.name === 'w:num' && 
-    el.attributes?.['w:numId'] === numId
-  );
+  const numDef = numberingElements.find((el) => el.name === 'w:num' && el.attributes?.['w:numId'] === numId);
 
   if (!numDef) return null;
 
@@ -592,20 +589,19 @@ function getLevelDataFromAbstractNum(abstractNumId, styleId, docx) {
   const listData = elements[0];
   const numberingElements = listData.elements || [];
 
-  const abstractNum = numberingElements.find((el) => 
-    el.name === 'w:abstractNum' && 
-    el.attributes?.['w:abstractNumId'] === abstractNumId
+  const abstractNum = numberingElements.find(
+    (el) => el.name === 'w:abstractNum' && el.attributes?.['w:abstractNumId'] === abstractNumId,
   );
 
   if (!abstractNum) return null;
 
-  const levels = abstractNum.elements?.filter(el => el.name === 'w:lvl') || [];
+  const levels = abstractNum.elements?.filter((el) => el.name === 'w:lvl') || [];
   for (const level of levels) {
     const pStyle = level.elements?.find((el) => el.name === 'w:pStyle');
     if (pStyle?.attributes?.['w:val'] === styleId) {
       const found = {
         level,
-        ilvl: Number(level.attributes?.['w:ilvl']) || 0
+        ilvl: Number(level.attributes?.['w:ilvl']) || 0,
       };
       return found;
     }

--- a/packages/super-editor/src/core/super-converter/v2/importer/markImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/markImporter.js
@@ -44,10 +44,7 @@ export function parseMarks(property, unknownMarks = [], docx = null) {
       const newMark = { type: m.type };
 
       const exceptionMarks = ['w:b', 'w:caps'];
-      if (
-        (attributes['w:val'] === '0' || attributes['w:val'] === 'none') 
-        && !exceptionMarks.includes(m.name)
-      ) {
+      if ((attributes['w:val'] === '0' || attributes['w:val'] === 'none') && !exceptionMarks.includes(m.name)) {
         return;
       }
 
@@ -76,7 +73,7 @@ export function parseMarks(property, unknownMarks = [], docx = null) {
         newMark.attrs = {};
         newMark.attrs[m.property] = value;
       }
-      
+
       marks.push(newMark);
     });
   });

--- a/packages/super-editor/src/core/super-converter/v2/importer/paragraphNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/paragraphNodeImporter.js
@@ -282,13 +282,13 @@ const getDefaultParagraphStyle = (docx, styleId = '') => {
   const { attributes: pPrNormalIndentAttr } = pPrNormalIndentTag;
   const { attributes: pPrByIdIndentAttr } = pPrStyleIdIndentTag;
 
-  const spacingRest = isNormalAsDefault 
-    ? (pPrNormalSpacingAttr || pPrDefaultSpacingAttr)
-    : (pPrDefaultSpacingAttr || pPrNormalSpacingAttr);
+  const spacingRest = isNormalAsDefault
+    ? pPrNormalSpacingAttr || pPrDefaultSpacingAttr
+    : pPrDefaultSpacingAttr || pPrNormalSpacingAttr;
 
   const indentRest = isNormalAsDefault
-    ? (pPrNormalIndentAttr || pPrDefaultIndentAttr)
-    : (pPrDefaultIndentAttr || pPrNormalIndentAttr);
+    ? pPrNormalIndentAttr || pPrDefaultIndentAttr
+    : pPrDefaultIndentAttr || pPrNormalIndentAttr;
 
   return {
     spacing: pPrByIdSpacingAttr || spacingRest,

--- a/packages/super-editor/src/extensions/list-item/ListItemNodeView.js
+++ b/packages/super-editor/src/extensions/list-item/ListItemNodeView.js
@@ -234,7 +234,7 @@ const getStylesFromLinkedStyles = ({ node, pos, editor }) => {
   const { state } = editor.view;
   const linkedStyles = LinkedStylesPluginKey.getState(state)?.decorations;
   const decorationsInPlace = linkedStyles?.find(pos, pos + node.nodeSize);
-  // We are looking from the end as there may be several decorations 
+  // We are looking from the end as there may be several decorations
   // and we need to find the most specific one.
   const styleDeco = decorationsInPlace?.findLast((dec) => dec.type.attrs?.style);
   const style = styleDeco?.type.attrs?.style;

--- a/packages/super-editor/src/extensions/table/table.js
+++ b/packages/super-editor/src/extensions/table/table.js
@@ -117,7 +117,7 @@ export const Table = Node.create({
             return { style: `margin: 0 auto` };
           }
           if (attrs.justification === 'right') {
-            return  { style: `margin-left: auto` };
+            return { style: `margin-left: auto` };
           }
 
           return {};

--- a/packages/super-editor/src/extensions/text-transform/text-transform.js
+++ b/packages/super-editor/src/extensions/text-transform/text-transform.js
@@ -18,7 +18,7 @@ export const TextTransform = Extension.create({
             default: null,
             renderDOM: (attrs) => {
               if (!attrs.textCase) return {};
-              return { 
+              return {
                 style: `text-transform: ${attrs.textCase}`,
               };
             },


### PR DESCRIPTION
Null handling issue in list translation logic causing annotation failures.

Added null safety checks in translateList function in exporter.js:
- Early null check with fallback paragraph structure
- Optional chaining for all property access
- Default values to prevent undefined errors