### PR TITLE
fix: use SUPERDOC_PAT to trigger e2e tests

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -139,7 +139,7 @@ jobs:
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" \
+            -H "Authorization: Bearer ${{ secrets.SUPERDOC_PAT }}" \
             ${{ secrets.SD_TESTS_URL }} \
             -d '{
               "ref": "main",


### PR DESCRIPTION
It seems like we are not able to trigger E2E tests due to a recent change to the token here. I'm adding the same token we used before to fix it for now.