### PR TITLE
fix: jsonOverride documentation

### DIFF
--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -130,7 +130,7 @@ import { createDocFromMarkdown, createDocFromHTML } from '@core/helpers/index.js
  * @property {Function} [handleImageUpload] - Handler for image uploads
  * @property {Object} [telemetry] - Telemetry configuration
  * @property {boolean} [suppressDefaultDocxStyles] - Prevent default styles from being applied in docx mode
- * @property {boolean} [jsonOverride] - Whether to override content with provided json
+ * @property {Object} [jsonOverride] - Provided JSON to override content with
  * @property {string} [html] - HTML content to initialize the editor with
  * @property {string} [markdown] - Markdown content to initialize the editor with
  */
@@ -213,7 +213,7 @@ export class Editor extends EventEmitter {
     isHeaderOrFooter: false,
     lastSelection: null,
     suppressDefaultDocxStyles: false,
-    jsonOverride: false,
+    jsonOverride: null,
     onBeforeCreate: () => null,
     onCreate: () => null,
     onUpdate: () => null,

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -105,7 +105,7 @@ import { initSuperdocYdoc, initCollaborationComments, makeDocumentsCollaborative
  * @property {User} [lockedBy] The user who locked the SuperDoc
  * @property {boolean} [rulers] Whether to show the ruler in the editor
  * @property {boolean} [suppressDefaultDocxStyles] Whether to suppress default styles in docx mode
- * @property {boolean} [jsonOverride] Whether to override content with provided JSON
+ * @property {Object} [jsonOverride] Provided JSON to override content with
  * @property {boolean} [disableContextMenu] Whether to disable slash / right-click custom context menu
  * @property {string} [html] HTML content to initialize the editor with
  * @property {string} [markdown] Markdown content to initialize the editor with


### PR DESCRIPTION
We expect jsonOverride to be an actual json to override content with in generatePmData function of Editor.js but documentation says that it's boolean. Eric faced this issue while trying to create an example of Superdoc usage