### PR TITLE
feat: add docx passthrough nodes

### DIFF
--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -100,6 +100,8 @@ export function exportSchemaToJson(params) {
     documentSection: translateDocumentSection,
     'page-number': translatePageNumberNode,
     'total-page-number': translateTotalPageNumberNode,
+    docxPassthroughBlock: translateDocxPassthrough,
+    docxPassthroughInline: translateDocxPassthrough,
   };
 
   let handler = router[type];
@@ -112,6 +114,10 @@ export function exportSchemaToJson(params) {
   // Call the handler for this node type
   return handler(params);
 }
+
+const translateDocxPassthrough = (params) => {
+  return params.node.attrs?.originalXml || null;
+};
 
 /**
  * There is no body node in the prose mirror schema, so it is stored separately

--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -24,6 +24,7 @@ import { ListHelpers } from '@helpers/list-numbering-helpers.js';
 import { translateChildNodes } from './v2/exporter/helpers/index.js';
 import { translateDocumentSection } from './v2/exporter/index.js';
 import { translator as wBrNodeTranslator } from './v3/handlers/w/br/br-translator.js';
+import { translator as docxPassthroughTranslator } from './v3/handlers/passthrough/index.js';
 
 /**
  * @typedef {Object} ExportParams
@@ -100,8 +101,8 @@ export function exportSchemaToJson(params) {
     documentSection: translateDocumentSection,
     'page-number': translatePageNumberNode,
     'total-page-number': translateTotalPageNumberNode,
-    docxPassthroughBlock: translateDocxPassthrough,
-    docxPassthroughInline: translateDocxPassthrough,
+    docxPassthroughBlock: docxPassthroughTranslator,
+    docxPassthroughInline: docxPassthroughTranslator,
   };
 
   let handler = router[type];
@@ -114,10 +115,6 @@ export function exportSchemaToJson(params) {
   // Call the handler for this node type
   return handler(params);
 }
-
-const translateDocxPassthrough = (params) => {
-  return params.node.attrs?.originalXml || null;
-};
 
 /**
  * There is no body node in the prose mirror schema, so it is stored separately

--- a/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
@@ -88,6 +88,7 @@ export const createDocumentJson = (docx, converter, editor) => {
       converter,
       editor,
       lists,
+      isBlock: true,
     });
 
     const result = {
@@ -189,6 +190,7 @@ const createNodeListHandler = (nodeHandlers) => {
     filename,
     parentStyleId,
     lists,
+    isBlock = true,
   }) => {
     if (!elements || !elements.length) return [];
 
@@ -216,6 +218,7 @@ const createNodeListHandler = (nodeHandlers) => {
                 filename,
                 parentStyleId,
                 lists,
+                isBlock,
               });
             },
             { nodes: [], consumed: 0 },
@@ -227,6 +230,12 @@ const createNodeListHandler = (nodeHandlers) => {
             if (!context.elementName) continue;
 
             converter?.telemetry?.trackStatistic('unknown', context);
+
+            const originalNode = nodesToHandle[0];
+            processedElements.push({
+              type: isBlock ? 'docxPassthroughBlock' : 'docxPassthroughInline',
+              attrs: { originalXml: originalNode },
+            });
             continue;
           } else {
             converter?.telemetry?.trackStatistic('node', context);
@@ -458,6 +467,7 @@ const importHeadersFooters = (docx, converter, mainEditor) => {
       converter,
       editor,
       filename: currentFileName,
+      isBlock: true,
     });
 
     if (!converter.headerIds.ids) converter.headerIds.ids = [];
@@ -484,6 +494,7 @@ const importHeadersFooters = (docx, converter, mainEditor) => {
       converter,
       editor,
       filename: currentFileName,
+      isBlock: true,
     });
 
     if (!converter.footerIds.ids) converter.footerIds.ids = [];

--- a/packages/super-editor/src/core/super-converter/v2/importer/passthroughNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/passthroughNodeImporter.js
@@ -1,0 +1,28 @@
+// @ts-check
+import { translator } from '../../v3/handlers/passthrough/index.js';
+
+/**
+ * Passthrough node handler that wraps unrecognized OOXML nodes and preserves
+ * their original XML for round-tripping.
+ * @type {import('./docxImporter.js').NodeHandler}
+ */
+export const handler = (params) => {
+  const { nodes } = params;
+  if (!nodes || nodes.length === 0) {
+    return { nodes: [], consumed: 0 };
+  }
+
+  const result = translator.encode(params);
+  if (!result) return { nodes: [], consumed: 0 };
+
+  return {
+    nodes: [result],
+    consumed: 1,
+  };
+};
+
+/** @type {import('./docxImporter.js').NodeHandlerEntry} */
+export const passthroughNodeHandlerEntity = {
+  handlerName: 'passthroughNodeHandler',
+  handler,
+};

