### PR TITLE
fix: structured content style with image

### DIFF
--- a/packages/super-editor/src/assets/styles/extensions/structured-content.css
+++ b/packages/super-editor/src/assets/styles/extensions/structured-content.css
@@ -7,6 +7,11 @@
   position: relative;
 }
 
+.sd-structured-content:has(img),
+.sd-structured-content:has(img) .sd-structured-content__content {
+  display: inline-block;
+}
+
 .sd-structured-content-draggable {
   font-size: 10px;
   align-items: center;


### PR DESCRIPTION
Before:

<img width="412" height="200" alt="Screenshot 2025-10-02 at 11 30 03" src="https://github.com/user-attachments/assets/03d1c198-7002-4060-b548-dbb63c8d002a" />

After:
<img width="366" height="197" alt="Screenshot 2025-10-02 at 11 30 17" src="https://github.com/user-attachments/assets/22c1eae6-d7e9-4aac-a75b-c9982cae022f" />

Note:
- This solution is well supported today and makes sense to me. However, this can be solved in another way if support for older browsers is required.
https://caniuse.com/css-has