### PR TITLE
Implement getMarkdown export method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4071,7 +4071,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
@@ -4093,7 +4092,6 @@
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/linkify-it": "^5",
@@ -4124,7 +4122,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimatch": {
@@ -5840,7 +5837,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/argv-formatter": {
@@ -12596,7 +12592,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -12998,7 +12993,6 @@
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
@@ -13112,7 +13106,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/media-typer": {
@@ -18246,6 +18239,17 @@
         "w3c-keyname": "^2.2.0"
       }
     },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
+      "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
     "node_modules/prosemirror-model": {
       "version": "1.25.3",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
@@ -18468,7 +18472,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22169,7 +22172,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ufo": {
@@ -24795,6 +24797,7 @@
         "prosemirror-gapcursor": "^1.3.2",
         "prosemirror-history": "^1.4.0",
         "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.0",
         "prosemirror-model": "^1.25.2",
         "prosemirror-schema-basic": "^1.2.2",
         "prosemirror-schema-list": "^1.3.0",
@@ -24977,7 +24980,7 @@
       }
     },
     "packages/superdoc": {
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "buffer-crc32": "^1.0.0",

--- a/packages/super-editor/package.json
+++ b/packages/super-editor/package.json
@@ -53,6 +53,7 @@
     "eventemitter3": "^5.0.1",
     "he": "^1.2.0",
     "jszip": "^3.10.1",
+    "prosemirror-markdown": "^1.13.0",
     "marked": "^16.2.0",
     "prosemirror-commands": "^1.5.2",
     "prosemirror-dropcursor": "^1.8.1",

--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -1,6 +1,7 @@
 import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { DOMSerializer } from 'prosemirror-model';
+import { MarkdownSerializer, defaultMarkdownSerializer } from 'prosemirror-markdown';
 import { yXmlFragmentToProseMirrorRootNode } from 'y-prosemirror';
 import { helpers } from '@core/index.js';
 import { EventEmitter } from './EventEmitter.js';
@@ -1591,6 +1592,15 @@ export class Editor extends EventEmitter {
       html = unflattenListsInHtml(html);
     }
     return html;
+  }
+
+  /**
+   * Get the editor content as Markdown
+   * @returns {string} Editor content as Markdown
+   */
+  getMarkdown() {
+    const serializer = new MarkdownSerializer(defaultMarkdownSerializer.nodes, defaultMarkdownSerializer.marks);
+    return serializer.serialize(this.state.doc);
   }
 
   /**


### PR DESCRIPTION
Add `getMarkdown()` method to the Editor class to provide a more token-efficient content export format.

---
Linear Issue: [SD-727](https://linear.app/superdocworkspace/issue/SD-727/implement-getmarkdown-export-method)

<a href="https://cursor.com/background-agent?bcId=bc-227c347f-a082-4915-87cd-ed18e0624cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-227c347f-a082-4915-87cd-ed18e0624cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

