### PR TITLE
feat: enhance text formatting extensions with detailed command

### DIFF
--- a/packages/super-editor/src/extensions/bold/bold.js
+++ b/packages/super-editor/src/extensions/bold/bold.js
@@ -1,5 +1,11 @@
+// @ts-check
 import { Mark, Attribute } from '@core/index.js';
 
+/**
+ * @module Bold
+ * @sidebarTitle Bold
+ * @snippetPath /snippets/extensions/bold.mdx
+ */
 export const Bold = Mark.create({
   name: 'bold',
 
@@ -38,12 +44,44 @@ export const Bold = Mark.create({
     return ['strong', Attribute.mergeAttributes(this.options.htmlAttributes, htmlAttributes), 0];
   },
 
-  //prettier-ignore
   addCommands() {
     return {
-      setBold: () => ({ commands }) => commands.setMark(this.name),
-      unsetBold: () => ({ commands }) => commands.unsetMark(this.name),
-      toggleBold: () => ({ commands }) => commands.toggleMark(this.name),
+      /**
+       * Apply bold formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * setBold()
+       * @note '0' renders as normal weight
+       */
+      setBold:
+        () =>
+        ({ commands }) =>
+          commands.setMark(this.name),
+
+      /**
+       * Remove bold formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * unsetBold()
+       */
+      unsetBold:
+        () =>
+        ({ commands }) =>
+          commands.unsetMark(this.name),
+
+      /**
+       * Toggle bold formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * toggleBold()
+       */
+      toggleBold:
+        () =>
+        ({ commands }) =>
+          commands.toggleMark(this.name),
     };
   },
 

--- a/packages/super-editor/src/extensions/highlight/highlight.js
+++ b/packages/super-editor/src/extensions/highlight/highlight.js
@@ -1,5 +1,11 @@
+// @ts-check
 import { Mark, Attribute } from '@core/index.js';
 
+/**
+ * @module Highlight
+ * @sidebarTitle Highlight
+ * @snippetPath /snippets/extensions/highlight.mdx
+ */
 export const Highlight = Mark.create({
   name: 'highlight',
 
@@ -18,7 +24,6 @@ export const Highlight = Mark.create({
           if (!attributes.color) {
             return {};
           }
-
           return {
             'data-color': attributes.color,
             style: `background-color: ${attributes.color}; color: inherit`,
@@ -36,12 +41,45 @@ export const Highlight = Mark.create({
     return ['mark', Attribute.mergeAttributes(this.options.htmlAttributes, htmlAttributes), 0];
   },
 
-  //prettier-ignore
   addCommands() {
     return {
-      setHighlight: (color) => ({ commands }) => commands.setMark(this.name, { color }),
-      unsetHighlight: () => ({ commands }) => commands.unsetMark(this.name),
-      toggleHighlight: () => ({ commands }) => commands.toggleMark(this.name),
+      /**
+       * Apply highlight with specified color
+       * @category Command
+       * @param {string} color - CSS color value
+       * @returns {Function} Command
+       * @example
+       * setHighlight('#FFEB3B')
+       * setHighlight('rgba(255, 235, 59, 0.5)')
+       */
+      setHighlight:
+        (color) =>
+        ({ commands }) =>
+          commands.setMark(this.name, { color }),
+
+      /**
+       * Remove highlight formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * unsetHighlight()
+       */
+      unsetHighlight:
+        () =>
+        ({ commands }) =>
+          commands.unsetMark(this.name),
+
+      /**
+       * Toggle highlight formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * toggleHighlight()
+       */
+      toggleHighlight:
+        () =>
+        ({ commands }) =>
+          commands.toggleMark(this.name),
     };
   },
 

--- a/packages/super-editor/src/extensions/italic/italic.js
+++ b/packages/super-editor/src/extensions/italic/italic.js
@@ -1,5 +1,11 @@
+// @ts-check
 import { Mark, Attribute } from '@core/index.js';
 
+/**
+ * @module Italic
+ * @sidebarTitle Italic
+ * @snippetPath /snippets/extensions/italic.mdx
+ */
 export const Italic = Mark.create({
   name: 'italic',
 
@@ -22,12 +28,43 @@ export const Italic = Mark.create({
     return ['em', Attribute.mergeAttributes(this.options.htmlAttributes, htmlAttributes), 0];
   },
 
-  //prettier-ignore
   addCommands() {
     return {
-      setItalic: () => ({ commands }) => commands.setMark(this.name),
-      unsetItalic: () => ({ commands }) => commands.unsetMark(this.name),
-      toggleItalic: () => ({ commands }) => commands.toggleMark(this.name),
+      /**
+       * Apply italic formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * setItalic()
+       */
+      setItalic:
+        () =>
+        ({ commands }) =>
+          commands.setMark(this.name),
+
+      /**
+       * Remove italic formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * unsetItalic()
+       */
+      unsetItalic:
+        () =>
+        ({ commands }) =>
+          commands.unsetMark(this.name),
+
+      /**
+       * Toggle italic formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * toggleItalic()
+       */
+      toggleItalic:
+        () =>
+        ({ commands }) =>
+          commands.toggleMark(this.name),
     };
   },
 

--- a/packages/super-editor/src/extensions/strike/strike.js
+++ b/packages/super-editor/src/extensions/strike/strike.js
@@ -1,5 +1,11 @@
+// @ts-check
 import { Mark, Attribute } from '@core/index.js';
 
+/**
+ * @module Strike
+ * @sidebarTitle Strike
+ * @snippetPath /snippets/extensions/strike.mdx
+ */
 export const Strike = Mark.create({
   name: 'strike',
 
@@ -23,16 +29,39 @@ export const Strike = Mark.create({
 
   addCommands() {
     return {
+      /**
+       * Apply strikethrough formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * setStrike()
+       */
       setStrike:
         () =>
         ({ commands }) => {
           return commands.setMark(this.name);
         },
+
+      /**
+       * Remove strikethrough formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * unsetStrike()
+       */
       unsetStrike:
         () =>
         ({ commands }) => {
           return commands.unsetMark(this.name);
         },
+
+      /**
+       * Toggle strikethrough formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * toggleStrike()
+       */
       toggleStrike:
         () =>
         ({ commands }) => {

--- a/packages/super-editor/src/extensions/text-style/text-style.js
+++ b/packages/super-editor/src/extensions/text-style/text-style.js
@@ -1,7 +1,12 @@
+// @ts-check
 import { Mark, Attribute } from '@core/index.js';
-
 import { annotationClass, annotationContentClass } from '../field-annotation/index.js';
 
+/**
+ * @module TextStyle
+ * @sidebarTitle Text Style
+ * @snippetPath /snippets/extensions/text-style.mdx
+ */
 export const TextStyle = Mark.create({
   name: 'textStyle',
 
@@ -37,6 +42,14 @@ export const TextStyle = Mark.create({
 
   addCommands() {
     return {
+      /**
+       * Remove empty text style marks
+       * @category Command
+       * @returns {Function} Command - Removes mark if no attributes present
+       * @example
+       * removeEmptyTextStyle()
+       * @note Cleanup utility to prevent empty span elements
+       */
       removeEmptyTextStyle:
         () =>
         ({ state, commands }) => {

--- a/packages/super-editor/src/extensions/underline/underline.js
+++ b/packages/super-editor/src/extensions/underline/underline.js
@@ -1,5 +1,16 @@
+// @ts-check
+/**
+ * Underline style types
+ * @typedef {'single'|'double'|'thick'|'dotted'|'dashed'|'wavy'} UnderlineType
+ */
+
 import { Mark, Attribute } from '@core/index.js';
 
+/**
+ * @module Underline
+ * @sidebarTitle Underline
+ * @snippetPath /snippets/extensions/underline.mdx
+ */
 export const Underline = Mark.create({
   name: 'underline',
 
@@ -29,12 +40,43 @@ export const Underline = Mark.create({
     };
   },
 
-  //prettier-ignore
   addCommands() {
     return {
-      setUnderline: () => ({ commands }) => commands.setMark(this.name),
-      unsetUnderline: () => ({ commands }) => commands.unsetMark(this.name),
-      toggleUnderline: () => ({ commands }) => commands.toggleMark(this.name),
+      /**
+       * Apply underline formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * setUnderline()
+       */
+      setUnderline:
+        () =>
+        ({ commands }) =>
+          commands.setMark(this.name),
+
+      /**
+       * Remove underline formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * unsetUnderline()
+       */
+      unsetUnderline:
+        () =>
+        ({ commands }) =>
+          commands.unsetMark(this.name),
+
+      /**
+       * Toggle underline formatting
+       * @category Command
+       * @returns {Function} Command
+       * @example
+       * toggleUnderline()
+       */
+      toggleUnderline:
+        () =>
+        ({ commands }) =>
+          commands.toggleMark(this.name),
     };
   },
 


### PR DESCRIPTION
- Added JSDoc comments for commands in Bold, Highlight, Italic, Strike, Underline, and Link extensions.
- Improved clarity on command usage with examples and parameter descriptions.
- Organized module metadata for better integration with documentation tools.