### PR TITLE
fix: node views in view mode

### DIFF
--- a/packages/super-editor/src/assets/styles/extensions/document-section.css
+++ b/packages/super-editor/src/assets/styles/extensions/document-section.css
@@ -37,3 +37,12 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+
+.ProseMirror.view-mode .sd-document-section-block {
+  background: none;
+  border: none;
+}
+
+.ProseMirror.view-mode .sd-document-section-block-info {
+  display: none;
+}

--- a/packages/super-editor/src/assets/styles/extensions/structured-content.css
+++ b/packages/super-editor/src/assets/styles/extensions/structured-content.css
@@ -45,3 +45,13 @@
 .sd-structured-content-block:hover .sd-structured-content-draggable {
   display: inline-flex;
 }
+
+.ProseMirror.view-mode .sd-structured-content,
+.ProseMirror.view-mode .sd-structured-content-block {
+  padding: 0;
+  border: none;
+}
+
+.ProseMirror.view-mode .sd-structured-content-draggable {
+  display: none;
+}


### PR DESCRIPTION
For document-section and structured-content in view mode:
- Hide draggable UI.
- No border and background.