### PR TITLE
feat: remove the heading node from superdoc

### DIFF
--- a/packages/super-editor/src/extensions/heading/heading.js
+++ b/packages/super-editor/src/extensions/heading/heading.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { Node, Attribute } from '@core/index.js';
+import { Extension } from '@core/index.js';
 
 /**
  * Heading attributes
@@ -18,14 +18,8 @@ import { Node, Attribute } from '@core/index.js';
  * @shortcut Mod-Alt-5 | toggleHeading | Toggle heading level 5
  * @shortcut Mod-Alt-6 | toggleHeading | Toggle heading level 6
  */
-export const Heading = Node.create({
+export const Heading = Extension.create({
   name: 'heading',
-
-  group: 'block',
-
-  content: 'inline*',
-
-  defining: true,
 
   addOptions() {
     return {
@@ -33,65 +27,9 @@ export const Heading = Node.create({
        * @typedef {Object} HeadingOptions
        * @category Options
        * @property {number[]} [levels=[1,2,3,4,5,6]] - Supported heading levels
-       * @property {Object} [htmlAttributes] - HTML attributes for heading elements
        */
       levels: [1, 2, 3, 4, 5, 6],
-      htmlAttributes: {
-        'aria-label': 'Heading node',
-      },
     };
-  },
-
-  addAttributes() {
-    return {
-      /**
-       * @category Attribute
-       * @param {number} [level=1] - Heading level from 1 (largest) to 6 (smallest)
-       */
-      level: {
-        default: 1,
-        rendered: false,
-      },
-
-      /**
-       * @private
-       * @category Attribute
-       * @param {Object} [tabStops] - Internal tab stop configuration
-       */
-      tabStops: { rendered: false },
-
-      /**
-       * @private
-       * @category Attribute
-       * @param {string} [sdBlockId] - Internal block tracking ID
-       */
-      sdBlockId: {
-        default: null,
-        keepOnSplit: false,
-        parseDOM: (elem) => elem.getAttribute('data-sd-block-id'),
-        renderDOM: (attrs) => {
-          return attrs.sdBlockId ? { 'data-sd-block-id': attrs.sdBlockId } : {};
-        },
-      },
-
-      /**
-       * @private
-       * @category Attribute
-       * @param {string} [styleId] - Style ID assigned according to heading level
-       */
-      styleId: {},
-    };
-  },
-
-  parseDOM() {
-    return this.options.levels.map((level) => ({
-      tag: `h${level}`,
-      attrs: { level, styleId: `Heading${level}` },
-    }));
-  },
-
-  renderDOM({ htmlAttributes }) {
-    return [`p`, Attribute.mergeAttributes(this.options.htmlAttributes, htmlAttributes), 0];
   },
 
   addCommands() {

--- a/packages/super-editor/src/extensions/heading/heading.js
+++ b/packages/super-editor/src/extensions/heading/heading.js
@@ -49,7 +49,7 @@ export const Heading = Extension.create({
         ({ commands }) => {
           const containsLevel = this.options.levels.includes(attributes.level);
           if (!containsLevel) return false;
-          return commands.setNode(this.name, attributes);
+          return commands.setLinkedStyle({ id: `Heading${attributes.level}` });
         },
 
       /**
@@ -70,7 +70,7 @@ export const Heading = Extension.create({
         ({ commands }) => {
           const containsLevel = this.options.levels.includes(attributes.level);
           if (!containsLevel) return false;
-          return commands.toggleNode(this.name, 'paragraph', attributes);
+          return commands.toggleLinkedStyle({ id: `Heading${attributes.level}` }, 'paragraph');
         },
     };
   },

--- a/packages/super-editor/src/extensions/heading/heading.test.js
+++ b/packages/super-editor/src/extensions/heading/heading.test.js
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TextSelection } from 'prosemirror-state';
+import { initTestEditor, loadTestDataForEditorTests } from '../../tests/helpers/helpers.js';
+
+const keymaps = {};
+vi.mock('prosemirror-keymap', async (importActual) => {
+  const actual = await importActual();
+  return {
+    ...actual,
+    keymap: vi.fn((bindings) => {
+      Object.assign(keymaps, bindings);
+      return actual.keymap(bindings);
+    }),
+  };
+});
+describe('Heading Extension', () => {
+  const filename = 'paragraph_spacing_missing.docx';
+  let docx, media, mediaFiles, fonts, editor, tr;
+
+  beforeAll(async () => {
+    ({ docx, media, mediaFiles, fonts } = await loadTestDataForEditorTests(filename));
+  });
+
+  beforeEach(() => {
+    ({ editor } = initTestEditor({ content: docx, media, mediaFiles, fonts }));
+    tr = editor.state.tr;
+    vi.clearAllMocks();
+  });
+
+  describe('Commands', () => {
+    describe('setHeading', () => {
+      it('should set heading style for a valid level', () => {
+        editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+        const result = editor.commands.setHeading({ level: 1 });
+
+        expect(result).toBe(true);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe('Heading1');
+      });
+
+      it('should not set heading style for an invalid level', () => {
+        editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+        const result = editor.commands.setHeading({ level: 7 });
+
+        expect(result).toBe(false);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe(null);
+      });
+
+      it('should set heading style for another valid level', () => {
+        editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+        const result = editor.commands.setHeading({ level: 2 });
+
+        expect(result).toBe(true);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe('Heading2');
+      });
+    });
+
+    describe('toggleHeading', () => {
+      it('should return false for an empty selection', () => {
+        tr.setSelection(TextSelection.create(tr.doc, 1)); // Cursor selection
+        const result = editor.commands.toggleHeading({ level: 1 });
+
+        expect(result).toBe(false);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe(null);
+      });
+
+      it('should toggle heading on for a paragraph', () => {
+        editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+        const result = editor.commands.toggleHeading({ level: 1 });
+
+        expect(result).toBe(true);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe('Heading1');
+      });
+
+      it('should toggle heading off for a heading', () => {
+        // First, set it to a heading
+        editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+        editor.commands.setHeading({ level: 1 });
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe('Heading1');
+
+        // Then toggle it
+        editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.tr.doc, 1, 16))); // Re-select
+        const result = editor.commands.toggleHeading({ level: 1 });
+
+        expect(result).toBe(true);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe(null);
+      });
+
+      it('should not toggle heading for an invalid level', () => {
+        editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+        const result = editor.commands.toggleHeading({ level: 7 });
+
+        expect(result).toBe(false);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe(null);
+      });
+
+      it('should switch to a different heading level when another heading is active', () => {
+        // First, set it to a heading
+        editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+        editor.commands.setHeading({ level: 1 });
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe('Heading1');
+
+        // Then toggle to another heading level
+        editor.view.dispatch(editor.view.state.tr.setSelection(TextSelection.create(editor.view.state.tr.doc, 1, 16))); // Re-select
+        const result = editor.commands.toggleHeading({ level: 2 });
+
+        expect(result).toBe(true);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe('Heading2');
+      });
+    });
+  });
+
+  describe('Shortcuts', () => {
+    it('should have default shortcuts for heading levels 1-6', () => {
+      for (let i = 1; i <= 6; i++) {
+        expect(keymaps).toHaveProperty(`Mod-Alt-${i}`);
+      }
+    });
+
+    it('should toggle heading when shortcut is triggered', () => {
+      editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+      keymaps['Mod-Alt-1']();
+      expect(editor.state.doc.content.content[0].attrs.styleId).toBe('Heading1');
+    });
+  });
+});

--- a/packages/super-editor/src/extensions/linked-styles/helpers.js
+++ b/packages/super-editor/src/extensions/linked-styles/helpers.js
@@ -181,6 +181,7 @@ export const generateLinkedStyleString = (linkedStyle, basedOnStyle, node, paren
  * @param {Transaction} tr The transaction to mutate
  * @param {Editor} editor The editor instance
  * @param {object} style The linked style to apply
+ * @param {string} style.id The style ID
  * @returns {boolean} Whether the transaction was modified
  */
 export const applyLinkedStyleToTransaction = (tr, editor, style) => {

--- a/packages/super-editor/src/extensions/linked-styles/linked-styles.js
+++ b/packages/super-editor/src/extensions/linked-styles/linked-styles.js
@@ -95,7 +95,7 @@ export const LinkedStyles = Extension.create({
        * @returns {object|null} The linked style object or null if not found
        */
       getStyleById: (styleId) => {
-        const styles = this.getStyles();
+        const styles = this.editor.helpers[this.name].getStyles();
         return styles.find((s) => s.id === styleId);
       },
 

--- a/packages/super-editor/src/extensions/linked-styles/linked-styles.js
+++ b/packages/super-editor/src/extensions/linked-styles/linked-styles.js
@@ -13,11 +13,23 @@ export const LinkedStyles = Extension.create({
 
   addCommands() {
     return {
+      /**
+       * Apply a linked style to the current selection.
+       *
+       * @param {object} style The linked style to apply
+       * @param {string} style.id The style ID (e.g., 'Heading1')
+       * @returns {boolean} Whether the style was correctly applied
+       */
       setLinkedStyle: (style) => (params) => {
         const { tr } = params;
         return applyLinkedStyleToTransaction(tr, this.editor, style);
       },
 
+      /**
+       * Apply a linked style by its ID.
+       * @param {string} styleId The style ID (e.g., 'Heading1')
+       * @returns {boolean} Whether the style was correctly applied
+       */
       setStyleById: (styleId) => (params) => {
         const { state, tr } = params;
         const pluginState = LinkedStylesPluginKey.getState(state);
@@ -33,11 +45,20 @@ export const LinkedStyles = Extension.create({
 
   addHelpers() {
     return {
+      /**
+       * Get all linked styles available in the editor
+       * @returns {Array} Array of linked style objects
+       */
       getStyles: () => {
         const styles = LinkedStylesPluginKey.getState(this.editor.state)?.styles || [];
         return styles;
       },
 
+      /**
+       * Get a linked style by its ID
+       * @param {string} styleId The style ID (e.g., 'Heading1')
+       * @returns {object|null} The linked style object or null if not found
+       */
       getStyleById: (styleId) => {
         const styles = this.getStyles();
         return styles.find((s) => s.id === styleId);

--- a/packages/super-editor/src/extensions/linked-styles/linked-styles.test.js
+++ b/packages/super-editor/src/extensions/linked-styles/linked-styles.test.js
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TextSelection } from 'prosemirror-state';
+import { LinkedStylesPluginKey } from './plugin.js';
+import { initTestEditor, loadTestDataForEditorTests } from '../../tests/helpers/helpers.js';
+
+describe('LinkedStyles Extension', () => {
+  const filename = 'paragraph_spacing_missing.docx';
+  let docx, media, mediaFiles, fonts, editor, tr;
+  beforeAll(async () => ({ docx, media, mediaFiles, fonts } = await loadTestDataForEditorTests(filename)));
+  beforeEach(() => {
+    ({ editor } = initTestEditor({ content: docx, media, mediaFiles, fonts }));
+    tr = editor.state.tr;
+    vi.clearAllMocks();
+  });
+
+  describe('Commands', () => {
+    const style1 = { id: 'Heading1' };
+
+    describe('setLinkedStyle', () => {
+      it('should call applyLinkedStyleToTransaction with the correct style', () => {
+        const result = editor.commands.setLinkedStyle(style1);
+
+        expect(result).toBe(true);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe('Heading1');
+      });
+    });
+
+    describe('toggleLinkedStyle', () => {
+      const styleToToggle = { id: 'Heading1' };
+
+      it('should return false for an empty selection', () => {
+        tr.setSelection(TextSelection.create(tr.doc, 1)); // Cursor selection
+        const result = editor.commands.toggleLinkedStyle(styleToToggle, 'paragraph');
+
+        expect(result).toBe(false);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe(null);
+      });
+
+      it('should apply style when no style is currently set', () => {
+        editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+        editor.commands.toggleLinkedStyle(styleToToggle, 'paragraph');
+
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe(styleToToggle.id);
+      });
+
+      it('should remove style when the same style is already applied', () => {
+        editor.view.dispatch(tr.setNodeMarkup(17, null, { styleId: styleToToggle.id })); // Apply existing style to second paragraph
+
+        expect(editor.state.doc.content.content[1].attrs.styleId).toBe(styleToToggle.id);
+
+        editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(tr.doc, 18, 34))); // Select "Second paragraph"
+        editor.commands.toggleLinkedStyle(styleToToggle, 'paragraph');
+        expect(editor.state.doc.content.content[1].attrs.styleId).toBe(null);
+      });
+
+      it('should apply new style when a different style is already applied', () => {
+        editor.view.dispatch(tr.setNodeMarkup(17, null, { styleId: 'Heading2' })); // Apply existing style to second paragraph
+
+        expect(editor.state.doc.content.content[1].attrs.styleId).toBe('Heading2');
+
+        editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(tr.doc, 18, 34))); // Select "Second paragraph"
+        editor.commands.toggleLinkedStyle(styleToToggle, 'paragraph');
+        expect(editor.state.doc.content.content[1].attrs.styleId).toBe('Heading1');
+      });
+
+      it('should return false if no node of the specified type can be found', () => {
+        editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+
+        const result = editor.commands.toggleLinkedStyle(styleToToggle, 'non-existent-type');
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('setStyleById', () => {
+      it('should apply style if styleId is valid', () => {
+        editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+
+        const result = editor.commands.setStyleById('Heading1');
+
+        expect(result).toBe(true);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe('Heading1');
+      });
+
+      it('should return false if styleId is not found', () => {
+        editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 16))); // Select "First paragraph"
+
+        const result = editor.commands.setStyleById('invalid-id');
+
+        expect(result).toBe(false);
+        expect(editor.state.doc.content.content[0].attrs.styleId).toBe(null);
+      });
+    });
+  });
+
+  describe('Helpers', () => {
+    let linkedStylesHelpers;
+
+    beforeEach(() => {
+      linkedStylesHelpers = editor.helpers.linkedStyles;
+    });
+
+    describe('getStyles', () => {
+      it('should return all styles from the plugin state', () => {
+        const styles = linkedStylesHelpers.getStyles();
+        expect(styles).toEqual(editor.state.linkedStyles$.styles);
+      });
+    });
+
+    describe('getStyleById', () => {
+      it('should return the correct style by its ID', () => {
+        const style = linkedStylesHelpers.getStyleById('Heading1');
+        expect(style.id).toEqual('Heading1');
+      });
+
+      it('should return undefined if style is not found', () => {
+        const style = linkedStylesHelpers.getStyleById('non-existent');
+        expect(style).toBeUndefined();
+      });
+    });
+
+    describe('getLinkedStyleString', () => {
+      it('should call generateLinkedStyleString for a valid style ID', () => {
+        const result = linkedStylesHelpers.getLinkedStyleString('Title');
+        expect(result).toBe('font-family: Aptos Display;letter-spacing: -0.5pt;font-size: 28pt');
+      });
+
+      it('should return an empty string for an invalid style ID', () => {
+        const result = linkedStylesHelpers.getLinkedStyleString('invalid-id');
+        expect(result).toBe('');
+      });
+    });
+  });
+});

--- a/packages/super-editor/src/extensions/paragraph/paragraph.js
+++ b/packages/super-editor/src/extensions/paragraph/paragraph.js
@@ -17,6 +17,13 @@ export const Paragraph = Node.create({
 
   addOptions() {
     return {
+      /**
+       * @typedef {Object} HeadingOptions
+       * @category Options
+       * @property {number[]} [headingLevels=[1,2,3,4,5,6]] - Supported heading levels
+       * @property {Object} [htmlAttributes] - HTML attributes for paragraph elements
+       */
+      headingLevels: [1, 2, 3, 4, 5, 6],
       htmlAttributes: {},
     };
   },
@@ -167,6 +174,10 @@ export const Paragraph = Node.create({
           return { extraAttrs: extra };
         },
       },
+      ...this.options.headingLevels.map((level) => ({
+        tag: `h${level}`,
+        attrs: { level, styleId: `Heading${level}` },
+      })),
     ];
   },
 

--- a/packages/super-editor/src/extensions/paragraph/paragraph.test.js
+++ b/packages/super-editor/src/extensions/paragraph/paragraph.test.js
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initTestEditor, loadTestDataForEditorTests } from '../../tests/helpers/helpers.js';
+import { exportSchemaToJson } from '../../core/super-converter/exporter.js';
+
+describe('Paragraph Node', () => {
+  let docx, media, mediaFiles, fonts, editor, tr;
+  beforeAll(async () => {
+    ({ docx, media, mediaFiles, fonts } = await loadTestDataForEditorTests('blank-doc.docx'));
+  });
+
+  beforeEach(() => {
+    ({ editor } = initTestEditor({ content: docx, media, mediaFiles, fonts }));
+    tr = editor.state.tr;
+    vi.clearAllMocks();
+  });
+
+  it('inserting html with <h1> tag adds paragraph styled as heading', async () => {
+    editor.commands.insertContent('<h1>Test Heading</h1>');
+    expect(editor.state.doc.content.content[0].type.name).toBe('paragraph');
+    expect(editor.state.doc.content.content[0].attrs.styleId).toBe('Heading1');
+
+    const result = await editor.exportDocx({
+      exportJsonOnly: true,
+    });
+
+    const body = result.elements[0];
+
+    expect(body.elements).toHaveLength(2);
+    expect(body.elements.map((el) => el.name)).toEqual(['w:p', 'w:sectPr']);
+    const paragraph = body.elements[0];
+    expect(paragraph.name).toBe('w:p');
+    expect(paragraph.elements).toEqual([
+      {
+        name: 'w:pPr',
+        elements: [
+          {
+            name: 'w:pStyle',
+            attributes: {
+              'w:val': 'Heading1',
+            },
+          },
+          {
+            name: 'w:spacing',
+            attributes: {
+              'w:before': 0,
+              'w:after': 0,
+              'w:lineRule': 'auto',
+            },
+          },
+        ],
+      },
+      {
+        name: 'w:r',
+        elements: [
+          {
+            name: 'w:t',
+            elements: [
+              {
+                text: 'Test Heading',
+                type: 'text',
+              },
+            ],
+            attributes: null,
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/super-editor/src/extensions/paragraph/paragraph.test.js
+++ b/packages/super-editor/src/extensions/paragraph/paragraph.test.js
@@ -66,4 +66,48 @@ describe('Paragraph Node', () => {
       },
     ]);
   });
+
+  it('inserting plain text creates a simple paragraph', async () => {
+    editor.commands.insertContent('This is a test paragraph.');
+    expect(editor.state.doc.content.content[0].type.name).toBe('paragraph');
+    expect(editor.state.doc.content.content[0].attrs.styleId).toBe(null);
+    const result = await editor.exportDocx({
+      exportJsonOnly: true,
+    });
+
+    const body = result.elements[0];
+
+    expect(body.elements).toHaveLength(2);
+    expect(body.elements.map((el) => el.name)).toEqual(['w:p', 'w:sectPr']);
+    const paragraph = body.elements[0];
+    expect(paragraph.name).toBe('w:p');
+    expect(paragraph.elements).toEqual([
+      {
+        name: 'w:pPr',
+        elements: [
+          {
+            name: 'w:spacing',
+            attributes: {
+              'w:lineRule': 'auto',
+            },
+          },
+        ],
+      },
+      {
+        name: 'w:r',
+        elements: [
+          {
+            name: 'w:t',
+            elements: [
+              {
+                text: 'This is a test paragraph.',
+                type: 'text',
+              },
+            ],
+            attributes: null,
+          },
+        ],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
- Modifies how headings are parsed so that they are represented as styled paragraphs
- Turns the heading node into an extension
- Adds tests to commands in the linked-styles extension
- Adds tests to commands in the heading extension