### PR TITLE
HAR-10236 - fix annotations export in list

### DIFF
--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -815,7 +815,6 @@ function translateList(params) {
    *  1. Final doc (keep paragraph field content inside list item)
    *  2. Not final doc (keep w:sdt node, process its content)
    */
-  let nodesToFlatten = [];
   if (Array.isArray(outputNode) && params.isFinalDoc) {
     const parsedElements = [];
     outputNode?.forEach((node, index) => {
@@ -838,16 +837,24 @@ function translateList(params) {
   }
 
   /** Case 2: Process w:sdt content */
+  let nodesToFlatten = [];
   const sdtNodes = outputNode.elements?.filter((n) => n.name === 'w:sdt');
   if (sdtNodes && sdtNodes.length > 0) {
     nodesToFlatten = sdtNodes;
     nodesToFlatten?.forEach((sdtNode) => {
       const sdtContent = sdtNode.elements.find((n) => n.name === 'w:sdtContent');
-      if (sdtContent && sdtContent.elements) {
+      const foundRun = sdtContent.elements?.find((el) => el.name === 'w:r'); // this is a regular text field.
+      if (sdtContent && sdtContent.elements && !foundRun) {
         const parsedElements = [];
         sdtContent.elements.forEach((element, index) => {
+          if (element.name === 'w:rPr' && element.elements?.length) {
+            parsedElements.push(element);
+          }
+
           const runs = element.elements?.filter((n) => n.name === 'w:r');
-          parsedElements.push(...runs);
+          if (runs && runs.length) {
+            parsedElements.push(...runs);
+          }
 
           if (element.name === 'w:p' && index < sdtContent.elements.length - 1) {
             parsedElements.push({


### PR DESCRIPTION
Fixed annotations export in list items.

Notes:
- In the test document I found such elements that are processed as `structuredContent` node (with empty annotation attributes in `w:tag`) during import/export. I have no idea how these elements ended up there, and I have not been able to reproduce anything like this.
```xml
<w:sdt>
  <w:sdtPr>
    <w:alias w:val="undefined" />
    <w:tag w:val="{&quot;displayLabel&quot;:&quot;&quot;,&quot;defaultDisplayLabel&quot;:&quot;&quot;,&quot;fieldId&quot;:&quot;agreementinput-1721689698154-41701942325&quot;,&quot;fieldType&quot;:&quot;TEXTINPUT&quot;,&quot;fieldTypeShort&quot;:&quot;text&quot;,&quot;fieldColor&quot;:&quot;#00000000&quot;,&quot;fieldMultipleImage&quot;:&quot;false&quot;,&quot;fieldFontFamily&quot;:&quot;Arial&quot;,&quot;fieldFontSize&quot;:&quot;9pt&quot;,&quot;fieldTextColor&quot;:null,&quot;fieldTextHighlight&quot;:null}" />
    <w:id w:val="-432052134" />
  </w:sdtPr>
  <w:sdtContent />
</w:sdt>
```