### PR TITLE
fix: html import parse styleId attr for round-trip fidelity

### DIFF
--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -1381,6 +1381,8 @@ export class Editor extends EventEmitter {
 
   /**
    * Get the editor content as HTML
+   * @param {Object} options - Options for the HTML serializer
+   * @param {boolean} [options.unflattenLists] - Whether to unflatten lists in the HTML
    * @returns {string} Editor content as HTML
    */
   getHTML({ unflattenLists = false } = {}) {

--- a/packages/super-editor/src/core/helpers/htmlSanitizer.js
+++ b/packages/super-editor/src/core/helpers/htmlSanitizer.js
@@ -12,8 +12,8 @@ export function stripHtmlStyles(html) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
 
-  // Semantic attributes to preserve
-  const SEMANTIC_ATTRS = [
+  // Supported attributes to preserve
+  const SUPPORTED_ATTRS = [
     'href',
     'src',
     'alt',
@@ -26,15 +26,16 @@ export function stripHtmlStyles(html) {
     'dir',
     'cite',
     'start',
-    'type', // for lists
+    'type',
+    'styleid',
   ];
 
   const cleanNode = (node) => {
     if (node.nodeType !== Node.ELEMENT_NODE) return;
 
-    // Remove all non-semantic attributes
+    // Remove all non-supported attributes
     [...node.attributes].forEach((attr) => {
-      if (!SEMANTIC_ATTRS.includes(attr.name.toLowerCase())) {
+      if (!SUPPORTED_ATTRS.includes(attr.name.toLowerCase())) {
         node.removeAttribute(attr.name);
       }
     });

--- a/packages/super-editor/src/extensions/paragraph/paragraph.js
+++ b/packages/super-editor/src/extensions/paragraph/paragraph.js
@@ -189,12 +189,35 @@ export const Paragraph = OxmlNode.create({
       {
         tag: 'p',
         getAttrs: (node) => {
-          let extra = {};
+          const styleId = node.getAttribute('styleid') || null;
+
+          const extra = {};
+          Array.from(node.attributes).forEach((attr) => {
+            // Don't include styleid in extraAttrs
+            if (attr.name !== 'styleid') {
+              extra[attr.name] = attr.value;
+            }
+          });
+
+          return {
+            styleId,
+            extraAttrs: extra,
+          };
+        },
+      },
+      {
+        tag: 'div',
+        getAttrs: (node) => {
+          const extra = {};
           Array.from(node.attributes).forEach((attr) => {
             extra[attr.name] = attr.value;
           });
           return { extraAttrs: extra };
         },
+      },
+      {
+        tag: 'blockquote',
+        attrs: { styleId: 'BlockQuote' },
       },
       ...this.options.headingLevels.map((level) => ({
         tag: `h${level}`,

--- a/packages/super-editor/src/extensions/paragraph/paragraph.js
+++ b/packages/super-editor/src/extensions/paragraph/paragraph.js
@@ -189,19 +189,14 @@ export const Paragraph = OxmlNode.create({
       {
         tag: 'p',
         getAttrs: (node) => {
-          const styleId = node.getAttribute('styleid') || null;
-
-          const extra = {};
-          Array.from(node.attributes).forEach((attr) => {
-            // Don't include styleid in extraAttrs
-            if (attr.name !== 'styleid') {
-              extra[attr.name] = attr.value;
-            }
-          });
+          const { styleid, ...extraAttrs } = Array.from(node.attributes).reduce((acc, attr) => {
+            acc[attr.name] = attr.value;
+            return acc;
+          }, {});
 
           return {
-            styleId,
-            extraAttrs: extra,
+            styleId: styleid || null,
+            extraAttrs,
           };
         },
       },

--- a/packages/superdoc/src/dev/components/SuperdocDev.vue
+++ b/packages/superdoc/src/dev/components/SuperdocDev.vue
@@ -212,6 +212,33 @@ const onContentError = ({ editor, error, documentId, file }) => {
   console.debug('Content error on', documentId, error);
 };
 
+const exportHTML = async (commentsType) => {
+  console.debug('Exporting HTML', { commentsType });
+
+  // Get HTML content from SuperDoc
+  const htmlArray = superdoc.value.getHTML();
+  const html = htmlArray.join('');
+
+  // Create a Blob from the HTML
+  const blob = new Blob([html], { type: 'text/html' });
+
+  // Create a download link and trigger the download
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${title.value || 'document'}.html`;
+
+  // Trigger the download
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  // Clean up the URL
+  URL.revokeObjectURL(url);
+
+  console.debug('HTML exported successfully');
+};
+
 const exportDocx = async (commentsType) => {
   console.debug('Exporting docx', { commentsType });
   await superdoc.value.export({ commentsType });
@@ -272,6 +299,7 @@ onMounted(async () => {
           </div>
         </div>
         <div class="dev-app__header-side dev-app__header-side--right">
+          <button class="dev-app__header-export-btn" @click="exportHTML()">Export HTML</button>
           <button class="dev-app__header-export-btn" @click="exportDocx()">Export Docx</button>
           <button class="dev-app__header-export-btn" @click="exportDocx('clean')">Export clean Docx</button>
           <button class="dev-app__header-export-btn" @click="exportDocx('external')">Export external Docx</button>


### PR DESCRIPTION
- Added `exportHTML` method in SuperdocDev.vue to allow users to export editor content as HTML.
- Updated `getHTML` method in Editor.js to include options for unflattening lists.
- Refactored attribute handling in htmlSanitizer.js and paragraph.js to support new `styleid` attribute and improve attribute preservation logic.