### PR TITLE
feat: add w:tab translator

### DIFF
--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -24,6 +24,7 @@ import { ListHelpers } from '@helpers/list-numbering-helpers.js';
 import { translateChildNodes } from './v2/exporter/helpers/index.js';
 import { translateDocumentSection } from './v2/exporter/index.js';
 import { translator as wBrNodeTranslator } from './v3/handlers/w/br/br-translator.js';
+import { translator as wTabNodeTranslator } from './v3/handlers/w/tab/tab-translator.js';
 
 /**
  * @typedef {Object} ExportParams
@@ -383,9 +384,10 @@ function generateParagraphProperties(node) {
   const { tabStops } = attrs;
   if (tabStops && tabStops.length > 0) {
     const tabElements = tabStops.map((tab) => {
+      const posValue = tab.originalPos !== undefined ? tab.originalPos : pixelsToTwips(tab.pos).toString();
       const tabAttributes = {
         'w:val': tab.val || 'start',
-        'w:pos': pixelsToTwips(tab.pos).toString(),
+        'w:pos': posValue,
       };
 
       if (tab.leader) {
@@ -1086,11 +1088,13 @@ function translateTab(params) {
   const { marks = [] } = params.node;
 
   const outputMarks = processOutputMarks(marks);
-  const tabNode = {
-    name: 'w:tab',
-  };
+  const tabRun = wTabNodeTranslator.decode(params);
 
-  return wrapTextInRun(tabNode, outputMarks);
+  if (outputMarks.length) {
+    tabRun.elements.unshift(generateRunProps(outputMarks));
+  }
+
+  return tabRun;
 }
 
 /**

--- a/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
@@ -16,12 +16,12 @@ import { lineBreakNodeHandlerEntity } from './lineBreakImporter.js';
 import { bookmarkNodeHandlerEntity } from './bookmarkNodeImporter.js';
 import { alternateChoiceHandler } from './alternateChoiceImporter.js';
 import { autoPageHandlerEntity, autoTotalPageCountEntity } from './autoPageNumberImporter.js';
-import { tabNodeEntityHandler } from './tabImporter.js';
 import { listHandlerEntity } from './listImporter.js';
 import { pictNodeHandlerEntity } from './pictNodeImporter.js';
 import { importCommentData } from './documentCommentsImporter.js';
 import { getDefaultStyleDefinition } from './paragraphNodeImporter.js';
 import { baseNumbering } from '../exporter/helpers/base-list.definitions.js';
+import { tabNodeEntityHandler } from './tabImporter.js';
 
 /**
  * @typedef {import()} XmlNode

--- a/packages/super-editor/src/core/super-converter/v2/importer/paragraphNodeImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/paragraphNodeImporter.js
@@ -152,10 +152,14 @@ export const handleParagraphNode = (params) => {
         } else if (val == 'right') {
           val = 'end';
         }
+        const rawPos = tab.attributes['w:pos'];
         const tabStop = {
           val,
-          pos: twipsToPixels(tab.attributes['w:pos']),
+          pos: twipsToPixels(rawPos),
         };
+        if (rawPos !== undefined) {
+          tabStop.originalPos = rawPos;
+        }
 
         // Add leader if present
         if (tab.attributes['w:leader']) {

--- a/packages/super-editor/src/core/super-converter/v2/importer/tabImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/tabImporter.js
@@ -1,42 +1,21 @@
-import { twipsToPixels } from '../../helpers.js';
+import { translator as wTabNodeTranslator } from '../../v3/handlers/w/tab/tab-translator.js';
 
 /**
- * @type {import("docxImporter").NodeHandler}
+ * @type {import('docxImporter').NodeHandler}
  */
 const handleTabNode = (params) => {
-  const { nodes, docx, parentStyleId } = params;
-  if (nodes.length === 0 || nodes[0].name !== 'w:tab') {
+  const { nodes } = params;
+  if (!nodes.length || nodes[0].name !== 'w:tab') {
     return { nodes: [], consumed: 0 };
   }
-  const node = nodes[0];
-
-  const styles = docx['word/styles.xml'];
-  let stylePos;
-  if (styles && styles.elements?.length) {
-    const style = styles.elements[0]?.elements?.find((s) => s.attributes?.['w:styleId'] === parentStyleId);
-    const pPr = style?.elements?.find((s) => s.name === 'w:pPr');
-    const tabsDef = pPr?.elements?.find((s) => s.name === 'w:tabs');
-    const firstTab = tabsDef?.elements?.find((s) => s.name === 'w:tab');
-
-    // eslint-disable-next-line no-unused-vars
-    stylePos = twipsToPixels(firstTab?.attributes?.['w:pos']);
-  }
-
-  const { attributes = {} } = node;
-  const processedNode = {
-    type: 'tab',
-    attrs: {
-      tabSize: attributes['w:val'] || 48,
-    },
-    content: [],
-  };
-  return { nodes: [processedNode], consumed: 1 };
+  const node = wTabNodeTranslator.encode(params);
+  return { nodes: [node], consumed: 1 };
 };
 
 /**
- * @type {import("docxImporter").NodeHandlerEntry}
+ * @type {import('docxImporter').NodeHandlerEntry}
  */
 export const tabNodeEntityHandler = {
-  handlerName: 'tabNodeHandler',
+  handlerName: 'w:tabTranslator',
   handler: handleTabNode,
 };

--- a/packages/super-editor/src/core/super-converter/v3/handlers/index.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/index.js
@@ -1,4 +1,5 @@
 import { translator as w_br_translator } from './w/br/br-translator.js';
+import { translator as w_tab_translator } from './w/tab/tab-translator.js';
 
 /**
  * @typedef {Object} RegisteredHandlers
@@ -6,4 +7,5 @@ import { translator as w_br_translator } from './w/br/br-translator.js';
 
 export const registeredHandlers = Object.freeze({
   'w:br': w_br_translator,
+  'w:tab': w_tab_translator,
 });

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/attributes/index.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/attributes/index.js
@@ -1,0 +1,1 @@
+export * from './w-tab-size.js';

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/attributes/w-tab-size.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/attributes/w-tab-size.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+/**
+ * Encoder for the 'w:val' attribute on the <w:tab> element.
+ * Maps to the 'tabSize' attribute in SuperDoc.
+ * @param {Object} attributes - The attributes from the OOXML element.
+ * @returns {string|undefined} The corresponding tab size in SuperDoc, or undefined if not applicable.
+ */
+export const tabSizeEncoder = (attributes) => {
+  return attributes['w:val'];
+};
+
+/**
+ * Decoder for the 'tabSize' attribute in SuperDoc.
+ * Maps to the 'w:val' attribute in OOXML.
+ * @param {Object} attrs - The attributes from the SuperDoc element.
+ * @returns {string|undefined} The corresponding tab size in OOXML, or undefined if not applicable.
+ */
+export const tabSizeDecoder = (attrs) => {
+  const { tabSize } = attrs;
+  return tabSize;
+};

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/index.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/index.js
@@ -1,0 +1,1 @@
+export * from './tab-translator.js';

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.js
@@ -1,0 +1,92 @@
+// @ts-check
+import { NodeTranslator } from '../../../node-translator/index.js';
+import { tabSizeEncoder, tabSizeDecoder } from './attributes/index.js';
+
+/** @type {import('../../../node-translator/index.js').XmlNodeName} */
+const XML_NODE_NAME = 'w:tab';
+
+/** @type {import('../../../node-translator/index.js').SuperDocNodeOrKeyName} */
+const SD_NODE_NAME = 'tab';
+
+/**
+ * The attributes that can be mapped between OOXML and SuperDoc.
+ * @type {import('../../../node-translator/index.js').AttributesHandlerList[]}
+ */
+const attributes = [{ xmlName: 'w:val', sdName: 'tabSize', encode: tabSizeEncoder, decode: tabSizeDecoder }];
+
+/**
+ * Encode a <w:tab> node as a SuperDoc tab node while preserving unknown attributes.
+ * @param {import('../../../node-translator/index.js').SCEncoderConfig} params
+ * @param {import('../../../node-translator/index.js').EncodedAttributes} [encodedAttrs] - The already encoded attributes
+ * @returns {import('../../../node-translator/index.js').SCEncoderResult}
+ */
+const encode = (params, encodedAttrs = {}) => {
+  const node = params?.nodes?.[0];
+  const originalAttrs = { ...(node?.attributes || {}) };
+
+  const translated = { type: 'tab' };
+
+  const mergedAttrs = { ...originalAttrs };
+
+  if (encodedAttrs && Object.keys(encodedAttrs).length) {
+    Object.assign(mergedAttrs, encodedAttrs);
+    if (encodedAttrs.tabSize !== undefined) {
+      delete mergedAttrs['w:val'];
+    }
+  }
+
+  if (Object.keys(mergedAttrs).length) {
+    translated.attrs = mergedAttrs;
+  }
+
+  return translated;
+};
+
+/**
+ * Decode a SuperDoc tab node back into OOXML <w:tab> wrapped in a run.
+ * @param {import('../../../node-translator/index.js').SCDecoderConfig} params
+ * @param {import('../../../node-translator/index.js').DecodedAttributes} [decodedAttrs] - The already decoded attributes
+ * @returns {import('../../../node-translator/index.js').SCDecoderResult}
+ */
+const decode = (params, decodedAttrs = {}) => {
+  const { node } = params || {};
+  if (!node) return;
+
+  const superDocAttrs = { ...(node.attrs || {}) };
+
+  const mergedAttrs = { ...superDocAttrs };
+  if (decodedAttrs && Object.keys(decodedAttrs).length) {
+    Object.assign(mergedAttrs, decodedAttrs);
+    if (decodedAttrs['w:val'] !== undefined) {
+      delete mergedAttrs.tabSize;
+    }
+  }
+
+  const wTab = { name: 'w:tab' };
+  if (Object.keys(mergedAttrs).length) {
+    wTab.attributes = mergedAttrs;
+  }
+
+  const translated = {
+    name: 'w:r',
+    elements: [wTab],
+  };
+
+  return translated;
+};
+
+/** @type {import('../../../node-translator/index.js').NodeTranslatorConfig} */
+export const config = {
+  xmlName: XML_NODE_NAME,
+  sdNodeOrKeyName: SD_NODE_NAME,
+  type: NodeTranslator.translatorTypes.NODE,
+  encode,
+  decode,
+  attributes,
+};
+
+/**
+ * The NodeTranslator instance for the <w:tab> element.
+ * @type {import('../../../node-translator/index.js').NodeTranslator}
+ */
+export const translator = NodeTranslator.from(config);

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { config } from './index.js';
+
+describe('w:tab translator config', () => {
+  describe('encode', () => {
+    it('encodes to a SuperDoc tab by default', () => {
+      const res = config.encode({}, undefined);
+      expect(res).toEqual({ type: 'tab' });
+    });
+
+    it('maps known attributes and preserves unknown ones', () => {
+      const params = {
+        nodes: [
+          {
+            attributes: {
+              'w:val': '96',
+              'w:custom': 'foo',
+            },
+          },
+        ],
+      };
+      const res = config.encode(params, { tabSize: '96' });
+      expect(res.type).toBe('tab');
+      expect(res.attrs).toEqual({ tabSize: '96', 'w:custom': 'foo' });
+    });
+  });
+
+  describe('decode', () => {
+    it('wraps <w:tab> in a <w:r> run', () => {
+      const res = config.decode({ node: { type: 'tab' } }, undefined);
+      expect(res).toBeTruthy();
+      expect(res.name).toBe('w:r');
+      expect(Array.isArray(res.elements)).toBe(true);
+      expect(res.elements[0]).toEqual({ name: 'w:tab' });
+    });
+
+    it('copies decoded attributes and preserves unknown ones', () => {
+      const params = { node: { type: 'tab', attrs: { tabSize: '96', 'w:custom': 'foo' } } };
+      const res = config.decode(params, { 'w:val': '96' });
+      expect(res.name).toBe('w:r');
+      expect(res.elements[0]).toEqual({
+        name: 'w:tab',
+        attributes: { 'w:val': '96', 'w:custom': 'foo' },
+      });
+    });
+
+    it('returns undefined when params.node is missing', () => {
+      const res = config.decode({}, { 'w:val': '96' });
+      expect(res).toBeUndefined();
+    });
+  });
+
+  describe('attributes mapping metadata', () => {
+    it('exposes expected attribute handler (w:val -> tabSize)', () => {
+      const attrMap = config.attributes;
+      const names = attrMap.map((a) => [a.xmlName, a.sdName]);
+      expect(names).toContainEqual(['w:val', 'tabSize']);
+
+      const byXml = Object.fromEntries(attrMap.map((a) => [a.xmlName, a]));
+      expect(typeof byXml['w:val'].encode).toBe('function');
+      expect(typeof byXml['w:val'].decode).toBe('function');
+    });
+  });
+});

--- a/packages/super-editor/src/tests/import-export/tabStopsRoundTrip.test.js
+++ b/packages/super-editor/src/tests/import-export/tabStopsRoundTrip.test.js
@@ -222,6 +222,51 @@ describe('Tab Stops Round Trip Tests', () => {
     expect(exportedTab.attributes['w:leader']).toBeUndefined();
   });
 
+  it('preserves original w:pos values for clearing tab stops', () => {
+    const mockDocxParagraph = {
+      name: 'w:p',
+      elements: [
+        {
+          name: 'w:pPr',
+          elements: [
+            {
+              name: 'w:tabs',
+              elements: [
+                {
+                  name: 'w:tab',
+                  attributes: {
+                    'w:val': 'clear',
+                    'w:pos': '1234',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { nodes } = handleParagraphNode({
+      nodes: [mockDocxParagraph],
+      docx: {},
+      nodeListHandler: defaultNodeListHandler(),
+    });
+
+    const importedNode = nodes[0];
+    expect(importedNode.attrs.tabStops[0].originalPos).toBe('1234');
+
+    const mockEditor = createMockEditor();
+    const exportedResult = translateParagraphNode({
+      editor: mockEditor,
+      node: importedNode,
+    });
+
+    const pPr = exportedResult.elements.find((el) => el.name === 'w:pPr');
+    const tabs = pPr.elements.find((el) => el.name === 'w:tabs');
+    const exportedTab = tabs.elements[0];
+    expect(exportedTab.attributes['w:pos']).toBe('1234');
+  });
+
   it('preserves tab stop order in round trip', () => {
     // Create a mock DOCX paragraph with multiple tab stops in specific order
     const mockDocxParagraph = {


### PR DESCRIPTION
## Summary
- add `w:tab` translator to v3 super-converter
- preserve unknown `w:tab` attributes during encode/decode
- cover encode/decode with tests
- integrate `w:tab` translator into v2 docx importer and exporter
- move `tabNodeEntityHandler` into dedicated importer that leverages the translator
- preserve original `w:pos` values for tab stops to avoid export drift

## Testing
- `npm test -- packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.test.js --run`
- `npm test -- packages/super-editor/src/tests/import-export/tabStopsRoundTrip.test.js --run`


------
https://chatgpt.com/codex/tasks/task_e_68bf7d2a779c8330a6d0caf31d8bfd29