### PR TITLE
fix(collaboration): exclude list sync from history

### DIFF
--- a/packages/super-editor/src/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/components/toolbar/super-toolbar.js
@@ -287,6 +287,24 @@ export class SuperToolbar extends EventEmitter {
     },
 
     /**
+     * Perform undo via a focused command chain
+     * @returns {void}
+     */
+    undo: () => {
+      if (!this.activeEditor) return;
+      this.activeEditor.chain().focus().undo().run();
+    },
+
+    /**
+     * Perform redo via a focused command chain
+     * @returns {void}
+     */
+    redo: () => {
+      if (!this.activeEditor) return;
+      this.activeEditor.chain().focus().redo().run();
+    },
+
+    /**
      * Sets the document mode
      * @param {Object} params - Command parameters
      * @param {CommandItem} params.item - The command item

--- a/packages/super-editor/src/core/commands/backspaceNextToList.test.js
+++ b/packages/super-editor/src/core/commands/backspaceNextToList.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Schema } from 'prosemirror-model';
-import { EditorState, TextSelection } from 'prosemirror-state';
+import { EditorState, TextSelection, NodeSelection } from 'prosemirror-state';
 
 vi.mock('./list-helpers', () => ({
   isList: (node) => {
@@ -223,13 +223,13 @@ describe('handleBackspaceNextToList', () => {
     expect(selParent).toBe(lastPara);
   });
 
-  it('returns false when parent is not a paragraph', () => {
+  it('returns false when selection is not a text cursor', () => {
     const liPara = schema.node('paragraph', null, schema.text('x'));
     const list = schema.node('orderedList', null, [schema.node('listItem', { level: 0 }, [liPara])]);
     const doc = schema.node('doc', null, [list]);
 
     const listPos = findNodePos(doc, (n) => n === list);
-    const sel = TextSelection.create(doc, listPos + 1, listPos + 1); // inside list container, not paragraph
+    const sel = NodeSelection.create(doc, listPos); // NodeSelection on the list
     const state = EditorState.create({ schema, doc, selection: sel });
 
     const cmd = handleBackspaceNextToList();

--- a/packages/super-editor/src/extensions/ordered-list/helpers/orderedListSyncPlugin.js
+++ b/packages/super-editor/src/extensions/ordered-list/helpers/orderedListSyncPlugin.js
@@ -24,6 +24,10 @@ export function orderedListSync(editor) {
 
       const tr = newState.tr;
       tr.setMeta('orderedListSync', true);
+      // Exclude plugin-driven list synchronization from history tracking so
+      // collaborative undo/redo (yjs) doesn't create extra steps for these
+      // automatic updates.
+      tr.setMeta('addToHistory', false);
 
       const listMap = new Map(); // numId -> [counts per level]
       const listInitialized = new Map(); // Track if we've initialized each numId

--- a/packages/super-editor/src/tests/editor/relationships.test.js
+++ b/packages/super-editor/src/tests/editor/relationships.test.js
@@ -20,7 +20,7 @@ describe('Relationships tests', () => {
   it('tests that the inserted link has a rId and a relationship', () => {
     editor.commands.insertContentAt(0, 'link');
 
-    editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 0, 5)));
+    editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 1, 5)));
     editor.commands.setLink({ href: 'https://www.superdoc.dev' });
 
     const linkMark = editor.state.doc.firstChild.firstChild.marks[0];


### PR DESCRIPTION
## Summary
- avoid adding ordered list synchronization transactions to history to stabilize collaborative undo/redo
- ensure toolbar undo/redo triggers through command chain for collaboration mode
- fix invalid test selections that caused ProseMirror errors

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfabf41dc48330b0fa27f008852570