### PR TITLE
fix: retain page break when exporting hardBreak

### DIFF
--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/br/br-translator.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/br/br-translator.js
@@ -47,10 +47,17 @@ const decode = (params, decodedAttrs) => {
   const { node } = params;
   if (!node) return;
 
+  const attrs = { ...(decodedAttrs || {}) };
+
+  // default to page break when exporting a hardBreak without an explicit lineBreakType
+  if (node.type === 'hardBreak' && !('w:type' in attrs)) {
+    attrs['w:type'] = 'page';
+  }
+
   const wBreak = { name: 'w:br' };
 
-  if (decodedAttrs) {
-    wBreak.attributes = { ...decodedAttrs };
+  if (Object.keys(attrs).length > 0) {
+    wBreak.attributes = attrs;
   }
 
   /** breaks are wrapped in runs for Google Docs compatibility */

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/br/br-translator.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/br/br-translator.test.js
@@ -76,6 +76,15 @@ describe('w:br translator config', () => {
         attributes: { 'w:type': 'page' },
       });
     });
+
+    it('defaults w:type="page" for hardBreak nodes without lineBreakType', () => {
+      const res = config.decode({ node: { type: 'hardBreak' } }, undefined);
+      expect(res.name).toBe('w:r');
+      expect(res.elements[0]).toEqual({
+        name: 'w:br',
+        attributes: { 'w:type': 'page' },
+      });
+    });
   });
 
   describe('attributes mapping metadata', () => {


### PR DESCRIPTION
## Summary
- default `w:type="page"` when exporting `hardBreak` nodes lacking `lineBreakType`
- add regression test for `hardBreak` export
