### PR TITLE
fix: preserve trailing spaces when inject html

### DIFF
--- a/packages/super-editor/src/core/helpers/htmlSanitizer.js
+++ b/packages/super-editor/src/core/helpers/htmlSanitizer.js
@@ -36,6 +36,11 @@ export function stripHtmlStyles(html) {
     [...node.attributes].forEach((attr) => {
       const name = attr.name.toLowerCase();
 
+      if (node.nodeName.toLowerCase() === 'span') {
+        // Preserve trailing spaces
+        node.innerHTML = node.innerHTML.replace(/(\S) (<\/span>)/g, '$1&nbsp;$2');
+      }
+
       if (name === 'style') {
         const cleanedStyle = cleanStyle(attr.value);
         if (!cleanedStyle) {
@@ -49,11 +54,6 @@ export function stripHtmlStyles(html) {
 
       if (!shouldKeep) {
         node.removeAttribute(attr.name);
-      }
-
-      if (node.nodeName.toLowerCase() === 'span') {
-        // Preserve trailing spaces
-        node.innerHTML = node.innerHTML.replace(/(\S) (<\/span>)/g, '$1&nbsp;$2');
       }
     });
     [...node.children].forEach(cleanNode);


### PR DESCRIPTION
@caio-pizzol didn't add test here since test env can't recognise special symbols like &nbsp; and still renders it as space