### PR TITLE
refactor: update document version handling and add SuperDoc ID [SD-428]

### DIFF
--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -924,8 +924,8 @@ export class Editor extends EventEmitter {
    * @param {string} version - New version
    * @returns {Object}
    */
-  static updateDocumentVersion(doc, version) {
-    const updatedContent = SuperConverter.updateDocumentVersion(doc, version);
+  static setDocumentVersion(doc, version) {
+    const updatedContent = SuperConverter.setStoredSuperdocVersion(doc, version);
     return updatedContent;
   }
 
@@ -1425,6 +1425,22 @@ export class Editor extends EventEmitter {
       html = unflattenListsInHtml(html);
     }
     return html;
+  }
+
+  /**
+   * Get the document ID from the converter
+   * @returns {string|null} The unique SuperDoc ID for this document
+   */
+  getDocumentId() {
+    return this.converter?.getSuperdocId() || null;
+  }
+
+  /**
+   * Get the document version from the converter
+   * @returns {string|null} The SuperDoc version stored in the document
+   */
+  getDocumentVersion() {
+    return this.converter?.getSuperdocVersion() || null;
   }
 
   /**

--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -934,7 +934,7 @@ export class Editor extends EventEmitter {
    * @returns {string|null} Document GUID
    */
   static getDocumentGuid(doc) {
-    return SuperConverter.getDocumentGuid(doc);
+    return SuperConverter.extractDocumentGuid(doc);
   }
 
   // Deprecated

--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -1660,7 +1660,10 @@ export class Editor extends EventEmitter {
 
       const customXml = this.converter.schemaToXml(this.converter.convertedXml['docProps/custom.xml'].elements[0]);
       const styles = this.converter.schemaToXml(this.converter.convertedXml['word/styles.xml'].elements[0]);
-      const customSettings = this.converter.schemaToXml(this.converter.convertedXml['word/settings.xml'].elements[0]);
+      const hasCustomSettings = !!this.converter.convertedXml['word/settings.xml']?.elements?.length;
+      const customSettings = hasCustomSettings
+        ? this.converter.schemaToXml(this.converter.convertedXml['word/settings.xml']?.elements?.[0])
+        : null;
       const rels = this.converter.schemaToXml(this.converter.convertedXml['word/_rels/document.xml.rels'].elements[0]);
       const media = this.converter.addedMedia;
 
@@ -1678,7 +1681,6 @@ export class Editor extends EventEmitter {
         ...this.options.customUpdatedFiles,
         'word/document.xml': String(documentXml),
         'docProps/custom.xml': String(customXml),
-        'word/settings.xml': String(customSettings),
         'word/_rels/document.xml.rels': String(rels),
         'word/numbering.xml': String(numbering),
 
@@ -1686,6 +1688,10 @@ export class Editor extends EventEmitter {
         'word/styles.xml': String(styles).replace(/&/gi, '&amp;'),
         ...updatedHeadersFooters,
       };
+
+      if (hasCustomSettings) {
+        updatedDocs['word/settings.xml'] = String(customSettings);
+      }
 
       if (comments.length) {
         const commentsXml = this.converter.schemaToXml(this.converter.convertedXml['word/comments.xml'].elements[0]);

--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -1474,14 +1474,22 @@ export class Editor extends EventEmitter {
    * @returns {Object} Editor content as JSON
    */
   getJSON() {
-    const json = this.state.doc.toJSON();
+    return this.state.doc.toJSON();
+  }
+
+  /**
+   * Get document metadata including GUID, modification status, and version
+   * @returns {{
+   *   documentGuid: string | null,
+   *   isModified: boolean,
+   *   version: string | null
+   * }} Document metadata
+   */
+  getMetadata() {
     return {
-      ...json,
-      metadata: {
-        documentGuid: this.converter?.documentGuid || null,
-        isModified: this.isDocumentModified(),
-        version: this.converter?.getSuperdocVersion() || null,
-      },
+      documentGuid: this.converter?.documentGuid || null,
+      isModified: this.isDocumentModified(),
+      version: this.converter?.getSuperdocVersion() || null,
     };
   }
 

--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -1509,14 +1509,6 @@ export class Editor extends EventEmitter {
   }
 
   /**
-   * Get the document ID from the converter
-   * @returns {string|null} The unique SuperDoc ID for this document
-   */
-  getDocumentId() {
-    return this.converter?.getSuperdocId() || null;
-  }
-
-  /**
    * Get the document version from the converter
    * @returns {string|null} The SuperDoc version stored in the document
    */

--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -452,7 +452,7 @@ class SuperConverter {
   /**
    * Generate document hash for telemetry (async, lazy)
    */
-  async generateDocumentHash() {
+  async #generateDocumentHash() {
     if (!this.fileSource) return `HASH-${Date.now()}`;
 
     try {
@@ -486,7 +486,7 @@ class SuperConverter {
     }
 
     if (!this.documentHash && this.fileSource) {
-      this.documentHash = await this.generateDocumentHash();
+      this.documentHash = await this.#generateDocumentHash();
     }
 
     return this.documentHash;

--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -510,6 +510,8 @@ class SuperConverter {
     this.documentModified = true;
     this.documentHash = null; // Clear temporary hash
 
+    // Note: GUID is stored to custom properties during export to avoid
+    // unnecessary XML modifications if the document is never saved
     return this.documentGuid;
   }
 

--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -326,7 +326,8 @@ class SuperConverter {
       // Get next available pid
       const existingPids = properties.elements
         .filter((el) => el.attributes?.pid)
-        .map((el) => parseInt(el.attributes.pid));
+        .map((el) => parseInt(el.attributes.pid, 10)) // Add radix for clarity
+        .filter(Number.isInteger); // Use isInteger instead of isFinite since PIDs should be integers
       const pid = existingPids.length > 0 ? Math.max(...existingPids) + 1 : 2;
 
       property = {

--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -375,7 +375,7 @@ class SuperConverter {
    * @param {Array} docx - Array of docx file objects
    * @returns {string|null} The document GUID
    */
-  static getDocumentGuid(docx) {
+  static extractDocumentGuid(docx) {
     try {
       const settingsXml = docx.find((doc) => doc.name === 'word/settings.xml');
       if (!settingsXml) return null;
@@ -1025,7 +1025,7 @@ class SuperConverter {
   // Deprecated methods for backward compatibility
   static getStoredSuperdocId(docx) {
     console.warn('getStoredSuperdocId is deprecated, use getDocumentGuid instead');
-    return SuperConverter.getDocumentGuid(docx);
+    return SuperConverter.extractDocumentGuid(docx);
   }
 
   static updateDocumentVersion(docx, version) {

--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -307,7 +307,8 @@ class SuperConverter {
     if (!docx[customLocation]) docx[customLocation] = generateCustomXml();
 
     const customXml = docx[customLocation];
-    const properties = customXml.elements.find((el) => el.name === 'Properties');
+    const properties = customXml.elements?.find((el) => el.name === 'Properties');
+    if (!properties) return null;
     if (!properties.elements) properties.elements = [];
 
     // Check if property already exists

--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -493,14 +493,6 @@ class SuperConverter {
   }
 
   /**
-   * Check if using temporary ID
-   */
-  hasTemporaryId() {
-    // Has temporary ID if no GUID but has hash (or could generate one)
-    return !this.documentGuid && !!(this.documentHash || this.fileSource);
-  }
-
-  /**
    * Promote from hash to GUID on first edit
    */
   promoteToGuid() {

--- a/packages/super-editor/src/core/super-converter/SuperConverter.test.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.test.js
@@ -181,6 +181,55 @@ describe('SuperConverter Document GUID', () => {
     });
   });
 
+  describe('Custom Properties', () => {
+    it('stores a custom property', () => {
+      const docx = {
+        'docProps/custom.xml': {
+          elements: [
+            {
+              name: 'Properties',
+              elements: [],
+            },
+          ],
+        },
+      };
+
+      SuperConverter.setStoredCustomProperty(docx, 'MyCustomProp', 'MyValue');
+      const prop = docx['docProps/custom.xml'].elements[0].elements[0];
+      expect(prop.attributes.name).toBe('MyCustomProp');
+      expect(prop.elements[0].elements[0].text).toBe('MyValue');
+    });
+
+    it('retrieves a custom property', () => {
+      const docx = {
+        name: 'docProps/custom.xml',
+        content: `<?xml version="1.0" encoding="UTF-8"?>
+        <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties">
+          <property name="MyCustomProp" pid="2">
+            <vt:lpwstr>MyValue</vt:lpwstr>
+          </property>
+        </Properties>`,
+      };
+      const value = SuperConverter.getStoredCustomProperty([docx], 'MyCustomProp');
+      expect(value).toBe('MyValue');
+    });
+
+    it('returns null if custom property does not exist', () => {
+      const value = SuperConverter.getStoredCustomProperty(
+        [
+          {
+            name: 'docProps/custom.xml',
+            content: `<?xml version="1.0" encoding="UTF-8"?>
+            <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties">
+            </Properties>`,
+          },
+        ],
+        'NonExistentProp',
+      );
+      expect(value).toBeNull();
+    });
+  });
+
   describe('Backward Compatibility', () => {
     it('deprecated methods show warnings', () => {
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/super-editor/src/core/super-converter/SuperConverter.test.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.test.js
@@ -72,14 +72,15 @@ describe('SuperConverter Document GUID', () => {
       expect(converter.hasTemporaryId()).toBe(false);
     });
 
-    it('generates hash for unmodified document without GUID', () => {
+    it('generates hash for unmodified document without GUID', async () => {
       const fileSource = Buffer.from('test file content');
       const converter = new SuperConverter({
         docx: mockDocx,
         fileSource,
       });
 
-      const identifier = converter.getDocumentIdentifier();
+      // getDocumentIdentifier is now async
+      const identifier = await converter.getDocumentIdentifier();
       expect(identifier).toMatch(/^HASH-/);
       expect(converter.hasTemporaryId()).toBe(true);
       expect(converter.getDocumentGuid()).toBeNull();
@@ -87,14 +88,17 @@ describe('SuperConverter Document GUID', () => {
   });
 
   describe('GUID Promotion', () => {
-    it('promotes hash to GUID when document is modified', () => {
+    it('promotes hash to GUID when document is modified', async () => {
       const fileSource = Buffer.from('test file content');
       const converter = new SuperConverter({
         docx: mockDocx,
         fileSource,
       });
 
-      // Initially has hash
+      // Generate hash first (async)
+      await converter.getDocumentIdentifier();
+
+      // Now check if has temporary ID
       expect(converter.hasTemporaryId()).toBe(true);
 
       // Promote to GUID

--- a/packages/super-editor/src/core/super-converter/SuperConverter.test.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.test.js
@@ -6,6 +6,11 @@ vi.mock('uuid', () => ({
   v4: vi.fn(() => 'test-uuid-1234'),
 }));
 
+function hasTemporaryId(converter) {
+  // Has temporary ID if no GUID but has hash (or could generate one)
+  return !converter.documentGuid && !!(converter.documentHash || converter.fileSource);
+}
+
 describe('SuperConverter Document GUID', () => {
   let mockDocx;
   let mockCustomXml;
@@ -51,7 +56,7 @@ describe('SuperConverter Document GUID', () => {
 
       const converter = new SuperConverter({ docx: mockDocx });
       expect(converter.getDocumentGuid()).toBe('MICROSOFT-GUID-123');
-      expect(converter.hasTemporaryId()).toBe(false);
+      expect(hasTemporaryId(converter)).toBe(false);
     });
 
     it('uses custom DocumentGuid when no Microsoft GUID exists', () => {
@@ -69,7 +74,7 @@ describe('SuperConverter Document GUID', () => {
 
       const converter = new SuperConverter({ docx: customDocx });
       expect(converter.getDocumentGuid()).toBe('CUSTOM-GUID-456');
-      expect(converter.hasTemporaryId()).toBe(false);
+      expect(hasTemporaryId(converter)).toBe(false);
     });
 
     it('generates hash for unmodified document without GUID', async () => {
@@ -82,7 +87,7 @@ describe('SuperConverter Document GUID', () => {
       // getDocumentIdentifier is now async
       const identifier = await converter.getDocumentIdentifier();
       expect(identifier).toMatch(/^HASH-/);
-      expect(converter.hasTemporaryId()).toBe(true);
+      expect(hasTemporaryId(converter)).toBe(true);
       expect(converter.getDocumentGuid()).toBeNull();
     });
   });
@@ -99,13 +104,13 @@ describe('SuperConverter Document GUID', () => {
       await converter.getDocumentIdentifier();
 
       // Now check if has temporary ID
-      expect(converter.hasTemporaryId()).toBe(true);
+      expect(hasTemporaryId(converter)).toBe(true);
 
       // Promote to GUID
       const guid = converter.promoteToGuid();
       expect(guid).toBe('test-uuid-1234');
       expect(converter.getDocumentGuid()).toBe('test-uuid-1234');
-      expect(converter.hasTemporaryId()).toBe(false);
+      expect(hasTemporaryId(converter)).toBe(false);
       expect(converter.documentModified).toBe(true);
     });
 

--- a/packages/super-editor/src/core/super-converter/SuperConverter.test.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.test.js
@@ -1,0 +1,348 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SuperConverter } from './SuperConverter.js';
+import { v4 as uuidv4 } from 'uuid';
+
+// Mock uuid
+vi.mock('uuid', () => ({
+  v4: vi.fn(() => 'test-uuid-1234'),
+}));
+
+describe('SuperConverter Custom Properties', () => {
+  let mockDocx;
+  let mockCustomXml;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Create a basic custom.xml structure
+    mockCustomXml = {
+      name: 'docProps/custom.xml',
+      content: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties">
+        </Properties>`,
+    };
+
+    mockDocx = [mockCustomXml];
+  });
+
+  describe('getStoredCustomProperty', () => {
+    it('returns null when custom.xml is missing', () => {
+      const result = SuperConverter.getStoredCustomProperty([], 'TestProperty');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when property does not exist', () => {
+      const result = SuperConverter.getStoredCustomProperty(mockDocx, 'NonExistent');
+      expect(result).toBeNull();
+    });
+
+    it('returns property value when it exists', () => {
+      mockCustomXml.content = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties">
+          <property name="TestProp" fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="2">
+            <vt:lpwstr>TestValue</vt:lpwstr>
+          </property>
+        </Properties>`;
+
+      const result = SuperConverter.getStoredCustomProperty(mockDocx, 'TestProp');
+      expect(result).toBe('TestValue');
+    });
+
+    it('handles parsing errors gracefully', () => {
+      mockCustomXml.content = 'invalid xml';
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = SuperConverter.getStoredCustomProperty(mockDocx, 'TestProp');
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('setStoredCustomProperty', () => {
+    it('creates custom.xml if missing', () => {
+      const docx = {};
+      SuperConverter.setStoredCustomProperty(docx, 'NewProp', 'NewValue');
+
+      expect(docx['docProps/custom.xml']).toBeDefined();
+      expect(docx['docProps/custom.xml'].elements).toBeDefined();
+    });
+
+    it('adds new property with correct structure', () => {
+      const docx = {
+        'docProps/custom.xml': {
+          elements: [
+            {
+              name: 'Properties',
+              elements: [],
+            },
+          ],
+        },
+      };
+
+      const result = SuperConverter.setStoredCustomProperty(docx, 'TestProp', 'TestValue');
+
+      expect(result).toBe('TestValue');
+      const props = docx['docProps/custom.xml'].elements[0].elements;
+      expect(props).toHaveLength(1);
+      expect(props[0].attributes.name).toBe('TestProp');
+      expect(props[0].elements[0].elements[0].text).toBe('TestValue');
+    });
+
+    it('updates existing property when preserveExisting is false', () => {
+      const docx = {
+        'docProps/custom.xml': {
+          elements: [
+            {
+              name: 'Properties',
+              elements: [
+                {
+                  type: 'element',
+                  name: 'property',
+                  attributes: { name: 'ExistingProp', pid: 2 },
+                  elements: [
+                    {
+                      name: 'vt:lpwstr',
+                      elements: [{ text: 'OldValue' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = SuperConverter.setStoredCustomProperty(docx, 'ExistingProp', 'NewValue', false);
+      expect(result).toBe('NewValue');
+
+      const prop = docx['docProps/custom.xml'].elements[0].elements[0];
+      expect(prop.elements[0].elements[0].text).toBe('NewValue');
+    });
+
+    it('preserves existing property when preserveExisting is true', () => {
+      const docx = {
+        'docProps/custom.xml': {
+          elements: [
+            {
+              name: 'Properties',
+              elements: [
+                {
+                  type: 'element',
+                  name: 'property',
+                  attributes: { name: 'ExistingProp', pid: 2 },
+                  elements: [
+                    {
+                      name: 'vt:lpwstr',
+                      elements: [{ text: 'OldValue' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = SuperConverter.setStoredCustomProperty(docx, 'ExistingProp', 'NewValue', true);
+      expect(result).toBe('OldValue');
+
+      const prop = docx['docProps/custom.xml'].elements[0].elements[0];
+      expect(prop.elements[0].elements[0].text).toBe('OldValue');
+    });
+
+    it('handles function values correctly', () => {
+      const docx = {
+        'docProps/custom.xml': {
+          elements: [
+            {
+              name: 'Properties',
+              elements: [],
+            },
+          ],
+        },
+      };
+
+      const valueFunc = () => 'GeneratedValue';
+      const result = SuperConverter.setStoredCustomProperty(docx, 'TestProp', valueFunc);
+
+      expect(result).toBe('GeneratedValue');
+    });
+
+    it('assigns sequential pids for multiple properties', () => {
+      const docx = {
+        'docProps/custom.xml': {
+          elements: [
+            {
+              name: 'Properties',
+              elements: [
+                {
+                  attributes: { pid: 2 },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      SuperConverter.setStoredCustomProperty(docx, 'Prop1', 'Value1');
+      const props = docx['docProps/custom.xml'].elements[0].elements;
+      expect(props[props.length - 1].attributes.pid).toBe(3);
+    });
+  });
+
+  describe('SuperDoc ID methods', () => {
+    it('getStoredSuperdocId retrieves stored ID', () => {
+      mockCustomXml.content = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties">
+          <property name="SuperDocId" fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="2">
+            <vt:lpwstr>doc-id-123</vt:lpwstr>
+          </property>
+        </Properties>`;
+
+      const result = SuperConverter.getStoredSuperdocId(mockDocx);
+      expect(result).toBe('doc-id-123');
+    });
+
+    it('setStoredSuperdocId generates UUID when id is null', () => {
+      const docx = {
+        'docProps/custom.xml': {
+          elements: [
+            {
+              name: 'Properties',
+              elements: [],
+            },
+          ],
+        },
+      };
+
+      const result = SuperConverter.setStoredSuperdocId(docx, null);
+      expect(result).toBe('test-uuid-1234');
+      expect(uuidv4).toHaveBeenCalled();
+    });
+
+    it('setStoredSuperdocId uses provided ID', () => {
+      const docx = {
+        'docProps/custom.xml': {
+          elements: [
+            {
+              name: 'Properties',
+              elements: [],
+            },
+          ],
+        },
+      };
+
+      const result = SuperConverter.setStoredSuperdocId(docx, 'custom-id');
+      expect(result).toBe('custom-id');
+      expect(uuidv4).not.toHaveBeenCalled();
+    });
+
+    it('setStoredSuperdocId preserves existing ID', () => {
+      const docx = {
+        'docProps/custom.xml': {
+          elements: [
+            {
+              name: 'Properties',
+              elements: [
+                {
+                  type: 'element',
+                  name: 'property',
+                  attributes: { name: 'SuperDocId', pid: 2 },
+                  elements: [
+                    {
+                      name: 'vt:lpwstr',
+                      elements: [{ text: 'existing-id' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = SuperConverter.setStoredSuperdocId(docx, 'new-id');
+      expect(result).toBe('existing-id');
+    });
+  });
+
+  describe('SuperDoc Version methods', () => {
+    it('getStoredSuperdocVersion retrieves version', () => {
+      mockCustomXml.content = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties">
+          <property name="SuperdocVersion" fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="2">
+            <vt:lpwstr>1.2.3</vt:lpwstr>
+          </property>
+        </Properties>`;
+
+      const result = SuperConverter.getStoredSuperdocVersion(mockDocx);
+      expect(result).toBe('1.2.3');
+    });
+
+    it('setStoredSuperdocVersion always updates version', () => {
+      const docx = {
+        'docProps/custom.xml': {
+          elements: [
+            {
+              name: 'Properties',
+              elements: [
+                {
+                  type: 'element',
+                  name: 'property',
+                  attributes: { name: 'SuperdocVersion', pid: 2 },
+                  elements: [
+                    {
+                      name: 'vt:lpwstr',
+                      elements: [{ text: '1.0.0' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = SuperConverter.setStoredSuperdocVersion(docx, '2.0.0');
+      expect(result).toBe('2.0.0');
+
+      const prop = docx['docProps/custom.xml'].elements[0].elements[0];
+      expect(prop.elements[0].elements[0].text).toBe('2.0.0');
+    });
+  });
+
+  describe('SuperConverter instance methods', () => {
+    it('getSuperdocId returns stored ID', () => {
+      const converter = new SuperConverter();
+      converter.superdocId = 'test-id';
+
+      expect(converter.getSuperdocId()).toBe('test-id');
+    });
+
+    it('getSuperdocId returns null when not set', () => {
+      const converter = new SuperConverter();
+
+      expect(converter.getSuperdocId()).toBeNull();
+    });
+
+    it('getSuperdocVersion retrieves version from docx', () => {
+      const converter = new SuperConverter();
+      converter.docx = mockDocx;
+
+      mockCustomXml.content = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties">
+          <property name="SuperdocVersion" fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="2">
+            <vt:lpwstr>3.0.0</vt:lpwstr>
+          </property>
+        </Properties>`;
+
+      expect(converter.getSuperdocVersion()).toBe('3.0.0');
+    });
+
+    it('getSuperdocVersion returns null when docx not available', () => {
+      const converter = new SuperConverter();
+
+      expect(converter.getSuperdocVersion()).toBeNull();
+    });
+  });
+});

--- a/packages/super-editor/src/core/super-converter/SuperConverter.test.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.test.js
@@ -144,10 +144,10 @@ describe('SuperConverter Document GUID', () => {
             '<w:settings xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w15:docId w15:val="{MS-GUID}"/></w:settings>',
         },
       ];
-      expect(SuperConverter.getDocumentGuid(docxWithMsGuid)).toBe('MS-GUID');
+      expect(SuperConverter.extractDocumentGuid(docxWithMsGuid)).toBe('MS-GUID');
 
       // Test when no GUID exists
-      const guid = SuperConverter.getDocumentGuid(mockDocx);
+      const guid = SuperConverter.extractDocumentGuid(mockDocx);
       expect(guid).toBeNull();
     });
   });

--- a/packages/super-editor/src/core/super-converter/exporter-docx-defs.js
+++ b/packages/super-editor/src/core/super-converter/exporter-docx-defs.js
@@ -62,19 +62,6 @@ export const DEFAULT_CUSTOM_XML = {
   ],
 };
 
-export const SETTINGS_CUSTOM_XML = {
-  elements: [
-    {
-      type: 'element',
-      name: 'w:settings',
-      attributes: {
-        'xmlns:w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
-      },
-      elements: [],
-    },
-  ],
-};
-
 export const COMMENT_REF = {
   type: 'element',
   name: 'w:r',


### PR DESCRIPTION
- Renamed `updateDocumentVersion` to `setDocumentVersion` for clarity.
- Introduced methods to get and set SuperDoc ID and version in `SuperConverter`.
- Improved error handling and structure for custom properties in docx.
- Added unit tests for new functionality in `SuperConverter`.

Notes:
- MD5 hash (when GUID present)
- Insert GUID on key stroke
- Do not count on blank document