### PR TITLE
feat: fix type export on build

### DIFF
--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -40,10 +40,11 @@
   "module": "./dist/superdoc.es.js",
   "scripts": {
     "dev": "vite",
-    "build": "cd ../super-editor && npm run build && cd ../superdoc && vite build && tsc && npm run build:umd",
+    "build": "cd ../super-editor && npm run build && cd ../superdoc && vite build && tsc && npm run verify:types && npm run build:umd",
     "build:es": "cd ../super-editor && npm run build && cd ../superdoc && vite build",
     "watch:es": "nodemon --watch src --watch ../super-editor/src --ext js,ts,vue --exec \"npm run build:es\" --delay 100ms",
     "build:umd": "vite build --config vite.config.umd.js",
+    "verify:types": "node scripts/verify-types.js",
     "release": "release-it --ci --increment=patch",
     "release:next": "release-it --config .release-it.next.json",
     "clean": "rm -rf dist",

--- a/packages/superdoc/scripts/verify-types.js
+++ b/packages/superdoc/scripts/verify-types.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+/**
+ * Build verification script to ensure SuperDoc is properly exported in generated types
+ * This script checks that the main export (SuperDoc) is correctly present in the generated .d.ts files
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const distPath = join(__dirname, '..', 'dist');
+const indexDtsPath = join(distPath, 'index.d.ts');
+
+function verifyTypes() {
+  console.log('🔍 Verifying TypeScript declarations...');
+
+  // Check if dist/index.d.ts exists
+  if (!existsSync(indexDtsPath)) {
+    console.error('❌ Error: dist/index.d.ts not found');
+    console.error('   Run `npm run build` first to generate type declarations');
+    process.exit(1);
+  }
+
+  // Read the index.d.ts file
+  const indexDtsContent = readFileSync(indexDtsPath, 'utf-8');
+
+  // Check for SuperDoc export
+  const hasSuperDocExport =
+    indexDtsContent.includes('export { SuperDoc }') ||
+    indexDtsContent.includes('export * from') ||
+    indexDtsContent.match(/export\s+{\s*[^}]*SuperDoc[^}]*\s*}/);
+
+  if (!hasSuperDocExport) {
+    console.error('❌ Error: SuperDoc is not properly exported in dist/index.d.ts');
+    console.error('   Expected to find: export { SuperDoc }');
+    console.error('   Found content:');
+    console.error('   ' + indexDtsContent.split('\n').slice(0, 5).join('\n   '));
+    process.exit(1);
+  }
+
+  // Check that .d.ts doesn't have incorrect references
+  const hasJsExtensions = indexDtsContent.match(/from\s+["']\.\/.*\.js["']/);
+  if (hasJsExtensions) {
+    console.warn('⚠️  Warning: Type declaration file references .js extensions');
+    console.warn('   This is acceptable but may cause issues in some TypeScript configurations');
+    console.warn('   Found:', hasJsExtensions[0]);
+  }
+
+  console.log('✅ TypeScript declarations verified successfully');
+  console.log('   - SuperDoc export: found');
+  console.log('   - Declaration file: dist/index.d.ts exists');
+}
+
+try {
+  verifyTypes();
+} catch (error) {
+  console.error('❌ Verification failed:', error.message);
+  process.exit(1);
+}

--- a/packages/superdoc/src/core/index.js
+++ b/packages/superdoc/src/core/index.js
@@ -1,1 +1,1 @@
-export * from './SuperDoc.js';
+export { SuperDoc } from './SuperDoc.js';

--- a/packages/superdoc/src/index.js
+++ b/packages/superdoc/src/index.js
@@ -16,7 +16,7 @@ import {
 import { DOCX, PDF, HTML, getFileObject, compareVersions } from '@harbour-enterprises/common';
 import BlankDOCX from '@harbour-enterprises/common/data/blank.docx?url';
 
-export * from './core/index.js';
+export { SuperDoc } from './core/index.js';
 export {
   BlankDOCX,
   getFileObject,


### PR DESCRIPTION
- Introduced a new script `verify-types.js` to ensure proper export of SuperDoc in generated TypeScript declarations.
- Updated the build script in `package.json` to include type verification step.
- Modified exports in `src/index.js` and `src/core/index.js` to explicitly export `SuperDoc`.