### PR TITLE
feat: structured content commands and helpers

### DIFF
--- a/packages/super-editor/src/assets/styles/extensions/structured-content.css
+++ b/packages/super-editor/src/assets/styles/extensions/structured-content.css
@@ -23,6 +23,7 @@
   border-bottom: none;
   border-radius: 6px 6px 0 0;
   background-color: #629be7dd;
+  box-sizing: border-box;
   z-index: 10;
   cursor: grab;
   display: none;

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-structured-content-node.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-structured-content-node.js
@@ -15,6 +15,10 @@ export function handleStructuredContentNode(params) {
   const sdtPr = node.elements.find((el) => el.name === 'w:sdtPr');
   const sdtContent = node.elements.find((el) => el.name === 'w:sdtContent');
 
+  const id = sdtPr?.elements?.find((el) => el.name === 'w:id');
+  const tag = sdtPr?.elements?.find((el) => el.name === 'w:tag');
+  const alias = sdtPr?.elements?.find((el) => el.name === 'w:alias');
+
   if (!sdtContent) {
     return null;
   }
@@ -28,17 +32,17 @@ export function handleStructuredContentNode(params) {
     path: [...(params.path || []), sdtContent],
   });
 
-  let sdtContentType = 'structuredContent';
-  if (paragraph || table) {
-    // If a paragraph or potentially another block node is found.
-    sdtContentType = 'structuredContentBlock';
-  }
+  const isBlockNode = paragraph || table;
+  const sdtContentType = isBlockNode ? 'structuredContentBlock' : 'structuredContent';
 
   let result = {
     type: sdtContentType,
     content: translatedContent,
     marks,
     attrs: {
+      id: id?.attributes?.['w:val'] || null,
+      tag: tag?.attributes?.['w:val'] || null,
+      alias: alias?.attributes?.['w:val'] || null,
       sdtPr,
     },
   };

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-structured-content.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-structured-content.js
@@ -6,22 +6,62 @@ import { translateChildNodes } from '@converter/v2/exporter/helpers/translateChi
  */
 export function translateStructuredContent(params) {
   const { node } = params;
-  const { attrs = {} } = node;
 
   const childContent = translateChildNodes({ ...params, nodes: node.content });
 
   // We build the sdt node elements here, and re-add passthrough sdtPr node
-  const nodeElements = [
-    {
-      name: 'w:sdtContent',
-      elements: childContent,
-    },
-  ];
-  nodeElements.unshift(attrs.sdtPr);
+  const sdtContent = { name: 'w:sdtContent', elements: childContent };
+  const sdtPr = generateSdtPrTagForStructuredContent({ node });
+  const nodeElements = [sdtPr, sdtContent];
 
   const result = {
     name: 'w:sdt',
     elements: nodeElements,
+  };
+
+  return result;
+}
+
+function generateSdtPrTagForStructuredContent({ node }) {
+  const { attrs = {} } = node;
+
+  const id = {
+    name: 'w:id',
+    type: 'element',
+    attributes: { 'w:val': attrs.id },
+  };
+  const alias = {
+    name: 'w:alias',
+    type: 'element',
+    attributes: { 'w:val': attrs.alias },
+  };
+  const tag = {
+    name: 'w:tag',
+    type: 'element',
+    attributes: { 'w:val': attrs.tag },
+  };
+
+  const resultElements = [];
+  if (attrs.id) resultElements.push(id);
+  if (attrs.alias) resultElements.push(alias);
+  if (attrs.tag) resultElements.push(tag);
+
+  if (attrs.sdtPr) {
+    const elements = attrs.sdtPr.elements || [];
+    const elementsToExclude = ['w:id', 'w:alias', 'w:tag'];
+    const restElements = elements.filter((el) => !elementsToExclude.includes(el.name));
+    const result = {
+      name: 'w:sdtPr',
+      type: 'element',
+      elements: [...resultElements, ...restElements],
+    };
+    return result;
+  }
+
+  const result = {
+    name: 'w:sdtPr',
+    type: 'element',
+    elements: resultElements,
   };
 
   return result;

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-structured-content.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-structured-content.test.js
@@ -16,7 +16,8 @@ describe('translateStructuredContent', () => {
   it('returns correct XML structure with sdtPr and sdtContent', () => {
     const mockSdtPr = {
       name: 'w:sdtPr',
-      elements: [{ name: 'w:tag', attributes: { 'w:val': 'test' } }],
+      elements: [],
+      type: 'element',
     };
 
     const node = {

--- a/packages/super-editor/src/extensions/index.js
+++ b/packages/super-editor/src/extensions/index.js
@@ -13,6 +13,7 @@ import { Collaboration } from './collaboration/index.js';
 import { CollaborationCursor } from './collaboration-cursor/index.js';
 import { AiPlugin, AiMark, AiAnimationMark, AiLoaderNode } from './ai/index.js';
 import { SlashMenu } from './slash-menu';
+import { StructuredContentCommands } from './structured-content/index.js';
 
 // Nodes extensions
 import { Document } from './document/index.js';
@@ -176,6 +177,7 @@ const getStarterExtensions = () => {
     Search,
     StructuredContent,
     StructuredContentBlock,
+    StructuredContentCommands,
     DocumentSection,
     NodeResizer,
     CustomSelection,
@@ -245,6 +247,7 @@ export {
   Search,
   StructuredContent,
   StructuredContentBlock,
+  StructuredContentCommands,
   DocumentSection,
   NodeResizer,
   CustomSelection,

--- a/packages/super-editor/src/extensions/structured-content/StructuredContentViewBase.js
+++ b/packages/super-editor/src/extensions/structured-content/StructuredContentViewBase.js
@@ -184,7 +184,7 @@ export class StructuredContentViewBase {
     dragHandle.contentEditable = 'false';
     dragHandle.dataset.dragHandle = '';
     const textElement = document.createElement('span');
-    textElement.textContent = 'Structured content';
+    textElement.textContent = this.node.attrs.alias || 'Structured content';
     dragHandle.append(textElement);
     return dragHandle;
   }

--- a/packages/super-editor/src/extensions/structured-content/index.js
+++ b/packages/super-editor/src/extensions/structured-content/index.js
@@ -1,3 +1,4 @@
 export * from './structured-content.js';
 export * from './structured-content-block.js';
+export * from './structured-content-commands.js';
 export * from './document-section.js';

--- a/packages/super-editor/src/extensions/structured-content/structured-content-block.js
+++ b/packages/super-editor/src/extensions/structured-content/structured-content-block.js
@@ -57,6 +57,24 @@ export const StructuredContentBlock = Node.create({
         },
       },
 
+      tag: {
+        default: null,
+        parseDOM: (elem) => elem.getAttribute('data-tag'),
+        renderDOM: (attrs) => {
+          if (!attrs.tag) return {};
+          return { 'data-tag': attrs.tag };
+        },
+      },
+
+      alias: {
+        default: null,
+        parseDOM: (elem) => elem.getAttribute('data-alias'),
+        renderDOM: (attrs) => {
+          if (!attrs.alias) return {};
+          return { 'data-alias': attrs.alias };
+        },
+      },
+
       sdtPr: {
         rendered: false,
       },

--- a/packages/super-editor/src/extensions/structured-content/structured-content-commands.js
+++ b/packages/super-editor/src/extensions/structured-content/structured-content-commands.js
@@ -1,0 +1,294 @@
+import { DOMParser as PMDOMParser } from 'prosemirror-model';
+import { Extension } from '@core/index';
+import { htmlHandler } from '@core/InputRule';
+import { findParentNode } from '@helpers/findParentNode';
+import { getStructuredContentTagsById } from './structuredContentHelpers/getStructuredContentTagsById';
+import * as structuredContentHelpers from './structuredContentHelpers/index';
+import { Node } from 'prosemirror-model';
+
+const STRUCTURED_CONTENT_NAMES = ['structuredContent', 'structuredContentBlock'];
+
+/**
+ * @typedef {Object} StructuredContentInlineInsert
+ * @property {string} [text] - Text content to insert
+ * @property {Object} [json] - ProseMirror JSON
+ * @property {Object} [attrs] - Node attributes
+ */
+
+/**
+ * @typedef {Object} StructuredContentBlockInsert
+ * @property {string} [html] - HTML content to insert
+ * @property {Object} [json] - ProseMirror JSON
+ * @property {Object} [attrs] - Node attributes
+ */
+
+/**
+ * @typedef {Object} StructuredContentUpdate
+ * @property {string} [text] - Replace content with text (only for structured content inline)
+ * @property {string} [html] - Replace content with HTML (only for structured content block)
+ * @property {Object} [json] - Replace content with ProseMirror JSON (overrides html)
+ * @property {Object} [attrs] - Update attributes only (preserves content)
+ */
+
+export const StructuredContentCommands = Extension.create({
+  name: 'structuredContentCommands',
+
+  addCommands() {
+    return {
+      /**
+       * Inserts a structured content inline at selection.
+       * @category Command
+       * @param {StructuredContentInlineInsert} options
+       */
+      insertStructuredContentInline:
+        (options = {}) =>
+        ({ editor, dispatch, state, tr }) => {
+          const { schema } = editor;
+          let { from, to } = state.selection;
+
+          if (dispatch) {
+            const selectionText = state.doc.textBetween(from, to);
+
+            let content = null;
+
+            if (selectionText) {
+              content = schema.text(selectionText);
+            }
+
+            if (options.text) {
+              content = schema.text(options.text);
+            }
+
+            if (options.json) {
+              content = schema.nodeFromJSON(options.json);
+            }
+
+            if (!content) {
+              content = schema.text(' ');
+            }
+
+            const attrs = {
+              ...options.attrs,
+              id: options.attrs?.id || randomId(),
+              tag: 'inline_text_sdt',
+              alias: options.attrs?.alias || 'Structured content',
+            };
+            const node = schema.nodes.structuredContent.create(attrs, content, null);
+
+            const parent = findParentNode((node) => node.type.name === 'structuredContent')(state.selection);
+            if (parent) {
+              const insertPos = parent.pos + parent.node.nodeSize;
+              from = to = insertPos;
+            }
+
+            tr.replaceWith(from, to, node);
+          }
+
+          return true;
+        },
+
+      /**
+       * Inserts a structured content block at selection.
+       * @category Command
+       * @param {StructuredContentBlockInsert} options
+       */
+      insertStructuredContentBlock:
+        (options = {}) =>
+        ({ editor, dispatch, state, tr }) => {
+          const { schema } = editor;
+          let { from, to } = state.selection;
+
+          if (dispatch) {
+            const selectionContent = state.selection.content();
+
+            let content = null;
+
+            if (selectionContent.size) {
+              content = selectionContent.content;
+            }
+
+            if (options.html) {
+              const html = htmlHandler(options.html, editor);
+              const doc = PMDOMParser.fromSchema(schema).parse(html);
+              content = doc.content;
+            }
+
+            if (options.json) {
+              content = schema.nodeFromJSON(options.json);
+            }
+
+            if (!content) {
+              content = schema.nodeFromJSON({ type: 'paragraph', content: [] });
+            }
+
+            const attrs = {
+              ...options.attrs,
+              id: options.attrs?.id || randomId(),
+              tag: 'block_table_sdt',
+              alias: options.attrs?.alias || 'Structured content',
+            };
+            const node = schema.nodes.structuredContentBlock.create(attrs, content, null);
+
+            const parent = findParentNode((node) => node.type.name === 'structuredContentBlock')(state.selection);
+            if (parent) {
+              const insertPos = parent.pos + parent.node.nodeSize;
+              from = to = insertPos;
+            }
+
+            tr.replaceRangeWith(from, to, node);
+          }
+
+          return true;
+        },
+
+      /**
+       * Updates a structured content attributes or content.
+       * If the updated node does not match the schema, it will not be updated.
+       * @category Command
+       * @param {string} id
+       * @param {StructuredContentUpdate} options
+       */
+      updateStructuredContentById:
+        (id, options = {}) =>
+        ({ editor, dispatch, state, tr }) => {
+          const structuredContentTags = getStructuredContentTagsById(id, state);
+
+          if (!structuredContentTags.length) {
+            return true;
+          }
+
+          const { schema } = editor;
+
+          if (dispatch) {
+            const structuredContent = structuredContentTags[0];
+            const { pos, node } = structuredContent;
+            const posFrom = pos;
+            const posTo = pos + node.nodeSize;
+
+            let content = null;
+
+            if (options.text) {
+              content = schema.text(options.text);
+            }
+
+            if (options.html) {
+              const html = htmlHandler(options.html, editor);
+              const doc = PMDOMParser.fromSchema(schema).parse(html);
+              content = doc.content;
+            }
+
+            if (options.json) {
+              content = schema.nodeFromJSON(options.json);
+            }
+
+            if (!content) {
+              content = node.content;
+            }
+
+            const updatedNode = node.type.create({ ...node.attrs, ...options.attrs }, content, node.marks);
+            try {
+              updatedNode.check();
+            } catch {
+              console.error('Updated node does not conform to the schema');
+              return false;
+            }
+
+            tr.replaceWith(posFrom, posTo, updatedNode);
+          }
+
+          return true;
+        },
+
+      /**
+       * Removes a structured content.
+       * @category Command
+       * @param {Array<{ node: Node, pos: number }>} structuredContentTags
+       */
+      deleteStructuredContent:
+        (structuredContentTags) =>
+        ({ dispatch, tr }) => {
+          if (!structuredContentTags.length) {
+            return true;
+          }
+
+          if (dispatch) {
+            structuredContentTags.forEach((structuredContent) => {
+              const { pos, node } = structuredContent;
+              const posFrom = tr.mapping.map(pos);
+              const posTo = tr.mapping.map(pos + node.nodeSize);
+              const currentNode = tr.doc.nodeAt(posFrom);
+              if (currentNode && node.eq(currentNode)) {
+                tr.delete(posFrom, posTo);
+              }
+            });
+          }
+
+          return true;
+        },
+
+      /**
+       * Removes a structured content by ID.
+       * @category Command
+       * @param {string | string[]} idOrIds
+       */
+      deleteStructuredContentById:
+        (idOrIds) =>
+        ({ dispatch, state, tr }) => {
+          const structuredContentTags = getStructuredContentTagsById(idOrIds, state);
+
+          if (!structuredContentTags.length) {
+            return true;
+          }
+
+          if (dispatch) {
+            structuredContentTags.forEach((structuredContent) => {
+              const { pos, node } = structuredContent;
+              const posFrom = tr.mapping.map(pos);
+              const posTo = tr.mapping.map(pos + node.nodeSize);
+              const currentNode = tr.doc.nodeAt(posFrom);
+              if (currentNode && node.eq(currentNode)) {
+                tr.delete(posFrom, posTo);
+              }
+            });
+          }
+
+          return true;
+        },
+
+      /**
+       * Removes a structured content at cursor, preserving its content.
+       * @category Command
+       */
+      deleteStructuredContentAtSelection:
+        () =>
+        ({ editor, dispatch, state, tr }) => {
+          const predicate = (node) => STRUCTURED_CONTENT_NAMES.includes(node.type.name);
+          const structuredContent = findParentNode(predicate)(state.selection);
+
+          if (!structuredContent) {
+            return true;
+          }
+
+          if (dispatch) {
+            const { node, pos } = structuredContent;
+            const posFrom = pos;
+            const posTo = posFrom + node.nodeSize;
+            const content = node.content;
+            tr.replaceWith(posFrom, posTo, content);
+          }
+
+          return true;
+        },
+    };
+  },
+
+  addHelpers() {
+    return {
+      ...structuredContentHelpers,
+    };
+  },
+});
+
+const randomId = () => {
+  return Math.floor(Math.random() * 0xffffffff).toString();
+};

--- a/packages/super-editor/src/extensions/structured-content/structured-content.js
+++ b/packages/super-editor/src/extensions/structured-content/structured-content.js
@@ -59,6 +59,24 @@ export const StructuredContent = Node.create({
         },
       },
 
+      tag: {
+        default: null,
+        parseDOM: (elem) => elem.getAttribute('data-tag'),
+        renderDOM: (attrs) => {
+          if (!attrs.tag) return {};
+          return { 'data-tag': attrs.tag };
+        },
+      },
+
+      alias: {
+        default: null,
+        parseDOM: (elem) => elem.getAttribute('data-alias'),
+        renderDOM: (attrs) => {
+          if (!attrs.alias) return {};
+          return { 'data-alias': attrs.alias };
+        },
+      },
+
       sdtPr: {
         rendered: false,
       },

--- a/packages/super-editor/src/extensions/structured-content/structuredContentHelpers/getStructuredContentBlockTags.js
+++ b/packages/super-editor/src/extensions/structured-content/structuredContentHelpers/getStructuredContentBlockTags.js
@@ -1,0 +1,12 @@
+import { findChildren } from '@core/helpers/findChildren';
+import { EditorState } from 'prosemirror-state';
+
+/**
+ * Gets all structured content block tags in the state.
+ * @param {EditorState} state Editor state.
+ * @returns {Array}
+ */
+export function getStructuredContentBlockTags(state) {
+  const result = findChildren(state.doc, (node) => node.type.name === 'structuredContentBlock');
+  return result;
+}

--- a/packages/super-editor/src/extensions/structured-content/structuredContentHelpers/getStructuredContentInlineTags.js
+++ b/packages/super-editor/src/extensions/structured-content/structuredContentHelpers/getStructuredContentInlineTags.js
@@ -1,0 +1,12 @@
+import { findChildren } from '@core/helpers/findChildren';
+import { EditorState } from 'prosemirror-state';
+
+/**
+ * Gets all structured content inline tags in the state.
+ * @param {EditorState} state Editor state.
+ * @returns {Array}
+ */
+export function getStructuredContentInlineTags(state) {
+  const result = findChildren(state.doc, (node) => node.type.name === 'structuredContent');
+  return result;
+}

--- a/packages/super-editor/src/extensions/structured-content/structuredContentHelpers/getStructuredContentTags.js
+++ b/packages/super-editor/src/extensions/structured-content/structuredContentHelpers/getStructuredContentTags.js
@@ -1,0 +1,14 @@
+import { findChildren } from '@core/helpers/findChildren';
+import { EditorState } from 'prosemirror-state';
+
+/**
+ * Gets all structured content tags in the state.
+ * @param {EditorState} state Editor state.
+ * @returns {Array}
+ */
+export function getStructuredContentTags(state) {
+  const result = findChildren(state.doc, (node) => {
+    return node.type.name === 'structuredContent' || node.type.name === 'structuredContentBlock';
+  });
+  return result;
+}

--- a/packages/super-editor/src/extensions/structured-content/structuredContentHelpers/getStructuredContentTagsById.js
+++ b/packages/super-editor/src/extensions/structured-content/structuredContentHelpers/getStructuredContentTagsById.js
@@ -1,0 +1,20 @@
+import { findChildren } from '@core/helpers/findChildren';
+import { EditorState } from 'prosemirror-state';
+
+/**
+ * Gets structured content tags by ID in the state.
+ * @param {string | string[]} idOrIds
+ * @param {EditorState} state Editor state.
+ * @returns {Array}
+ */
+export function getStructuredContentTagsById(idOrIds, state) {
+  const result = findChildren(state.doc, (node) => {
+    const isStructuredContent = ['structuredContent', 'structuredContentBlock'].includes(node.type.name);
+    if (Array.isArray(idOrIds)) {
+      return isStructuredContent && idOrIds.includes(node.attrs.id);
+    } else {
+      return isStructuredContent && node.attrs.id === idOrIds;
+    }
+  });
+  return result;
+}

--- a/packages/super-editor/src/extensions/structured-content/structuredContentHelpers/index.js
+++ b/packages/super-editor/src/extensions/structured-content/structuredContentHelpers/index.js
@@ -1,0 +1,4 @@
+export * from './getStructuredContentTags';
+export * from './getStructuredContentInlineTags';
+export * from './getStructuredContentBlockTags';
+export * from './getStructuredContentTagsById';

--- a/packages/super-editor/src/tests/editor/structuredContent.test.js
+++ b/packages/super-editor/src/tests/editor/structuredContent.test.js
@@ -1,0 +1,110 @@
+import { loadTestDataForEditorTests, initTestEditor } from '@tests/helpers/helpers';
+import { expect } from 'vitest';
+import {
+  getStructuredContentBlockTags,
+  getStructuredContentInlineTags,
+  getStructuredContentTags,
+  getStructuredContentTagsById,
+} from '@extensions/structured-content/structuredContentHelpers/index';
+
+describe('Structured content tests', () => {
+  const filename = 'blank-doc.docx';
+  let docx, media, mediaFiles, fonts, editor;
+
+  beforeAll(async () => ({ docx, media, mediaFiles, fonts } = await loadTestDataForEditorTests(filename)));
+  beforeEach(() => ({ editor } = initTestEditor({ content: docx, media, mediaFiles, fonts })));
+
+  it('tests commands and helpers for structued content inline', () => {
+    editor.commands.insertStructuredContentInline({
+      text: 'Structured content inline 1',
+      attrs: { id: '1' },
+    });
+    editor.commands.insertStructuredContentInline({
+      json: { type: 'text', text: 'Structured content inline 2' },
+      attrs: { id: '2' },
+    });
+
+    expect(getStructuredContentTags(editor.state).length).toBe(2);
+    expect(getStructuredContentInlineTags(editor.state).length).toBe(2);
+    expect(getStructuredContentBlockTags(editor.state).length).toBe(0);
+
+    expect(getStructuredContentTagsById('1', editor.state).length).toBe(1);
+    expect(getStructuredContentTagsById('2', editor.state).length).toBe(1);
+    expect(getStructuredContentTagsById(['1', '2'], editor.state).length).toBe(2);
+
+    const structuredContent1 = getStructuredContentTagsById('1', editor.state)[0];
+    const structuredContent2 = getStructuredContentTagsById('2', editor.state)[0];
+
+    expect(structuredContent1.node.textContent).toBe('Structured content inline 1');
+    expect(structuredContent2.node.textContent).toBe('Structured content inline 2');
+
+    editor.commands.updateStructuredContentById('1', {
+      text: 'Structured content inline 1 - Updated',
+      attrs: { alias: 'Updated' },
+    });
+    editor.commands.updateStructuredContentById('2', {
+      json: { type: 'text', text: 'Structured content inline 2 - Updated' },
+      attrs: { alias: 'Updated' },
+    });
+
+    const structuredContent1Updated = getStructuredContentTagsById('1', editor.state)[0];
+    const structuredContent2Updated = getStructuredContentTagsById('2', editor.state)[0];
+
+    expect(structuredContent1Updated.node.textContent).toBe('Structured content inline 1 - Updated');
+    expect(structuredContent2Updated.node.textContent).toBe('Structured content inline 2 - Updated');
+
+    expect(structuredContent1Updated.node.attrs.alias).toBe('Updated');
+    expect(structuredContent2Updated.node.attrs.alias).toBe('Updated');
+
+    editor.commands.deleteStructuredContentById(['1', '2']);
+
+    expect(getStructuredContentTags(editor.state).length).toBe(0);
+  });
+
+  it('tests commands and helpers for structued content block', () => {
+    editor.commands.insertStructuredContentBlock({
+      html: '<p>Structured content block 1</p>',
+      attrs: { id: '1' },
+    });
+    editor.commands.insertStructuredContentBlock({
+      json: { type: 'paragraph', content: [{ type: 'text', text: 'Structured content block 2' }] },
+      attrs: { id: '2' },
+    });
+
+    expect(getStructuredContentTags(editor.state).length).toBe(2);
+    expect(getStructuredContentBlockTags(editor.state).length).toBe(2);
+    expect(getStructuredContentInlineTags(editor.state).length).toBe(0);
+
+    expect(getStructuredContentTagsById('1', editor.state).length).toBe(1);
+    expect(getStructuredContentTagsById('2', editor.state).length).toBe(1);
+    expect(getStructuredContentTagsById(['1', '2'], editor.state).length).toBe(2);
+
+    const structuredContent1 = getStructuredContentTagsById('1', editor.state)[0];
+    const structuredContent2 = getStructuredContentTagsById('2', editor.state)[0];
+
+    expect(structuredContent1.node.textContent).toBe('Structured content block 1');
+    expect(structuredContent2.node.textContent).toBe('Structured content block 2');
+
+    editor.commands.updateStructuredContentById('1', {
+      html: '<p>Structured content block 1 - Updated</p>',
+      attrs: { alias: 'Updated' },
+    });
+    editor.commands.updateStructuredContentById('2', {
+      json: { type: 'paragraph', content: [{ type: 'text', text: 'Structured content block 2 - Updated' }] },
+      attrs: { alias: 'Updated' },
+    });
+
+    const structuredContent1Updated = getStructuredContentTagsById('1', editor.state)[0];
+    const structuredContent2Updated = getStructuredContentTagsById('2', editor.state)[0];
+
+    expect(structuredContent1Updated.node.textContent).toBe('Structured content block 1 - Updated');
+    expect(structuredContent2Updated.node.textContent).toBe('Structured content block 2 - Updated');
+
+    expect(structuredContent1Updated.node.attrs.alias).toBe('Updated');
+    expect(structuredContent2Updated.node.attrs.alias).toBe('Updated');
+
+    editor.commands.deleteStructuredContent(getStructuredContentTags(editor.state));
+
+    expect(getStructuredContentTags(editor.state).length).toBe(0);
+  });
+});


### PR DESCRIPTION
Linear ticket - SD-75.

Commands:
- insertStructuredContentInline
- insertStructuredContentBlock
- updateStructuredContentById
- deleteStructuredContent
- deleteStructuredContentById
- deleteStructuredContentAtSelection

Helpers:
- getStructuredContentTags
- getStructuredContentBlockTags
- getStructuredContentInlineTags
- getStructuredContentTagsById

Schema and import/export updates.

`packages/super-editor/src/tests/editor/structuredContent.test.js` - tests and usage examples. 