### PR TITLE
import/export/display of transformed images

### DIFF
--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -12,6 +12,7 @@ import {
   pixelsToTwips,
   ptToTwips,
   rgbToHex,
+  degreesToRot,
 } from './helpers.js';
 import { generateDocxRandomId } from '@helpers/generateDocxRandomId.js';
 import { DEFAULT_DOCX_DEFS } from './exporter-docx-defs.js';
@@ -1439,6 +1440,32 @@ function translateImageNode(params, imageSize) {
       }
     : imageSize;
 
+  const xfrmAttrs = {};
+  const effectExtentAttrs = {
+    l: 0,
+    t: 0,
+    r: 0,
+    b: 0,
+  };
+  const transformData = attrs.transformData;
+  if (transformData) {
+    if (transformData.rotation) {
+      xfrmAttrs.rot = degreesToRot(transformData.rotation);
+    }
+    if (transformData.verticalFlip) {
+      xfrmAttrs.flipV = '1';
+    }
+    if (transformData.horizontalFlip) {
+      xfrmAttrs.flipH = '1';
+    }
+    if (transformData.sizeExtension) {
+      effectExtentAttrs.l = pixelsToEmu(transformData.sizeExtension.left);
+      effectExtentAttrs.t = pixelsToEmu(transformData.sizeExtension.top);
+      effectExtentAttrs.r = pixelsToEmu(transformData.sizeExtension.right);
+      effectExtentAttrs.b = pixelsToEmu(transformData.sizeExtension.bottom);
+    }
+  }
+
   if (originalWidth && originalHeight) {
     const boxWidthPx = emuToPixels(size.w);
     const boxHeightPx = emuToPixels(size.h);
@@ -1616,12 +1643,7 @@ function translateImageNode(params, imageSize) {
             },
             {
               name: 'wp:effectExtent',
-              attributes: {
-                l: 0,
-                t: 0,
-                r: 0,
-                b: 0,
-              },
+              attributes: effectExtentAttrs,
             },
             ...wrapProp,
             {
@@ -1702,6 +1724,7 @@ function translateImageNode(params, imageSize) {
                           elements: [
                             {
                               name: 'a:xfrm',
+                              attributes: xfrmAttrs,
                               elements: [
                                 {
                                   name: 'a:ext',

--- a/packages/super-editor/src/core/super-converter/helpers.js
+++ b/packages/super-editor/src/core/super-converter/helpers.js
@@ -84,6 +84,16 @@ function ptToTwips(pt) {
   return pt * 20;
 }
 
+function rotToDegrees(rot) {
+  if (rot == null) return;
+  return rot / 60000;
+}
+
+function degreesToRot(degrees) {
+  if (degrees == null) return;
+  return degrees * 60000;
+}
+
 /**
  * Get the export value for text indent
  * @param {string|number} indent - The text indent value to export
@@ -236,6 +246,8 @@ export {
   halfPointToPoints,
   eigthPointsToPixels,
   pixelsToEightPoints,
+  rotToDegrees,
+  degreesToRot,
   getArrayBufferFromUrl,
   getContentTypesFromXml,
   getHexColorFromDocxSystem,

--- a/packages/super-editor/src/extensions/image/image.js
+++ b/packages/super-editor/src/extensions/image/image.js
@@ -1,6 +1,7 @@
 import { Attribute, Node } from '@core/index.js';
 import { ImagePlaceholderPlugin } from './imageHelpers/imagePlaceholderPlugin.js';
 import { ImagePositionPlugin } from './imageHelpers/imagePositionPlugin.js';
+import { getRotationMargins } from './imageHelpers/rotation.js';
 
 /**
  * @module Image
@@ -129,6 +130,42 @@ export const Image = Node.create({
 
       /**
        * @category Attribute
+       * @param {Object} [transformData] - Transform data for image (turn and flip)
+       * @param {number} [transformData.rotation] - Turn angle in degrees
+       * @param {boolean} [transformData.verticalFlip] - Whether to flip vertically
+       * @param {boolean} [transformData.horizontalFlip] - Whether to flip horizontally
+       * @param {Object} [transformData.sizeExtension] - Size extension for image due to transformation
+       * @param {number} [transformData.sizeExtension.left] - Left size extension for image
+       * @param {number} [transformData.sizeExtension.top] - Top size extension for image
+       * @param {number} [transformData.sizeExtension.right] - Right size extension for image
+       * @param {number} [transformData.sizeExtension.bottom] - Bottom size extension for image
+       *
+       * @private
+       */
+
+      transformData: {
+        default: {},
+        renderDOM: ({ transformData }) => {
+          let style = '';
+          if (transformData?.rotation) {
+            style += `rotate(${Math.round(transformData.rotation)}deg) `;
+          }
+          if (transformData?.verticalFlip) {
+            style += 'scaleY(-1) ';
+          }
+          if (transformData?.horizontalFlip) {
+            style += 'scaleX(-1) ';
+          }
+          style = style.trim();
+          if (style.length > 0) {
+            return { style: `transform: ${style};` };
+          }
+          return;
+        },
+      },
+
+      /**
+       * @category Attribute
        * @param {boolean} [simplePos] - Simple positioning flag
        * @private
        */
@@ -152,8 +189,7 @@ export const Image = Node.create({
         default: {},
         renderDOM: ({ size, extension }) => {
           let style = '';
-
-          const { width, height } = size ?? {};
+          let { width, height } = size ?? {};
           if (width) style += `width: ${width}px;`;
           if (height && ['emf', 'wmf'].includes(extension))
             style += `height: ${height}px; border: 1px solid black; position: absolute;`;
@@ -172,8 +208,26 @@ export const Image = Node.create({
        */
       padding: {
         default: {},
-        renderDOM: ({ padding, marginOffset }) => {
-          const { left = 0, top = 0, bottom = 0, right = 0 } = padding ?? {};
+        renderDOM: ({ size, padding, marginOffset, transformData }) => {
+          let { left = 0, top = 0, bottom = 0, right = 0 } = padding ?? {};
+          // TODO: The wp:effectExtent (transformData.sizeExtension) sometimes
+          // gives the right data (as calculated by getRotationMargins)
+          // and sometimes it doesn't. We should investigate why there is a discrepancy.
+          // if (transformData?.sizeExtension) {
+          //   left += transformData.sizeExtension.left || 0;
+          //   right += transformData.sizeExtension.right || 0;
+          //   top += transformData.sizeExtension.top || 0;
+          //   bottom += transformData.sizeExtension.bottom || 0;
+          // }
+          const { rotation } = transformData;
+          const { height, width } = size;
+          if (rotation && height && width) {
+            const { horizontal, vertical } = getRotationMargins(width, height, rotation);
+            left += horizontal;
+            right += horizontal;
+            top += vertical;
+            bottom += vertical;
+          }
           let style = '';
           if (left && !marginOffset?.left) style += `margin-left: ${left}px;`;
           if (top && !marginOffset?.top) style += `margin-top: ${top}px;`;

--- a/packages/super-editor/src/extensions/image/imageHelpers/index.js
+++ b/packages/super-editor/src/extensions/image/imageHelpers/index.js
@@ -4,3 +4,4 @@ export * from './handleImageUpload.js';
 export * from './imagePlaceholderPlugin.js';
 export * from './processUploadedImage.js';
 export * from './imagePositionPlugin.js';
+export * from './rotation.js';

--- a/packages/super-editor/src/extensions/image/imageHelpers/rotation.js
+++ b/packages/super-editor/src/extensions/image/imageHelpers/rotation.js
@@ -1,0 +1,16 @@
+export const getRotationMargins = (w, h, angleDegrees) => {
+  const rad = angleDegrees * (Math.PI / 180);
+  const cos = Math.abs(Math.cos(rad));
+  const sin = Math.abs(Math.sin(rad));
+
+  const boundingWidth = w * cos + h * sin;
+  const boundingHeight = w * sin + h * cos;
+
+  const marginLeftRight = Math.round(Math.max(0, (boundingWidth - w) / 2));
+  const marginTopBottom = Math.round(Math.max(0, (boundingHeight - h) / 2));
+
+  return {
+    horizontal: marginLeftRight,
+    vertical: marginTopBottom,
+  };
+};

--- a/packages/super-editor/src/tests/export/imageNodeExporter.test.js
+++ b/packages/super-editor/src/tests/export/imageNodeExporter.test.js
@@ -1,4 +1,6 @@
-import { getExportedResult, getExportMediaFiles } from './export-helpers/index';
+import { getExportedResult, getExportMediaFiles, getExportedResultWithDocContent } from './export-helpers/index';
+import { exportSchemaToJson } from '@converter/exporter';
+import { pixelsToEmu, degreesToRot } from '@converter/helpers';
 
 describe('ImageNodeExporter', async () => {
   window.URL.createObjectURL = vi.fn().mockImplementation((file) => {
@@ -29,6 +31,76 @@ describe('ImageNodeExporter', async () => {
     expect(
       imageNode.elements[0].elements[4].elements[0].elements[0].elements[1].elements[0].attributes['r:embed'],
     ).toBe('rId4');
+  });
+
+  it('exports image with transformData correctly', async () => {
+    const imageNodeWithTransform = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'word/media/test-image.jpg',
+            rId: 'rId5',
+            alt: 'Test transformed image',
+            size: { width: 400, height: 300 },
+            padding: { top: 8, bottom: 8, left: 8, right: 8 },
+            transformData: {
+              rotation: 30,
+              verticalFlip: true,
+              horizontalFlip: false,
+              sizeExtension: {
+                left: 5,
+                top: 0,
+                right: 0,
+                bottom: 10,
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = await getExportedResultWithDocContent([imageNodeWithTransform]);
+    const body = result.elements?.find((el) => el.name === 'w:body');
+
+    // Navigate to the image more carefully
+    const paragraph = body.elements[0];
+    expect(paragraph.name).toBe('w:p');
+
+    const run = paragraph.elements.find((el) => el.name === 'w:r');
+    expect(run).toBeTruthy();
+
+    const imageNode = run.elements.find((el) => el.name === 'w:drawing');
+    expect(imageNode).toBeTruthy();
+
+    const drawing = imageNode;
+
+    // Check basic structure
+    expect(drawing.name).toBe('w:drawing');
+    const inlineElement = drawing.elements[0];
+    expect(inlineElement.name).toBe('wp:inline');
+
+    // Check effectExtent (sizeExtension)
+    const effectExtent = inlineElement.elements.find((el) => el.name === 'wp:effectExtent');
+    expect(effectExtent).toBeTruthy();
+    expect(effectExtent.attributes.l).toBe(pixelsToEmu(5));
+    expect(effectExtent.attributes.t).toBe(0);
+    expect(effectExtent.attributes.r).toBe(0);
+    expect(effectExtent.attributes.b).toBe(pixelsToEmu(10));
+
+    // Navigate to spPr more carefully
+    const graphic = inlineElement.elements.find((el) => el.name === 'a:graphic');
+    const graphicData = graphic.elements.find((el) => el.name === 'a:graphicData');
+    const pic = graphicData.elements.find((el) => el.name === 'pic:pic');
+    const spPr = pic.elements.find((el) => el.name === 'pic:spPr');
+
+    expect(spPr.name).toBe('pic:spPr');
+    const xfrm = spPr.elements.find((el) => el.name === 'a:xfrm');
+    expect(xfrm).toBeTruthy();
+    expect(xfrm.attributes.rot).toBe(degreesToRot(30));
+    expect(xfrm.attributes.flipV).toBe('1');
+    expect(xfrm.attributes.flipH).toBeUndefined();
   });
 
   it('exports anchor image node correctly', async () => {});
@@ -80,5 +152,181 @@ describe('ImageNodeExporter images with absolute path', async () => {
   it('exports image with absolute path correctly', async () => {
     expect(result).toHaveProperty('word/media/image1.jpeg');
     expect(result).toHaveProperty('media/image.png');
+  });
+
+  it('exports image with minimal transformData correctly', async () => {
+    const imageNodeMinimal = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'word/media/simple-image.png',
+            rId: 'rId1',
+            alt: 'Simple image',
+            size: { width: 200, height: 150 },
+            transformData: {
+              rotation: 0,
+              verticalFlip: false,
+              horizontalFlip: false,
+            },
+          },
+        },
+      ],
+    };
+
+    const result = await getExportedResultWithDocContent([imageNodeMinimal]);
+    const body = result.elements?.find((el) => el.name === 'w:body');
+
+    const paragraph = body.elements[0];
+    const run = paragraph.elements.find((el) => el.name === 'w:r');
+    const drawing = run.elements.find((el) => el.name === 'w:drawing');
+
+    // Check that transform data is handled correctly even when minimal
+    const inlineElement = drawing.elements[0];
+    const graphic = inlineElement.elements.find((el) => el.name === 'a:graphic');
+    const graphicData = graphic.elements.find((el) => el.name === 'a:graphicData');
+    const pic = graphicData.elements.find((el) => el.name === 'pic:pic');
+    const spPr = pic.elements.find((el) => el.name === 'pic:spPr');
+    const xfrm = spPr.elements.find((el) => el.name === 'a:xfrm');
+    expect(xfrm).toBeTruthy();
+    expect(xfrm.attributes.rot).toBeUndefined(); // No rotation should not add attribute
+    expect(xfrm.attributes.flipV).toBeUndefined(); // No vertical flip
+    expect(xfrm.attributes.flipH).toBeUndefined(); // No horizontal flip
+  });
+
+  it('exports image with horizontal flip only', async () => {
+    const imageNodeHorizontalFlip = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'word/media/flipped-image.jpg',
+            rId: 'rId2',
+            alt: 'Horizontally flipped image',
+            size: { width: 300, height: 200 },
+            transformData: {
+              rotation: 0,
+              verticalFlip: false,
+              horizontalFlip: true,
+            },
+          },
+        },
+      ],
+    };
+
+    const result = await getExportedResultWithDocContent([imageNodeHorizontalFlip]);
+    const body = result.elements?.find((el) => el.name === 'w:body');
+
+    const paragraph = body.elements[0];
+    const run = paragraph.elements.find((el) => el.name === 'w:r');
+    const drawing = run.elements.find((el) => el.name === 'w:drawing');
+
+    const inlineElement = drawing.elements[0];
+    const graphic = inlineElement.elements.find((el) => el.name === 'a:graphic');
+    const graphicData = graphic.elements.find((el) => el.name === 'a:graphicData');
+    const pic = graphicData.elements.find((el) => el.name === 'pic:pic');
+    const spPr = pic.elements.find((el) => el.name === 'pic:spPr');
+    const xfrm = spPr.elements.find((el) => el.name === 'a:xfrm');
+    expect(xfrm).toBeTruthy();
+    expect(xfrm.attributes.flipH).toBe('1');
+    expect(xfrm.attributes.flipV).toBeUndefined();
+  });
+
+  it('exports image with rotation and both flips', async () => {
+    const imageNodeFullTransform = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'word/media/complex-transform.png',
+            rId: 'rId3',
+            alt: 'Fully transformed image',
+            size: { width: 400, height: 400 },
+            transformData: {
+              rotation: -45,
+              verticalFlip: true,
+              horizontalFlip: true,
+              sizeExtension: {
+                left: 10,
+                top: 15,
+                right: 20,
+                bottom: 5,
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = await getExportedResultWithDocContent([imageNodeFullTransform]);
+    const body = result.elements?.find((el) => el.name === 'w:body');
+
+    const paragraph = body.elements[0];
+    const run = paragraph.elements.find((el) => el.name === 'w:r');
+    const drawing = run.elements.find((el) => el.name === 'w:drawing');
+
+    // Check effectExtent
+    const inlineElement = drawing.elements[0];
+    const effectExtent = inlineElement.elements.find((el) => el.name === 'wp:effectExtent');
+    expect(effectExtent.attributes.l).toBe(pixelsToEmu(10));
+    expect(effectExtent.attributes.t).toBe(pixelsToEmu(15));
+    expect(effectExtent.attributes.r).toBe(pixelsToEmu(20));
+    expect(effectExtent.attributes.b).toBe(pixelsToEmu(5));
+
+    // Check transform
+    const graphic = inlineElement.elements.find((el) => el.name === 'a:graphic');
+    const graphicData = graphic.elements.find((el) => el.name === 'a:graphicData');
+    const pic = graphicData.elements.find((el) => el.name === 'pic:pic');
+    const spPr = pic.elements.find((el) => el.name === 'pic:spPr');
+    const xfrm = spPr.elements.find((el) => el.name === 'a:xfrm');
+    expect(xfrm.attributes.rot).toBe(degreesToRot(-45));
+    expect(xfrm.attributes.flipV).toBe('1');
+    expect(xfrm.attributes.flipH).toBe('1');
+  });
+
+  it('exports image without transformData correctly', async () => {
+    const imageNodeNoTransform = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'word/media/normal-image.jpg',
+            rId: 'rId4',
+            alt: 'Normal image without transforms',
+            size: { width: 250, height: 180 },
+          },
+        },
+      ],
+    };
+
+    const result = await getExportedResultWithDocContent([imageNodeNoTransform]);
+    const body = result.elements?.find((el) => el.name === 'w:body');
+
+    const paragraph = body.elements[0];
+    const run = paragraph.elements.find((el) => el.name === 'w:r');
+    const drawing = run.elements.find((el) => el.name === 'w:drawing');
+
+    // Check that no effectExtent is added when no sizeExtension
+    const inlineElement = drawing.elements[0];
+    const effectExtent = inlineElement.elements.find((el) => el.name === 'wp:effectExtent');
+    expect(effectExtent.attributes.l).toBe(0);
+    expect(effectExtent.attributes.t).toBe(0);
+    expect(effectExtent.attributes.r).toBe(0);
+    expect(effectExtent.attributes.b).toBe(0);
+
+    // Check that no transform attributes are added
+    const graphic = inlineElement.elements.find((el) => el.name === 'a:graphic');
+    const graphicData = graphic.elements.find((el) => el.name === 'a:graphicData');
+    const pic = graphicData.elements.find((el) => el.name === 'pic:pic');
+    const spPr = pic.elements.find((el) => el.name === 'pic:spPr');
+    const xfrm = spPr.elements.find((el) => el.name === 'a:xfrm');
+    expect(xfrm).toBeTruthy();
+    expect(xfrm.attributes.rot).toBeUndefined();
+    expect(xfrm.attributes.flipV).toBeUndefined();
+    expect(xfrm.attributes.flipH).toBeUndefined();
   });
 });

--- a/packages/super-editor/src/tests/extensions/image.test.js
+++ b/packages/super-editor/src/tests/extensions/image.test.js
@@ -1,0 +1,379 @@
+import { createTestEditor } from '../helpers/editor-test-utils.js';
+import { Image } from '@extensions/image/image.js';
+import { getStarterExtensions } from '@extensions/index.js';
+
+describe('Image Extension', () => {
+  let editor;
+
+  beforeEach(() => {
+    const extensions = getStarterExtensions();
+    editor = createTestEditor({ extensions });
+  });
+
+  afterEach(() => {
+    editor?.destroy();
+  });
+
+  describe('DOM rendering', () => {
+    it('renders basic image without transformData', () => {
+      const imageNode = editor.schema.nodes.image.create({
+        src: 'test-image.jpg',
+        alt: 'Test image',
+        size: { width: 200, height: 150 },
+      });
+
+      const dom = editor.schema.nodes.image.spec.renderDOM({
+        node: imageNode,
+        htmlAttributes: {},
+      });
+
+      expect(dom[0]).toBe('img');
+      expect(dom[1].src).toBe('test-image.jpg');
+      expect(dom[1].alt).toBe('Test image');
+      expect(dom[1].style).toContain('width: 200px');
+    });
+
+    it('renders transformData with rotation only', () => {
+      const imageNode = editor.schema.nodes.image.create({
+        src: 'rotated-image.jpg',
+        alt: 'Rotated image',
+        transformData: {
+          rotation: 45,
+        },
+      });
+
+      const renderDOM = editor.schema.nodes.image.spec.attributes.transformData.renderDOM;
+      const result = renderDOM({ transformData: { rotation: 45 } });
+
+      expect(result.style).toBe('transform: rotate(45deg);');
+    });
+
+    it('renders transformData with vertical flip only', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.transformData.renderDOM;
+      const result = renderDOM({
+        transformData: {
+          verticalFlip: true,
+        },
+      });
+
+      expect(result.style).toBe('transform: scaleY(-1);');
+    });
+
+    it('renders transformData with horizontal flip only', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.transformData.renderDOM;
+      const result = renderDOM({
+        transformData: {
+          horizontalFlip: true,
+        },
+      });
+
+      expect(result.style).toBe('transform: scaleX(-1);');
+    });
+
+    it('renders transformData with all transformations combined', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.transformData.renderDOM;
+      const result = renderDOM({
+        transformData: {
+          rotation: 30,
+          verticalFlip: true,
+          horizontalFlip: true,
+        },
+      });
+
+      expect(result.style).toBe('transform: rotate(30deg) scaleY(-1) scaleX(-1);');
+    });
+
+    it('renders transformData with fractional rotation', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.transformData.renderDOM;
+      const result = renderDOM({
+        transformData: {
+          rotation: 45.7,
+        },
+      });
+
+      expect(result.style).toBe('transform: rotate(46deg);');
+    });
+
+    it('renders transformData with negative rotation', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.transformData.renderDOM;
+      const result = renderDOM({
+        transformData: {
+          rotation: -90,
+        },
+      });
+
+      expect(result.style).toBe('transform: rotate(-90deg);');
+    });
+
+    it('returns undefined when no transformData is provided', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.transformData.renderDOM;
+      const result = renderDOM({ transformData: {} });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when transformData is null', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.transformData.renderDOM;
+      const result = renderDOM({ transformData: null });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('ignores sizeExtension in DOM rendering', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.transformData.renderDOM;
+      const result = renderDOM({
+        transformData: {
+          rotation: 45,
+          sizeExtension: {
+            left: 10,
+            top: 5,
+            right: 15,
+            bottom: 20,
+          },
+        },
+      });
+
+      // sizeExtension should not affect DOM transform style
+      expect(result.style).toBe('transform: rotate(45deg);');
+    });
+  });
+
+  describe('size rendering', () => {
+    it('renders size with width and height', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.size.renderDOM;
+      const result = renderDOM({
+        size: { width: 300, height: 200 },
+      });
+
+      expect(result.style).toContain('width: 300px');
+      expect(result.style).toContain('height: auto');
+    });
+
+    it('renders EMF/WMF with special height styling', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.size.renderDOM;
+      const result = renderDOM({
+        size: { width: 300, height: 200 },
+        extension: 'emf',
+      });
+
+      expect(result.style).toContain('width: 300px');
+      expect(result.style).toContain('height: 200px');
+      expect(result.style).toContain('border: 1px solid black');
+      expect(result.style).toContain('position: absolute');
+    });
+
+    it('renders WMF with special height styling', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.size.renderDOM;
+      const result = renderDOM({
+        size: { width: 250, height: 150 },
+        extension: 'wmf',
+      });
+
+      expect(result.style).toContain('width: 250px');
+      expect(result.style).toContain('height: 150px');
+      expect(result.style).toContain('border: 1px solid black');
+      expect(result.style).toContain('position: absolute');
+    });
+
+    it('handles missing size gracefully', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.size.renderDOM;
+      const result = renderDOM({ size: null });
+
+      expect(result.style).toBe('');
+    });
+  });
+
+  describe('padding rendering', () => {
+    it('renders all padding values', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.padding.renderDOM;
+      const result = renderDOM({
+        size: { width: 200, height: 150 },
+        padding: {
+          left: 10,
+          top: 15,
+          bottom: 20,
+          right: 25,
+        },
+      });
+
+      expect(result.style).toContain('margin-left: 10px');
+      expect(result.style).toContain('margin-top: 15px');
+      expect(result.style).toContain('margin-bottom: 20px');
+      expect(result.style).toContain('margin-right: 25px');
+    });
+
+    it('adds rotation margins for rotated images', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.padding.renderDOM;
+      const result = renderDOM({
+        size: { width: 100, height: 100 },
+        padding: { left: 5, top: 5, bottom: 5, right: 5 },
+        transformData: { rotation: 45 },
+      });
+
+      // Should include base padding plus rotation margins
+      expect(result.style).toContain('margin-left:');
+      expect(result.style).toContain('margin-top:');
+      expect(result.style).toContain('margin-bottom:');
+      expect(result.style).toContain('margin-right:');
+
+      // Values should be higher than base padding due to rotation margins
+      const leftMatch = result.style.match(/margin-left: (\d+)px/);
+      const topMatch = result.style.match(/margin-top: (\d+)px/);
+
+      if (leftMatch && topMatch) {
+        expect(parseInt(leftMatch[1])).toBeGreaterThan(5);
+        expect(parseInt(topMatch[1])).toBeGreaterThan(5);
+      }
+    });
+
+    it('respects marginOffset for left and top margins', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.padding.renderDOM;
+      const result = renderDOM({
+        size: { width: 200, height: 150 },
+        padding: { left: 10, top: 15, bottom: 20, right: 25 },
+        marginOffset: { left: true, top: true },
+      });
+
+      expect(result.style).not.toContain('margin-left');
+      expect(result.style).not.toContain('margin-top');
+      expect(result.style).toContain('margin-bottom: 20px');
+      expect(result.style).toContain('margin-right: 25px');
+    });
+  });
+
+  describe('marginOffset rendering', () => {
+    it('renders marginOffset values', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.marginOffset.renderDOM;
+      const result = renderDOM({
+        marginOffset: { left: 30, top: 40 },
+      });
+
+      expect(result.style).toContain('margin-left: 30px');
+      expect(result.style).toContain('margin-top: 40px');
+    });
+
+    it('limits top margin for page-relative anchors', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.marginOffset.renderDOM;
+      const result = renderDOM({
+        marginOffset: { left: 30, top: 600 },
+        anchorData: { vRelativeFrom: 'page' },
+      });
+
+      expect(result.style).toContain('margin-left: 30px');
+      expect(result.style).toContain('margin-top: 500px'); // Capped at 500px
+    });
+
+    it('does not limit top margin for non-page-relative anchors', () => {
+      const renderDOM = editor.schema.nodes.image.spec.attributes.marginOffset.renderDOM;
+      const result = renderDOM({
+        marginOffset: { left: 30, top: 600 },
+        anchorData: { vRelativeFrom: 'margin' },
+      });
+
+      expect(result.style).toContain('margin-left: 30px');
+      expect(result.style).toContain('margin-top: 600px');
+    });
+  });
+
+  describe('src attribute rendering', () => {
+    beforeEach(() => {
+      // Mock storage.media
+      if (editor.extensionService.extensions.find((e) => e.name === 'image')) {
+        const imageExtension = editor.extensionService.extensions.find((e) => e.name === 'image');
+        imageExtension.storage.media = {
+          'stored-key': 'actual-image-path.jpg',
+        };
+      }
+    });
+
+    it('uses media storage when src is a key', () => {
+      const imageExtension = editor.extensionService.extensions.find((e) => e.name === 'image');
+      const renderDOM = imageExtension.spec.attributes.src.renderDOM;
+      const result = renderDOM.call(imageExtension, { src: 'stored-key' });
+
+      expect(result.src).toBe('actual-image-path.jpg');
+    });
+
+    it('uses src directly when not in media storage', () => {
+      const imageExtension = editor.extensionService.extensions.find((e) => e.name === 'image');
+      const renderDOM = imageExtension.spec.attributes.src.renderDOM;
+      const result = renderDOM.call(imageExtension, { src: 'direct-path.jpg' });
+
+      expect(result.src).toBe('direct-path.jpg');
+    });
+  });
+
+  describe('commands', () => {
+    it('setImage command creates image node with correct attributes', () => {
+      const imageAttrs = {
+        src: 'command-test.jpg',
+        alt: 'Command test image',
+        size: { width: 150, height: 100 },
+        transformData: {
+          rotation: 90,
+          verticalFlip: true,
+        },
+      };
+
+      editor.commands.setImage(imageAttrs);
+
+      const imageNode = editor.state.doc.firstChild.firstChild;
+      expect(imageNode.type.name).toBe('image');
+      expect(imageNode.attrs.src).toBe('command-test.jpg');
+      expect(imageNode.attrs.alt).toBe('Command test image');
+      expect(imageNode.attrs.transformData.rotation).toBe(90);
+      expect(imageNode.attrs.transformData.verticalFlip).toBe(true);
+    });
+  });
+
+  describe('parseDOM', () => {
+    it('parses img tags correctly', () => {
+      const parseRule = editor.schema.nodes.image.spec.parseDOM[0];
+
+      // Test with regular img tag
+      const imgElement = document.createElement('img');
+      imgElement.src = 'test.jpg';
+      imgElement.alt = 'Test';
+
+      expect(parseRule.tag).toMatch(imgElement);
+    });
+
+    it('excludes base64 images when allowBase64 is false', () => {
+      const extensions = getStarterExtensions().map((ext) => {
+        if (ext.name === 'image') {
+          return Image.configure({
+            allowBase64: false,
+          });
+        }
+        return ext;
+      });
+
+      const editorNoBase64 = createTestEditor({ extensions });
+
+      const parseRule = editorNoBase64.schema.nodes.image.spec.parseDOM[0];
+      expect(parseRule.tag).toBe('img[src]:not([src^="data:"])');
+
+      editorNoBase64.destroy();
+    });
+  });
+
+  describe('integration with helpers', () => {
+    it('integrates with getRotationMargins helper', () => {
+      // This test verifies that rotation margin calculation is working
+      const renderDOM = editor.schema.nodes.image.spec.attributes.padding.renderDOM;
+
+      // Test with square image rotated 45 degrees
+      const result = renderDOM({
+        size: { width: 100, height: 100 },
+        padding: { left: 0, top: 0, bottom: 0, right: 0 },
+        transformData: { rotation: 45 },
+      });
+
+      // Should have added rotation margins
+      expect(result.style).toContain('margin-left:');
+      expect(result.style).toContain('margin-right:');
+      expect(result.style).toContain('margin-top:');
+      expect(result.style).toContain('margin-bottom:');
+    });
+  });
+});