--- a/packages/super-editor/src/core/super-converter/v2/importer/runNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/runNodeImporter.js
@@ -11,7 +11,7 @@ export const handleRunNode = (params) => {
   }
   const node = nodes[0];
 
-  const childParams = { ...params, nodes: node.elements };
+  const childParams = { ...params, nodes: node.elements, isBlock: false };
   let processedRun = nodeListHandler.handler(childParams)?.filter((n) => n) || [];
   const hasRunProperties = node.elements?.some((el) => el.name === 'w:rPr');
   const defaultNodeStyles = getMarksFromStyles(docx, parentStyleId);

--- a/packages/super-editor/src/core/super-converter/v2/importer/standardNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/standardNodeImporter.js
@@ -32,20 +32,9 @@ export const handleStandardNode = (params) => {
     };
   }
 
-  // Unhandled nodes
+  // Unhandled nodes are ignored here so the passthrough handler can process them
   if (!getElementName(node)) {
-    return {
-      nodes: [
-        {
-          type: name,
-          content: elements,
-          attrs: { ...attributes },
-          marks,
-        },
-      ],
-      consumed: 0,
-      unhandled: true,
-    };
+    return { nodes: [], consumed: 0 };
   }
 
   // Iterate through the children and build the schemaNode content

--- a/packages/super-editor/src/core/super-converter/v3/handlers/passthrough/index.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/passthrough/index.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+/**
+ * Translator for unhandled OOXML nodes. It encodes nodes into ProseMirror
+ * passthrough nodes that retain the original XML and decodes them back to the
+ * stored XML when exporting.
+ */
+export const translator = {
+  /**
+   * Encode an unknown XML node as a passthrough node.
+   * @param {import('../../node-translator').SCEncoderConfig} params
+   * @returns {import('../../node-translator').SCEncoderResult | null}
+   */
+  encode(params) {
+    const { nodes, isBlock } = params;
+    if (!nodes || nodes.length === 0) return null;
+
+    const originalNode = nodes[0];
+    return {
+      type: isBlock ? 'docxPassthroughBlock' : 'docxPassthroughInline',
+      attrs: { originalXml: originalNode },
+    };
+  },
+
+  /**
+   * Decode a passthrough node back to its original XML.
+   * @param {import('../../node-translator').SCDecoderConfig} params
+   * @returns {import('../../node-translator').SCDecoderResult | null}
+   */
+  decode(params) {
+    const { node } = params;
+    return node?.attrs?.originalXml || null;
+  },
+};

--- a/packages/super-editor/src/extensions/block-node/block-node.js
+++ b/packages/super-editor/src/extensions/block-node/block-node.js
@@ -129,14 +129,17 @@ export const BlockNode = Extension.create({
             // Only allow block nodes with a valid sdBlockId attribute
             if (!nodeAllowsSdBlockIdAttr(node) || !nodeNeedsSdBlockId(node)) return null;
 
+            const currentNode = tr.doc.nodeAt(pos);
+            if (!currentNode || !currentNode.type.validContent(currentNode.content)) return null;
+
             tr.setNodeMarkup(
               pos,
               undefined,
               {
-                ...node.attrs,
+                ...currentNode.attrs,
                 sdBlockId: uuidv4(),
               },
-              node.marks,
+              currentNode.marks,
             );
             changed = true;
           });

