### PR TITLE
feat: support additional tab attributes

### DIFF
--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/attributes/index.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/attributes/index.js
@@ -1,1 +1,3 @@
+export * from './w-tab-leader.js';
+export * from './w-tab-position.js';
 export * from './w-tab-size.js';

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/attributes/w-tab-leader.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/attributes/w-tab-leader.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+/**
+ * Encoder for the 'w:leader' attribute on the <w:tab> element.
+ * Maps to the 'tabLeader' attribute in SuperDoc.
+ * @param {Object} attributes - The attributes from the OOXML element.
+ * @returns {string|undefined} The corresponding leader value in SuperDoc, or undefined if not applicable.
+ */
+export const tabLeaderEncoder = (attributes) => {
+  return attributes['w:leader'];
+};
+
+/**
+ * Decoder for the 'tabLeader' attribute in SuperDoc.
+ * Maps to the 'w:leader' attribute in OOXML.
+ * @param {Object} attrs - The attributes from the SuperDoc element.
+ * @returns {string|undefined} The corresponding leader value in OOXML, or undefined if not applicable.
+ */
+export const tabLeaderDecoder = (attrs) => {
+  const { tabLeader } = attrs;
+  return tabLeader;
+};

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/attributes/w-tab-position.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/attributes/w-tab-position.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+/**
+ * Encoder for the 'w:pos' attribute on the <w:tab> element.
+ * Maps to the 'tabPosition' attribute in SuperDoc.
+ * @param {Object} attributes - The attributes from the OOXML element.
+ * @returns {string|undefined} The corresponding position value in SuperDoc, or undefined if not applicable.
+ */
+export const tabPositionEncoder = (attributes) => {
+  return attributes['w:pos'];
+};
+
+/**
+ * Decoder for the 'tabPosition' attribute in SuperDoc.
+ * Maps to the 'w:pos' attribute in OOXML.
+ * @param {Object} attrs - The attributes from the SuperDoc element.
+ * @returns {string|undefined} The corresponding position value in OOXML, or undefined if not applicable.
+ */
+export const tabPositionDecoder = (attrs) => {
+  const { tabPosition } = attrs;
+  return tabPosition;
+};

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.js
@@ -1,6 +1,13 @@
 // @ts-check
 import { NodeTranslator } from '../../../node-translator/index.js';
-import { tabSizeEncoder, tabSizeDecoder } from './attributes/index.js';
+import {
+  tabSizeEncoder,
+  tabSizeDecoder,
+  tabPositionEncoder,
+  tabPositionDecoder,
+  tabLeaderEncoder,
+  tabLeaderDecoder,
+} from './attributes/index.js';
 
 /** @type {import('../../../node-translator/index.js').XmlNodeName} */
 const XML_NODE_NAME = 'w:tab';
@@ -12,7 +19,11 @@ const SD_NODE_NAME = 'tab';
  * The attributes that can be mapped between OOXML and SuperDoc.
  * @type {import('../../../node-translator/index.js').AttributesHandlerList[]}
  */
