### PR TITLE
fix: toolbar font-size when multiple selected

### DIFF
--- a/packages/super-editor/src/components/toolbar/ToolbarButton.vue
+++ b/packages/super-editor/src/components/toolbar/ToolbarButton.vue
@@ -125,7 +125,7 @@ const caretIcon = computed(() => {
           v-model="inlineTextInput"
           @keydown.enter.prevent="handleInputSubmit"
           type="text"
-          class="button-text-input"
+          class="button-text-input button-text-input--font-size"
           :class="{ 'high-contrast': isHighContrastMode }"
           :id="'inlineTextInput-' + name"
           autocomplete="off"
@@ -271,6 +271,10 @@ const caretIcon = computed(() => {
   &.high-contrast {
     background-color: #fff;
   }
+}
+
+.button-text-input--font-size {
+  width: 36px;
 }
 
 .button-text-input::placeholder {

--- a/packages/super-editor/src/components/toolbar/defaultItems.js
+++ b/packages/super-editor/src/components/toolbar/defaultItems.js
@@ -153,7 +153,14 @@ export const makeDefaultItems = ({
       ariaLabel: 'Font size',
     },
     options: fontSizeOptions,
-    onActivate: ({ fontSize: size }) => {
+    onActivate: ({ fontSize: size }, isMultiple = false) => {
+      if (isMultiple) {
+        // if there are multiple sizes in the selection.
+        fontSize.label.value = '';
+        fontSize.selectedValue.value = '';
+        return;
+      }
+
       const defaultSize = fontSizeOptions.find((i) => i.label === String(fontSize.defaultLabel.value));
       if (!size) {
         fontSize.label.value = fontSize.defaultLabel.value;
@@ -172,8 +179,6 @@ export const makeDefaultItems = ({
       });
       if (foundSize) {
         fontSize.selectedValue.value = foundSize.key;
-      } else if (defaultSize) {
-        fontSize.selectedValue.value = defaultSize.key;
       } else {
         fontSize.selectedValue.value = '';
       }

--- a/packages/super-editor/src/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/components/toolbar/super-toolbar.js
@@ -790,7 +790,13 @@ export class SuperToolbar extends EventEmitter {
       const activeMark = markNegated ? null : rawActiveMark;
 
       if (activeMark) {
-        item.activate(activeMark.attrs);
+        if (activeMark.name === 'fontSize') {
+          const fontSizes = marks.filter((i) => i.name === 'fontSize').map((i) => i.attrs.fontSize);
+          const isMultiple = [...new Set(fontSizes)].length > 1;
+          item.activate(activeMark.attrs, isMultiple);
+        } else {
+          item.activate(activeMark.attrs);
+        }
       } else {
         item.deactivate();
       }

--- a/packages/super-editor/src/components/toolbar/use-toolbar-item.js
+++ b/packages/super-editor/src/components/toolbar/use-toolbar-item.js
@@ -76,8 +76,8 @@ export const useToolbarItem = (options) => {
   }
 
   // Activation & Deactivation
-  const activate = (attrs) => {
-    onActivate(attrs);
+  const activate = (attrs, ...args) => {
+    onActivate(attrs, ...args);
 
     if (suppressActiveHighlight.value) return;
     active.value = true;

--- a/packages/super-editor/src/tests/toolbar/updateToolbarState.test.js
+++ b/packages/super-editor/src/tests/toolbar/updateToolbarState.test.js
@@ -338,7 +338,7 @@ describe('updateToolbarState', () => {
     toolbar.updateToolbarState();
 
     const fontSizeItem = toolbar.toolbarItems.find((item) => item.name.value === 'fontSize');
-    expect(fontSizeItem.activate).toHaveBeenCalledWith({ fontSize: '20pt' });
+    expect(fontSizeItem.activate).toHaveBeenCalledWith({ fontSize: '20pt' }, false);
     expect(fontSizeItem.activate).not.toHaveBeenCalledWith({ fontSize: '14pt' });
   });
 });


### PR DESCRIPTION
Increase input size.
<img width="217" height="149" alt="Screenshot 2025-10-15 at 17 09 20" src="https://github.com/user-attachments/assets/e853270d-c2e8-462f-828c-37be35546372" />

Empty input if multiple sizes are selected.
<img width="379" height="281" alt="Screenshot 2025-10-15 at 17 09 46" src="https://github.com/user-attachments/assets/20155a1b-f3ee-4b94-96b8-3a9f3d7d2e43" />
