### PR TITLE
fix: add processing for line-height defined in px

### DIFF
--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -271,16 +271,20 @@ function generateParagraphProperties(node) {
     if (lineSpaceBefore >= 0) attributes['w:before'] = pixelsToTwips(lineSpaceBefore);
     if (lineSpaceAfter >= 0) attributes['w:after'] = pixelsToTwips(lineSpaceAfter);
 
+    attributes['w:lineRule'] = lineRule || 'auto';
+
     const normalized = normalizeLineHeight(lineHeight);
     if (normalized !== null) {
       if (lineRule === 'exact') {
         attributes['w:line'] = ptToTwips(normalized);
+      } else if (lineHeight.endsWith('px')) {
+        // Conditional for agreements created via API
+        attributes['w:line'] = pixelsToTwips(normalized);
+        attributes['w:lineRule'] = 'exact';
       } else {
         attributes['w:line'] = linesToTwips(normalized);
       }
     }
-
-    attributes['w:lineRule'] = lineRule || 'auto';
 
     const spacingElement = {
       name: 'w:spacing',


### PR DESCRIPTION
Hi @harbournick. Not sure if I can add some tests for it because most probably this content was either copied and pasted from somewhere or added via API. It's not possible to have px for line height when importing fro docx