### PR TITLE
Rename slashMenu to contextMenu

### DIFF
--- a/packages/super-editor/src/extensions/slash-menu/slash-menu.js
+++ b/packages/super-editor/src/extensions/slash-menu/slash-menu.js
@@ -90,8 +90,9 @@ export const SlashMenu = Extension.create({
                 menuPosition,
               };
 
-              // Emit event after state update
+              // Emit events after state update (back-compat and new name)
               editor.emit('slashMenu:open', { menuPosition });
+              editor.emit('contextMenu:open', { menuPosition });
 
               return newState;
             }
@@ -101,7 +102,9 @@ export const SlashMenu = Extension.create({
             }
 
             case 'close': {
+              // Emit both legacy and new close events
               editor.emit('slashMenu:close');
+              editor.emit('contextMenu:close');
               return { ...value, open: false, anchorPos: null };
             }
 


### PR DESCRIPTION
Add `contextMenu` event aliases to maintain backward compatibility during the rename from `slashMenu`.

---
Linear Issue: [SD-567](https://linear.app/harbour/issue/SD-567/rename-slashmenu-to-contextmenu)

<a href="https://cursor.com/background-agent?bcId=bc-514d72ba-0cec-45d5-8c02-28a069ff61be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-514d72ba-0cec-45d5-8c02-28a069ff61be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

