### PR TITLE
Prepare for node translator (import/export upgrades), OxmlNode

### DIFF
--- a/packages/ooxml-inspector/src/children/cli.js
+++ b/packages/ooxml-inspector/src/children/cli.js
@@ -101,6 +101,6 @@ Options:
 }
 
 function notFound(q) {
-  console.error(`Unknown element: ${q}`);
+  console.error(`Unknown element: \${q}\\`);
   process.exit(2);
 }

--- a/packages/ooxml-inspector/src/children/cli.js
+++ b/packages/ooxml-inspector/src/children/cli.js
@@ -101,6 +101,6 @@ Options:
 }
 
 function notFound(q) {
-  console.error(`Unknown element: \${q}\\`);
+  console.error(`Unknown element: ${q}`);
   process.exit(2);
 }

--- a/packages/super-editor/src/core/Node.js
+++ b/packages/super-editor/src/core/Node.js
@@ -1,22 +1,37 @@
+// @ts-check
 import { getExtensionConfigField } from './helpers/getExtensionConfigField.js';
 import { callOrGet } from './utilities/callOrGet.js';
 
-/**
- * Node class is used to create Node extensions.
- */
 export class Node {
+  /** @type {import('prosemirror-model').NodeType | String} */
   type = 'node';
 
+  /** @type {string} */
   name = 'node';
 
+  /** @type {import('./types/index.js').EditorNodeOptions} */
   options;
 
+  /** @type {string} */
+  group;
+
+  /** @type {boolean} */
+  atom;
+
+  /** @type {import('./Editor.js').Editor} */
+  editor;
+
+  /** @type {import('./types/index.js').EditorNodeStorage} */
   storage;
 
+  /** @type {import('./types/index.js').EditorNodeConfig} */
   config = {
     name: this.name,
   };
 
+  /**
+   * @param {import('./types/index.js').EditorNodeConfig} config
+   */
   constructor(config) {
     this.config = {
       ...this.config,
@@ -24,6 +39,7 @@ export class Node {
     };
 
     this.name = this.config.name;
+    this.group = this.config.group;
 
     if (this.config.addOptions) {
       this.options = callOrGet(
@@ -43,10 +59,12 @@ export class Node {
   }
 
   /**
-   * Static method for creating Node extension.
-   * @param args Arguments for the constructor.
+   * Factory method to construct a new Node extension.
+   *
+   * @param {import('./types/index.js').EditorNodeConfig} config - The node configuration.
+   * @returns {Node} A new Node instance.
    */
-  static create(...args) {
-    return new Node(...args);
+  static create(config) {
+    return new Node(config);
   }
 }

--- a/packages/super-editor/src/core/OxmlNode.js
+++ b/packages/super-editor/src/core/OxmlNode.js
@@ -1,0 +1,38 @@
+// @ts-check
+
+import { Node } from '@core/index.js';
+import { childrenOf } from '@superdoc-dev/ooxml-inspector';
+
+/**
+ * @type {import('./types/index.js').OxmlNode}
+ */
+export class OxmlNode extends Node {
+  /** @type {string} */
+  oXmlName;
+
+  /**
+   * @param {import('./types/index.js').OxmlNodeConfig} config
+   */
+  constructor(config) {
+    super(config);
+    this.oXmlName = config.oXmlName;
+  }
+
+  /**
+   * Factory method to construct a new OxmlNode instance.
+   *
+   * @param {import('./types/index.js').OxmlNodeConfig} config
+   * @returns {OxmlNode} A new OxmlNode instance.
+   */
+  static create(config) {
+    return new OxmlNode(config);
+  }
+
+  /**
+   * Get the valid children of the OxmlNode.
+   * @returns {string[]} The valid children.
+   */
+  get validChildren() {
+    return childrenOf(this.oXmlName);
+  }
+}

--- a/packages/super-editor/src/core/OxmlNode.js
+++ b/packages/super-editor/src/core/OxmlNode.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { Node } from '@core/index.js';
+import { Node } from './Node.js';
 import { childrenOf } from '@superdoc-dev/ooxml-inspector';
 
 /**

--- a/packages/super-editor/src/core/Schema.js
+++ b/packages/super-editor/src/core/Schema.js
@@ -3,7 +3,6 @@ import { Attribute } from './Attribute.js';
 import { getExtensionConfigField } from './helpers/getExtensionConfigField.js';
 import { cleanSchemaItem } from './helpers/cleanSchemaItem.js';
 import { callOrGet } from './utilities/callOrGet.js';
-import { childrenOf } from '@superdoc-dev/ooxml-inspector';
 
 /**
  * Schema class is used to create and work with schema.

--- a/packages/super-editor/src/core/Schema.js
+++ b/packages/super-editor/src/core/Schema.js
@@ -3,6 +3,7 @@ import { Attribute } from './Attribute.js';
 import { getExtensionConfigField } from './helpers/getExtensionConfigField.js';
 import { cleanSchemaItem } from './helpers/cleanSchemaItem.js';
 import { callOrGet } from './utilities/callOrGet.js';
+import { childrenOf } from '@superdoc-dev/ooxml-inspector';
 
 /**
  * Schema class is used to create and work with schema.

--- a/packages/super-editor/src/core/Schema.js
+++ b/packages/super-editor/src/core/Schema.js
@@ -72,6 +72,15 @@ export class Schema {
         ...additionalNodeFields,
       });
 
+      // Attach OOXML metadata if the extension supports it
+      if (typeof extension.validChildren === 'function' || Array.isArray(extension.validChildren)) {
+        Object.defineProperty(schema, 'validChildren', {
+          enumerable: false,
+          configurable: false,
+          get: () => extension.validChildren,
+        });
+      }
+
       const parseDOM = callOrGet(getExtensionConfigField(extension, 'parseDOM', context));
       if (parseDOM) {
         schema.parseDOM = parseDOM.map((parseRule) => {

--- a/packages/super-editor/src/core/index.js
+++ b/packages/super-editor/src/core/index.js
@@ -5,6 +5,7 @@ export * from './Attribute.js';
 export * from './CommandService.js';
 export * from './Extension.js';
 export * from './super-converter/SuperConverter.js';
+export * from './OxmlNode.js';
 
 export * as coreExtensions from './extensions/index.js';
 export * as helpers from './helpers/index.js';

--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -13,8 +13,11 @@ import {
 } from './v2/exporter/commentsExporter.js';
 import { FOOTER_RELATIONSHIP_TYPE, HEADER_RELATIONSHIP_TYPE, HYPERLINK_RELATIONSHIP_TYPE } from './constants.js';
 import { DocxHelpers } from './docx-helpers/index.js';
+import { HandlerRegistry } from './v2/handlers/registry/index.js';
 
 class SuperConverter {
+  #handlerRegistry = new HandlerRegistry();
+
   static allowedElements = Object.freeze({
     'w:document': 'doc',
     'w:body': 'body',
@@ -134,6 +137,14 @@ class SuperConverter {
 
     // Parse the initial XML, if provided
     if (this.docx.length || this.xml) this.parseFromXml();
+  }
+
+  /**
+   * Get the handler registry.
+   * @returns {HandlerRegistry} The handler registry.
+   */
+  get handlerRegistry() {
+    return this.#handlerRegistry;
   }
 
   /**

--- a/packages/super-editor/src/core/super-converter/v2/handlers/index.js
+++ b/packages/super-editor/src/core/super-converter/v2/handlers/index.js
@@ -1,0 +1,1 @@
+export const registeredHandlers = Object.freeze({});

--- a/packages/super-editor/src/core/super-converter/v2/handlers/registry/handler-registry.js
+++ b/packages/super-editor/src/core/super-converter/v2/handlers/registry/handler-registry.js
@@ -1,0 +1,157 @@
+import { registeredHandlers } from '../index.js';
+import { childrenOf } from '@superdoc-dev/ooxml-inspector';
+import {
+  createCoverageGroupTitle,
+  startCoverageGroup,
+  showCoverageLegend,
+  showProgressBar,
+  showItemList,
+  endCoverageGroup,
+  computeCoverageSummary,
+  displayCoverageReport,
+  displayNotHandledMessage,
+} from './logger.js';
+
+/**
+ * The handler registry class for managing document handlers.
+ * Provides methods to analyze coverage of registered handlers against OOXML specifications.
+ */
+export class HandlerRegistry {
+  /** @type {import('../index.js').RegisteredHandlers} */
+  #registeredHandlers;
+
+  constructor() {
+    this.#registeredHandlers = registeredHandlers;
+  }
+
+  /**
+   * Gets the registered handlers
+   * @returns {import('../index.js').RegisteredHandlers} The registered handlers
+   */
+  get handlers() {
+    return this.#registeredHandlers;
+  }
+
+  /**
+   * Builds a set of handled XML names from the registered handlers
+   * @returns {Set<string>} Set of XML names that have handlers
+   */
+  #buildHandledSet() {
+    let handlerList = [];
+
+    if (Array.isArray(this.#registeredHandlers?.all)) {
+      handlerList = this.#registeredHandlers.all;
+    } else if (this.#registeredHandlers) {
+      handlerList = Object.values(this.#registeredHandlers);
+    }
+
+    return new Set(handlerList.map((handler) => handler?.xmlName).filter(Boolean));
+  }
+
+  /**
+   * Analyzes and displays coverage for a specific XML tag
+   * @param {string} tagName - The XML tag name to analyze coverage for
+   * @returns {Object} Coverage summary object
+   */
+  coverage(tagName) {
+    const handledSet = this.#buildHandledSet();
+    if (!handledSet.has(tagName)) {
+      displayNotHandledMessage(tagName);
+      return;
+    }
+
+    const allowedChildren = childrenOf(tagName);
+    const summary = computeCoverageSummary(tagName, allowedChildren, handledSet);
+
+    // Display the coverage report using the new API
+    const title = createCoverageGroupTitle(summary.tagName, summary.coveredItems.length, summary.totalCount);
+
+    startCoverageGroup(title);
+    showCoverageLegend();
+    showProgressBar(summary.coveragePercentage);
+    showItemList(`Covered (${summary.coveredItems.length})`, summary.coveredItems, 'covered');
+    showItemList(`Missing (${summary.missingItems.length})`, summary.missingItems, 'missing');
+    endCoverageGroup();
+
+    // Return summary in legacy format for backward compatibility
+    return {
+      tagName: summary.tagName,
+      total: summary.totalCount,
+      covered: summary.coveredItems,
+      missing: summary.missingItems,
+      percent: summary.coveragePercentage,
+    };
+  }
+
+  /**
+   * Simplified coverage analysis using the all-in-one report function
+   * @param {string} tagName - The XML tag name to analyze coverage for
+   * @returns {Object} Coverage summary object
+   */
+  coverageReport(tagName) {
+    const handledSet = this.#buildHandledSet();
+    const allowedChildren = childrenOf(tagName);
+
+    const summary = displayCoverageReport(tagName, allowedChildren, handledSet);
+
+    // Return summary in legacy format for backward compatibility
+    return {
+      tagName: summary.tagName,
+      total: summary.totalCount,
+      covered: summary.coveredItems,
+      missing: summary.missingItems,
+      percent: summary.coveragePercentage,
+    };
+  }
+
+  /**
+   * Gets coverage statistics without displaying console output
+   * @param {string} tagName - The XML tag name to analyze coverage for
+   * @returns {Object} Coverage summary object
+   */
+  getCoverageStats(tagName) {
+    const handledSet = this.#buildHandledSet();
+    const allowedChildren = childrenOf(tagName);
+    const summary = computeCoverageSummary(tagName, allowedChildren, handledSet);
+
+    // Return summary in legacy format for backward compatibility
+    return {
+      tagName: summary.tagName,
+      total: summary.totalCount,
+      covered: summary.coveredItems,
+      missing: summary.missingItems,
+      percent: summary.coveragePercentage,
+    };
+  }
+
+  /**
+   * Analyzes coverage for multiple tags
+   * @param {string[]} tagNames - Array of XML tag names to analyze
+   * @returns {Object[]} Array of coverage summary objects
+   */
+  multipleCoverage(tagNames) {
+    if (!Array.isArray(tagNames)) {
+      throw new Error('tagNames must be an array');
+    }
+
+    return tagNames.map((tagName) => this.getCoverageStats(tagName));
+  }
+
+  /**
+   * Gets the total number of registered handlers
+   * @returns {number} Number of registered handlers
+   */
+  getHandlerCount() {
+    const handledSet = this.#buildHandledSet();
+    return handledSet.size;
+  }
+
+  /**
+   * Gets all handled XML names
+   * @returns {string[]} Array of XML names that have handlers
+   */
+  getHandledXmlNames() {
+    const handledSet = this.#buildHandledSet();
+    return Array.from(handledSet).sort();
+  }
+}

--- a/packages/super-editor/src/core/super-converter/v2/handlers/registry/handler-registry.test.js
+++ b/packages/super-editor/src/core/super-converter/v2/handlers/registry/handler-registry.test.js
@@ -1,0 +1,565 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { HandlerRegistry } from './handler-registry.js';
+
+vi.mock('../index.js', () => ({
+  registeredHandlers: {},
+}));
+
+vi.mock('@superdoc-dev/ooxml-inspector', () => ({
+  childrenOf: vi.fn(),
+}));
+
+vi.mock('./logger.js', () => ({
+  createCoverageGroupTitle: vi.fn(),
+  startCoverageGroup: vi.fn(),
+  showCoverageLegend: vi.fn(),
+  showProgressBar: vi.fn(),
+  showItemList: vi.fn(),
+  endCoverageGroup: vi.fn(),
+  computeCoverageSummary: vi.fn(),
+  displayCoverageReport: vi.fn(),
+  displayNotHandledMessage: vi.fn(),
+}));
+
+import { registeredHandlers } from '../index.js';
+import { childrenOf } from '@superdoc-dev/ooxml-inspector';
+import {
+  createCoverageGroupTitle,
+  startCoverageGroup,
+  showCoverageLegend,
+  showProgressBar,
+  showItemList,
+  endCoverageGroup,
+  computeCoverageSummary,
+  displayCoverageReport,
+  displayNotHandledMessage,
+} from './logger.js';
+
+describe('HandlerRegistry', () => {
+  let registry;
+
+  // Helper function to setup mock handlers
+  const setupMockHandlers = (handlerData) => {
+    // Clear existing properties
+    Object.keys(registeredHandlers).forEach((key) => {
+      delete registeredHandlers[key];
+    });
+    // Set new properties
+    Object.assign(registeredHandlers, handlerData);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Clear all properties from registeredHandlers mock
+    Object.keys(registeredHandlers).forEach((key) => {
+      delete registeredHandlers[key];
+    });
+
+    registry = new HandlerRegistry();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Constructor and Basic Properties', () => {
+    it('should initialize with registeredHandlers', () => {
+      expect(registry.handlers).toBe(registeredHandlers);
+    });
+
+    it('should create new instance each time', () => {
+      const registry1 = new HandlerRegistry();
+      const registry2 = new HandlerRegistry();
+
+      expect(registry1).not.toBe(registry2);
+      expect(registry1.handlers).toBe(registry2.handlers);
+    });
+  });
+
+  describe('handlers getter', () => {
+    it('should return the registered handlers', () => {
+      const mockHandlers = { test: 'handlers' };
+      registeredHandlers.mockValue = mockHandlers;
+
+      const newRegistry = new HandlerRegistry();
+      expect(newRegistry.handlers).toBe(registeredHandlers);
+    });
+  });
+
+  describe('#buildHandledSet', () => {
+    it('should build set from handlers.all array', () => {
+      setupMockHandlers({
+        all: [{ xmlName: 'w:p' }, { xmlName: 'w:r' }, { xmlName: 'w:t' }],
+      });
+
+      const newRegistry = new HandlerRegistry();
+      const handledNames = newRegistry.getHandledXmlNames();
+
+      expect(handledNames).toEqual(['w:p', 'w:r', 'w:t']);
+    });
+
+    it('should build set from handlers object values when no all array', () => {
+      setupMockHandlers({
+        handler1: { xmlName: 'w:p' },
+        handler2: { xmlName: 'w:r' },
+        handler3: { xmlName: 'w:t' },
+      });
+
+      const newRegistry = new HandlerRegistry();
+      const handledNames = newRegistry.getHandledXmlNames();
+
+      expect(handledNames.sort()).toEqual(['w:p', 'w:r', 'w:t']);
+    });
+
+    it('should filter out handlers without xmlName', () => {
+      setupMockHandlers({
+        all: [
+          { xmlName: 'w:p' },
+          { name: 'no-xml-name' },
+          null,
+          undefined,
+          { xmlName: 'w:r' },
+          { xmlName: '' },
+          { xmlName: 'w:t' },
+        ],
+      });
+
+      const newRegistry = new HandlerRegistry();
+      const handledNames = newRegistry.getHandledXmlNames();
+
+      expect(handledNames).toEqual(['w:p', 'w:r', 'w:t']);
+    });
+
+    it('should handle empty handlers', () => {
+      setupMockHandlers({});
+
+      const newRegistry = new HandlerRegistry();
+      const handledNames = newRegistry.getHandledXmlNames();
+
+      expect(handledNames).toEqual([]);
+    });
+
+    it('should handle null/undefined handlers', () => {
+      setupMockHandlers({ all: null });
+
+      const newRegistry = new HandlerRegistry();
+      const handledNames = newRegistry.getHandledXmlNames();
+
+      expect(handledNames).toEqual([]);
+    });
+  });
+
+  describe('getHandlerCount', () => {
+    it('should return correct count of handlers', () => {
+      setupMockHandlers({
+        all: [{ xmlName: 'w:p' }, { xmlName: 'w:r' }, { xmlName: 'w:t' }],
+      });
+
+      const newRegistry = new HandlerRegistry();
+      expect(newRegistry.getHandlerCount()).toBe(3);
+    });
+
+    it('should return 0 for empty handlers', () => {
+      setupMockHandlers({});
+
+      const newRegistry = new HandlerRegistry();
+      expect(newRegistry.getHandlerCount()).toBe(0);
+    });
+
+    it('should not count duplicate xmlNames', () => {
+      setupMockHandlers({
+        all: [
+          { xmlName: 'w:p' },
+          { xmlName: 'w:p' }, // Duplicate
+          { xmlName: 'w:r' },
+        ],
+      });
+
+      const newRegistry = new HandlerRegistry();
+      expect(newRegistry.getHandlerCount()).toBe(2); // Set removes duplicates
+    });
+  });
+
+  describe('getHandledXmlNames', () => {
+    it('should return sorted array of XML names', () => {
+      setupMockHandlers({
+        all: [{ xmlName: 'w:t' }, { xmlName: 'w:p' }, { xmlName: 'w:r' }],
+      });
+
+      const newRegistry = new HandlerRegistry();
+      const names = newRegistry.getHandledXmlNames();
+
+      expect(names).toEqual(['w:p', 'w:r', 'w:t']); // Sorted
+      expect(Array.isArray(names)).toBe(true);
+    });
+
+    it('should return empty array when no handlers', () => {
+      setupMockHandlers({});
+
+      const newRegistry = new HandlerRegistry();
+      const names = newRegistry.getHandledXmlNames();
+
+      expect(names).toEqual([]);
+      expect(Array.isArray(names)).toBe(true);
+    });
+  });
+
+  describe('getCoverageStats', () => {
+    beforeEach(() => {
+      setupMockHandlers({
+        all: [{ xmlName: 'w:p' }, { xmlName: 'w:r' }],
+      });
+
+      childrenOf.mockReturnValue(['w:p', 'w:r', 'w:t', 'w:br']);
+      computeCoverageSummary.mockReturnValue({
+        tagName: 'w:document',
+        totalCount: 4,
+        coveredItems: ['w:p', 'w:r'],
+        missingItems: ['w:t', 'w:br'],
+        coveragePercentage: 50,
+      });
+    });
+
+    it('should return coverage statistics without console output', () => {
+      const result = registry.getCoverageStats('w:document');
+
+      expect(childrenOf).toHaveBeenCalledWith('w:document');
+      expect(computeCoverageSummary).toHaveBeenCalledWith('w:document', ['w:p', 'w:r', 'w:t', 'w:br'], expect.any(Set));
+
+      expect(result).toEqual({
+        tagName: 'w:document',
+        total: 4,
+        covered: ['w:p', 'w:r'],
+        missing: ['w:t', 'w:br'],
+        percent: 50,
+      });
+
+      // Should not call any console display functions
+      expect(startCoverageGroup).not.toHaveBeenCalled();
+      expect(showCoverageLegend).not.toHaveBeenCalled();
+      expect(showProgressBar).not.toHaveBeenCalled();
+    });
+
+    it('should pass correct handled set to computeCoverageSummary', () => {
+      registry.getCoverageStats('w:test');
+
+      const calledSet = computeCoverageSummary.mock.calls[0][2];
+      expect(calledSet).toBeInstanceOf(Set);
+      expect([...calledSet].sort()).toEqual(['w:p', 'w:r']);
+    });
+  });
+
+  describe('coverage', () => {
+    beforeEach(() => {
+      setupMockHandlers({
+        all: [{ xmlName: 'w:p' }, { xmlName: 'w:r' }],
+      });
+
+      childrenOf.mockReturnValue(['w:p', 'w:r', 'w:t']);
+      computeCoverageSummary.mockReturnValue({
+        tagName: 'w:document',
+        totalCount: 3,
+        coveredItems: ['w:p', 'w:r'],
+        missingItems: ['w:t'],
+        coveragePercentage: 67,
+      });
+
+      createCoverageGroupTitle.mockReturnValue({
+        text: '%cCoverage%c w:document  %c2/3 (67%)',
+        styles: ['color1', 'color2', 'color3'],
+      });
+    });
+
+    it('should handle empty coverage correctly', () => {
+      computeCoverageSummary.mockReturnValue({
+        tagName: 'w:empty',
+        totalCount: 0,
+        coveredItems: [],
+        missingItems: [],
+        coveragePercentage: 0,
+      });
+
+      registry.coverage('w:empty');
+      expect(displayNotHandledMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe('coverageReport', () => {
+    beforeEach(() => {
+      setupMockHandlers({
+        all: [{ xmlName: 'w:p' }],
+      });
+
+      childrenOf.mockReturnValue(['w:p', 'w:t']);
+      displayCoverageReport.mockReturnValue({
+        tagName: 'w:test',
+        totalCount: 2,
+        coveredItems: ['w:p'],
+        missingItems: ['w:t'],
+        coveragePercentage: 50,
+      });
+    });
+
+    it('should use displayCoverageReport function', () => {
+      const result = registry.coverageReport('w:test');
+
+      expect(childrenOf).toHaveBeenCalledWith('w:test');
+      expect(displayCoverageReport).toHaveBeenCalledWith('w:test', ['w:p', 'w:t'], expect.any(Set));
+
+      expect(result).toEqual({
+        tagName: 'w:test',
+        total: 2,
+        covered: ['w:p'],
+        missing: ['w:t'],
+        percent: 50,
+      });
+    });
+  });
+
+  describe('multipleCoverage', () => {
+    beforeEach(() => {
+      setupMockHandlers({
+        all: [{ xmlName: 'w:p' }, { xmlName: 'w:r' }],
+      });
+
+      childrenOf.mockImplementation((tagName) => {
+        const childrenMap = {
+          'w:document': ['w:p', 'w:r', 'w:t'],
+          'w:body': ['w:p', 'w:table'],
+          'w:p': ['w:r', 'w:br'],
+        };
+        return childrenMap[tagName] || [];
+      });
+
+      computeCoverageSummary.mockImplementation((tagName, children, handledSet) => {
+        const covered = children.filter((child) => handledSet.has(child));
+        const missing = children.filter((child) => !handledSet.has(child));
+        return {
+          tagName,
+          totalCount: children.length,
+          coveredItems: covered,
+          missingItems: missing,
+          coveragePercentage: Math.round((covered.length / children.length) * 100),
+        };
+      });
+    });
+
+    it('should analyze coverage for multiple tags', () => {
+      const result = registry.multipleCoverage(['w:document', 'w:body', 'w:p']);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].tagName).toBe('w:document');
+      expect(result[1].tagName).toBe('w:body');
+      expect(result[2].tagName).toBe('w:p');
+
+      // Check that each tag was processed
+      expect(childrenOf).toHaveBeenCalledWith('w:document');
+      expect(childrenOf).toHaveBeenCalledWith('w:body');
+      expect(childrenOf).toHaveBeenCalledWith('w:p');
+      expect(computeCoverageSummary).toHaveBeenCalledTimes(3);
+    });
+
+    it('should handle empty array', () => {
+      const result = registry.multipleCoverage([]);
+
+      expect(result).toEqual([]);
+      expect(childrenOf).not.toHaveBeenCalled();
+      expect(computeCoverageSummary).not.toHaveBeenCalled();
+    });
+
+    it('should throw error for non-array input', () => {
+      expect(() => registry.multipleCoverage('not-an-array')).toThrow('tagNames must be an array');
+      expect(() => registry.multipleCoverage(null)).toThrow('tagNames must be an array');
+      expect(() => registry.multipleCoverage(undefined)).toThrow('tagNames must be an array');
+      expect(() => registry.multipleCoverage(123)).toThrow('tagNames must be an array');
+    });
+
+    it('should handle array with single element', () => {
+      const result = registry.multipleCoverage(['w:document']);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].tagName).toBe('w:document');
+    });
+  });
+
+  describe('Integration Tests', () => {
+    beforeEach(() => {
+      setupMockHandlers({
+        all: [{ xmlName: 'w:p' }, { xmlName: 'w:r' }, { xmlName: 'w:t' }],
+      });
+    });
+
+    it('should work with realistic OOXML data', () => {
+      childrenOf.mockReturnValue(['w:p', 'w:tbl', 'w:sectPr', 'w:bookmarkStart', 'w:bookmarkEnd', 'w:r', 'w:t']);
+
+      computeCoverageSummary.mockReturnValue({
+        tagName: 'w:document',
+        totalCount: 7,
+        coveredItems: ['w:p', 'w:r', 'w:t'],
+        missingItems: ['w:tbl', 'w:sectPr', 'w:bookmarkStart', 'w:bookmarkEnd'],
+        coveragePercentage: 43,
+      });
+
+      const result = registry.getCoverageStats('w:document');
+
+      expect(result.total).toBe(7);
+      expect(result.covered).toHaveLength(3);
+      expect(result.missing).toHaveLength(4);
+      expect(result.percent).toBe(43);
+    });
+
+    it('should maintain consistency across different methods', () => {
+      childrenOf.mockReturnValue(['w:p', 'w:r']);
+      computeCoverageSummary.mockReturnValue({
+        tagName: 'w:test',
+        totalCount: 2,
+        coveredItems: ['w:p', 'w:r'],
+        missingItems: [],
+        coveragePercentage: 100,
+      });
+      displayCoverageReport.mockReturnValue({
+        tagName: 'w:test',
+        totalCount: 2,
+        coveredItems: ['w:p', 'w:r'],
+        missingItems: [],
+        coveragePercentage: 100,
+      });
+
+      const stats = registry.getCoverageStats('w:r');
+      const coverage = registry.coverage('w:r');
+      const report = registry.coverageReport('w:r');
+
+      // All methods should return equivalent data (just different property names)
+      expect(stats.total).toBe(coverage.total);
+      expect(stats.total).toBe(report.total);
+      expect(stats.covered).toEqual(coverage.covered);
+      expect(stats.covered).toEqual(report.covered);
+      expect(stats.percent).toBe(coverage.percent);
+      expect(stats.percent).toBe(report.percent);
+    });
+  });
+
+  describe('Edge Cases and Error Handling', () => {
+    it('should handle malformed handler objects', () => {
+      setupMockHandlers({
+        all: [
+          { xmlName: 'w:p' },
+          { notXmlName: 'should-be-ignored' },
+          null,
+          undefined,
+          { xmlName: null },
+          { xmlName: '' },
+          'string-handler',
+          123,
+        ],
+      });
+
+      const newRegistry = new HandlerRegistry();
+      const names = newRegistry.getHandledXmlNames();
+
+      expect(names).toEqual(['w:p']); // Only valid xmlName
+      expect(newRegistry.getHandlerCount()).toBe(1);
+    });
+
+    it('should handle childrenOf returning null/undefined', () => {
+      childrenOf.mockReturnValue(null);
+      computeCoverageSummary.mockReturnValue({
+        tagName: 'w:null',
+        totalCount: 0,
+        coveredItems: [],
+        missingItems: [],
+        coveragePercentage: 0,
+      });
+
+      const result = registry.getCoverageStats('w:null');
+
+      expect(result.total).toBe(0);
+      expect(computeCoverageSummary).toHaveBeenCalledWith('w:null', null, expect.any(Set));
+    });
+
+    it('should handle very large datasets', () => {
+      // Create large handler set
+      setupMockHandlers({
+        all: Array.from({ length: 1000 }, (_, i) => ({ xmlName: `w:element${i}` })),
+      });
+
+      // Set up mocks needed for getCoverageStats
+      childrenOf.mockReturnValue(['w:element1', 'w:element2']);
+      computeCoverageSummary.mockReturnValue({
+        tagName: 'w:test',
+        totalCount: 2,
+        coveredItems: ['w:element1'],
+        missingItems: ['w:element2'],
+        coveragePercentage: 50,
+      });
+
+      const newRegistry = new HandlerRegistry();
+
+      expect(newRegistry.getHandlerCount()).toBe(1000);
+      expect(() => newRegistry.getHandledXmlNames()).not.toThrow();
+      expect(() => newRegistry.getCoverageStats('w:test')).not.toThrow();
+    });
+
+    it('should handle empty string tag names', () => {
+      childrenOf.mockReturnValue([]);
+      computeCoverageSummary.mockReturnValue({
+        tagName: '',
+        totalCount: 0,
+        coveredItems: [],
+        missingItems: [],
+        coveragePercentage: 0,
+      });
+
+      expect(() => registry.getCoverageStats('')).not.toThrow();
+    });
+  });
+
+  describe('Performance and Memory', () => {
+    it('should not recreate handled set unnecessarily', () => {
+      setupMockHandlers({
+        all: [{ xmlName: 'w:p' }],
+      });
+
+      // Set up mocks needed for getCoverageStats
+      childrenOf.mockReturnValue(['w:p', 'w:r']);
+      computeCoverageSummary.mockReturnValue({
+        tagName: 'w:test',
+        totalCount: 2,
+        coveredItems: ['w:p'],
+        missingItems: ['w:r'],
+        coveragePercentage: 50,
+      });
+
+      const newRegistry = new HandlerRegistry();
+
+      // Multiple calls should work efficiently
+      newRegistry.getHandlerCount();
+      newRegistry.getHandledXmlNames();
+      newRegistry.getCoverageStats('w:test');
+
+      // Each call should create its own set, but efficiently
+      expect(() => {
+        for (let i = 0; i < 100; i++) {
+          newRegistry.getHandlerCount();
+        }
+      }).not.toThrow();
+    });
+
+    it('should handle Set operations correctly', () => {
+      setupMockHandlers({
+        all: [
+          { xmlName: 'w:p' },
+          { xmlName: 'w:p' }, // Duplicate
+          { xmlName: 'w:r' },
+        ],
+      });
+
+      const newRegistry = new HandlerRegistry();
+
+      // Set should automatically handle duplicates
+      expect(newRegistry.getHandlerCount()).toBe(2);
+      expect(newRegistry.getHandledXmlNames()).toEqual(['w:p', 'w:r']);
+    });
+  });
+});

--- a/packages/super-editor/src/core/super-converter/v2/handlers/registry/index.js
+++ b/packages/super-editor/src/core/super-converter/v2/handlers/registry/index.js
@@ -1,0 +1,1 @@
+export * from './handler-registry.js';

--- a/packages/super-editor/src/core/super-converter/v2/handlers/registry/logger.js
+++ b/packages/super-editor/src/core/super-converter/v2/handlers/registry/logger.js
@@ -1,0 +1,309 @@
+const CONSOLE_STYLES = {
+  muted: 'color:#AAAAAA',
+  primary: 'color:#AAFFAA;font-weight:700',
+  success: 'color:#059669;font-weight:700',
+  warning: 'color:#d97706;font-weight:700',
+  missing: 'color:#f97316;font-weight:700',
+  successSecondary: 'color:#065f46',
+  missingSecondary: 'color:#ea580c',
+  progressBar: 'color:#d97706;font-weight:700;background:#1f2937',
+  dimmed: 'color:#6b7280',
+};
+
+const PROGRESS_BAR_LENGTH = 20;
+const COVERAGE_THRESHOLDS = {
+  good: 80,
+  fair: 50,
+};
+
+const DISPLAY_OPTIONS = {
+  expandMainGroup: true,
+  collapseItemLists: true,
+  showProgressBars: true,
+  showItemCounts: true,
+};
+
+/**
+ * Calculates percentage with safe division
+ * @param {Number} numerator - The numerator value
+ * @param {Number} denominator - The denominator value
+ * @returns {Number} Percentage rounded to nearest integer
+ */
+function calculatePercentage(numerator, denominator) {
+  if (!denominator || denominator === 0) {
+    // If there are no items to cover, coverage is 100% (complete)
+    return 100;
+  }
+  return Math.round((numerator / denominator) * 100);
+}
+
+/**
+ * Creates a visual progress bar using Unicode characters
+ * @param {Number} percentage - Percentage to display (0-100)
+ * @param {Number} length - Length of the progress bar
+ * @returns {String} Unicode progress bar
+ */
+function createProgressBar(percentage, length = PROGRESS_BAR_LENGTH) {
+  const filledBlocks = Math.round((percentage / 100) * length);
+  const emptyBlocks = length - filledBlocks;
+  return '█'.repeat(filledBlocks) + '░'.repeat(emptyBlocks);
+}
+
+/**
+ * Determines the appropriate color style based on coverage percentage
+ * @param {Number} percentage - Coverage percentage
+ * @returns {String} CSS style string
+ */
+function getCoverageColor(percentage) {
+  if (percentage >= COVERAGE_THRESHOLDS.good) {
+    return CONSOLE_STYLES.success;
+  }
+  if (percentage >= COVERAGE_THRESHOLDS.fair) {
+    return CONSOLE_STYLES.warning;
+  }
+  return CONSOLE_STYLES.missing; // Orange for missing items instead of red
+}
+
+/**
+ * Extracts a readable name from various object types
+ * @param {*} item - Object to extract name from
+ * @returns {String} Extracted name or string representation
+ */
+function extractItemName(item) {
+  if (typeof item === 'string') {
+    return item;
+  }
+
+  // Try common name properties in order of preference
+  const nameProperties = ['qname', 'xmlName', 'name', 'tag'];
+
+  for (const property of nameProperties) {
+    if (item?.[property]) {
+      return item[property];
+    }
+  }
+
+  return String(item);
+}
+
+/**
+ * Displays a message for unhandled tags
+ * @param {String} tagName
+ * @returns {void}
+ */
+export function displayNotHandledMessage(tagName) {
+  const message = `%c⚠️ Not Handled:%c ${tagName}`;
+  console.log(message, CONSOLE_STYLES.muted, CONSOLE_STYLES.missing);
+}
+
+/**
+ * Creates a formatted title for coverage group display
+ * @param {String} tagName - Name of the tag being analyzed
+ * @param {Number} coveredCount - Number of covered items
+ * @param {Number} totalCount - Total number of items
+ * @returns {Object} Formatted title with text and styles
+ */
+export function createCoverageGroupTitle(tagName, coveredCount, totalCount) {
+  const percentage = calculatePercentage(coveredCount, totalCount);
+
+  return {
+    text: `%c📊 Coverage%c ${tagName}  %c${coveredCount}/${totalCount} (${percentage}%)`,
+    styles: [CONSOLE_STYLES.muted, CONSOLE_STYLES.primary, getCoverageColor(percentage)],
+  };
+}
+
+/**
+ * Starts a console group with the given title
+ * @param {Object} title - Title object with text and styles
+ */
+export function startCoverageGroup(title) {
+  if (DISPLAY_OPTIONS.expandMainGroup) {
+    // Use expanded groups for main coverage groups to show legend and progress
+    console.group(title.text, ...title.styles);
+  } else {
+    console.groupCollapsed(title.text, ...title.styles);
+  }
+}
+
+/**
+ * Displays a legend explaining the coverage symbols
+ */
+export function showCoverageLegend() {
+  console.log(
+    '%cLegend: %c✅ covered  %c⚠️ missing',
+    CONSOLE_STYLES.muted,
+    CONSOLE_STYLES.success,
+    CONSOLE_STYLES.missing, // Orange for missing instead of red
+  );
+}
+
+/**
+ * Displays a progress bar for coverage percentage
+ * @param {Number} percentage - Coverage percentage to display
+ */
+export function showProgressBar(percentage) {
+  if (!DISPLAY_OPTIONS.showProgressBars) {
+    return;
+  }
+
+  const progressBar = createProgressBar(percentage);
+  console.log(`%c[${progressBar}] ${percentage}%`, CONSOLE_STYLES.progressBar);
+}
+
+/**
+ * Displays a list of items with consistent formatting
+ * @param {String} label - Label for the list (e.g., "Covered Items")
+ * @param {Array} items - Array of items to display
+ * @param {'covered'|'missing'} listType - Type of list for appropriate styling
+ */
+export function showItemList(label, items, listType) {
+  const itemNames = (items || []).map(extractItemName).filter(Boolean).sort();
+
+  if (itemNames.length === 0) {
+    console.log(`%cNo ${label.toLowerCase()}.`, CONSOLE_STYLES.dimmed);
+    return;
+  }
+
+  // Determine styling based on list type
+  const isCoveredList = listType === 'covered';
+  const headerIcon = isCoveredList ? '✅' : '⚠️'; // Warning icon instead of X
+  const headerStyle = isCoveredList ? CONSOLE_STYLES.success : CONSOLE_STYLES.missing; // Orange instead of red
+  const itemStyle = isCoveredList ? CONSOLE_STYLES.successSecondary : CONSOLE_STYLES.missingSecondary; // Orange secondary
+
+  // Use collapsed groups for item lists to keep the display clean
+  if (DISPLAY_OPTIONS.collapseItemLists) {
+    console.groupCollapsed(`%c${headerIcon} ${label}`, headerStyle);
+  } else {
+    console.group(`%c${headerIcon} ${label}`, headerStyle);
+  }
+
+  // Display each item with bullet point
+  itemNames.forEach((name) => {
+    console.log('%c• %s', itemStyle, name);
+  });
+
+  // Show count if enabled
+  if (DISPLAY_OPTIONS.showItemCounts) {
+    const itemText = itemNames.length === 1 ? 'item' : 'items';
+    console.log(`%c— ${itemNames.length} ${itemText}`, CONSOLE_STYLES.muted);
+  }
+
+  console.groupEnd();
+}
+
+/**
+ * Ends the current console group
+ */
+export function endCoverageGroup() {
+  console.groupEnd();
+}
+
+/**
+ * Computes coverage statistics for a given tag and its children
+ * @param {String} tagName - Name of the tag being analyzed
+ * @param {Array} allowedChildren - Array of allowed child elements
+ * @param {Set} handledItemsSet - Set of items that have been handled
+ * @returns {Object} Coverage summary with statistics
+ */
+export function computeCoverageSummary(tagName, allowedChildren, handledItemsSet) {
+  const validChildren = (allowedChildren || []).filter(Boolean);
+
+  const coveredItems = validChildren.filter((child) => handledItemsSet.has(child));
+
+  const missingItems = validChildren.filter((child) => !handledItemsSet.has(child));
+
+  const coveragePercentage = calculatePercentage(coveredItems.length, validChildren.length);
+
+  return {
+    tagName,
+    totalCount: validChildren.length,
+    coveredItems,
+    missingItems,
+    coveragePercentage,
+  };
+}
+
+/**
+ * Displays a complete coverage report for a tag
+ * @param {String} tagName - Name of the tag
+ * @param {Array} allowedChildren - Array of allowed children
+ * @param {Set} handledItemsSet - Set of handled items
+ */
+export function displayCoverageReport(tagName, allowedChildren, handledItemsSet) {
+  const summary = computeCoverageSummary(tagName, allowedChildren, handledItemsSet);
+
+  // Create and start the main group
+  const title = createCoverageGroupTitle(summary.tagName, summary.coveredItems.length, summary.totalCount);
+
+  startCoverageGroup(title);
+
+  // Show legend and progress
+  showCoverageLegend();
+  showProgressBar(summary.coveragePercentage);
+
+  // Show covered and missing items
+  showItemList('Covered Items', summary.coveredItems, 'covered');
+  showItemList('Missing Items', summary.missingItems, 'missing');
+
+  endCoverageGroup();
+
+  return summary;
+}
+
+/**
+ * Updates display options for customizing output
+ * @param {Object} options - Options to update
+ * @param {Boolean} [options.expandMainGroup] - Whether to expand main coverage groups
+ * @param {Boolean} [options.collapseItemLists] - Whether to collapse item lists
+ * @param {Boolean} [options.showProgressBars] - Whether to show progress bars
+ * @param {Boolean} [options.showItemCounts] - Whether to show item counts
+ */
+export function updateDisplayOptions(options) {
+  Object.assign(DISPLAY_OPTIONS, options);
+}
+
+/**
+ * Gets current display options
+ * @returns {Object} Current display options
+ */
+export function getDisplayOptions() {
+  return { ...DISPLAY_OPTIONS };
+}
+
+/**
+ * Sets display mode for different use cases
+ * @param {'compact'|'expanded'|'minimal'} mode - Display mode to set
+ */
+export function setDisplayMode(mode) {
+  switch (mode) {
+    case 'compact':
+      // Main group expanded, lists collapsed - best for overview
+      updateDisplayOptions({
+        expandMainGroup: true,
+        collapseItemLists: true,
+        showProgressBars: true,
+        showItemCounts: true,
+      });
+      break;
+    case 'expanded':
+      // Everything expanded - best for detailed analysis
+      updateDisplayOptions({
+        expandMainGroup: true,
+        collapseItemLists: false,
+        showProgressBars: true,
+        showItemCounts: true,
+      });
+      break;
+    case 'minimal':
+      // Everything collapsed - best for large reports
+      updateDisplayOptions({
+        expandMainGroup: false,
+        collapseItemLists: true,
+        showProgressBars: false,
+        showItemCounts: false,
+      });
+      break;
+    default:
+      throw new Error(`Unknown display mode: ${mode}. Use 'compact', 'expanded', or 'minimal'.`);
+  }
+}

--- a/packages/super-editor/src/core/super-converter/v2/handlers/registry/logger.test.js
+++ b/packages/super-editor/src/core/super-converter/v2/handlers/registry/logger.test.js
@@ -1,0 +1,556 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createCoverageGroupTitle,
+  startCoverageGroup,
+  showCoverageLegend,
+  showProgressBar,
+  showItemList,
+  endCoverageGroup,
+  computeCoverageSummary,
+  displayCoverageReport,
+  updateDisplayOptions,
+  getDisplayOptions,
+  setDisplayMode,
+  displayNotHandledMessage,
+} from './logger.js';
+
+// Mock console methods
+const mockConsole = {
+  group: vi.fn(),
+  groupCollapsed: vi.fn(),
+  groupEnd: vi.fn(),
+  log: vi.fn(),
+};
+
+describe('Coverage Logger', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.clearAllMocks();
+
+    // Mock console methods
+    global.console = mockConsole;
+
+    // Reset display options to defaults
+    setDisplayMode('compact');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('createCoverageGroupTitle', () => {
+    it('should create title with correct format and styles', () => {
+      const result = createCoverageGroupTitle('w:document', 5, 10);
+
+      expect(result.text).toBe('%c📊 Coverage%c w:document  %c5/10 (50%)');
+      expect(result.styles).toHaveLength(3);
+      expect(result.styles[0]).toContain('color:#AAAAAA'); // muted (from your current file)
+      expect(result.styles[1]).toContain('color:#AAFFAA'); // primary (from your current file)
+      expect(result.styles[2]).toContain('color:#d97706'); // warning (50%)
+    });
+
+    it('should use success color for high coverage', () => {
+      const result = createCoverageGroupTitle('w:document', 9, 10);
+
+      expect(result.text).toBe('%c📊 Coverage%c w:document  %c9/10 (90%)');
+      expect(result.styles[2]).toContain('color:#059669'); // success
+    });
+
+    it('should use missing color for low coverage', () => {
+      const result = createCoverageGroupTitle('w:document', 1, 10);
+
+      expect(result.text).toBe('%c📊 Coverage%c w:document  %c1/10 (10%)');
+      expect(result.styles[2]).toContain('color:#f97316'); // missing
+    });
+
+    it('should handle zero denominator as 100% coverage', () => {
+      const result = createCoverageGroupTitle('w:document', 0, 0);
+
+      expect(result.text).toBe('%c📊 Coverage%c w:document  %c0/0 (100%)');
+      expect(result.styles[2]).toContain('color:#059669'); // success (100% - no children means perfect coverage)
+    });
+
+    it('should handle undefined values', () => {
+      const result = createCoverageGroupTitle('w:document', undefined, null);
+
+      expect(result.text).toBe('%c📊 Coverage%c w:document  %cundefined/null (100%)');
+    });
+  });
+
+  describe('startCoverageGroup', () => {
+    it('should call console.group when expandMainGroup is true', () => {
+      const title = {
+        text: '%cTest%cTitle',
+        styles: ['color:red', 'color:blue'],
+      };
+
+      startCoverageGroup(title);
+
+      expect(mockConsole.group).toHaveBeenCalledWith('%cTest%cTitle', 'color:red', 'color:blue');
+      expect(mockConsole.groupCollapsed).not.toHaveBeenCalled();
+    });
+
+    it('should call console.groupCollapsed when expandMainGroup is false', () => {
+      updateDisplayOptions({ expandMainGroup: false });
+      const title = {
+        text: '%cTest%cTitle',
+        styles: ['color:red'],
+      };
+
+      startCoverageGroup(title);
+
+      expect(mockConsole.groupCollapsed).toHaveBeenCalledWith('%cTest%cTitle', 'color:red');
+      expect(mockConsole.group).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('showCoverageLegend', () => {
+    it('should display legend with correct formatting', () => {
+      showCoverageLegend();
+
+      expect(mockConsole.log).toHaveBeenCalledWith(
+        '%cLegend: %c✅ covered  %c⚠️ missing',
+        'color:#AAAAAA', // muted (from your current file)
+        'color:#059669;font-weight:700', // success
+        'color:#f97316;font-weight:700', // missing
+      );
+    });
+  });
+
+  describe('showProgressBar', () => {
+    it('should display progress bar when enabled', () => {
+      showProgressBar(25);
+
+      expect(mockConsole.log).toHaveBeenCalledWith(
+        expect.stringContaining('[█████░░░░░░░░░░░░░░░] 25%'),
+        'color:#d97706;font-weight:700;background:#1f2937',
+      );
+    });
+
+    it('should display full progress bar for 100%', () => {
+      showProgressBar(100);
+
+      expect(mockConsole.log).toHaveBeenCalledWith(
+        expect.stringContaining('[████████████████████] 100%'),
+        'color:#d97706;font-weight:700;background:#1f2937',
+      );
+    });
+
+    it('should display empty progress bar for 0%', () => {
+      showProgressBar(0);
+
+      expect(mockConsole.log).toHaveBeenCalledWith(
+        expect.stringContaining('[░░░░░░░░░░░░░░░░░░░░] 0%'),
+        'color:#d97706;font-weight:700;background:#1f2937',
+      );
+    });
+
+    it('should not display when showProgressBars is false', () => {
+      updateDisplayOptions({ showProgressBars: false });
+
+      showProgressBar(50);
+
+      expect(mockConsole.log).not.toHaveBeenCalled();
+    });
+
+    it('should handle edge cases correctly', () => {
+      showProgressBar(33); // Should round to nearest filled blocks
+
+      expect(mockConsole.log).toHaveBeenCalledWith(expect.stringContaining('] 33%'), expect.any(String));
+    });
+  });
+
+  describe('showItemList', () => {
+    const mockItems = ['w:p', 'w:r', 'w:t'];
+
+    it('should display covered items with correct styling', () => {
+      showItemList('Covered Items', mockItems, 'covered');
+
+      expect(mockConsole.groupCollapsed).toHaveBeenCalledWith('%c✅ Covered Items', 'color:#059669;font-weight:700');
+
+      expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', 'color:#065f46', 'w:p');
+      expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', 'color:#065f46', 'w:r');
+      expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', 'color:#065f46', 'w:t');
+      expect(mockConsole.log).toHaveBeenCalledWith('%c— 3 items', 'color:#AAAAAA');
+      expect(mockConsole.groupEnd).toHaveBeenCalled();
+    });
+
+    it('should display missing items with correct styling', () => {
+      showItemList('Missing Items', mockItems, 'missing');
+
+      expect(mockConsole.groupCollapsed).toHaveBeenCalledWith('%c⚠️ Missing Items', 'color:#f97316;font-weight:700');
+
+      expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', 'color:#ea580c', 'w:p');
+      expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', 'color:#ea580c', 'w:r');
+      expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', 'color:#ea580c', 'w:t');
+    });
+
+    it('should handle empty list', () => {
+      showItemList('Empty Items', [], 'covered');
+
+      expect(mockConsole.log).toHaveBeenCalledWith('%cNo empty items.', 'color:#6b7280');
+      expect(mockConsole.groupCollapsed).not.toHaveBeenCalled();
+      expect(mockConsole.groupEnd).not.toHaveBeenCalled();
+    });
+
+    it('should handle null/undefined items', () => {
+      showItemList('Test Items', null, 'covered');
+
+      expect(mockConsole.log).toHaveBeenCalledWith('%cNo test items.', 'color:#6b7280');
+    });
+
+    it('should extract names from objects', () => {
+      const objectItems = [{ qname: 'w:p' }, { xmlName: 'w:r' }, { name: 'w:t' }, { tag: 'w:br' }, 'w:tab'];
+
+      showItemList('Object Items', objectItems, 'covered');
+
+      expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', expect.any(String), 'w:br');
+      expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', expect.any(String), 'w:p');
+      expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', expect.any(String), 'w:r');
+      expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', expect.any(String), 'w:t');
+      expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', expect.any(String), 'w:tab');
+    });
+
+    it('should sort items alphabetically', () => {
+      const unsortedItems = ['w:z', 'w:a', 'w:m'];
+      showItemList('Sorted Items', unsortedItems, 'covered');
+
+      // Check that items were logged in sorted order
+      const logCalls = mockConsole.log.mock.calls.filter((call) => call[0] === '%c• %s');
+
+      expect(logCalls[0][2]).toBe('w:a');
+      expect(logCalls[1][2]).toBe('w:m');
+      expect(logCalls[2][2]).toBe('w:z');
+    });
+
+    it('should use expanded groups when collapseItemLists is false', () => {
+      updateDisplayOptions({ collapseItemLists: false });
+
+      showItemList('Expanded Items', mockItems, 'covered');
+
+      expect(mockConsole.group).toHaveBeenCalledWith('%c✅ Expanded Items', 'color:#059669;font-weight:700');
+      expect(mockConsole.groupCollapsed).not.toHaveBeenCalled();
+    });
+
+    it('should not show item counts when disabled', () => {
+      updateDisplayOptions({ showItemCounts: false });
+
+      showItemList('No Count Items', mockItems, 'covered');
+
+      const countCall = mockConsole.log.mock.calls.find((call) => call[0].includes('—') && call[0].includes('items'));
+      expect(countCall).toBeUndefined();
+    });
+
+    it('should handle singular vs plural items correctly', () => {
+      showItemList('Single Item', ['w:p'], 'covered');
+
+      expect(mockConsole.log).toHaveBeenCalledWith('%c— 1 item', 'color:#AAAAAA');
+    });
+  });
+
+  describe('endCoverageGroup', () => {
+    it('should call console.groupEnd', () => {
+      endCoverageGroup();
+
+      expect(mockConsole.groupEnd).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('computeCoverageSummary', () => {
+    const allowedChildren = ['w:p', 'w:r', 'w:t', 'w:br', 'w:tab'];
+    const handledSet = new Set(['w:p', 'w:r']);
+
+    it('should compute coverage statistics correctly', () => {
+      const result = computeCoverageSummary('w:document', allowedChildren, handledSet);
+
+      expect(result).toEqual({
+        tagName: 'w:document',
+        totalCount: 5,
+        coveredItems: ['w:p', 'w:r'],
+        missingItems: ['w:t', 'w:br', 'w:tab'],
+        coveragePercentage: 40,
+      });
+    });
+
+    it('should handle empty children list', () => {
+      const result = computeCoverageSummary('w:empty', [], handledSet);
+
+      expect(result).toEqual({
+        tagName: 'w:empty',
+        totalCount: 0,
+        coveredItems: [],
+        missingItems: [],
+        coveragePercentage: 100, // 0/0 should be 100% coverage
+      });
+    });
+
+    it('should handle null children', () => {
+      const result = computeCoverageSummary('w:null', null, handledSet);
+
+      expect(result.totalCount).toBe(0);
+      expect(result.coveredItems).toEqual([]);
+      expect(result.missingItems).toEqual([]);
+      expect(result.coveragePercentage).toBe(100); // null children should be 100% coverage
+    });
+
+    it('should filter out falsy children', () => {
+      const childrenWithFalsyValues = ['w:p', null, '', undefined, 'w:r', false];
+      const result = computeCoverageSummary('w:test', childrenWithFalsyValues, handledSet);
+
+      expect(result.totalCount).toBe(2);
+      expect(result.coveredItems).toEqual(['w:p', 'w:r']);
+      expect(result.missingItems).toEqual([]);
+    });
+
+    it('should handle 100% coverage', () => {
+      const fullHandledSet = new Set(['w:p', 'w:r', 'w:t', 'w:br', 'w:tab']);
+      const result = computeCoverageSummary('w:complete', allowedChildren, fullHandledSet);
+
+      expect(result.coveragePercentage).toBe(100);
+      expect(result.coveredItems).toEqual(allowedChildren);
+      expect(result.missingItems).toEqual([]);
+    });
+
+    it('should handle 0% coverage', () => {
+      const emptyHandledSet = new Set();
+      const result = computeCoverageSummary('w:incomplete', allowedChildren, emptyHandledSet);
+
+      expect(result.coveragePercentage).toBe(0);
+      expect(result.coveredItems).toEqual([]);
+      expect(result.missingItems).toEqual(allowedChildren);
+    });
+  });
+
+  describe('displayCoverageReport', () => {
+    const allowedChildren = ['w:p', 'w:r', 'w:t'];
+    const handledSet = new Set(['w:p']);
+
+    it('should display complete coverage report', () => {
+      const result = displayCoverageReport('w:test', allowedChildren, handledSet);
+
+      // Check that all console methods were called
+      expect(mockConsole.group).toHaveBeenCalled();
+      expect(mockConsole.log).toHaveBeenCalledWith(
+        '%cLegend: %c✅ covered  %c⚠️ missing',
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+      );
+      expect(mockConsole.log).toHaveBeenCalledWith(
+        expect.stringContaining('['), // Progress bar
+        expect.any(String),
+      );
+      expect(mockConsole.groupCollapsed).toHaveBeenCalledTimes(2); // Covered and Missing groups
+      expect(mockConsole.groupEnd).toHaveBeenCalledTimes(3); // 2 item lists + 1 main group
+
+      // Check return value
+      expect(result).toEqual({
+        tagName: 'w:test',
+        totalCount: 3,
+        coveredItems: ['w:p'],
+        missingItems: ['w:r', 'w:t'],
+        coveragePercentage: 33,
+      });
+    });
+  });
+
+  describe('updateDisplayOptions and getDisplayOptions', () => {
+    it('should update display options', () => {
+      const newOptions = {
+        expandMainGroup: false,
+        showProgressBars: false,
+      };
+
+      updateDisplayOptions(newOptions);
+      const options = getDisplayOptions();
+
+      expect(options.expandMainGroup).toBe(false);
+      expect(options.showProgressBars).toBe(false);
+      expect(options.collapseItemLists).toBe(true); // Should retain existing values
+    });
+
+    it('should return copy of options to prevent mutation', () => {
+      const options1 = getDisplayOptions();
+      const options2 = getDisplayOptions();
+
+      options1.expandMainGroup = false;
+
+      expect(options2.expandMainGroup).toBe(true); // Should not be affected
+    });
+  });
+
+  describe('setDisplayMode', () => {
+    it('should set compact mode correctly', () => {
+      setDisplayMode('compact');
+      const options = getDisplayOptions();
+
+      expect(options).toEqual({
+        expandMainGroup: true,
+        collapseItemLists: true,
+        showProgressBars: true,
+        showItemCounts: true,
+      });
+    });
+
+    it('should set expanded mode correctly', () => {
+      setDisplayMode('expanded');
+      const options = getDisplayOptions();
+
+      expect(options).toEqual({
+        expandMainGroup: true,
+        collapseItemLists: false,
+        showProgressBars: true,
+        showItemCounts: true,
+      });
+    });
+
+    it('should set minimal mode correctly', () => {
+      setDisplayMode('minimal');
+      const options = getDisplayOptions();
+
+      expect(options).toEqual({
+        expandMainGroup: false,
+        collapseItemLists: true,
+        showProgressBars: false,
+        showItemCounts: false,
+      });
+    });
+
+    it('should throw error for invalid mode', () => {
+      expect(() => setDisplayMode('invalid')).toThrow(
+        "Unknown display mode: invalid. Use 'compact', 'expanded', or 'minimal'.",
+      );
+    });
+  });
+
+  describe('Integration Tests', () => {
+    it('should work end-to-end with different display modes', () => {
+      const allowedChildren = ['w:p', 'w:r', 'w:t', 'w:br'];
+      const handledSet = new Set(['w:p', 'w:r']);
+
+      // Test compact mode
+      setDisplayMode('compact');
+      displayCoverageReport('w:test', allowedChildren, handledSet);
+
+      expect(mockConsole.group).toHaveBeenCalled(); // Main group expanded
+      expect(mockConsole.groupCollapsed).toHaveBeenCalled(); // Item lists collapsed
+
+      vi.clearAllMocks();
+
+      // Test expanded mode
+      setDisplayMode('expanded');
+      displayCoverageReport('w:test', allowedChildren, handledSet);
+
+      expect(mockConsole.group).toHaveBeenCalledTimes(3); // Main group + 2 item lists expanded
+      expect(mockConsole.groupCollapsed).not.toHaveBeenCalled();
+
+      vi.clearAllMocks();
+
+      // Test minimal mode
+      setDisplayMode('minimal');
+      displayCoverageReport('w:test', allowedChildren, handledSet);
+
+      expect(mockConsole.groupCollapsed).toHaveBeenCalledWith(
+        expect.stringContaining('Coverage'), // Main group collapsed
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+      );
+
+      // Progress bar should not be shown
+      const progressBarCalls = mockConsole.log.mock.calls.filter(
+        (call) => call[0].includes('[') && call[0].includes(']'),
+      );
+      expect(progressBarCalls).toHaveLength(0);
+    });
+
+    it('should handle edge cases gracefully', () => {
+      // Empty data should be 100% coverage (perfect coverage of nothing)
+      expect(() => displayCoverageReport('w:empty', [], new Set())).not.toThrow();
+
+      // Null data should be 100% coverage
+      expect(() => displayCoverageReport('w:null', null, new Set())).not.toThrow();
+
+      // Large dataset
+      const largeChildren = Array.from({ length: 100 }, (_, i) => `w:item${i}`);
+      const largeHandledSet = new Set(largeChildren.slice(0, 50));
+
+      expect(() => displayCoverageReport('w:large', largeChildren, largeHandledSet)).not.toThrow();
+    });
+  });
+
+  describe('Helper Function Tests', () => {
+    describe('calculatePercentage', () => {
+      // These tests would be for the internal function if it was exported
+      // Since it's not exported, we test it indirectly through other functions
+      it('should calculate percentages correctly through computeCoverageSummary', () => {
+        const result1 = computeCoverageSummary('test', ['a', 'b', 'c'], new Set(['a']));
+        expect(result1.coveragePercentage).toBe(33);
+
+        const result2 = computeCoverageSummary('test', ['a', 'b'], new Set(['a', 'b']));
+        expect(result2.coveragePercentage).toBe(100);
+
+        const result3 = computeCoverageSummary('test', ['a', 'b'], new Set());
+        expect(result3.coveragePercentage).toBe(0);
+
+        // Test the key fix: empty children should be 100% coverage
+        const result4 = computeCoverageSummary('test', [], new Set());
+        expect(result4.coveragePercentage).toBe(100);
+      });
+    });
+
+    describe('createProgressBar', () => {
+      // Test through showProgressBar function
+      it('should create correct progress bars', () => {
+        showProgressBar(0);
+        expect(mockConsole.log).toHaveBeenCalledWith(
+          expect.stringContaining('░░░░░░░░░░░░░░░░░░░░'), // All empty
+          expect.any(String),
+        );
+
+        vi.clearAllMocks();
+
+        showProgressBar(100);
+        expect(mockConsole.log).toHaveBeenCalledWith(
+          expect.stringContaining('████████████████████'), // All filled
+          expect.any(String),
+        );
+      });
+    });
+
+    describe('extractItemName', () => {
+      // Test through showItemList function
+      it('should extract names correctly through showItemList', () => {
+        const complexItems = [
+          { qname: 'test1' },
+          { xmlName: 'test2' },
+          { name: 'test3' },
+          { tag: 'test4' },
+          'test5',
+          { other: 'test6' }, // Should fall back to String()
+        ];
+
+        showItemList('Complex Items', complexItems, 'covered');
+
+        expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', expect.any(String), 'test1');
+        expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', expect.any(String), 'test2');
+        expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', expect.any(String), 'test3');
+        expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', expect.any(String), 'test4');
+        expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', expect.any(String), 'test5');
+        expect(mockConsole.log).toHaveBeenCalledWith('%c• %s', expect.any(String), '[object Object]');
+      });
+    });
+  });
+
+  describe('displayNotHandledMessage', () => {
+    it('should display a not handled message for a given tag name', () => {
+      displayNotHandledMessage('w:unknown');
+
+      expect(mockConsole.log).toHaveBeenCalledWith(
+        '%c⚠️ Not Handled:%c w:unknown',
+        'color:#AAAAAA',
+        'color:#f97316;font-weight:700',
+      );
+    });
+  });
+});

--- a/packages/super-editor/src/core/types/index.js
+++ b/packages/super-editor/src/core/types/index.js
@@ -1,0 +1,55 @@
+/**
+ * @typedef {Object} EditorNodeConfig
+ * @property {String} name The node name.
+ * @property {String} [group] The node group.
+ * @property {Object} [options] The node options.
+ * @property {Boolean} [atom=false] Whether the node is an atom node.
+ * @property {Boolean} [draggable=false] Whether the node is draggable.
+ * @property {Boolean} [isolating=false] Whether the node is isolating.
+ * @property {Boolean} [defining=false] Whether the node is defining.
+ * @property {Boolean} [topNode=false] Whether the node is a top-level node.
+ * @property {String} [tableRole] The role of the node in a table.
+ * @property {Function | String} [content] ProseMirror string for what content this node accepts.
+ * @property {String} [marks] The marks applied to this node.
+ * @property {Boolean} [inline=false] Whether the node is an inline node.
+ * @property {Boolean} [selectable=true] Whether the node is selectable.
+ * @property {import('prosemirror-model').NodeType} [type] The node type.
+ * @property {import('../Editor').Editor} [editor] The editor instance.
+ * @property {Function} [parseDOM] The DOM parsing rules.
+ * @property {Function} [renderDOM] The DOM rendering function.
+ * @property {Function} [addOptions] Function or object to add options to the node.
+ * @property {Function} [addStorage] Function or object to add storage to the node.
+ * @property {Function} [addAttributes] Function or object to add attributes to the node.
+ * @property {Function} [addCommands] Function or object to add commands to the node.
+ * @property {Function} [addHelpers] Function or object to add helpers to the node.
+ * @property {Function} [addShortcuts] Function or object to add shortcuts to the node.
+ * @property {Function} [addInputRules] Function or object to add input rules to the node.
+ * @property {Function} [addNodeView] Function to add a custom node view to the node.
+ * @property {Function} [addPmPlugins] Function to add ProseMirror plugins to the node.
+ * @property {Function} [extendNodeSchema] Function to extend the ProseMirror node schema.
+ */
+
+/**
+ * @typedef {Object} EditorNodeOptions
+ */
+
+/**
+ * @typedef {Object} EditorNodeStorage
+ */
+
+/**
+ * Config required to construct an OxmlNode
+ * (extends EditorNodeConfig)
+ * @typedef {EditorNodeConfig & { oXmlName: string, childToAttributes: string[] }} OxmlNodeConfig
+ */
+
+/**
+ * Runtime shape of an OxmlNode instance
+ * (extends EditorNode)
+ * @typedef {import('../Node').Node & {
+ *   oXmlName: string,
+ *   readonly validChildren: string[],
+ * }} OxmlNode
+ */
+
+export {};

--- a/packages/super-editor/vite.config.js
+++ b/packages/super-editor/vite.config.js
@@ -85,7 +85,6 @@ export default defineConfig(({ mode }) => {
         '@packages': fileURLToPath(new URL('../', import.meta.url)),
         '@converter': fileURLToPath(new URL('./src/core/super-converter', import.meta.url)),
         '@tests': fileURLToPath(new URL('./src/tests', import.meta.url)),
-        '@ooxml-inspector': fileURLToPath(new URL('../../../ooxml-inspector/dist/index.js', import.meta.url)),
       },
       extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json'],
     },

--- a/packages/super-editor/vite.config.js
+++ b/packages/super-editor/vite.config.js
@@ -85,7 +85,7 @@ export default defineConfig(({ mode }) => {
         '@packages': fileURLToPath(new URL('../', import.meta.url)),
         '@converter': fileURLToPath(new URL('./src/core/super-converter', import.meta.url)),
         '@tests': fileURLToPath(new URL('./src/tests', import.meta.url)),
-        '@ooxml-inspector': fileURLToPath(new URL('../../../ooxml-inspector/dist/index.js', import.meta.url))
+        '@ooxml-inspector': fileURLToPath(new URL('../../../ooxml-inspector/dist/index.js', import.meta.url)),
       },
       extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json'],
     },


### PR DESCRIPTION
- Adds new OxmlNode (extends Node) for nodes that we fully migrate to mirror MS Word
- Connects ooxml-inspector (soon to be renamed ooxml-oracle) with super-editor
- Adds set up for handler registry, connect to super converter
- types fixes and improvements