### PR TITLE
fix: removed duplicate unit tests on CI/CD

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,9 +8,6 @@ jobs:
   pre-commit:
     uses: ./.github/workflows/pre-commit.yml
 
-  run-unit-tests:
-    uses: ./.github/workflows/run-unit-tests.yml
-
   trigger-superdoc-tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We currently have the unit tests being executed by another workflow. See [.github/workflows/ci.yml](https://github.com/Harbour-Enterprises/SuperDoc/blob/develop/.github/workflows/ci.yml#L42).

This removes this duplication.

<img width="880" height="153" alt="Screenshot 2025-08-06 at 15 25 27" src="https://github.com/user-attachments/assets/b6789c1b-7115-492f-aaa3-a908e3178786" />