--- a/packages/super-editor/src/extensions/index.js
+++ b/packages/super-editor/src/extensions/index.js
@@ -40,6 +40,7 @@ import { ShapeTextbox } from './shape-textbox/index.js';
 import { ContentBlock } from './content-block/index.js';
 import { StructuredContent, StructuredContentBlock, DocumentSection } from './structured-content/index.js';
 import { BlockNode } from './block-node/index.js';
+import { DocxPassthroughBlock, DocxPassthroughInline } from './passthrough/index.js';
 
 // Marks extensions
 import { TextStyle } from './text-style/text-style.js';
@@ -107,6 +108,8 @@ const getRichTextExtensions = () => {
     Image,
     NodeResizer,
     CustomSelection,
+    DocxPassthroughBlock,
+    DocxPassthroughInline,
   ];
 };
 
@@ -179,6 +182,8 @@ const getStarterExtensions = () => {
     NodeResizer,
     CustomSelection,
     TextTransform,
+    DocxPassthroughBlock,
+    DocxPassthroughInline,
   ];
 };
 
@@ -247,4 +252,6 @@ export {
   NodeResizer,
   CustomSelection,
   TextTransform,
+  DocxPassthroughBlock,
+  DocxPassthroughInline,
 };

--- a/packages/super-editor/src/extensions/passthrough/index.js
+++ b/packages/super-editor/src/extensions/passthrough/index.js
@@ -1,0 +1,1 @@
+export { DocxPassthroughBlock, DocxPassthroughInline } from './passthrough.js';

--- a/packages/super-editor/src/extensions/passthrough/passthrough.js
+++ b/packages/super-editor/src/extensions/passthrough/passthrough.js
@@ -1,0 +1,43 @@
+import { Node } from '@core/index.js';
+
+export const DocxPassthroughBlock = Node.create({
+  name: 'docxPassthroughBlock',
+  group: 'block',
+  atom: true,
+  selectable: false,
+  defining: false,
+  addAttributes() {
+    return {
+      originalXml: {
+        default: null,
+      },
+    };
+  },
+  parseDOM() {
+    return [];
+  },
+  renderDOM() {
+    return ['div', { 'data-docx-passthrough': 'block', style: 'display:none' }];
+  },
+});
+
+export const DocxPassthroughInline = Node.create({
+  name: 'docxPassthroughInline',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  selectable: false,
+  addAttributes() {
+    return {
+      originalXml: {
+        default: null,
+      },
+    };
+  },
+  parseDOM() {
+    return [];
+  },
+  renderDOM() {
+    return ['span', { 'data-docx-passthrough': 'inline', style: 'display:none' }];
+  },
+});