--- a/packages/super-editor/src/tests/helpers/editor-test-utils.js
+++ b/packages/super-editor/src/tests/helpers/editor-test-utils.js
@@ -1,0 +1,125 @@
+import { initTestEditor } from './helpers.js';
+import { Editor } from '@core/Editor.js';
+import { getStarterExtensions } from '@extensions/index.js';
+
+/**
+ * Create a test editor with custom extensions and options
+ * @param {Object} options - Editor configuration options
+ * @param {Array} options.extensions - Array of extensions to include
+ * @param {Object} options.content - Initial content for the editor
+ * @param {Object} options.editorOptions - Additional editor options
+ * @returns {Editor} Configured test editor instance
+ */
+export const createTestEditor = (options = {}) => {
+  const { extensions = getStarterExtensions(), content = null, editorOptions = {} } = options;
+
+  const { editor } = initTestEditor({
+    extensions,
+    content,
+    ...editorOptions,
+  });
+
+  return editor;
+};
+
+/**
+ * Create a minimal test editor with only specified extensions
+ * @param {Array} extensions - Extensions to include
+ * @param {Object} options - Additional options
+ * @returns {Editor} Test editor instance
+ */
+export const createMinimalTestEditor = (extensions = [], options = {}) => {
+  return new Editor({
+    mode: 'text',
+    documentId: 'test-minimal',
+    isHeadless: true,
+    extensions,
+    ...options,
+  });
+};
+
+/**
+ * Create a test editor with docx mode and full extensions
+ * @param {Object} options - Editor options
+ * @returns {Editor} Test editor instance
+ */
+export const createDocxTestEditor = (options = {}) => {
+  return createTestEditor({
+    editorOptions: {
+      mode: 'docx',
+      ...options,
+    },
+  });
+};
+
+/**
+ * Helper to get node from editor state by type and position
+ * @param {Editor} editor - Editor instance
+ * @param {string} nodeType - Node type name
+ * @param {number} pos - Position in document (default: 0 for first occurrence)
+ * @returns {Node|null} Found node or null
+ */
+export const getNodeFromEditor = (editor, nodeType, pos = 0) => {
+  let foundNode = null;
+  let currentPos = 0;
+
+  editor.state.doc.descendants((node, nodePos) => {
+    if (node.type.name === nodeType) {
+      if (currentPos === pos) {
+        foundNode = { node, pos: nodePos };
+        return false; // Stop traversal
+      }
+      currentPos++;
+    }
+  });
+
+  return foundNode;
+};
+
+/**
+ * Helper to simulate user input in test editor
+ * @param {Editor} editor - Editor instance
+ * @param {string} text - Text to insert
+ * @param {number} pos - Position to insert at (default: end of document)
+ */
+export const insertText = (editor, text, pos = null) => {
+  const insertPos = pos !== null ? pos : editor.state.doc.content.size;
+  const tr = editor.state.tr.insertText(text, insertPos);
+  editor.view.dispatch(tr);
+};
+
+/**
+ * Helper to create a transaction for testing
+ * @param {Editor} editor - Editor instance
+ * @returns {Transaction} New transaction
+ */
+export const createTransaction = (editor) => {
+  return editor.state.tr;
+};
+
+/**
+ * Helper to apply a transaction to test editor
+ * @param {Editor} editor - Editor instance
+ * @param {Transaction} tr - Transaction to apply
+ */
+export const applyTransaction = (editor, tr) => {
+  editor.view.dispatch(tr);
+};
+
+/**
+ * Helper to get editor JSON content for testing
+ * @param {Editor} editor - Editor instance
+ * @returns {Object} JSON representation of document
+ */
+export const getEditorJSON = (editor) => {
+  return editor.getJSON();
+};
+
+/**
+ * Helper to set editor content from JSON
+ * @param {Editor} editor - Editor instance
+ * @param {Object} content - JSON content to set
+ */
+export const setEditorContent = (editor, content) => {
+  editor.commands.setContent(content);
+};

