### PR TITLE
feat: default field export background transparent, allow config on export

### DIFF
--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -1553,6 +1553,7 @@ export class Editor extends EventEmitter {
     exportXmlOnly = false,
     comments = [],
     getUpdatedDocs = false,
+    fieldsHighlightColor = null,
   } = {}) {
     // Pre-process the document state to prepare for export
     const json = this.#prepareDocumentForExport(comments);
@@ -1567,6 +1568,7 @@ export class Editor extends EventEmitter {
       comments,
       this,
       exportJsonOnly,
+      fieldsHighlightColor,
     );
 
     if (exportXmlOnly || exportJsonOnly) return documentXml;

--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -409,6 +409,7 @@ class SuperConverter {
     comments = [],
     editor,
     exportJsonOnly = false,
+    fieldsHighlightColor,
   ) {
     const commentsWithParaIds = comments.map((c) => prepareCommentParaIds(c));
     const commentDefinitions = commentsWithParaIds.map((c, index) =>
@@ -423,6 +424,7 @@ class SuperConverter {
       commentsExportType,
       isFinalDoc,
       editor,
+      fieldsHighlightColor,
     });
 
     if (exportJsonOnly) return result;
@@ -478,6 +480,7 @@ class SuperConverter {
     isFinalDoc = false,
     editor,
     isHeaderFooter = false,
+    fieldsHighlightColor = null,
   }) {
     const bodyNode = this.savedTagsToRestore.find((el) => el.name === 'w:body');
 
@@ -496,6 +499,7 @@ class SuperConverter {
       exportedCommentDefs: commentDefinitions,
       editor,
       isHeaderFooter,
+      fieldsHighlightColor,
     });
 
     return { result, params };

--- a/packages/super-editor/src/core/super-converter/getFieldHighlightJson.test.js
+++ b/packages/super-editor/src/core/super-converter/getFieldHighlightJson.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getFieldHighlightJson } from './exporter.js';
+
+const extractFill = (result) => result?.elements?.[0]?.attributes?.['w:fill'];
+
+describe('getFieldHighlightJson (non-throwing)', () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('returns null for falsy inputs (undefined, null, empty string)', () => {
+    expect(getFieldHighlightJson()).toBeNull();
+    expect(getFieldHighlightJson(undefined)).toBeNull();
+    expect(getFieldHighlightJson(null)).toBeNull();
+    expect(getFieldHighlightJson('')).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts 3/4/6/8-digit HEX with or without # (case preserved)', () => {
+    const cases = [
+      ['#FFF', '#FFF'],
+      ['FFF', '#FFF'],
+      ['#ffff', '#ffff'],
+      ['FFFF', '#FFFF'],
+      ['#A1B2C3', '#A1B2C3'],
+      ['a1b2c3', '#a1b2c3'],
+      ['#A1B2C3D4', '#A1B2C3D4'],
+      ['a1b2c3d4', '#a1b2c3d4'],
+    ];
+
+    for (const [input, expectedFill] of cases) {
+      const out = getFieldHighlightJson(input);
+      expect(out).toBeTruthy();
+      expect(out.name).toBe('w:rPr');
+      expect(extractFill(out)).toBe(expectedFill);
+      expect(out.elements[0].attributes['w:color']).toBe('auto');
+      expect(out.elements[0].attributes['w:val']).toBe('clear');
+    }
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('trims surrounding whitespace and still validates', () => {
+    const out1 = getFieldHighlightJson('   #ABCDEF   ');
+    expect(extractFill(out1)).toBe('#ABCDEF');
+
+    const out2 = getFieldHighlightJson('   abc   ');
+    expect(extractFill(out2)).toBe('#abc');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats pure whitespace as invalid (returns null and warns)', () => {
+    const out = getFieldHighlightJson('   ');
+    expect(out).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/Invalid HEX color/i);
+  });
+
+  it('returns null and warns for invalid HEX formats', () => {
+    const invalid = [
+      '#GGG',
+      'GGGZ',
+      'red',
+      '12345',
+      '#12345',
+      '#1234567',
+      '1234567',
+      '#',
+      '##123',
+      'xyz',
+      '#ffffgfff',
+      '12',
+      '#12',
+    ];
+
+    for (const input of invalid) {
+      const out = getFieldHighlightJson(input);
+      expect(out).toBeNull();
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(invalid.length);
+    for (let i = 0; i < invalid.length; i++) {
+      expect(warnSpy.mock.calls[i][0]).toMatch(/Invalid HEX color/i);
+    }
+  });
+
+  it('adds a leading # when missing', () => {
+    const out = getFieldHighlightJson('ABCDEF');
+    expect(extractFill(out)).toBe('#ABCDEF');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -742,10 +742,11 @@ export class SuperDoc extends EventEmitter {
     additionalFileNames = [],
     isFinalDoc = false,
     triggerDownload = true,
+    fieldsHighlightColor = null,
   } = {}) {
     // Get the docx files first
     const baseFileName = exportedName ? cleanName(exportedName) : cleanName(this.config.title);
-    const docxFiles = await this.exportEditorsToDOCX({ commentsType, isFinalDoc });
+    const docxFiles = await this.exportEditorsToDOCX({ commentsType, isFinalDoc, fieldsHighlightColor });
     const blobsToZip = [...additionalFiles];
     const filenames = [...additionalFileNames];
 
@@ -780,7 +781,7 @@ export class SuperDoc extends EventEmitter {
    * @param {{ commentsType?: string, isFinalDoc?: boolean }} [options]
    * @returns {Promise<Array<Blob>>}
    */
-  async exportEditorsToDOCX({ commentsType, isFinalDoc } = {}) {
+  async exportEditorsToDOCX({ commentsType, isFinalDoc, fieldsHighlightColor } = {}) {
     const comments = [];
     if (commentsType !== 'clean') {
       if (this.commentsStore && typeof this.commentsStore.translateCommentsForExport === 'function') {
@@ -792,7 +793,7 @@ export class SuperDoc extends EventEmitter {
     this.superdocStore.documents.forEach((doc) => {
       const editor = doc.getEditor();
       if (editor) {
-        docxPromises.push(editor.exportDocx({ isFinalDoc, comments, commentsType }));
+        docxPromises.push(editor.exportDocx({ isFinalDoc, comments, commentsType, fieldsHighlightColor }));
       }
     });
     return await Promise.all(docxPromises);


### PR DESCRIPTION
- Revert exported fields to have transparent background by default
- Adds _fieldsHighlightColor_ config at export time (expects hex)
- Adds unit tests for field color generation