### PR TITLE
HAR-10370 - fix: strikethrough not active on toolbar

### DIFF
--- a/packages/super-editor/src/components/toolbar/defaultItems.js
+++ b/packages/super-editor/src/components/toolbar/defaultItems.js
@@ -200,7 +200,7 @@ export const makeDefaultItems = ({
 
   const strikethrough = useToolbarItem({
     type: 'button',
-    name: 'strikethrough',
+    name: 'strike',
     command: 'toggleStrike',
     icon: toolbarIcons.strikethrough,
     active: false,


### PR DESCRIPTION
Strikethrough is not active on the toolbar even if the selected text has it. This happens because the mark is added with the `strike` name, but the toolbar is added as `strikethrough`. So, when the [updateToolbarState](https://github.com/Harbour-Enterprises/SuperDoc/blob/develop/packages/super-editor/src/components/toolbar/super-toolbar.js#L713) function is called, it doesn't set it as active. 

<img width="997" height="271" alt="Screenshot 2025-08-22 at 14 57 53" src="https://github.com/user-attachments/assets/4da8aad8-5edd-42b4-9163-397db47ff1ed" />