--- a/packages/super-editor/src/tests/import-export/imageRoundTrip.test.js
+++ b/packages/super-editor/src/tests/import-export/imageRoundTrip.test.js
@@ -1,0 +1,384 @@
+import { getTestDataByFileName } from '../helpers/helpers.js';
+import { defaultNodeListHandler } from '@converter/v2/importer/docxImporter.js';
+import { handleParagraphNode } from '../../core/super-converter/v2/importer/paragraphNodeImporter.js';
+import { getExportedResultWithDocContent } from '../export/export-helpers/index.js';
+import { Editor } from '@core/Editor.js';
+import { getStarterExtensions } from '@extensions/index.js';
+import { exportSchemaToJson } from '@converter/exporter';
+import { pixelsToEmu, degreesToRot, emuToPixels, rotToDegrees } from '@converter/helpers';
+
+describe('Image Import/Export Round Trip Tests', () => {
+  let editor;
+
+  beforeEach(() => {
+    editor = new Editor({
+      isHeadless: true,
+      extensions: getStarterExtensions(),
+      documentId: 'test-doc',
+      mode: 'docx',
+      annotations: true,
+    });
+  });
+
+  afterEach(() => {
+    if (editor) {
+      editor.destroy();
+    }
+  });
+
+  it('round trip: basic image import and export', async () => {
+    const dataName = 'image_doc.docx';
+    const docx = await getTestDataByFileName(dataName);
+    const documentXml = docx['word/document.xml'];
+
+    const doc = documentXml.elements[0];
+    const body = doc.elements[0];
+    const content = body.elements;
+
+    // Import
+    const { nodes } = handleParagraphNode({
+      nodes: [content[0]],
+      docx,
+      nodeListHandler: defaultNodeListHandler(),
+    });
+
+    const paragraphNode = nodes[0];
+    const importedImageNode = paragraphNode.content[0];
+
+    // Verify import
+    expect(importedImageNode.type).toBe('image');
+    expect(importedImageNode.attrs.src).toBe('word/media/image1.jpeg');
+    expect(importedImageNode.attrs.rId).toBe('rId4');
+
+    // Export
+    const exportResult = await getExportedResultWithDocContent([paragraphNode]);
+    const exportedBody = exportResult.elements?.find((el) => el.name === 'w:body');
+    const exportedImageNode = exportedBody.elements[0].elements[1].elements[0];
+
+    // Verify export structure
+    expect(exportedImageNode.elements[0].name).toBe('w:drawing');
+    expect(exportedImageNode.elements[0].elements[0].name).toBe('wp:inline');
+
+    // Verify relationship ID is preserved
+    const blipElement =
+      exportedImageNode.elements[0].elements[0].elements[4].elements[0].elements[0].elements[1].elements[0];
+    expect(blipElement.attributes['r:embed']).toBe('rId4');
+  });
+
+  it('round trip: anchor image with positioning data', async () => {
+    const dataName = 'anchor_images.docx';
+    const docx = await getTestDataByFileName(dataName);
+    const documentXml = docx['word/document.xml'];
+
+    const doc = documentXml.elements[0];
+    const body = doc.elements[0];
+    const content = body.elements;
+
+    // Import
+    const { nodes } = handleParagraphNode({
+      nodes: [content[1]],
+      docx,
+      nodeListHandler: defaultNodeListHandler(),
+    });
+
+    const paragraphNode = nodes[0];
+    const importedImageNode = paragraphNode.content[3];
+
+    // Verify import of anchor data
+    expect(importedImageNode.attrs.isAnchor).toBeTruthy();
+    expect(importedImageNode.attrs.anchorData.hRelativeFrom).toBe('margin');
+    expect(importedImageNode.attrs.anchorData.vRelativeFrom).toBe('margin');
+    expect(importedImageNode.attrs.anchorData.alignH).toBe('left');
+    expect(importedImageNode.attrs.anchorData.alignV).toBe('top');
+
+    // Export
+    const exportResult = await getExportedResultWithDocContent([paragraphNode]);
+    const exportedBody = exportResult.elements?.find((el) => el.name === 'w:body');
+    const exportedImageNode = exportedBody.elements[0].elements[4].elements[0];
+
+    // Verify anchor export
+    const anchorNode = exportedImageNode.elements[0];
+    expect(anchorNode.name).toBe('wp:anchor');
+    expect(anchorNode.elements[1].attributes.relativeFrom).toBe('margin');
+    expect(anchorNode.elements[2].attributes.relativeFrom).toBe('margin');
+  });
+
+  it('round trip: image with transform data (rotation, flips, size extensions)', async () => {
+    // Create mock image node with transform data
+    const mockImageNode = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'word/media/transformed-image.jpg',
+            rId: 'rId10',
+            alt: 'Transformed image',
+            size: { width: 300, height: 200 },
+            padding: { top: 10, bottom: 10, left: 10, right: 10 },
+            transformData: {
+              rotation: 45,
+              verticalFlip: true,
+              horizontalFlip: false,
+              sizeExtension: {
+                left: 5,
+                top: 8,
+                right: 12,
+                bottom: 3,
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    // Export first
+    const exportResult = await getExportedResultWithDocContent([mockImageNode]);
+    const exportedBody = exportResult.elements?.find((el) => el.name === 'w:body');
+    const exportedImageNode = exportedBody.elements[0].elements[1].elements[0];
+    const drawing = exportedImageNode.elements[0];
+
+    // Verify export of transform data
+    const effectExtent = drawing.elements[0].elements.find((el) => el.name === 'wp:effectExtent');
+    expect(effectExtent.attributes.l).toBe(pixelsToEmu(5));
+    expect(effectExtent.attributes.t).toBe(pixelsToEmu(8));
+    expect(effectExtent.attributes.r).toBe(pixelsToEmu(12));
+    expect(effectExtent.attributes.b).toBe(pixelsToEmu(3));
+
+    const spPr = drawing.elements[0].elements[4].elements[0].elements[0].elements[2];
+    const xfrm = spPr.elements.find((el) => el.name === 'a:xfrm');
+    expect(xfrm.attributes.rot).toBe(degreesToRot(45));
+    expect(xfrm.attributes.flipV).toBe('1');
+    expect(xfrm.attributes.flipH).toBeUndefined();
+
+    // Now simulate import back (we would need to convert the exported XML back to PM schema)
+    // For this test, we'll verify the conversion functions work correctly
+    expect(rotToDegrees(degreesToRot(45))).toBeCloseTo(45, 1);
+    expect(emuToPixels(pixelsToEmu(5))).toBeCloseTo(5, 1);
+  });
+
+  it('round trip: image with wrapping and positioning', async () => {
+    const mockImageNode = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'word/media/wrapped-image.png',
+            rId: 'rId11',
+            alt: 'Wrapped image',
+            size: { width: 250, height: 150 },
+            isAnchor: true,
+            wrapText: 'bothSides',
+            wrapTopAndBottom: false,
+            anchorData: {
+              hRelativeFrom: 'page',
+              vRelativeFrom: 'paragraph',
+              alignH: 'center',
+              alignV: 'bottom',
+            },
+            marginOffset: {
+              left: 50,
+              top: 25,
+            },
+          },
+        },
+      ],
+    };
+
+    // Export
+    const exportResult = await getExportedResultWithDocContent([mockImageNode]);
+    const exportedBody = exportResult.elements?.find((el) => el.name === 'w:body');
+    const exportedImageNode = exportedBody.elements[0].elements[1].elements[0];
+    const anchorNode = exportedImageNode.elements[0].elements[0];
+
+    // Verify anchor positioning export
+    expect(anchorNode.name).toBe('wp:anchor');
+
+    const positionH = anchorNode.elements.find((el) => el.name === 'wp:positionH');
+    expect(positionH.attributes.relativeFrom).toBe('page');
+
+    const positionV = anchorNode.elements.find((el) => el.name === 'wp:positionV');
+    expect(positionV.attributes.relativeFrom).toBe('paragraph');
+
+    // Verify wrapping export
+    const wrapSquare = anchorNode.elements.find((el) => el.name === 'wp:wrapSquare');
+    expect(wrapSquare.attributes.wrapText).toBe('bothSides');
+  });
+
+  it('round trip: preserves image metadata and properties', async () => {
+    const mockImageNode = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'word/media/metadata-image.jpg',
+            rId: 'rId12',
+            alt: 'Image with metadata',
+            title: 'Descriptive title',
+            id: 'img123',
+            size: { width: 400, height: 300 },
+            padding: { top: 15, bottom: 20, left: 10, right: 5 },
+            originalPadding: {
+              distT: '190500',
+              distB: '254000',
+              distL: '127000',
+              distR: '63500',
+            },
+            originalAttributes: {
+              someAttr: 'someValue',
+            },
+          },
+        },
+      ],
+    };
+
+    // Export
+    const exportResult = await getExportedResultWithDocContent([mockImageNode]);
+    const exportedBody = exportResult.elements?.find((el) => el.name === 'w:body');
+    const exportedImageNode = exportedBody.elements[0].elements[1].elements[0];
+    const inlineNode = exportedImageNode.elements[0].elements[0];
+
+    // Verify padding is exported from originalPadding if available
+    expect(inlineNode.attributes.distT).toBe('190500');
+    expect(inlineNode.attributes.distB).toBe('254000');
+    expect(inlineNode.attributes.distL).toBe('127000');
+    expect(inlineNode.attributes.distR).toBe('63500');
+
+    // Verify image properties
+    const docPr = inlineNode.elements.find((el) => el.name === 'wp:docPr');
+    expect(docPr.attributes.id).toBe('img123');
+    expect(docPr.attributes.name).toBe('Image with metadata');
+
+    // Verify title in pic:cNvPr
+    const picCNvPr = inlineNode.elements[4].elements[0].elements[0].elements[0].elements[0];
+    expect(picCNvPr.attributes.name).toBe('Descriptive title');
+  });
+
+  it('round trip: handles missing or invalid image data gracefully', async () => {
+    const mockImageNode = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'word/media/missing-image.jpg',
+            // No rId - should be handled gracefully
+            alt: 'Missing image',
+            size: { width: 100, height: 100 },
+          },
+        },
+      ],
+    };
+
+    // Export should create a new relationship ID
+    const exportResult = await getExportedResultWithDocContent([mockImageNode]);
+    const exportedBody = exportResult.elements?.find((el) => el.name === 'w:body');
+    const exportedImageNode = exportedBody.elements[0].elements[1].elements[0];
+
+    // Should still create valid image structure
+    expect(exportedImageNode.elements[0].name).toBe('w:drawing');
+    expect(exportedImageNode.elements[0].elements[0].name).toBe('wp:inline');
+  });
+
+  it('round trip: EMF/WMF image handling', async () => {
+    const mockEmfImageNode = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'word/media/vector-image.emf',
+            rId: 'rId13',
+            alt: 'Unable to render EMF/WMF image',
+            extension: 'emf',
+            size: { width: 200, height: 150 },
+          },
+        },
+      ],
+    };
+
+    // Export
+    const exportResult = await getExportedResultWithDocContent([mockEmfImageNode]);
+    const exportedBody = exportResult.elements?.find((el) => el.name === 'w:body');
+    const exportedImageNode = exportedBody.elements[0].elements[1].elements[0];
+
+    // Verify structure is created correctly for EMF/WMF files
+    expect(exportedImageNode.elements[0].name).toBe('w:drawing');
+
+    // EMF/WMF files should still generate valid drawing markup
+    const docPr = exportedImageNode.elements[0].elements[0].elements.find((el) => el.name === 'wp:docPr');
+    expect(docPr.attributes.name).toBe('Unable to render EMF/WMF image');
+  });
+
+  it('round trip: complex transformation combinations', async () => {
+    const combinations = [
+      { rotation: 90, verticalFlip: false, horizontalFlip: true },
+      { rotation: 180, verticalFlip: true, horizontalFlip: false },
+      { rotation: 270, verticalFlip: true, horizontalFlip: true },
+      { rotation: -30, verticalFlip: false, horizontalFlip: false },
+    ];
+
+    for (const [index, transform] of combinations.entries()) {
+      const mockImageNode = {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'image',
+            attrs: {
+              src: `word/media/combo-${index}.jpg`,
+              rId: `rId1${index}`,
+              alt: `Combo transform ${index}`,
+              size: { width: 300, height: 300 },
+              transformData: transform,
+            },
+          },
+        ],
+      };
+
+      // Export
+      const exportResult = await getExportedResultWithDocContent([mockImageNode]);
+      const exportedBody = exportResult.elements?.find((el) => el.name === 'w:body');
+      const exportedImageNode = exportedBody.elements[0].elements[1].elements[0];
+      const spPr = exportedImageNode.elements[0].elements[0].elements[4].elements[0].elements[0].elements[2];
+      const xfrm = spPr.elements.find((el) => el.name === 'a:xfrm');
+
+      // Verify each transformation is exported correctly
+      if (transform.rotation !== 0) {
+        expect(xfrm.attributes.rot).toBe(degreesToRot(transform.rotation));
+      }
+      if (transform.verticalFlip) {
+        expect(xfrm.attributes.flipV).toBe('1');
+      }
+      if (transform.horizontalFlip) {
+        expect(xfrm.attributes.flipH).toBe('1');
+      }
+    }
+  });
+
+  it('round trip: preserves image storage references', async () => {
+    // Test that image storage references are maintained through round trip
+    const mockImageWithStorage = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'stored-image-ref', // This would be a key in storage.media
+            alt: 'Stored image',
+            size: { width: 200, height: 200 },
+          },
+        },
+      ],
+    };
+
+    // Export should handle storage references correctly
+    const exportResult = await getExportedResultWithDocContent([mockImageWithStorage]);
+    const exportedBody = exportResult.elements?.find((el) => el.name === 'w:body');
+    const exportedImageNode = exportedBody.elements[0].elements[1].elements[0];
+
+    // Should create valid structure even with storage reference
+    expect(exportedImageNode.elements[0].name).toBe('w:drawing');
+  });
+});