--- a/packages/super-editor/src/tests/export/export-helpers/export-helpers.js
+++ b/packages/super-editor/src/tests/export/export-helpers/export-helpers.js
@@ -13,10 +13,10 @@ import { getCommentDefinition } from '@converter/v2/exporter/commentsExporter.js
  * @returns {string} The text from the node
  */
 export const getTextFromNode = (node) => {
-  const listTextNode = node.elements.find((el) => el.name === 'w:r');
-  const textNode = listTextNode?.elements?.find((el) => el.name === 'w:t');
-  const text = textNode?.elements?.find((el) => el.type === 'text')?.text;
-  return text;
+  const runs = node.elements?.filter((el) => el.name === 'w:r') || [];
+  return runs
+    .map((run) => run.elements?.find((el) => el.name === 'w:t')?.elements?.find((el) => el.type === 'text')?.text || '')
+    .join('');
 };
 
 /**

--- a/packages/super-editor/src/tests/import-export/passthroughNode.test.js
+++ b/packages/super-editor/src/tests/import-export/passthroughNode.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { defaultNodeListHandler } from '../../core/super-converter/v2/importer/docxImporter.js';
+import { exportSchemaToJson } from '../../core/super-converter/exporter.js';
+
+describe('docx passthrough nodes', () => {
+  it('preserves unknown block nodes through import/export', () => {
+    const nodeListHandler = defaultNodeListHandler();
+    const xmlNode = { name: 'w:unknownBlock', attributes: { foo: 'bar' } };
+    const result = nodeListHandler.handler({
+      nodes: [xmlNode],
+      docx: {},
+      converter: null,
+      editor: null,
+      isBlock: true,
+    });
+    expect(result).toHaveLength(1);
+    const passthrough = result[0];
+    expect(passthrough.type).toBe('docxPassthroughBlock');
+    expect(passthrough.attrs.originalXml).toEqual(xmlNode);
+    const exported = exportSchemaToJson({ node: passthrough });
+    expect(exported).toEqual(xmlNode);
+  });
+
+  it('preserves unknown inline nodes through import/export', () => {
+    const nodeListHandler = defaultNodeListHandler();
+    const xmlNode = { name: 'w:unknownInline', attributes: { foo: 'baz' } };
+    const result = nodeListHandler.handler({
+      nodes: [xmlNode],
+      docx: {},
+      converter: null,
+      editor: null,
+      isBlock: false,
+    });
+    expect(result).toHaveLength(1);
+    const passthrough = result[0];
+    expect(passthrough.type).toBe('docxPassthroughInline');
+    expect(passthrough.attrs.originalXml).toEqual(xmlNode);
+    const exported = exportSchemaToJson({ node: passthrough });
+    expect(exported).toEqual(xmlNode);
+  });
+});

--- a/packages/super-editor/src/tests/import/commentsImporter.test.js
+++ b/packages/super-editor/src/tests/import/commentsImporter.test.js
@@ -33,7 +33,7 @@ describe('basic comment import [basic-comment.docx]', () => {
     const commentText = comment.textJson;
     expect(commentText.type).toBe('paragraph');
 
-    const commentContent = commentText.content;
+    const commentContent = commentText.content.filter((n) => n.type !== 'docxPassthroughInline');
     expect(commentContent).toHaveLength(1);
     expect(commentContent[0].text).toBe('abcabc');
     expect(commentContent[0].type).toBe('text');

--- a/packages/super-editor/src/tests/import/imageImporter.test.js
+++ b/packages/super-editor/src/tests/import/imageImporter.test.js
@@ -15,7 +15,7 @@ describe('ImageNodeImporter', () => {
     const { nodes } = handleParagraphNode({ nodes: [content[0]], docx, nodeListHandler: defaultNodeListHandler() });
 
     const paragraphNode = nodes[0];
-    const drawingNode = paragraphNode.content[0];
+    const drawingNode = paragraphNode.content.find((n) => n.type === 'image');
     const { attrs } = drawingNode;
     const { padding, size } = attrs;
 
@@ -68,7 +68,7 @@ describe('ImageNodeImporter', () => {
     const { nodes } = handleParagraphNode({ nodes: [content[0]], docx, nodeListHandler: defaultNodeListHandler() });
 
     let paragraphNode = nodes[0];
-    let drawingNode = paragraphNode.content[0];
+    let drawingNode = paragraphNode.content.find((n) => n.type === 'image');
     const { attrs } = drawingNode;
     expect(attrs.src).toBe('media/image.png');
 
@@ -78,7 +78,7 @@ describe('ImageNodeImporter', () => {
       nodeListHandler: defaultNodeListHandler(),
     });
     paragraphNode = nodes1[0];
-    drawingNode = paragraphNode.content[1];
+    drawingNode = paragraphNode.content.find((n) => n.type === 'image');
     expect(drawingNode.attrs.src).toBe('word/media/image1.jpeg');
   });
 });


### PR DESCRIPTION
## Summary
- add block and inline passthrough node extensions for unhandled docx XML
- persist raw XML on import and restore it on export
- cover passthrough behavior with tests
- guard block node plugin against invalid node content
- adjust tests for passthrough nodes and multi-run text