### PR TITLE
fix: replace tracked change bubble [SD-484]

### DIFF
--- a/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/markDeletion.js
+++ b/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/markDeletion.js
@@ -11,9 +11,10 @@ import { findTrackedMarkBetween } from './findTrackedMarkBetween.js';
  * @param {number} options.to To position.
  * @param {object} options.user User object ({ name, email }).
  * @param {string} options.date Date.
+ * @param {string} options.id Optional ID to use (for replace operations where insertion and deletion share the same ID).
  * @returns {Object} Deletion map and deletionMark
  */
-export const markDeletion = ({ tr, from, to, user, date }) => {
+export const markDeletion = ({ tr, from, to, user, date, id: providedId }) => {
   let trackedMark = findTrackedMarkBetween({
     tr,
     from,
@@ -23,7 +24,10 @@ export const markDeletion = ({ tr, from, to, user, date }) => {
   });
 
   let id;
-  if (trackedMark) {
+  if (providedId) {
+    // Use the provided ID (for replace operations)
+    id = providedId;
+  } else if (trackedMark) {
     id = trackedMark.mark.attrs.id;
   } else {
     id = uuidv4();

--- a/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/replaceStep.js
+++ b/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/replaceStep.js
@@ -81,6 +81,7 @@ export const replaceStep = ({ state, tr, step, newTr, map, user, date, originalS
       to: step.to,
       user,
       date,
+      id: meta.insertedMark?.attrs?.id,
     });
 
     meta.deletionNodes = deletionNodes;


### PR DESCRIPTION
- When replacing text, pass insertion ID to deletion to link with the same ID
- Add tests for single insertion, single deletion and replace

<img width="1678" height="623" alt="image" src="https://github.com/user-attachments/assets/18755bcd-6815-46d4-98d3-7e432ab44633" />
