### PR TITLE
fix: emit editor exception on import/export errors

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -117,6 +117,9 @@ const loadNewFileData = async () => {
     return { content: docx, media, mediaFiles, fonts };
   } catch (err) {
     console.debug('Error loading new file data:', err);
+    if (typeof props.options.onException === 'function') {
+      props.options.onException({ error: err, editor: null });
+    }
   }
 };
 

--- a/packages/super-editor/src/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/components/toolbar/super-toolbar.js
@@ -868,7 +868,10 @@ export class SuperToolbar extends EventEmitter {
 
     // If we don't know what to do with this command, throw an error
     else {
-      throw new Error(`[super-toolbar 🎨] Command not found: ${command}`);
+      const error = new Error(`[super-toolbar 🎨] Command not found: ${command}`);
+      this.emit('exception', { error, editor: this.activeEditor });
+
+      throw error;
     }
 
     this.updateToolbarState();

--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -381,8 +381,13 @@ class SuperConverter {
   }
 
   getSchema(editor) {
-    this.getDocumentInternalId();
-    const result = createDocumentJson({ ...this.convertedXml, media: this.media }, this, editor);
+    let result;
+    try {
+      this.getDocumentInternalId();
+      result = createDocumentJson({ ...this.convertedXml, media: this.media }, this, editor);
+    } catch (error) {
+      editor?.emit('exception', { error, editor });
+    }
 
     if (result) {
       this.savedTagsToRestore.push({ ...result.savedTagsToRestore });

--- a/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
@@ -276,7 +276,7 @@ const createNodeListHandler = (nodeHandlers) => {
           }
         } catch (error) {
           console.debug('Import error', error);
-          editor?.emit('exception', { error });
+          editor?.emit('exception', { error, editor });
 
           converter?.telemetry?.trackStatistic('error', {
             type: 'processing_error',
@@ -291,7 +291,7 @@ const createNodeListHandler = (nodeHandlers) => {
       return processedElements;
     } catch (error) {
       console.debug('Error during import', error);
-      editor?.emit('exception', { error });
+      editor?.emit('exception', { error, editor });
 
       // Track only catastrophic handler failures
       converter?.telemetry?.trackStatistic('error', {

--- a/packages/super-editor/src/extensions/image/imageHelpers/startImageUpload.js
+++ b/packages/super-editor/src/extensions/image/imageHelpers/startImageUpload.js
@@ -39,6 +39,7 @@ export const startImageUpload = async ({ editor, view, file }) => {
     file = processedImageResult.file;
   } catch (err) {
     console.warn('Error processing image:', err);
+    editor.emit('exception', { error: err, editor });
     return;
   }
 
@@ -135,10 +136,11 @@ export async function uploadImage({ editor, view, file, size, uploadHandler }) {
         .replaceWith(placeholderPos, placeholderPos, imageNode) // or .insert(placeholderPos, imageNode)
         .setMeta(ImagePlaceholderPluginKey, removeMeta),
     );
-  } catch {
+  } catch (error) {
     let removeMeta = { type: 'remove', id };
     // On failure, just clean up the placeholder
     view.dispatch(tr.setMeta(ImagePlaceholderPluginKey, removeMeta));
+    editor.emit('exception', { error, editor });
   }
 }
 

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -549,6 +549,7 @@ export class SuperDoc extends EventEmitter {
     this.toolbar = new SuperToolbar(config);
 
     this.toolbar.on('superdoc-command', this.onToolbarCommand.bind(this));
+    this.toolbar.on('exception', this.config.onException);
     this.once('editorCreate', () => this.toolbar.updateToolbarState());
   }
 


### PR DESCRIPTION
Hi @harbournick! Tested Superdoc's onException hook and it catches unhandled import exceptions. Added another event on document export error. 
We have some try/catch blocks in the import/export process. How do you think should I also emit exception event there if there is a handler for error?