### PR TITLE
feat: add table module documentation + keyboard shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "pack": "npm run build:super-editor && npm --prefix ./packages/superdoc run pack",
     "prepare": "husky",
     "lint:staged": "lint-staged",
-    "watch": "npm run watch:es --workspace=packages/superdoc"
+    "watch": "npm run watch:es --workspace=packages/superdoc",
+    "check:all": "npm run format && npm run lint:fix && npm --workspace=packages/super-editor run types:build"
   },
   "lint-staged": {
     "*.{js,jsx}": [

--- a/packages/super-editor/src/core/helpers/isInTable.js
+++ b/packages/super-editor/src/core/helpers/isInTable.js
@@ -1,3 +1,15 @@
+// @ts-check
+/**
+ * Check if cursor is inside a table
+ * @private
+ * @category Helper
+ * @param {Object} state - Editor state
+ * @returns {boolean} True if cursor is in table
+ * @example
+ * if (isInTable(state)) {
+ *   // Enable table-specific commands
+ * }
+ */
 export const isInTable = (state) => {
   const { $head } = state.selection;
 

--- a/packages/super-editor/src/extensions/bold/bold.js
+++ b/packages/super-editor/src/extensions/bold/bold.js
@@ -19,11 +19,14 @@ export const Bold = Mark.create({
 
   addAttributes() {
     return {
+      /**
+       * @category Attribute
+       * @param {string} [value] - Bold weight value ('0' renders as normal)
+       */
       value: {
         default: null,
         renderDOM: (attrs) => {
           if (!attrs.value) return {};
-
           if (attrs.value === '0') {
             return { style: 'font-weight: normal' };
           }

--- a/packages/super-editor/src/extensions/bold/bold.js
+++ b/packages/super-editor/src/extensions/bold/bold.js
@@ -5,6 +5,8 @@ import { Mark, Attribute } from '@core/index.js';
  * @module Bold
  * @sidebarTitle Bold
  * @snippetPath /snippets/extensions/bold.mdx
+ * @shortcut Mod-b | toggleBold | Toggle bold formatting
+ * @shortcut Mod-B | toggleBold | Toggle bold formatting (uppercase)
  */
 export const Bold = Mark.create({
   name: 'bold',

--- a/packages/super-editor/src/extensions/highlight/highlight.js
+++ b/packages/super-editor/src/extensions/highlight/highlight.js
@@ -18,6 +18,10 @@ export const Highlight = Mark.create({
 
   addAttributes() {
     return {
+      /**
+       * @category Attribute
+       * @param {string} [color] - Background color (CSS color value)
+       */
       color: {
         default: null,
         parseDOM: (element) => element.getAttribute('data-color') || element.style.backgroundColor,

--- a/packages/super-editor/src/extensions/highlight/highlight.js
+++ b/packages/super-editor/src/extensions/highlight/highlight.js
@@ -5,6 +5,7 @@ import { Mark, Attribute } from '@core/index.js';
  * @module Highlight
  * @sidebarTitle Highlight
  * @snippetPath /snippets/extensions/highlight.mdx
+ * @shortcut Mod-Shift-h | toggleHighlight | Toggle highlighted formatting
  */
 export const Highlight = Mark.create({
   name: 'highlight',

--- a/packages/super-editor/src/extensions/italic/italic.js
+++ b/packages/super-editor/src/extensions/italic/italic.js
@@ -5,6 +5,8 @@ import { Mark, Attribute } from '@core/index.js';
  * @module Italic
  * @sidebarTitle Italic
  * @snippetPath /snippets/extensions/italic.mdx
+ * @shortcut Mod-i | toggleItalic | Toggle italic formatting
+ * @shortcut Mod-I | toggleItalic | Toggle italic formatting (uppercase)
  */
 export const Italic = Mark.create({
   name: 'italic',

--- a/packages/super-editor/src/extensions/link/link.js
+++ b/packages/super-editor/src/extensions/link/link.js
@@ -55,6 +55,10 @@ export const Link = Mark.create({
 
   addAttributes() {
     return {
+      /**
+       * @category Attribute
+       * @param {string} [href] - URL or anchor reference
+       */
       href: {
         default: null,
         renderDOM: ({ href, name }) => {
@@ -63,10 +67,31 @@ export const Link = Mark.create({
           return {};
         },
       },
+      /**
+       * @category Attribute
+       * @param {string} [target='_blank'] - Link target window
+       */
       target: { default: this.options.htmlAttributes.target },
+      /**
+       * @category Attribute
+       * @param {string} [rel='noopener noreferrer nofollow'] - Relationship attributes
+       */
       rel: { default: this.options.htmlAttributes.rel },
+      /**
+       * @private
+       * @category Attribute
+       * @param {string} [rId] - Word relationship ID for internal links
+       */
       rId: { default: this.options.htmlAttributes.rId || null },
+      /**
+       * @category Attribute
+       * @param {string} [text] - Display text for the link
+       */
       text: { default: null },
+      /**
+       * @category Attribute
+       * @param {string} [name] - Anchor name for internal references
+       */
       name: { default: null },
     };
   },

--- a/packages/super-editor/src/extensions/strike/strike.js
+++ b/packages/super-editor/src/extensions/strike/strike.js
@@ -5,6 +5,7 @@ import { Mark, Attribute } from '@core/index.js';
  * @module Strike
  * @sidebarTitle Strike
  * @snippetPath /snippets/extensions/strike.mdx
+ * @shortcut Mod-Shift-s | toggleStrike | Toggle strikethrough formatting
  */
 export const Strike = Mark.create({
   name: 'strike',

--- a/packages/super-editor/src/extensions/structured-content/document-section.js
+++ b/packages/super-editor/src/extensions/structured-content/document-section.js
@@ -75,7 +75,16 @@ export const DocumentSection = Node.create({
 
   addAttributes() {
     return {
+      /**
+       * @category Attribute
+       * @param {number} [id] - Unique section identifier
+       */
       id: {},
+      /**
+       * @private
+       * @category Attribute
+       * @param {string} [sdBlockId] - Internal block tracking
+       */
       sdBlockId: {
         default: null,
         keepOnSplit: false,
@@ -84,9 +93,25 @@ export const DocumentSection = Node.create({
           return attrs.sdBlockId ? { 'data-sd-block-id': attrs.sdBlockId } : {};
         },
       },
+      /**
+       * @category Attribute
+       * @param {string} [title] - Section display label
+       */
       title: {},
+      /**
+       * @category Attribute
+       * @param {string} [description] - Section metadata
+       */
       description: {},
+      /**
+       * @category Attribute
+       * @param {string} [sectionType] - Business classification (e.g., 'legal', 'pricing')
+       */
       sectionType: {},
+      /**
+       * @category Attribute
+       * @param {boolean} [isLocked=false] - Lock state preventing edits
+       */
       isLocked: { default: false },
     };
   },

--- a/packages/super-editor/src/extensions/table-cell/helpers/createCellBorders.js
+++ b/packages/super-editor/src/extensions/table-cell/helpers/createCellBorders.js
@@ -1,3 +1,30 @@
+// @ts-check
+/**
+ * Cell border configuration
+ * @typedef {Object} CellBorder
+ * @property {number} [size=1] - Border width in pixels
+ * @property {string} [color='#000000'] - Border color
+ * @property {string} [style='solid'] - Border style
+ */
+
+/**
+ * Cell borders object
+ * @typedef {Object} CellBorders
+ * @property {CellBorder} [top] - Top border
+ * @property {CellBorder} [right] - Right border
+ * @property {CellBorder} [bottom] - Bottom border
+ * @property {CellBorder} [left] - Left border
+ */
+
+/**
+ * Create cell border configuration object
+ * @private
+ * @category Helper
+ * @param {Object} [options] - Border options
+ * @param {number} [options.size=0.66665] - Border width in pixels
+ * @param {string} [options.color='#000000'] - Border color (hex)
+ * @returns {CellBorders} Complete borders object for all cell sides
+ */
 export const createCellBorders = ({ size = 0.66665, color = '#000000' } = {}) => {
   return {
     top: { size, color },

--- a/packages/super-editor/src/extensions/table-cell/table-cell.js
+++ b/packages/super-editor/src/extensions/table-cell/table-cell.js
@@ -71,14 +71,26 @@ export const TableCell = Node.create({
 
   addAttributes() {
     return {
+      /**
+       * @category Attribute
+       * @param {number} [colspan=1] - Number of columns this cell spans
+       */
       colspan: {
         default: 1,
       },
 
+      /**
+       * @category Attribute
+       * @param {number} [rowspan=1] - Number of rows this cell spans
+       */
       rowspan: {
         default: 1,
       },
 
+      /**
+       * @category Attribute
+       * @param {number[]} [colwidth=[100]] - Column widths array in pixels
+       */
       colwidth: {
         default: [100],
         parseDOM: (elem) => {
@@ -94,16 +106,10 @@ export const TableCell = Node.create({
         },
       },
 
-      /* width: {
-        renderDOM: ({ width, widthType, widthUnit }) => {
-          if (!width) return {};
-          let unit = widthUnit === 'px' ? widthUnit : 'in';
-          if (widthType === 'pct') unit = '%';
-          const style = `width: ${width}${unit}`;
-          return { style };
-        },
-      }, */
-
+      /**
+       * @category Attribute
+       * @param {CellBackground} [background] - Cell background color configuration
+       */
       background: {
         renderDOM({ background }) {
           if (!background) return {};
@@ -113,6 +119,10 @@ export const TableCell = Node.create({
         },
       },
 
+      /**
+       * @category Attribute
+       * @param {string} [verticalAlign] - Vertical content alignment (top, middle, bottom)
+       */
       verticalAlign: {
         renderDOM({ verticalAlign }) {
           if (!verticalAlign) return {};
@@ -121,6 +131,10 @@ export const TableCell = Node.create({
         },
       },
 
+      /**
+       * @category Attribute
+       * @param {CellMargins} [cellMargins] - Internal cell padding
+       */
       cellMargins: {
         renderDOM({ cellMargins }) {
           if (!cellMargins) return {};
@@ -136,6 +150,10 @@ export const TableCell = Node.create({
         },
       },
 
+      /**
+       * @category Attribute
+       * @param {CellBorders} [borders] - Cell border configuration
+       */
       borders: {
         default: () => createCellBorders(),
         renderDOM({ borders }) {
@@ -153,11 +171,21 @@ export const TableCell = Node.create({
         },
       },
 
+      /**
+       * @private
+       * @category Attribute
+       * @param {string} [widthType='auto'] - Internal width type
+       */
       widthType: {
         default: 'auto',
         rendered: false,
       },
 
+      /**
+       * @private
+       * @category Attribute
+       * @param {string} [widthUnit='px'] - Internal width unit
+       */
       widthUnit: {
         default: 'px',
         rendered: false,

--- a/packages/super-editor/src/extensions/table-cell/table-cell.js
+++ b/packages/super-editor/src/extensions/table-cell/table-cell.js
@@ -1,5 +1,4 @@
 // @ts-check
-
 /**
  * Cell border configuration
  * @typedef {Object} CellBorder
@@ -30,18 +29,6 @@
  * Cell background configuration
  * @typedef {Object} CellBackground
  * @property {string} color - Background color (hex without #)
- */
-
-/**
- * Table cell attributes
- * @typedef {Object} TableCellAttributes
- * @property {number} [colspan=1] - Number of columns spanned
- * @property {number} [rowspan=1] - Number of rows spanned
- * @property {number[]} [colwidth=[100]] - Column widths array
- * @property {CellBackground} [background] - Background configuration
- * @property {string} [verticalAlign] - Vertical alignment (top, middle, bottom)
- * @property {CellMargins} [cellMargins] - Cell padding margins
- * @property {CellBorders} [borders] - Cell border configuration
  */
 
 import { Node, Attribute } from '@core/index.js';

--- a/packages/super-editor/src/extensions/table-cell/table-cell.js
+++ b/packages/super-editor/src/extensions/table-cell/table-cell.js
@@ -1,22 +1,5 @@
 // @ts-check
 /**
- * Cell border configuration
- * @typedef {Object} CellBorder
- * @property {number} [size=1] - Border width in pixels
- * @property {string} [color='#000000'] - Border color
- * @property {string} [style='solid'] - Border style
- */
-
-/**
- * Cell borders object
- * @typedef {Object} CellBorders
- * @property {CellBorder} [top] - Top border
- * @property {CellBorder} [right] - Right border
- * @property {CellBorder} [bottom] - Bottom border
- * @property {CellBorder} [left] - Left border
- */
-
-/**
  * Cell margins configuration
  * @typedef {Object} CellMargins
  * @property {number} [top] - Top margin in pixels
@@ -186,30 +169,5 @@ export const TableCell = Node.create({
 
   renderDOM({ htmlAttributes }) {
     return ['td', Attribute.mergeAttributes(this.options.htmlAttributes, htmlAttributes), 0];
-  },
-
-  addHelpers() {
-    return {
-      /**
-       * Create cell border configuration object
-       * @category Helper
-       * @param {Object} [options] - Border options
-       * @param {number} [options.size=0.66665] - Border width in pixels
-       * @param {string} [options.color='#000000'] - Border color (hex)
-       * @returns {CellBorders} Complete borders object for all cell sides
-       * @example
-       *
-       * // Using default values
-       * const borders = createCellBorders()
-       *
-       * // Using custom values
-       * const borders = createCellBorders({ size: 1, color: '#cccccc' })
-       * @note Creates uniform borders for all four sides of a cell
-       * @note Default size matches Word's default cell border width
-       */
-      createCellBorders: ({ size = 0.66665, color = '#000000' } = {}) => {
-        return createCellBorders({ size, color });
-      },
-    };
   },
 });

--- a/packages/super-editor/src/extensions/table-cell/table-cell.js
+++ b/packages/super-editor/src/extensions/table-cell/table-cell.js
@@ -1,6 +1,57 @@
+// @ts-check
+
+/**
+ * Cell border configuration
+ * @typedef {Object} CellBorder
+ * @property {number} [size=1] - Border width in pixels
+ * @property {string} [color='#000000'] - Border color
+ * @property {string} [style='solid'] - Border style
+ */
+
+/**
+ * Cell borders object
+ * @typedef {Object} CellBorders
+ * @property {CellBorder} [top] - Top border
+ * @property {CellBorder} [right] - Right border
+ * @property {CellBorder} [bottom] - Bottom border
+ * @property {CellBorder} [left] - Left border
+ */
+
+/**
+ * Cell margins configuration
+ * @typedef {Object} CellMargins
+ * @property {number} [top] - Top margin in pixels
+ * @property {number} [right] - Right margin in pixels
+ * @property {number} [bottom] - Bottom margin in pixels
+ * @property {number} [left] - Left margin in pixels
+ */
+
+/**
+ * Cell background configuration
+ * @typedef {Object} CellBackground
+ * @property {string} color - Background color (hex without #)
+ */
+
+/**
+ * Table cell attributes
+ * @typedef {Object} TableCellAttributes
+ * @property {number} [colspan=1] - Number of columns spanned
+ * @property {number} [rowspan=1] - Number of rows spanned
+ * @property {number[]} [colwidth=[100]] - Column widths array
+ * @property {CellBackground} [background] - Background configuration
+ * @property {string} [verticalAlign] - Vertical alignment (top, middle, bottom)
+ * @property {CellMargins} [cellMargins] - Cell padding margins
+ * @property {CellBorders} [borders] - Cell border configuration
+ */
+
 import { Node, Attribute } from '@core/index.js';
 import { createCellBorders } from './helpers/createCellBorders.js';
 
+/**
+ * @module TableCell
+ * @sidebarTitle Table Cell
+ * @snippetPath /snippets/extensions/table-cell.mdx
+ */
 export const TableCell = Node.create({
   name: 'tableCell',
 
@@ -120,5 +171,30 @@ export const TableCell = Node.create({
 
   renderDOM({ htmlAttributes }) {
     return ['td', Attribute.mergeAttributes(this.options.htmlAttributes, htmlAttributes), 0];
+  },
+
+  addHelpers() {
+    return {
+      /**
+       * Create cell border configuration object
+       * @category Helper
+       * @param {Object} [options] - Border options
+       * @param {number} [options.size=0.66665] - Border width in pixels
+       * @param {string} [options.color='#000000'] - Border color (hex)
+       * @returns {CellBorders} Complete borders object for all cell sides
+       * @example
+       *
+       * // Using default values
+       * const borders = createCellBorders()
+       *
+       * // Using custom values
+       * const borders = createCellBorders({ size: 1, color: '#cccccc' })
+       * @note Creates uniform borders for all four sides of a cell
+       * @note Default size matches Word's default cell border width
+       */
+      createCellBorders: ({ size = 0.66665, color = '#000000' } = {}) => {
+        return createCellBorders({ size, color });
+      },
+    };
   },
 });

--- a/packages/super-editor/src/extensions/table-header/table-header.js
+++ b/packages/super-editor/src/extensions/table-header/table-header.js
@@ -1,13 +1,4 @@
 // @ts-check
-
-/**
- * Table header attributes
- * @typedef {Object} TableHeaderAttributes
- * @property {number} [colspan=1] - Number of columns spanned
- * @property {number} [rowspan=1] - Number of rows spanned
- * @property {number[]} [colwidth] - Column widths array
- */
-
 import { Node, Attribute } from '@core/index.js';
 
 /**

--- a/packages/super-editor/src/extensions/table-header/table-header.js
+++ b/packages/super-editor/src/extensions/table-header/table-header.js
@@ -34,12 +34,26 @@ export const TableHeader = Node.create({
 
   addAttributes() {
     return {
+      /**
+       * @category Attribute
+       * @param {number} [colspan=1] - Number of columns this header spans
+       */
       colspan: {
         default: 1,
       },
+
+      /**
+       * @category Attribute
+       * @param {number} [rowspan=1] - Number of rows this header spans
+       */
       rowspan: {
         default: 1,
       },
+
+      /**
+       * @category Attribute
+       * @param {number[]} [colwidth] - Column widths array in pixels
+       */
       colwidth: {
         default: null,
         parseDOM: (element) => {

--- a/packages/super-editor/src/extensions/table-header/table-header.js
+++ b/packages/super-editor/src/extensions/table-header/table-header.js
@@ -1,5 +1,20 @@
+// @ts-check
+
+/**
+ * Table header attributes
+ * @typedef {Object} TableHeaderAttributes
+ * @property {number} [colspan=1] - Number of columns spanned
+ * @property {number} [rowspan=1] - Number of rows spanned
+ * @property {number[]} [colwidth] - Column widths array
+ */
+
 import { Node, Attribute } from '@core/index.js';
 
+/**
+ * @module TableHeader
+ * @sidebarTitle Table Header
+ * @snippetPath /snippets/extensions/table-header.mdx
+ */
 export const TableHeader = Node.create({
   name: 'tableHeader',
 

--- a/packages/super-editor/src/extensions/table-row/table-row.js
+++ b/packages/super-editor/src/extensions/table-row/table-row.js
@@ -1,5 +1,11 @@
+// @ts-check
 import { Node, Attribute } from '@core/index.js';
 
+/**
+ * @module TableRow
+ * @sidebarTitle Table Row
+ * @snippetPath /snippets/extensions/table-row.mdx
+ */
 export const TableRow = Node.create({
   name: 'tableRow',
 

--- a/packages/super-editor/src/extensions/table-row/table-row.js
+++ b/packages/super-editor/src/extensions/table-row/table-row.js
@@ -23,6 +23,10 @@ export const TableRow = Node.create({
 
   addAttributes() {
     return {
+      /**
+       * @category Attribute
+       * @param {number} [rowHeight] - Fixed row height in pixels
+       */
       rowHeight: {
         renderDOM({ rowHeight }) {
           if (!rowHeight) return {};

--- a/packages/super-editor/src/extensions/table/table.js
+++ b/packages/super-editor/src/extensions/table/table.js
@@ -9,31 +9,12 @@
  */
 
 /**
- * Table border configuration
- * @typedef {Object} TableBorder
- * @property {number} [size=1] - Border width in pixels
- * @property {string} [color='#000000'] - Border color (hex or CSS color)
- * @property {string} [style='solid'] - Border style (solid, dashed, dotted)
- */
-
-/**
- * Table borders object
- * @typedef {Object} TableBorders
- * @property {TableBorder} [top] - Top border configuration
- * @property {TableBorder} [right] - Right border configuration
- * @property {TableBorder} [bottom] - Bottom border configuration
- * @property {TableBorder} [left] - Left border configuration
- * @property {TableBorder} [insideH] - Inside horizontal borders
- * @property {TableBorder} [insideV] - Inside vertical borders
- */
-
-/**
  * Table attributes
  * @typedef {Object} TableAttributes
  * @property {Object} [tableIndent] - Table indentation
  * @property {number} tableIndent.width - Indent width in pixels
  * @property {string} [tableIndent.type='dxa'] - Indent type
- * @property {TableBorders} [borders] - Table border configuration
+ * @property {import("./tableHelpers/createTableBorders.js").TableBorders} [borders] - Table border configuration
  * @property {string} [borderCollapse='collapse'] - CSS border-collapse value
  * @property {string} [tableStyleId] - Reference to table style ID
  * @property {string} [tableLayout] - Table layout algorithm
@@ -72,13 +53,6 @@
  * @property {Object} rect - Selected rectangle from ProseMirror
  * @property {Object} cell - Current cell node
  * @property {Object} attrs - Cell attributes without span properties
- */
-
-/**
- * Border creation options
- * @typedef {Object} BorderOptions
- * @property {number} [size=0.66665] - Border width in pixels
- * @property {string} [color='#000000'] - Border color (hex)
  */
 
 import { Node, Attribute } from '@core/index.js';
@@ -953,73 +927,6 @@ export const Table = Node.create({
           storage: extension.storage,
         }),
       ),
-    };
-  },
-
-  addHelpers() {
-    return {
-      /**
-       * Create a new table with specified dimensions
-       * @category Helper
-       * @param {Object} schema - Editor schema
-       * @param {number} rowsCount - Number of rows
-       * @param {number} colsCount - Number of columns
-       * @param {boolean} withHeaderRow - Create first row as header
-       * @param {Object} [cellContent=null] - Initial cell content
-       * @returns {Object} Complete table node with borders
-       * @example
-       * const table = createTable(schema, 3, 3, true)
-       * @example
-       * const table = createTable(schema, 2, 4, false, paragraphNode)
-       */
-      createTable: (schema, rowsCount, colsCount, withHeaderRow, cellContent = null) => {
-        return createTable(schema, rowsCount, colsCount, withHeaderRow, cellContent);
-      },
-
-      /**
-       * Create table border configuration object
-       * @category Helper
-       * @param {BorderOptions} [options] - Border options
-       * @returns {TableBorders} Complete borders object for all sides
-       * @example
-       * // Using default values
-       * const borders = createTableBorders()
-       *
-       * // Using custom values
-       * const borders = createTableBorders({ size: 1, color: '#cccccc' })
-       * @note Creates uniform borders for all sides including inside borders
-       */
-      createTableBorders: ({ size = 0.66665, color = '#000000' } = {}) => {
-        return createTableBorders({ size, color });
-      },
-
-      /**
-       * Check if selection is a cell selection
-       * @category Helper
-       * @param {*} value - Selection to check
-       * @returns {boolean} True if cell selection
-       * @example
-       * if (isCellSelection(editor.state.selection)) {
-       *   // Handle cell selection
-       * }
-       */
-      isCellSelection: (value) => {
-        return isCellSelection(value);
-      },
-
-      /**
-       * Check if cursor is inside a table
-       * @category Helper
-       * @param {Object} state - Editor state
-       * @returns {boolean} True if cursor is in table
-       * @example
-       * if (isInTable(state)) {
-       *   // Enable table-specific commands
-       * }
-       */
-      isInTable: (state) => {
-        return isInTable(state);
-      },
     };
   },
 });

--- a/packages/super-editor/src/extensions/table/table.js
+++ b/packages/super-editor/src/extensions/table/table.js
@@ -950,8 +950,10 @@ export const Table = Node.create({
        * @param {BorderOptions} [options] - Border options
        * @returns {TableBorders} Complete borders object for all sides
        * @example
+       * // Using default values
        * const borders = createTableBorders()
-       * @example
+       *
+       * // Using custom values
        * const borders = createTableBorders({ size: 1, color: '#cccccc' })
        * @note Creates uniform borders for all sides including inside borders
        */

--- a/packages/super-editor/src/extensions/table/table.js
+++ b/packages/super-editor/src/extensions/table/table.js
@@ -127,7 +127,7 @@ import { cellWrapping } from './tableHelpers/cellWrapping.js';
  * @shortcut Tab | goToNextCell/addRowAfter | Navigate to next cell or add row
  * @shortcut Shift-Tab | goToPreviousCell | Navigate to previous cell
  * @shortcut Backspace | deleteTableWhenSelected | Delete table when all cells selected
- * @shortcut Delete | deleteTableWhenSelected | Delete table when all cells selected*
+ * @shortcut Delete | deleteTableWhenSelected | Delete table when all cells selected
  */
 export const Table = Node.create({
   name: 'table',

--- a/packages/super-editor/src/extensions/table/table.js
+++ b/packages/super-editor/src/extensions/table/table.js
@@ -182,7 +182,7 @@ export const Table = Node.create({
 
       /**
        * @category Attribute
-       * @param {TableBorders} [borders] - Border styling for this table
+       * @param {import("./tableHelpers/createTableBorders.js").TableBorders} [borders] - Border styling for this table
        */
       borders: {
         default: {},

--- a/packages/super-editor/src/extensions/table/table.js
+++ b/packages/super-editor/src/extensions/table/table.js
@@ -177,6 +177,7 @@ export const Table = Node.create({
       }, */
 
       /**
+       * @private
        * @category Attribute
        * @param {string} [sdBlockId] - Internal block tracking ID (not user-configurable)
        */
@@ -257,6 +258,7 @@ export const Table = Node.create({
       },
 
       /**
+       * @private
        * @category Attribute
        * @param {string} [tableStyleId] - Internal reference to table style (not user-configurable)
        */
@@ -265,6 +267,7 @@ export const Table = Node.create({
       },
 
       /**
+       * @private
        * @category Attribute
        * @param {string} [tableLayout] - CSS table-layout property (advanced usage)
        */

--- a/packages/super-editor/src/extensions/table/tableHelpers/cellAround.js
+++ b/packages/super-editor/src/extensions/table/tableHelpers/cellAround.js
@@ -1,3 +1,4 @@
+// @ts-check
 // https://github.com/ProseMirror/prosemirror-tables/blob/a99f70855f2b3e2433bc77451fedd884305fda5b/src/util.ts
 export function cellAround($pos) {
   for (let d = $pos.depth - 1; d > 0; d--)

--- a/packages/super-editor/src/extensions/table/tableHelpers/cellWrapping.js
+++ b/packages/super-editor/src/extensions/table/tableHelpers/cellWrapping.js
@@ -1,3 +1,4 @@
+// @ts-check
 // https://github.com/ProseMirror/prosemirror-tables/blob/a99f70855f2b3e2433bc77451fedd884305fda5b/src/util.ts
 export function cellWrapping($pos) {
   for (let d = $pos.depth; d > 0; d--) {

--- a/packages/super-editor/src/extensions/table/tableHelpers/createCell.js
+++ b/packages/super-editor/src/extensions/table/tableHelpers/createCell.js
@@ -1,3 +1,4 @@
+// @ts-check
 export const createCell = (cellType, cellContent = null) => {
   if (cellContent) {
     return cellType.createChecked(null, cellContent);

--- a/packages/super-editor/src/extensions/table/tableHelpers/createColGroup.js
+++ b/packages/super-editor/src/extensions/table/tableHelpers/createColGroup.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { getColStyleDeclaration } from './getColStyleDeclaration.js';
 
 export const createColGroup = (node, cellMinWidth, overrideCol, overrideValue) => {

--- a/packages/super-editor/src/extensions/table/tableHelpers/createTable.js
+++ b/packages/super-editor/src/extensions/table/tableHelpers/createTable.js
@@ -1,7 +1,23 @@
+// @ts-check
 import { getNodeType } from '@core/helpers/getNodeType.js';
 import { createCell } from './createCell.js';
 import { createTableBorders } from './createTableBorders.js';
 
+/**
+ * Create a new table with specified dimensions
+ * @private
+ * @category Helper
+ * @param {Object} schema - Editor schema
+ * @param {number} rowsCount - Number of rows
+ * @param {number} colsCount - Number of columns
+ * @param {boolean} withHeaderRow - Create first row as header
+ * @param {Object} [cellContent=null] - Initial cell content
+ * @returns {Object} Complete table node with borders
+ * @example
+ * const table = createTable(schema, 3, 3, true)
+ * @example
+ * const table = createTable(schema, 2, 4, false, paragraphNode)
+ */
 export const createTable = (schema, rowsCount, colsCount, withHeaderRow, cellContent = null) => {
   const types = {
     table: getNodeType('table', schema),

--- a/packages/super-editor/src/extensions/table/tableHelpers/createTableBorders.js
+++ b/packages/super-editor/src/extensions/table/tableHelpers/createTableBorders.js
@@ -1,3 +1,43 @@
+// @ts-check
+/**
+ * Table border configuration
+ * @typedef {Object} TableBorder
+ * @property {number} [size=1] - Border width in pixels
+ * @property {string} [color='#000000'] - Border color (hex or CSS color)
+ * @property {string} [style='solid'] - Border style (solid, dashed, dotted)
+ */
+
+/**
+ * Table borders object
+ * @typedef {Object} TableBorders
+ * @property {TableBorder} [top] - Top border configuration
+ * @property {TableBorder} [right] - Right border configuration
+ * @property {TableBorder} [bottom] - Bottom border configuration
+ * @property {TableBorder} [left] - Left border configuration
+ * @property {TableBorder} [insideH] - Inside horizontal borders
+ * @property {TableBorder} [insideV] - Inside vertical borders
+ */
+/**
+ * Border creation options
+ * @typedef {Object} BorderOptions
+ * @property {number} [size=0.66665] - Border width in pixels
+ * @property {string} [color='#000000'] - Border color (hex)
+ */
+
+/**
+ * Create table border configuration object
+ * @private
+ * @category Helper
+ * @param {BorderOptions} [options] - Border options
+ * @returns {TableBorders} Complete borders object for all sides
+ * @example
+ * // Using default values
+ * const borders = createTableBorders()
+ *
+ * // Using custom values
+ * const borders = createTableBorders({ size: 1, color: '#cccccc' })
+ * @note Creates uniform borders for all sides including inside borders
+ */
 export const createTableBorders = ({ size = 0.66665, color = '#000000' } = {}) => {
   return {
     top: { size, color },

--- a/packages/super-editor/src/extensions/table/tableHelpers/deleteTableWhenSelected.js
+++ b/packages/super-editor/src/extensions/table/tableHelpers/deleteTableWhenSelected.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { findParentNodeClosestToPos } from '@core/helpers/findParentNodeClosestToPos.js';
 import { isCellSelection } from './isCellSelection.js';
 

--- a/packages/super-editor/src/extensions/table/tableHelpers/getColStyleDeclaration.js
+++ b/packages/super-editor/src/extensions/table/tableHelpers/getColStyleDeclaration.js
@@ -1,3 +1,4 @@
+// @ts-check
 export const getColStyleDeclaration = (minWidth, width) => {
   if (width) {
     // Apply the stored width unless it is below the configured minimum cell width.

--- a/packages/super-editor/src/extensions/table/tableHelpers/isCellSelection.js
+++ b/packages/super-editor/src/extensions/table/tableHelpers/isCellSelection.js
@@ -1,3 +1,15 @@
+// @ts-check
 import { CellSelection } from 'prosemirror-tables';
 
+/**
+ * Check if selection is a cell selection
+ * @private
+ * @category Helper
+ * @param {*} value - Selection to check
+ * @returns {boolean} True if cell selection
+ * @example
+ * if (isCellSelection(editor.state.selection)) {
+ *   // Handle cell selection
+ * }
+ */
 export const isCellSelection = (value) => value instanceof CellSelection;

--- a/packages/super-editor/src/extensions/underline/underline.js
+++ b/packages/super-editor/src/extensions/underline/underline.js
@@ -1,7 +1,8 @@
 // @ts-check
 /**
- * Underline style types
- * @typedef {'single'|'double'|'thick'|'dotted'|'dashed'|'wavy'} UnderlineType
+ * Underline style configuration
+ * @typedef {Object} UnderlineType
+ * @property {'single'|'double'|'thick'|'dotted'|'dashed'|'wavy'} value - Style variant
  */
 
 import { Mark, Attribute } from '@core/index.js';

--- a/packages/super-editor/src/extensions/underline/underline.js
+++ b/packages/super-editor/src/extensions/underline/underline.js
@@ -10,6 +10,8 @@ import { Mark, Attribute } from '@core/index.js';
  * @module Underline
  * @sidebarTitle Underline
  * @snippetPath /snippets/extensions/underline.mdx
+ * @shortcut Mod-u | toggleUnderline | Toggle underline formatting
+ * @shortcut Mod-U | toggleUnderline | Toggle underline formatting (uppercase)
  */
 export const Underline = Mark.create({
   name: 'underline',

--- a/packages/super-editor/src/extensions/underline/underline.js
+++ b/packages/super-editor/src/extensions/underline/underline.js
@@ -1,7 +1,7 @@
 // @ts-check
 /**
  * Underline style configuration
- * @typedef {Object} UnderlineType
+ * @typedef {Object} UnderlineConfig
  * @property {'single'|'double'|'thick'|'dotted'|'dashed'|'wavy'} value - Style variant
  */
 
@@ -39,7 +39,7 @@ export const Underline = Mark.create({
     return {
       /**
        * @category Attribute
-       * @param {UnderlineType} [underlineType='single'] - Style of underline
+       * @param {UnderlineConfig} [underlineType='single'] - Style of underline
        */
       underlineType: {
         default: 'single',

--- a/packages/super-editor/src/extensions/underline/underline.js
+++ b/packages/super-editor/src/extensions/underline/underline.js
@@ -36,6 +36,10 @@ export const Underline = Mark.create({
 
   addAttributes() {
     return {
+      /**
+       * @category Attribute
+       * @param {UnderlineType} [underlineType='single'] - Style of underline
+       */
       underlineType: {
         default: 'single',
       },


### PR DESCRIPTION
- Added keyboard shortcuts for bold (Mod-b, Mod-B), italic (Mod-i, Mod-I), underline (Mod-u, Mod-U), highlight (Mod-Shift-h), and strikethrough (Mod-Shift-s).
- Enhanced table module with detailed configuration options, commands, and helper functions for better usability and documentation clarity.