### PR TITLE
fix: prevent resize decorations in view mode and when editor is not editable

### DIFF
--- a/packages/super-editor/src/extensions/noderesizer/noderesizer.js
+++ b/packages/super-editor/src/extensions/noderesizer/noderesizer.js
@@ -51,6 +51,11 @@ const nodeResizer = (nodeNames = ['image'], editor) => {
 
         if (typeof document === 'undefined' || editor.options.isHeadless) return oldState;
 
+        // Check if document is in view mode or not editable
+        if (editor.options.documentMode === 'viewing' || !editor.isEditable) {
+          return DecorationSet.empty;
+        }
+
         // If selection is not on a resizable node — keep current decorations
         const { selection } = newState;
         const node = selection.node;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents node resize decorations from rendering when the document is in viewing mode or the editor is not editable, with tests updated and added to cover these cases.
> 
> - **NodeResizer**:
>   - Add guard in `packages/super-editor/src/extensions/noderesizer/noderesizer.js` to return `DecorationSet.empty` when `editor.options.documentMode === 'viewing'` or `!editor.isEditable`.
> - **Tests**:
>   - Update existing tests to set `documentMode: 'editing'` and `isEditable: true`.
>   - Add tests ensuring no resize decorations are created in view mode and when the editor is not editable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c02c1ff11604d68bd5a5347397bac70834fa683. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->