--- a/packages/super-editor/src/tests/import/imageImporter.test.js
+++ b/packages/super-editor/src/tests/import/imageImporter.test.js
@@ -1,7 +1,9 @@
+import { describe, it, expect, vi } from 'vitest';
 import { getTestDataByFileName } from '../helpers/helpers.js';
 import { defaultNodeListHandler } from '@converter/v2/importer/docxImporter.js';
-import { handleDrawingNode } from '../../core/super-converter/v2/importer/imageImporter.js';
+import { handleDrawingNode, handleImageImport } from '../../core/super-converter/v2/importer/imageImporter.js';
 import { handleParagraphNode } from '../../core/super-converter/v2/importer/paragraphNodeImporter.js';
+import { emuToPixels, rotToDegrees } from '../../core/super-converter/helpers.js';
 
 describe('ImageNodeImporter', () => {
   it('imports image node correctly', async () => {
@@ -63,7 +65,6 @@ describe('ImageNodeImporter', () => {
     const doc = documentXml.elements[0];
     const body = doc.elements[0];
     const content = body.elements;
-    console.log(content[6].elements[2]);
 
     const { nodes } = handleParagraphNode({ nodes: [content[0]], docx, nodeListHandler: defaultNodeListHandler() });
 
@@ -80,5 +81,446 @@ describe('ImageNodeImporter', () => {
     paragraphNode = nodes1[0];
     drawingNode = paragraphNode.content[1];
     expect(drawingNode.attrs.src).toBe('word/media/image1.jpeg');
+  });
+
+  it('imports image with transformData correctly', () => {
+    // Create mock XML data for an image with transformData
+    const mockXmlData = {
+      name: 'wp:inline',
+      attributes: {
+        distT: '114300', // 8px in EMU
+        distB: '114300', // 8px in EMU
+        distL: '114300', // 8px in EMU
+        distR: '114300', // 8px in EMU
+      },
+      elements: [
+        {
+          name: 'wp:extent',
+          attributes: { cx: '5715000', cy: '4285500' }, // Sample dimensions
+        },
+        {
+          name: 'wp:effectExtent',
+          attributes: { l: '19050', t: '0', r: '0', b: '9525' },
+        },
+        {
+          name: 'a:graphic',
+          elements: [
+            {
+              name: 'a:graphicData',
+              attributes: { uri: 'http://schemas.openxmlformats.org/drawingml/2006/picture' },
+              elements: [
+                {
+                  name: 'pic:pic',
+                  elements: [
+                    {
+                      name: 'pic:blipFill',
+                      elements: [
+                        {
+                          name: 'a:blip',
+                          attributes: { 'r:embed': 'rId5' },
+                        },
+                      ],
+                    },
+                    {
+                      name: 'pic:spPr',
+                      elements: [
+                        {
+                          name: 'a:xfrm',
+                          attributes: {
+                            rot: '5400000', // 30 degrees in 60000ths
+                            flipV: '1',
+                            flipH: '1',
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'wp:docPr',
+          attributes: { id: '1', name: 'Picture 1', descr: 'Test image' },
+        },
+      ],
+    };
+
+    const mockDocx = {
+      'word/_rels/document.xml.rels': {
+        elements: [
+          {
+            name: 'Relationships',
+            elements: [
+              {
+                attributes: {
+                  Id: 'rId5',
+                  Target: 'media/test-image.jpg',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const params = { docx: mockDocx };
+    const result = handleImageImport(mockXmlData, 'document.xml', params);
+
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('image');
+    expect(result.attrs.src).toBe('word/media/test-image.jpg');
+
+    // Test transformData
+    expect(result.attrs.transformData).toBeDefined();
+    expect(result.attrs.transformData.rotation).toBe(rotToDegrees('5400000'));
+    expect(result.attrs.transformData.verticalFlip).toBe(true);
+    expect(result.attrs.transformData.horizontalFlip).toBe(true);
+
+    // Test sizeExtension from effectExtent
+    expect(result.attrs.transformData.sizeExtension).toBeDefined();
+    expect(result.attrs.transformData.sizeExtension.left).toBe(emuToPixels('19050'));
+    expect(result.attrs.transformData.sizeExtension.top).toBe(emuToPixels('0'));
+    expect(result.attrs.transformData.sizeExtension.right).toBe(emuToPixels('0'));
+    expect(result.attrs.transformData.sizeExtension.bottom).toBe(emuToPixels('9525'));
+
+    // Test other attributes
+    expect(result.attrs.padding.top).toBe(emuToPixels('114300'));
+    expect(result.attrs.padding.bottom).toBe(emuToPixels('114300'));
+    expect(result.attrs.padding.left).toBe(emuToPixels('114300'));
+    expect(result.attrs.padding.right).toBe(emuToPixels('114300'));
+  });
+
+  it('handles drawing node with no image content', () => {
+    const mockNodes = [
+      {
+        name: 'w:drawing',
+        elements: [
+          {
+            name: 'wp:inline',
+            attributes: {
+              distT: '0',
+              distB: '0',
+              distL: '0',
+              distR: '0',
+            },
+            elements: [
+              {
+                name: 'wp:extent',
+                attributes: { cx: '100', cy: '100' },
+              },
+              {
+                name: 'a:graphic',
+                elements: [
+                  {
+                    name: 'a:graphicData',
+                    attributes: { uri: 'http://schemas.openxmlformats.org/drawingml/2006/picture' },
+                    elements: [], // Empty elements - no pic:pic
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const params = { docx: {} };
+    const result = handleDrawingNode({ nodes: mockNodes });
+
+    expect(result.nodes).toEqual([]);
+    expect(result.consumed).toBe(1);
+  });
+
+  it('imports image with minimal transformData correctly', () => {
+    const mockXmlData = {
+      name: 'wp:inline',
+      attributes: { distT: '0', distB: '0', distL: '0', distR: '0' },
+      elements: [
+        {
+          name: 'wp:extent',
+          attributes: { cx: '1000000', cy: '1000000' },
+        },
+        {
+          name: 'a:graphic',
+          elements: [
+            {
+              name: 'a:graphicData',
+              attributes: { uri: 'http://schemas.openxmlformats.org/drawingml/2006/picture' },
+              elements: [
+                {
+                  name: 'pic:pic',
+                  elements: [
+                    {
+                      name: 'pic:blipFill',
+                      elements: [
+                        {
+                          name: 'a:blip',
+                          attributes: { 'r:embed': 'rId1' },
+                        },
+                      ],
+                    },
+                    {
+                      name: 'pic:spPr',
+                      elements: [
+                        {
+                          name: 'a:xfrm',
+                          attributes: { rot: '0' }, // No rotation
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'wp:docPr',
+          attributes: { id: '2', name: 'Test Image' },
+        },
+      ],
+    };
+
+    const mockDocx = {
+      'word/_rels/document.xml.rels': {
+        elements: [
+          {
+            name: 'Relationships',
+            elements: [
+              {
+                attributes: {
+                  Id: 'rId1',
+                  Target: 'media/simple-image.png',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const params = { docx: mockDocx };
+    const result = handleImageImport(mockXmlData, null, params);
+
+    expect(result.attrs.transformData).toBeDefined();
+    expect(result.attrs.transformData.rotation).toBe(0);
+    expect(result.attrs.transformData.verticalFlip).toBe(false);
+    expect(result.attrs.transformData.horizontalFlip).toBe(false);
+  });
+
+  it('handles shape drawing correctly', () => {
+    const mockNodes = [
+      {
+        name: 'w:drawing',
+        elements: [
+          {
+            name: 'wp:anchor',
+            attributes: {
+              distT: '0',
+              distB: '0',
+              distL: '0',
+              distR: '0',
+            },
+            elements: [
+              {
+                name: 'wp:extent',
+                attributes: { cx: '1000000', cy: '1000000' },
+              },
+              {
+                name: 'a:graphic',
+                elements: [
+                  {
+                    name: 'a:graphicData',
+                    attributes: { uri: 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape' },
+                    elements: [
+                      {
+                        name: 'wps:wsp',
+                        elements: [
+                          {
+                            name: 'wps:spPr',
+                            elements: [
+                              {
+                                name: 'a:xfrm',
+                                elements: [
+                                  { name: 'a:off', attributes: { x: '0', y: '0' } },
+                                  { name: 'a:ext', attributes: { cx: '1000000', cy: '1000000' } },
+                                ],
+                              },
+                              {
+                                name: 'a:prstGeom',
+                                attributes: { prst: 'rect' },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                name: 'wp:docPr',
+                attributes: { id: '1', name: 'Rectangle 1' },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const params = {
+      docx: {},
+      nodeListHandler: { handler: vi.fn().mockReturnValue([]) },
+    };
+
+    const result = handleDrawingNode({ nodes: mockNodes, ...params });
+
+    expect(result.consumed).toBe(1);
+    // Should handle shape drawing without throwing errors
+  });
+
+  it('imports image with wrapping properties correctly', () => {
+    const mockXmlData = {
+      name: 'wp:anchor',
+      attributes: { distT: '0', distB: '0', distL: '0', distR: '0' },
+      elements: [
+        {
+          name: 'wp:extent',
+          attributes: { cx: '2000000', cy: '1500000' },
+        },
+        {
+          name: 'wp:wrapSquare',
+          attributes: { wrapText: 'bothSides' },
+        },
+        {
+          name: 'wp:wrapTopAndBottom',
+        },
+        {
+          name: 'a:graphic',
+          elements: [
+            {
+              name: 'a:graphicData',
+              attributes: { uri: 'http://schemas.openxmlformats.org/drawingml/2006/picture' },
+              elements: [
+                {
+                  name: 'pic:pic',
+                  elements: [
+                    {
+                      name: 'pic:blipFill',
+                      elements: [
+                        {
+                          name: 'a:blip',
+                          attributes: { 'r:embed': 'rId3' },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'wp:docPr',
+          attributes: { id: '3', name: 'Wrapped Image' },
+        },
+      ],
+    };
+
+    const mockDocx = {
+      'word/_rels/document.xml.rels': {
+        elements: [
+          {
+            name: 'Relationships',
+            elements: [
+              {
+                attributes: {
+                  Id: 'rId3',
+                  Target: 'media/wrapped-image.jpg',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const params = { docx: mockDocx };
+    const result = handleImageImport(mockXmlData, null, params);
+
+    expect(result.attrs.wrapText).toBe('bothSides');
+    expect(result.attrs.wrapTopAndBottom).toBe(true);
+  });
+
+  it('handles missing relationships gracefully', () => {
+    const mockXmlData = {
+      name: 'wp:inline',
+      attributes: { distT: '0', distB: '0', distL: '0', distR: '0' },
+      elements: [
+        {
+          name: 'wp:extent',
+          attributes: { cx: '1000000', cy: '1000000' },
+        },
+        {
+          name: 'a:graphic',
+          elements: [
+            {
+              name: 'a:graphicData',
+              attributes: { uri: 'http://schemas.openxmlformats.org/drawingml/2006/picture' },
+              elements: [
+                {
+                  name: 'pic:pic',
+                  elements: [
+                    {
+                      name: 'pic:blipFill',
+                      elements: [
+                        {
+                          name: 'a:blip',
+                          attributes: { 'r:embed': 'rIdNonExistent' },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const mockDocx = {
+      'word/_rels/document.xml.rels': {
+        elements: [
+          {
+            name: 'Relationships',
+            elements: [], // No relationships
+          },
+        ],
+      },
+    };
+
+    const params = { docx: mockDocx };
+    const result = handleImageImport(mockXmlData, null, params);
+
+    expect(result).toBeNull();
+  });
+
+  it('handles invalid node types gracefully', () => {
+    const invalidNodes = [{ name: 'w:invalidNode' }, { name: 'w:t' }];
+
+    const result = handleDrawingNode({ nodes: invalidNodes });
+
+    expect(result.nodes).toEqual([]);
+    expect(result.consumed).toBe(0);
+  });
+
+  it('handles empty nodes array', () => {
+    const result = handleDrawingNode({ nodes: [] });
+
+    expect(result.nodes).toEqual([]);
+    expect(result.consumed).toBe(0);
   });
 });


### PR DESCRIPTION
Implemented features:
* import of transformed images (flip h, flip v, rotated) with `wp:effectExtent` 
* export of transformed images with `wp:effectExtent`
* display of transformed images using custom formula to calculate needed extra space
* tests

**TODO:**
1. Custom formula and values from `wp:effectExtent` should be the same - but this is only the case sometimes. Custom formula gives values as they are needed for display in browser, while values from `wp:effectExtent` are only used for export. Once formulas fully align, values for export should be calculated based on formula.
2. Custom command to change the rotation and flip state of individual images (will need to recalculate values for `wp:effectExtent` based on custom formula - issue 1).
3. Code works with provided test file, but other test files produced with LibreOffice currently don't work in import.
