### PR TITLE
fix: toolbar overflow command error

### DIFF
--- a/packages/super-editor/src/components/toolbar/defaultItems.js
+++ b/packages/super-editor/src/components/toolbar/defaultItems.js
@@ -654,7 +654,7 @@ export const makeDefaultItems = ({
   const overflow = useToolbarItem({
     type: 'overflow',
     name: 'overflow',
-    command: 'toggleOverflow',
+    command: null,
     icon: toolbarIcons.overflow,
     active: false,
     disabled: false,


### PR DESCRIPTION
We can have a null command for a toolbar item. https://github.com/Harbour-Enterprises/SuperDoc/blob/toolbar-overflow-command-error/packages/super-editor/src/components/toolbar/super-toolbar.js#L841

This command (toggleOverflow) does not exist, so omitting it prevents this console error.