### PR TITLE
feat: extend editor to allow addHelpers in extensions

### DIFF
--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -45,6 +45,16 @@ import { SuperValidator } from '@core/super-validator/index.js';
  */
 
 /**
+ * A map of plugin names to their helper API objects.
+ * Each plugin defines its own helper methods.
+ *
+ * Example:
+ * editor.helpers.linkedStyles.getStyles()
+ *
+ * @typedef {Object<string, Object<string, Function>>} EditorHelpers
+ */
+
+/**
  * Editor main class.
  *
  * Expects a config object.
@@ -492,6 +502,14 @@ export class Editor extends EventEmitter {
    */
   get commands() {
     return this.#commandService?.commands;
+  }
+
+  /**
+   * Get extension helpers.
+   * @returns {EditorHelpers} Object with helper methods for extensions
+   */
+  get helpers() {
+    return this.extensionService.helpers;
   }
 
   /**

--- a/packages/super-editor/src/core/ExtensionService.js
+++ b/packages/super-editor/src/core/ExtensionService.js
@@ -110,6 +110,37 @@ export class ExtensionService {
   }
 
   /**
+   * Get all helper methods defined in the extensions.
+   * Each extension can define its own helper methods.
+   * Example: editor.helpers.linkedStyles.getStyles()
+   * @returns {Object} Object with helper methods for extensions.
+   */
+  get helpers() {
+    const helpersObject = {};
+
+    for (const extension of this.extensions) {
+      const name = extension.name;
+      if (!name) continue;
+
+      const context = {
+        name: extension.name,
+        options: extension.options,
+        storage: extension.storage,
+        editor: this.editor,
+        type: getSchemaTypeByName(extension.name, this.schema),
+      };
+
+      const addHelpers = getExtensionConfigField(extension, 'addHelpers', context);
+
+      if (addHelpers) {
+        helpersObject[name] = addHelpers();
+      }
+    }
+
+    return helpersObject;
+  }
+
+  /**
    * Get all PM plugins defined in the extensions.
    * And also keyboard shortcuts.
    * @returns Array of PM plugins.


### PR DESCRIPTION
- Extends the extensions service and editor to allow addHelpers in extensions
- adds editor.helpers with extension namespace