### PR TITLE
fix(runs): add ability to store an export run styleIds

### DIFF
--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -54,6 +54,7 @@ class SuperConverter {
     { name: 'w:jc', type: 'textAlign', mark: 'textStyle', property: 'textAlign' },
     { name: 'w:ind', type: 'textIndent', mark: 'textStyle', property: 'textIndent' },
     { name: 'w:spacing', type: 'lineHeight', mark: 'textStyle', property: 'lineHeight' },
+    { name: 'w:spacing', type: 'letterSpacing', mark: 'textStyle', property: 'letterSpacing' },
     { name: 'link', type: 'link', mark: 'link', property: 'href' },
     { name: 'w:highlight', type: 'highlight', mark: 'highlight', property: 'color' },
     { name: 'w:shd', type: 'highlight', mark: 'highlight', property: 'color' },

--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -51,6 +51,7 @@ class SuperConverter {
     { name: 'w:sz', type: 'fontSize', mark: 'textStyle', property: 'fontSize' },
     // { name: 'w:szCs', type: 'fontSize', mark: 'textStyle', property: 'fontSize' },
     { name: 'w:rFonts', type: 'fontFamily', mark: 'textStyle', property: 'fontFamily' },
+    { name: 'w:rStyle', type: 'styleId', mark: 'textStyle', property: 'styleId' },
     { name: 'w:jc', type: 'textAlign', mark: 'textStyle', property: 'textAlign' },
     { name: 'w:ind', type: 'textIndent', mark: 'textStyle', property: 'textIndent' },
     { name: 'w:spacing', type: 'lineHeight', mark: 'textStyle', property: 'lineHeight' },

--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -1430,6 +1430,12 @@ function translateMark(mark) {
       });
       break;
 
+    // Add ability to get run styleIds from textStyle marks and inject to run properties in word
+    case 'styleId':
+      markElement.name = 'w:rStyle';
+      markElement.attributes['w:val'] = attrs.styleId;
+      break;
+
     case 'color':
       let processedColor = attrs.color.replace(/^#/, '').replace(/;$/, ''); // Remove `#` and `;` if present
       if (processedColor.startsWith('rgb')) {
@@ -1458,7 +1464,6 @@ function translateMark(mark) {
     case 'lineHeight':
       markElement.attributes['w:line'] = linesToTwips(attrs.lineHeight);
       break;
-
     case 'highlight':
       markElement.attributes['w:fill'] = attrs.color?.substring(1);
       markElement.attributes['w:color'] = 'auto';

--- a/packages/super-editor/src/core/super-converter/v2/importer/markImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/markImporter.js
@@ -38,7 +38,27 @@ export function parseMarks(property, unknownMarks = [], docx = null) {
       }
     }
 
-    marksForType.forEach((m) => {
+    let filteredMarksForType = marksForType;
+
+    /**
+     * Now that we have 2 marks named 'spacing' we need to determine if its
+     * for line height or letter spacing.
+     *
+     * If the spacing has a w:val attribute, it's for letter spacing.
+     * If the spacing has a w:line, w:lineRule, w:before, w:after attribute, it's for line height.
+     */
+    if (element.name === 'w:spacing') {
+      const attrs = element.attributes || {};
+      const hasLetterSpacing = attrs['w:val'];
+      filteredMarksForType = marksForType.filter((m) => {
+        if (hasLetterSpacing) {
+          return m.type === 'letterSpacing';
+        }
+        return m.type === 'lineHeight';
+      });
+    }
+
+    filteredMarksForType.forEach((m) => {
       if (!m || seen.has(m.type)) return;
       seen.add(m.type);
 
@@ -145,6 +165,7 @@ function getMarkValue(markType, attributes, docx) {
     textIndent: () => getIndentValue(attributes),
     fontFamily: () => getFontFamilyValue(attributes, docx),
     lineHeight: () => getLineHeightValue(attributes),
+    letterSpacing: () => `${twipsToPt(attributes['w:val'])}pt`,
     textAlign: () => attributes['w:val'],
     link: () => attributes['href'],
     underline: () => attributes['w:val'],

--- a/packages/super-editor/src/core/super-converter/v2/importer/runNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/runNodeImporter.js
@@ -49,13 +49,20 @@ const handleRunNode = (params) => {
       });
     }
 
+    console.log('paragraphStyleAttributes', paragraphStyleAttributes);
+    console.log('runStyleAttributes', runStyleAttributes);
+    console.log('marks', marks);
     // Combine with correct precedence: paragraph styles first, then run styles (which override)
     const combinedMarks = [...paragraphStyleAttributes, ...runStyleAttributes, ...marks];
+    console.log('combinedMarks', combinedMarks);
 
     if (node.marks) combinedMarks.push(...node.marks);
     const newMarks = createImportMarks(combinedMarks);
+    console.log('newMarks', newMarks);
     processedRun = processedRun.map((n) => {
       const existingMarks = n.marks || [];
+      console.log('existingMarks', existingMarks);
+      console.log('returning', { ...n, marks: [...newMarks, ...existingMarks], attributes });
       return { ...n, marks: [...newMarks, ...existingMarks], attributes };
     });
   }

--- a/packages/super-editor/src/core/super-converter/v2/importer/runNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/runNodeImporter.js
@@ -62,8 +62,6 @@ const handleRunNode = (params) => {
       return {
         ...n,
         marks: [...newMarks, ...existingMarks],
-        attributes: { ...attributes, styleid: runStyleId },
-        attrs: { styleid: runStyleId },
       };
     });
   }

--- a/packages/super-editor/src/core/super-converter/v2/importer/runNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/runNodeImporter.js
@@ -4,7 +4,7 @@ import { createImportMarks } from './markImporter.js';
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-const handleRunNode = (params) => {
+export const handleRunNode = (params) => {
   const { nodes, nodeListHandler, parentStyleId, docx } = params;
   if (nodes.length === 0 || nodes[0].name !== 'w:r') {
     return { nodes: [], consumed: 0 };
@@ -79,7 +79,7 @@ const getMarksFromStyles = (docx, styleId) => {
 
   if (!style) return {};
 
-  return parseProperties(style, docx);
+  return parseProperties(style);
 };
 
 /**

--- a/packages/super-editor/src/extensions/linked-styles/plugin.js
+++ b/packages/super-editor/src/extensions/linked-styles/plugin.js
@@ -50,11 +50,17 @@ const generateDecorations = (state, styles) => {
   doc.descendants((node, pos) => {
     const { name } = node.type;
 
-    // Track the current StyleId
     if (node?.attrs?.styleId) lastStyleId = node.attrs.styleId;
     if (name === 'paragraph' && !node.attrs?.styleId) lastStyleId = null;
     if (name !== 'text' && name !== 'listItem' && name !== 'orderedList') return;
 
+    // Get the last styleId from the node marks
+    // This allows run-level styles and styleIds to override paragraph-level styles
+    for (const mark of node.marks) {
+      if (mark.type.name === 'textStyle') {
+        lastStyleId = mark.attrs.styleId;
+      }
+    }
     const { linkedStyle, basedOnStyle } = getLinkedStyle(lastStyleId, styles);
     if (!linkedStyle) return;
 

--- a/packages/super-editor/src/extensions/linked-styles/plugin.js
+++ b/packages/super-editor/src/extensions/linked-styles/plugin.js
@@ -57,7 +57,7 @@ const generateDecorations = (state, styles) => {
     // Get the last styleId from the node marks
     // This allows run-level styles and styleIds to override paragraph-level styles
     for (const mark of node.marks) {
-      if (mark.type.name === 'textStyle') {
+      if (mark.type.name === 'textStyle' && mark.attrs.styleId) {
         lastStyleId = mark.attrs.styleId;
       }
     }

--- a/packages/super-editor/src/extensions/text-style/text-style.js
+++ b/packages/super-editor/src/extensions/text-style/text-style.js
@@ -29,6 +29,12 @@ export const TextStyle = Mark.create({
     return ['span', Attribute.mergeAttributes(this.options.htmlAttributes, htmlAttributes), 0];
   },
 
+  addAttributes() {
+    return {
+      styleId: {},
+    };
+  },
+
   addCommands() {
     return {
       removeEmptyTextStyle:

--- a/packages/super-editor/src/tests/import/runImporter.test.js
+++ b/packages/super-editor/src/tests/import/runImporter.test.js
@@ -1,0 +1,290 @@
+import { expect, describe, it } from 'vitest';
+import { handleRunNode } from '@core/super-converter/v2/importer/runNodeImporter.js';
+
+// Helper functions to create common mocks
+const createMockDocx = (styles = []) => ({
+  'word/styles.xml': {
+    elements: [
+      {
+        elements: styles,
+      },
+    ],
+  },
+});
+
+const createMockStyle = (styleId, runProperties = []) => ({
+  name: 'w:style',
+  attributes: { 'w:styleId': styleId },
+  elements: [
+    {
+      name: 'w:rPr',
+      elements: runProperties,
+    },
+  ],
+});
+
+const createMockRunProperty = (name, attributes = {}) => ({
+  name,
+  attributes,
+});
+
+const createMockRunNode = (runProperties = [], text = 'Test text') => ({
+  name: 'w:r',
+  elements: [
+    {
+      name: 'w:rPr',
+      elements: runProperties,
+    },
+    {
+      name: 'w:t',
+      elements: [{ text }],
+    },
+  ],
+});
+
+const createMockNodeListHandler = (returnType = 'text', returnText = 'Test text') => ({
+  handler: () => [{ type: returnType, text: returnText, marks: [] }],
+});
+
+const createMockRunStyle = (styleId) => createMockRunProperty('w:rStyle', { 'w:val': styleId });
+
+const createMockFont = (fontFamily) => createMockRunProperty('w:rFonts', { 'w:ascii': fontFamily });
+
+const createMockSize = (size) => createMockRunProperty('w:sz', { 'w:val': size });
+
+const createMockColor = (color) => createMockRunProperty('w:color', { 'w:val': color });
+
+const createMockBold = () => createMockRunProperty('w:b', {});
+
+const createMockItalic = () => createMockRunProperty('w:i', {});
+
+describe('runImporter', () => {
+  describe('runStyle attributes override paragraphStyleAttributes', () => {
+    it('should override paragraph style attributes with run style attributes', () => {
+      // Create styles with paragraph and run styles
+      const paragraphStyle = createMockStyle('ParagraphStyle', [
+        createMockFont('Times New Roman'),
+        createMockSize('24'), // 12pt
+      ]);
+
+      const runStyle = createMockStyle('RunStyle', [
+        createMockFont('Arial'),
+        createMockSize('32'), // 16pt
+      ]);
+
+      const mockDocx = createMockDocx([paragraphStyle, runStyle]);
+      const mockRunNode = createMockRunNode([createMockRunStyle('RunStyle')]);
+      const mockNodeListHandler = createMockNodeListHandler();
+
+      const result = handleRunNode({
+        nodes: [mockRunNode],
+        nodeListHandler: mockNodeListHandler,
+        parentStyleId: 'ParagraphStyle',
+        docx: mockDocx,
+      });
+
+      expect(result.nodes).toHaveLength(1);
+      expect(result.consumed).toBe(1);
+
+      const textNode = result.nodes[0];
+      expect(textNode.type).toBe('text');
+      expect(textNode.text).toBe('Test text');
+
+      // Check that run style attributes override paragraph style attributes
+      const textStyleMark = textNode.marks.find((mark) => mark.type === 'textStyle');
+      expect(textStyleMark).toBeDefined();
+      expect(textStyleMark.attrs.fontFamily).toBe('Arial'); // Run style font
+      expect(textStyleMark.attrs.fontSize).toBe('16pt'); // Run style size
+      expect(textStyleMark.attrs.styleId).toBe('RunStyle'); // Run style ID
+    });
+
+    it('should combine paragraph and run styles with correct precedence', () => {
+      // Create styles with paragraph and run styles
+      const paragraphStyle = createMockStyle('ParagraphStyle', [
+        createMockFont('Times New Roman'),
+        createMockSize('24'), // 12pt
+        createMockBold(),
+      ]);
+
+      const runStyle = createMockStyle('RunStyle', [createMockFont('Arial'), createMockItalic()]);
+
+      const mockDocx = createMockDocx([paragraphStyle, runStyle]);
+      const mockRunNode = createMockRunNode([createMockRunStyle('RunStyle')]);
+      const mockNodeListHandler = createMockNodeListHandler();
+
+      const result = handleRunNode({
+        nodes: [mockRunNode],
+        nodeListHandler: mockNodeListHandler,
+        parentStyleId: 'ParagraphStyle',
+        docx: mockDocx,
+      });
+
+      expect(result.nodes).toHaveLength(1);
+      const textNode = result.nodes[0];
+
+      // Check that all marks are present with correct precedence
+      const textStyleMark = textNode.marks.find((mark) => mark.type === 'textStyle');
+      const boldMark = textNode.marks.find((mark) => mark.type === 'bold');
+      const italicMark = textNode.marks.find((mark) => mark.type === 'italic');
+
+      expect(textStyleMark).toBeDefined();
+      expect(boldMark).toBeDefined();
+      expect(italicMark).toBeDefined();
+
+      // Run style should override paragraph style for font properties
+      expect(textStyleMark.attrs.fontFamily).toBe('Arial'); // Run style overrides
+      expect(textStyleMark.attrs.fontSize).toBe('12pt'); // Paragraph style (no override)
+    });
+
+    it('should handle run nodes without run styles', () => {
+      // Create style with only paragraph styles
+      const paragraphStyle = createMockStyle('ParagraphStyle', [
+        createMockFont('Times New Roman'),
+        createMockSize('24'), // 12pt
+      ]);
+
+      const mockDocx = createMockDocx([paragraphStyle]);
+      const mockRunNode = createMockRunNode([createMockBold()]);
+      const mockNodeListHandler = createMockNodeListHandler();
+
+      const result = handleRunNode({
+        nodes: [mockRunNode],
+        nodeListHandler: mockNodeListHandler,
+        parentStyleId: 'ParagraphStyle',
+        docx: mockDocx,
+      });
+
+      expect(result.nodes).toHaveLength(1);
+      const textNode = result.nodes[0];
+
+      // Should have paragraph style attributes
+      const textStyleMark = textNode.marks.find((mark) => mark.type === 'textStyle');
+      const boldMark = textNode.marks.find((mark) => mark.type === 'bold');
+
+      expect(textStyleMark).toBeDefined();
+      expect(textStyleMark.attrs.fontFamily).toBe('Times New Roman');
+      expect(textStyleMark.attrs.fontSize).toBe('12pt');
+      expect(boldMark).toBeDefined();
+
+      // Should not have styleId since no run style was applied
+      expect(textStyleMark.attrs.styleId).toBeUndefined();
+    });
+  });
+
+  describe('textStyle mark stores the styleId', () => {
+    it('should store run style ID in textStyle mark', () => {
+      const runStyle = createMockStyle('CustomRunStyle', [createMockFont('Calibri')]);
+
+      const mockDocx = createMockDocx([runStyle]);
+      const mockRunNode = createMockRunNode([createMockRunStyle('CustomRunStyle')]);
+      const mockNodeListHandler = createMockNodeListHandler('text', 'Styled text');
+
+      const result = handleRunNode({
+        nodes: [mockRunNode],
+        nodeListHandler: mockNodeListHandler,
+        parentStyleId: null,
+        docx: mockDocx,
+      });
+
+      expect(result.nodes).toHaveLength(1);
+      const textNode = result.nodes[0];
+
+      // Check that styleId is stored in textStyle mark
+      const textStyleMark = textNode.marks.find((mark) => mark.type === 'textStyle');
+      expect(textStyleMark).toBeDefined();
+      expect(textStyleMark.attrs.styleId).toBe('CustomRunStyle');
+      expect(textStyleMark.attrs.fontFamily).toBe('Calibri');
+    });
+
+    it('should not add styleId when no run style is present', () => {
+      const mockDocx = createMockDocx([]);
+      const mockRunNode = createMockRunNode([createMockBold()]);
+      const mockNodeListHandler = createMockNodeListHandler('text', 'Plain text');
+
+      const result = handleRunNode({
+        nodes: [mockRunNode],
+        nodeListHandler: mockNodeListHandler,
+        parentStyleId: null,
+        docx: mockDocx,
+      });
+
+      expect(result.nodes).toHaveLength(1);
+      const textNode = result.nodes[0];
+
+      // Should not have textStyle mark with styleId
+      const textStyleMark = textNode.marks.find((mark) => mark.type === 'textStyle');
+      if (textStyleMark) {
+        expect(textStyleMark.attrs.styleId).toBeUndefined();
+      }
+    });
+
+    it('should handle multiple textStyle marks correctly', () => {
+      const runStyle = createMockStyle('MultiStyle', [
+        createMockFont('Verdana'),
+        createMockSize('40'), // 20pt
+      ]);
+
+      const mockDocx = createMockDocx([runStyle]);
+      const mockRunNode = createMockRunNode([createMockRunStyle('MultiStyle'), createMockColor('FF0000')]);
+      const mockNodeListHandler = createMockNodeListHandler('text', 'Multi-styled text');
+
+      const result = handleRunNode({
+        nodes: [mockRunNode],
+        nodeListHandler: mockNodeListHandler,
+        parentStyleId: null,
+        docx: mockDocx,
+      });
+
+      expect(result.nodes).toHaveLength(1);
+      const textNode = result.nodes[0];
+
+      // Should have combined textStyle mark with all attributes
+      const textStyleMark = textNode.marks.find((mark) => mark.type === 'textStyle');
+      expect(textStyleMark).toBeDefined();
+      expect(textStyleMark.attrs.styleId).toBe('MultiStyle');
+      expect(textStyleMark.attrs.fontFamily).toBe('Verdana');
+      expect(textStyleMark.attrs.fontSize).toBe('20pt');
+      expect(textStyleMark.attrs.color).toBe('#FF0000');
+    });
+  });
+
+  describe('integration with real document structure', () => {
+    it('should handle run nodes with complex style hierarchies', () => {
+      // Create a more complex document structure
+      const headingStyle = createMockStyle('Heading1', [
+        createMockFont('Georgia'),
+        createMockSize('48'), // 24pt
+        createMockBold(),
+      ]);
+
+      const emphasisStyle = createMockStyle('Emphasis', [createMockItalic(), createMockColor('0000FF')]);
+
+      const mockDocx = createMockDocx([headingStyle, emphasisStyle]);
+      const mockRunNode = createMockRunNode([createMockRunStyle('Emphasis')], 'emphasized text');
+      const mockNodeListHandler = createMockNodeListHandler('text', 'emphasized text');
+
+      const result = handleRunNode({
+        nodes: [mockRunNode],
+        nodeListHandler: mockNodeListHandler,
+        parentStyleId: 'Heading1',
+        docx: mockDocx,
+      });
+
+      expect(result.nodes).toHaveLength(1);
+      const textNode = result.nodes[0];
+
+      // Should have both paragraph and run styles with correct precedence
+      const textStyleMark = textNode.marks.find((mark) => mark.type === 'textStyle');
+      const boldMark = textNode.marks.find((mark) => mark.type === 'bold');
+      const italicMark = textNode.marks.find((mark) => mark.type === 'italic');
+
+      expect(textStyleMark).toBeDefined();
+      expect(textStyleMark.attrs.styleId).toBe('Emphasis'); // Run style ID
+      expect(textStyleMark.attrs.fontFamily).toBe('Georgia'); // From paragraph style
+      expect(textStyleMark.attrs.fontSize).toBe('24pt'); // From paragraph style
+      expect(textStyleMark.attrs.color).toBe('#0000FF'); // From run style
+      expect(boldMark).toBeDefined(); // From paragraph style
+      expect(italicMark).toBeDefined(); // From run style
+    });
+  });
+});


### PR DESCRIPTION
- Adds import support for run style ids added to textMarks
- Ensure run styles override paragraph styles
- exporter can get the runStyle and put back into rPr xml nodes