-const attributes = [{ xmlName: 'w:val', sdName: 'tabSize', encode: tabSizeEncoder, decode: tabSizeDecoder }];
+const attributes = [
+  { xmlName: 'w:val', sdName: 'tabSize', encode: tabSizeEncoder, decode: tabSizeDecoder },
+  { xmlName: 'w:pos', sdName: 'tabPosition', encode: tabPositionEncoder, decode: tabPositionDecoder },
+  { xmlName: 'w:leader', sdName: 'tabLeader', encode: tabLeaderEncoder, decode: tabLeaderDecoder },
+];
 
 /**
  * Encode a <w:tab> node as a SuperDoc tab node while preserving unknown attributes.
@@ -30,9 +41,11 @@ const encode = (params, encodedAttrs = {}) => {
 
   if (encodedAttrs && Object.keys(encodedAttrs).length) {
     Object.assign(mergedAttrs, encodedAttrs);
-    if (encodedAttrs.tabSize !== undefined) {
-      delete mergedAttrs['w:val'];
-    }
+    attributes.forEach(({ xmlName, sdName }) => {
+      if (encodedAttrs[sdName] !== undefined) {
+        delete mergedAttrs[xmlName];
+      }
+    });
   }
 
   if (Object.keys(mergedAttrs).length) {
@@ -57,9 +70,11 @@ const decode = (params, decodedAttrs = {}) => {
   const mergedAttrs = { ...superDocAttrs };
   if (decodedAttrs && Object.keys(decodedAttrs).length) {
     Object.assign(mergedAttrs, decodedAttrs);
-    if (decodedAttrs['w:val'] !== undefined) {
-      delete mergedAttrs.tabSize;
-    }
+    attributes.forEach(({ xmlName, sdName }) => {
+      if (decodedAttrs[xmlName] !== undefined) {
+        delete mergedAttrs[sdName];
+      }
+    });
   }
 
   const wTab = { name: 'w:tab' };

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.test.js
@@ -14,14 +14,25 @@ describe('w:tab translator config', () => {
           {
             attributes: {
               'w:val': '96',
+              'w:pos': '720',
+              'w:leader': 'dot',
               'w:custom': 'foo',
             },
           },
         ],
       };
-      const res = config.encode(params, { tabSize: '96' });
+      const res = config.encode(params, {
+        tabSize: '96',
+        tabPosition: '720',
+        tabLeader: 'dot',
+      });
       expect(res.type).toBe('tab');
-      expect(res.attrs).toEqual({ tabSize: '96', 'w:custom': 'foo' });
+      expect(res.attrs).toEqual({
+        tabSize: '96',
+        tabPosition: '720',
+        tabLeader: 'dot',
+        'w:custom': 'foo',
+      });
     });
   });
 
@@ -35,12 +46,31 @@ describe('w:tab translator config', () => {
     });
 
     it('copies decoded attributes and preserves unknown ones', () => {
-      const params = { node: { type: 'tab', attrs: { tabSize: '96', 'w:custom': 'foo' } } };
-      const res = config.decode(params, { 'w:val': '96' });
+      const params = {
+        node: {
+          type: 'tab',
+          attrs: {
+            tabSize: '96',
+            tabPosition: '720',
+            tabLeader: 'dot',
+            'w:custom': 'foo',
+          },
+        },
+      };
+      const res = config.decode(params, {
+        'w:val': '96',
+        'w:pos': '720',
+        'w:leader': 'dot',
+      });
       expect(res.name).toBe('w:r');
       expect(res.elements[0]).toEqual({
         name: 'w:tab',
-        attributes: { 'w:val': '96', 'w:custom': 'foo' },
+        attributes: {
+          'w:val': '96',
+          'w:pos': '720',
+          'w:leader': 'dot',
+          'w:custom': 'foo',
+        },
       });
     });
 
@@ -51,14 +81,20 @@ describe('w:tab translator config', () => {
   });
 
   describe('attributes mapping metadata', () => {
-    it('exposes expected attribute handler (w:val -> tabSize)', () => {
+    it('exposes expected attribute handlers', () => {
       const attrMap = config.attributes;
       const names = attrMap.map((a) => [a.xmlName, a.sdName]);
       expect(names).toContainEqual(['w:val', 'tabSize']);
+      expect(names).toContainEqual(['w:pos', 'tabPosition']);
+      expect(names).toContainEqual(['w:leader', 'tabLeader']);
 
       const byXml = Object.fromEntries(attrMap.map((a) => [a.xmlName, a]));
       expect(typeof byXml['w:val'].encode).toBe('function');
       expect(typeof byXml['w:val'].decode).toBe('function');
+      expect(typeof byXml['w:pos'].encode).toBe('function');
+      expect(typeof byXml['w:pos'].decode).toBe('function');
+      expect(typeof byXml['w:leader'].encode).toBe('function');
+      expect(typeof byXml['w:leader'].decode).toBe('function');
     });
   });
 });

--- a/packages/super-editor/src/extensions/tab/tab.js
+++ b/packages/super-editor/src/extensions/tab/tab.js
@@ -42,6 +42,8 @@ export const TabNode = Node.create({
           return { style };
         },
       },
+      tabPosition: { rendered: false },
+      tabLeader: { rendered: false },
     };
   },
 


### PR DESCRIPTION
## Summary
- handle `w:pos` and `w:leader` on `w:tab` elements
- ensure tab node extension preserves new attributes
- cover new attributes in tab translator tests
- streamline attribute cleanup using shared mapping