### PR TITLE
feat: streaming and superdoc-ai demo

### DIFF
--- a/examples/superdoc-ai-quickstart/.env.example
+++ b/examples/superdoc-ai-quickstart/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to ".env" and fill in your API key before running the demo.
+VITE_OPENAI_API_KEY=sk-your-openai-key
+VITE_OPENAI_MODEL=gpt-4o-mini

--- a/examples/superdoc-ai-quickstart/README.md
+++ b/examples/superdoc-ai-quickstart/README.md
@@ -1,0 +1,57 @@
+# SuperDoc AI Quickstart
+
+Launch a live SuperDoc editor with AI helpers. This example shows how to wire up
+`@superdoc-dev/superdoc-ai` with a fresh SuperDoc instance, register a few buttons, and stream results back into the
+document.
+
+## Prerequisites
+
+- Node.js 18+
+- An OpenAI API key (or update the provider section in `src/main.js` for another provider)
+
+## Run the demo
+
+```bash
+cd examples/superdoc-ai-quickstart
+cp .env.example .env               # add your OpenAI key + preferred model
+npm install
+npm run dev
+```
+
+Vite will print a local URL (defaults to <http://localhost:5173>). Open it in your browser and use the action chips at
+the top of the editor to generate, locate, or revise content while the status pill reports progress.
+
+## What this example covers
+
+- creating a SuperDoc instance with a ready-to-edit document
+- initializing `SuperDocAI` after the editor mounts
+- streaming UI feedback via the built-in callbacks
+- wiring multiple AI actions (`insertContent`, `insertTrackedChange`, `highlight`, `replace`, `replaceAll`, `find`,
+  `findAll`, `insertComment`, `insertComments`) through a shared handler
+- safely handling missing API keys and error states
+
+## Key files
+
+- `src/main.js` – core integration logic
+- `src/style.css` – quick styling for the layout and status panel
+- `.env.example` – environment variables expected by the example
+
+## Switching providers
+
+OpenAI is used here, but you can swap in another provider by changing the `provider` block inside
+`initializeAI()` in `src/main.js`. For example, to call a custom HTTP endpoint:
+
+```js
+aiInstance = new SuperDocAI(superdoc, {
+  user: { displayName: 'SuperDoc AI Assistant' },
+  provider: {
+    type: 'http',
+    url: import.meta.env.VITE_AI_HTTP_URL,
+    headers: {
+      Authorization: `Bearer ${import.meta.env.VITE_AI_HTTP_TOKEN}`
+    }
+  }
+});
+```
+
+Restart the dev server after updating environment variables so Vite can pick them up.

--- a/examples/superdoc-ai-quickstart/index.html
+++ b/examples/superdoc-ai-quickstart/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SuperDoc AI Quickstart</title>
+  </head>
+  <body>
+    <div class="page">
+      <div class="page-shell">
+        <header class="page-header">
+          <div>
+            <h1>SuperDoc AI Quickstart</h1>
+            <p>Tap an action to see how SuperDoc AI collaborates with your document.</p>
+          </div>
+            <div class="status-pill">
+              <span>Status</span>
+              <strong id="statusText">Waiting for SuperDoc...</strong>
+            </div>
+        </header>
+
+        <main class="editor-area">
+          <div class="action-bar">
+              <button title="insert" id="insertIntro">Intro Draft</button>
+              <button title="summarize" id="summarizeDoc">Doc Summary</button>
+              <button title="highlight" id="highlightTasks">Highlight Tasks</button>
+              <button title="replace" id="rewriteGoals">Change Title</button>
+              <button title="find" id="findLaunchDate">Find Date</button>
+              <button title="insertComment" id="addSingleComment">Add Comment</button>
+          </div>
+          <div id="superdoc"></div>
+        </main>
+      </div>
+    </div>
+
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/examples/superdoc-ai-quickstart/package.json
+++ b/examples/superdoc-ai-quickstart/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "superdoc-ai-quickstart",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@superdoc-dev/superdoc-ai": "latest",
+    "superdoc": "0.28.0"
+  },
+  "devDependencies": {
+    "vite": "^6.3.5"
+  }
+}

--- a/examples/superdoc-ai-quickstart/src/main.js
+++ b/examples/superdoc-ai-quickstart/src/main.js
@@ -1,0 +1,181 @@
+import { SuperDoc } from 'superdoc';
+import { SuperDocAI } from '@superdoc-dev/superdoc-ai';
+import 'superdoc/style.css';
+import './style.css';
+
+const statusText = document.getElementById('statusText');
+const insertIntroButton = document.getElementById('insertIntro');
+const summarizeDocButton = document.getElementById('summarizeDoc');
+const highlightTasksButton = document.getElementById('highlightTasks');
+const rewriteGoalsButton = document.getElementById('rewriteGoals');
+const findLaunchDateButton = document.getElementById('findLaunchDate');
+const refineLaunchTasksButton = document.getElementById('refineLaunchTasks');
+const addSingleCommentButton = document.getElementById('addSingleComment');
+
+const allButtons = [
+  insertIntroButton,
+  summarizeDocButton,
+  highlightTasksButton,
+  rewriteGoalsButton,
+  findLaunchDateButton,
+  refineLaunchTasksButton,
+  addSingleCommentButton,
+].filter((button) => button instanceof HTMLButtonElement);
+
+let aiInstance = null;
+
+const initialDocument = `
+  <h1>SuperDoc AI Overview</h1>
+  <p>
+    SuperDoc AI is the LLM bridge for SuperDoc editors, packaging provider management and document-context enrichment into one consistent API. It sits directly in the collaborative canvas so teams can call AI assistance the moment content is drafted.
+  </p>
+  <p>
+  Launched on November 1st, 2025, this package seamlessly integrates search, rewriting, highlighting, tracked changes, comment insertion, and streaming completions to maintain editorial momentum. It transforms every SuperDoc workspace into an AI-powered collaborator, enabling teams to uncover insights, implement structured edits, and document feedback—all within a single environment. 
+  </p>
+  <p>
+  The next milestone is to create a comprehensive demos and documentation, and proactively communicating changes to customers to ensure adoption feels effortless.
+  </p>
+
+`;
+
+function setButtonsEnabled(enabled) {
+  allButtons.forEach((button) => {
+    button.disabled = !enabled;
+  });
+}
+
+function handleAction(button, action) {
+  if (!(button instanceof HTMLButtonElement)) {
+    return;
+  }
+
+  button.addEventListener('click', async () => {
+    if (!aiInstance) {
+      statusText.textContent = 'AI is not ready yet. Add your API key and reload.';
+      return;
+    }
+
+    setButtonsEnabled(false);
+
+    try {
+      await aiInstance.waitUntilReady();
+      await action(aiInstance);
+    } catch (error) {
+      console.error(error);
+      statusText.textContent = `AI error: ${error.message}`;
+    } finally {
+      setButtonsEnabled(true);
+    }
+  });
+}
+
+function initializeAI(superdoc) {
+  if (aiInstance) {
+    return aiInstance;
+  }
+
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+  const model = import.meta.env.VITE_OPENAI_MODEL || 'gpt-4o-mini';
+
+  if (!apiKey) {
+    statusText.textContent =
+      'Add VITE_OPENAI_API_KEY to .env then restart the dev server to enable AI actions.';
+    return null;
+  }
+
+  statusText.textContent = 'Connecting to OpenAI...';
+  setButtonsEnabled(false);
+
+  aiInstance = new SuperDocAI(superdoc, {
+    user: {
+      displayName: 'SuperDoc AI Assistant',
+      userId: 'superdoc-ai-demo',
+      // profileUrl: 'your bot url',
+    },
+    provider: {
+      type: 'openai',
+      apiKey,
+      model
+    },
+    enableLogging: false,
+    onReady: () => {
+      statusText.textContent = 'AI is ready. Try one of the quick actions.';
+      setButtonsEnabled(true);
+    },
+    onStreamingStart: () => {
+      statusText.textContent = 'AI is thinking...';
+    },
+    onStreamingEnd: () => {
+      statusText.textContent = 'AI finished. Ready for the next action.';
+    },
+    onError: (error) => {
+      console.error(error);
+      statusText.textContent = `AI error: ${error.message}`;
+      setButtonsEnabled(false);
+    }
+  });
+
+  aiInstance.waitUntilReady().catch((error) => {
+    console.error(error);
+    statusText.textContent = `AI failed to initialize: ${error.message}`;
+  });
+
+  return aiInstance;
+}
+
+const superdoc = new SuperDoc({
+  selector: '#superdoc',
+  documentMode: 'editing',
+  pagination: true,
+  rulers: true,
+  toolbar: '#superdoc-toolbar',
+  onEditorCreate: ({ editor }) => {
+    editor?.commands?.insertContent?.(initialDocument);
+    statusText.textContent = 'SuperDoc is ready. Initializing AI...';
+    initializeAI(superdoc);
+  }
+});
+
+
+const actionBindings = [
+  {
+    button: insertIntroButton,
+    run: (ai) =>
+      ai.action.insertContent(
+        'Add a concise paragraph that lists two immediate next steps for preparing the SuperDoc AI public preview.'
+      ),
+  },
+  {
+    button: summarizeDocButton,
+    run: (ai) =>
+      ai.action.insertTrackedChange(
+        'Suggest an improved language for the first paragraph of the document.'
+      ),
+  },
+  {
+    button: highlightTasksButton,
+    run: (ai) =>
+      ai.action.highlight('Highlight the next milestone.'),
+  },
+  {
+    button: rewriteGoalsButton,
+    run: (ai) =>
+      ai.action.replace(
+        'Rename the document title to a descriptive title.'
+      ),
+  },
+  {
+    button: findLaunchDateButton,
+    run: (ai) =>
+      ai.action.find('Find the sentence that includes the release date.'),
+  },
+  {
+    button: addSingleCommentButton,
+    run: (ai) =>
+      ai.action.insertComment('Add a comment asking stakeholders to add any missing details.'),
+  },
+];
+
+actionBindings.forEach(({button, run}) => handleAction(button, run));
+
+setButtonsEnabled(false);

--- a/examples/superdoc-ai-quickstart/src/style.css
+++ b/examples/superdoc-ai-quickstart/src/style.css
@@ -1,0 +1,136 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #f6f8fb;
+  color: #0f172a;
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.8), rgba(241, 245, 249, 0.95));
+  padding: 3rem 1.5rem;
+}
+
+.page-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  align-items: center;
+}
+
+.page-header {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.page-header h1 {
+  margin: 0 0 0.35rem;
+  font-size: 1.6rem;
+  color: #0f172a;
+}
+
+.page-header > div:first-child {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.page-header p {
+  margin: 0;
+  line-height: 1.45;
+  color: #475569;
+}
+
+.status-pill {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.6rem 1rem;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  min-width: 220px;
+}
+
+.status-pill span {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #3b82f6;
+}
+
+.status-pill strong {
+  font-size: 0.95rem;
+  color: #1e293b;
+  font-weight: 600;
+}
+
+
+
+.action-bar button {
+  padding: 0.65rem 1.1rem;
+  border: none;
+  border-radius: 11px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #0f172a;
+  background: rgba(150, 166, 182, 0.29);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+.action-bar button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.15);
+}
+
+.action-bar button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.editor-area {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.88);
+  border-radius: 1rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  padding: 1.5rem clamp(1rem, 4vw, 2rem);
+}
+
+#superdoc-toolbar {
+  width: 100%;
+  max-width: 820px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0.5rem;
+  border-radius: 0.75rem;
+  background: white;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+#superdoc {
+  width: 100%;
+  margin: 0 auto;
+  background: white;
+  border-radius: 0.75rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+}

--- a/examples/superdoc-ai-quickstart/vite.config.js
+++ b/examples/superdoc-ai-quickstart/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  optimizeDeps: {
+    include: ['superdoc', '@superdoc-dev/superdoc-ai']
+  }
+});

--- a/packages/superdoc-ai/README.md
+++ b/packages/superdoc-ai/README.md
@@ -212,6 +212,7 @@ Generate a summary.
 
 ```typescript
 const result = await ai.action.summarize('create executive summary');
+// onStreamingPartialResult receives partial updates when the provider allows streaming.
 ```
 
 #### `insertContent(instruction)`
@@ -221,6 +222,8 @@ Generate and insert new content.
 ```typescript
 await ai.action.insertContent('write a conclusion paragraph');
 ```
+
+When the provider configuration leaves `streamResults` enabled (default), generated content streams into the document incrementally instead of waiting for the full response.
 
 ## AI Providers
 
@@ -237,6 +240,7 @@ const ai = new SuperDocAI(superdoc, {
     organizationId: 'org-...', // optional
     temperature: 0.7, // optional
     maxTokens: 2000, // optional
+    streamResults: false, // optional (applies to AI insert/summarize actions; default true)
   },
 });
 ```
@@ -254,6 +258,7 @@ const ai = new SuperDocAI(superdoc, {
     baseURL: 'https://api.anthropic.com', // optional
     temperature: 0.7, // optional
     maxTokens: 2000, // optional
+    streamResults: false, // optional (applies to AI insert/summarize actions; default true)
   },
 });
 ```
@@ -272,6 +277,7 @@ const ai = new SuperDocAI(superdoc, {
       'X-Custom-Header': 'value',
     },
     method: 'POST', // default
+    streamResults: true, // optional (used by insertContent/summarize; default true)
     buildRequestBody: (context) => ({
       messages: context.messages,
       stream: context.stream,
@@ -291,6 +297,7 @@ Implement the `AIProvider` interface:
 
 ```typescript
 const customProvider: AIProvider = {
+  streamResults: true,
   async *streamCompletion(messages, options) {
     // Yield chunks
     yield 'chunk1';

--- a/packages/superdoc-ai/package.json
+++ b/packages/superdoc-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdoc-dev/superdoc-ai",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "AI integration package for SuperDoc",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,7 +25,7 @@
     "superdoc": "*"
   },
   "devDependencies": {
-    "superdoc": "^0.26.0",
+    "superdoc": "^0.28.0",
     "@types/node": "^20.0.0",
     "typescript": "^5.0.0",
     "eslint": "^8.0.0",

--- a/packages/superdoc-ai/src/ai-actions.test.ts
+++ b/packages/superdoc-ai/src/ai-actions.test.ts
@@ -104,7 +104,7 @@ describe('AIActions', () => {
                 .mockReturnValueOnce([{ from: 0, to: 6 }])
                 .mockReturnValueOnce([{ from: 7, to: 15 }]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.find('find sample');
 
             expect(result.success).toBe(true);
@@ -117,7 +117,7 @@ describe('AIActions', () => {
                 JSON.stringify({ success: false, results: [] })
             );
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.find('find nothing');
 
             expect(result.success).toBe(false);
@@ -125,14 +125,14 @@ describe('AIActions', () => {
         });
 
         it('should validate input query', async () => {
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             
             await expect(actions.find('')).rejects.toThrow('Query cannot be empty');
             await expect(actions.find('   ')).rejects.toThrow('Query cannot be empty');
         });
 
         it('should return empty when no document context', async () => {
-            const actions = new AIActions(mockProvider, mockEditor, '', false);
+            const actions = new AIActions(mockProvider, mockEditor, () => '', false);
             const result = await actions.find('query');
 
             expect(result).toEqual({ success: false, results: [] });
@@ -157,7 +157,7 @@ describe('AIActions', () => {
                 { from: 20, to: 24 }
             ]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.findAll('find all test');
 
             expect(result.success).toBe(true);
@@ -175,7 +175,7 @@ describe('AIActions', () => {
             mockProvider.getCompletion = vi.fn().mockResolvedValue(response);
             mockEditor.commands.search = vi.fn().mockReturnValue([{ from: 5, to: 17 }]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.highlight('highlight this');
 
             expect(result.success).toBe(true);
@@ -194,7 +194,7 @@ describe('AIActions', () => {
             mockProvider.getCompletion = vi.fn().mockResolvedValue(response);
             mockEditor.commands.search = vi.fn().mockReturnValue([{ from: 0, to: 4 }]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             await actions.highlight('highlight', '#FF0000');
 
             expect(chainApi.setHighlight).toHaveBeenCalledWith('#FF0000');
@@ -209,7 +209,7 @@ describe('AIActions', () => {
             mockProvider.getCompletion = vi.fn().mockResolvedValue(response);
             mockEditor.commands.search = vi.fn().mockReturnValue([]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.highlight('highlight');
 
             expect(result.success).toBe(false);
@@ -229,7 +229,7 @@ describe('AIActions', () => {
             mockProvider.getCompletion = vi.fn().mockResolvedValue(response);
             mockEditor.commands.search = vi.fn().mockReturnValue([{ from: 0, to: 3 }]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.replace('replace old with new');
 
             expect(result.success).toBe(true);
@@ -237,7 +237,7 @@ describe('AIActions', () => {
         });
 
         it('should validate input', async () => {
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             
             await expect(actions.replace('')).rejects.toThrow('Query cannot be empty');
         });
@@ -258,7 +258,7 @@ describe('AIActions', () => {
                 .mockReturnValueOnce([{ from: 0, to: 3 }])
                 .mockReturnValueOnce([{ from: 10, to: 13 }]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.replaceAll('replace all old with new');
 
             expect(result.success).toBe(true);
@@ -278,7 +278,7 @@ describe('AIActions', () => {
             mockProvider.getCompletion = vi.fn().mockResolvedValue(response);
             mockEditor.commands.search = vi.fn().mockReturnValue([{ from: 0, to: 8 }]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.insertTrackedChange('suggest change');
 
             expect(result.success).toBe(true);
@@ -302,7 +302,7 @@ describe('AIActions', () => {
                 .mockReturnValueOnce([{ from: 0, to: 5 }])
                 .mockReturnValueOnce([{ from: 10, to: 16 }]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.insertTrackedChanges('suggest multiple changes');
 
             expect(result.success).toBe(true);
@@ -322,7 +322,7 @@ describe('AIActions', () => {
             mockProvider.getCompletion = vi.fn().mockResolvedValue(response);
             mockEditor.commands.search = vi.fn().mockReturnValue([{ from: 0, to: 4 }]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.insertComment('add comment');
 
             expect(result.success).toBe(true);
@@ -347,7 +347,7 @@ describe('AIActions', () => {
                 .mockReturnValueOnce([{ from: 0, to: 5 }])
                 .mockReturnValueOnce([{ from: 10, to: 15 }]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.insertComments('add multiple comments');
 
             expect(result.success).toBe(true);
@@ -365,7 +365,7 @@ describe('AIActions', () => {
 
             mockProvider.getCompletion = vi.fn().mockResolvedValue(response);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.summarize('summarize this document');
 
             expect(result.success).toBe(true);
@@ -373,10 +373,73 @@ describe('AIActions', () => {
         });
 
         it('should return failure when no document context', async () => {
-            const actions = new AIActions(mockProvider, mockEditor, '', false);
+            const actions = new AIActions(mockProvider, mockEditor, () => '', false);
             const result = await actions.summarize('summarize');
 
             expect(result).toEqual({ results: [], success: false });
+        });
+
+        it('should disable streaming when stream preference is false', async () => {
+            const response = JSON.stringify({
+                success: true,
+                results: [{ suggestedText: 'summary' }]
+            });
+
+            const streamSpy = vi.fn().mockImplementation(async function* () {
+                yield response;
+            });
+            const completionSpy = vi.fn().mockResolvedValue(response);
+
+            mockProvider.streamCompletion = streamSpy as any;
+            mockProvider.getCompletion = completionSpy;
+
+            const actions = new AIActions(
+                mockProvider,
+                mockEditor,
+                () => mockEditor.state.doc.textContent,
+                false,
+                undefined,
+                false
+            );
+
+            const result = await actions.summarize('summarize this document');
+
+            expect(result.success).toBe(true);
+            expect(streamSpy).not.toHaveBeenCalled();
+            expect(completionSpy).toHaveBeenCalled();
+        });
+
+        it('should emit partial summaries via onStreamChunk when streaming', async () => {
+            const streamingChunks = [
+                '{"success":true,"results":[{"suggestedText":"Part ',
+                'One"}]}'
+            ];
+
+            mockProvider.streamCompletion = vi.fn().mockImplementation(async function* () {
+                for (const chunk of streamingChunks) {
+                    yield chunk;
+                }
+            });
+
+            mockProvider.getCompletion = vi.fn().mockResolvedValue(
+                JSON.stringify({ success: true, results: [{ suggestedText: 'Part One' }] })
+            );
+
+            const onStreamChunk = vi.fn();
+            const actions = new AIActions(
+                mockProvider,
+                mockEditor,
+                () => mockEditor.state.doc.textContent,
+                false,
+                onStreamChunk,
+                true
+            );
+
+            const result = await actions.summarize('summarize this document');
+
+            expect(result.success).toBe(true);
+            expect(onStreamChunk).toHaveBeenCalled();
+            expect(onStreamChunk.mock.calls.at(-1)?.[0]).toBe('Part One');
         });
     });
 
@@ -391,12 +454,11 @@ describe('AIActions', () => {
 
             mockProvider.getCompletion = vi.fn().mockResolvedValue(response);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.insertContent('generate introduction');
 
             expect(result.success).toBe(true);
-            expect(mockEditor.commands.insertContentAt).toHaveBeenCalledWith(
-                100,
+            expect(mockEditor.commands.insertContent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     type: 'text',
                     text: 'New content to insert'
@@ -405,13 +467,13 @@ describe('AIActions', () => {
         });
 
         it('should validate input', async () => {
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             
             await expect(actions.insertContent('')).rejects.toThrow('Query cannot be empty');
         });
 
         it('should return failure when no editor', async () => {
-            const actions = new AIActions(mockProvider, null, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, null, () => mockEditor.state.doc.textContent, false);
             const result = await actions.insertContent('insert content');
 
             expect(result).toEqual({ success: false, results: [] });
@@ -425,10 +487,82 @@ describe('AIActions', () => {
 
             mockProvider.getCompletion = vi.fn().mockResolvedValue(response);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.insertContent('insert content');
 
             expect(result).toEqual({ success: false, results: [] });
+        });
+
+        it('should stream content chunks into the editor when enabled', async () => {
+            const finalPayload = JSON.stringify({
+                success: true,
+                results: [{ suggestedText: 'Generated content' }]
+            });
+
+            const streamingChunks = [
+                '{"success":true,"results":[{"suggestedText":"Generated ',
+                'content"}]}'
+            ];
+
+            const streamedPieces: string[] = [];
+            mockEditor.commands.insertContent = vi.fn((content: { text: string }) => {
+                streamedPieces.push(content.text);
+            });
+
+            mockProvider.streamCompletion = vi.fn().mockImplementation(async function* () {
+                for (const chunk of streamingChunks) {
+                    yield chunk;
+                }
+            });
+
+            mockProvider.getCompletion = vi.fn().mockResolvedValue(finalPayload);
+
+            const actions = new AIActions(
+                mockProvider,
+                mockEditor,
+                () => mockEditor.state.doc.textContent,
+                false,
+                undefined,
+                true
+            );
+
+            const result = await actions.insertContent('generate introduction');
+
+            expect(result.success).toBe(true);
+            expect(streamedPieces.join('')).toBe('Generated content');
+            expect(streamedPieces.length).toBeGreaterThan(1);
+        });
+
+        it('should disable streaming when stream preference is false', async () => {
+            const response = JSON.stringify({
+                success: true,
+                results: [{
+                    suggestedText: 'Generated content'
+                }]
+            });
+
+            const streamSpy = vi.fn().mockImplementation(async function* () {
+                yield response;
+            });
+            const completionSpy = vi.fn().mockResolvedValue(response);
+
+            mockProvider.streamCompletion = streamSpy as any;
+            mockProvider.getCompletion = completionSpy;
+
+            const actions = new AIActions(
+                mockProvider,
+                mockEditor,
+                () => mockEditor.state.doc.textContent,
+                false,
+                undefined,
+                false
+            );
+
+            const result = await actions.insertContent('generate introduction');
+
+            expect(result.success).toBe(true);
+            expect(streamSpy).not.toHaveBeenCalled();
+            expect(completionSpy).toHaveBeenCalled();
         });
     });
 
@@ -440,7 +574,7 @@ describe('AIActions', () => {
             mockEditor.commands.search = vi.fn().mockReturnValue([{ from: 0, to: 4 }]);
 
             // Test with logging disabled
-            const actions1 = new AIActions(mockProvider, mockEditor, 'context', false);
+            const actions1 = new AIActions(mockProvider, mockEditor, () => 'context', false);
             const response1 = JSON.stringify({
                 success: true,
                 results: [{ originalText: 'test', suggestedText: 'new' }]
@@ -464,7 +598,7 @@ describe('AIActions', () => {
             mockProvider.getCompletion = vi.fn().mockResolvedValue(response);
             mockEditor.commands.search = vi.fn().mockReturnValue([]);
 
-            const actions = new AIActions(mockProvider, mockEditor, mockEditor.state.doc.textContent, false);
+            const actions = new AIActions(mockProvider, mockEditor, () => mockEditor.state.doc.textContent, false);
             const result = await actions.replace('replace text');
 
             expect(result.results).toHaveLength(0);

--- a/packages/superdoc-ai/src/editor-adapter.test.ts
+++ b/packages/superdoc-ai/src/editor-adapter.test.ts
@@ -257,16 +257,7 @@ describe('EditorAdapter', () => {
 
             await mockAdapter.insertText('New content');
 
-            const expectedPos = mockEditor.state.doc.content.size;
-            const expectedFrom = Math.max(0, expectedPos - 50);
-
-            expect(mockEditor.commands.setTextSelection).toHaveBeenCalledWith({
-                from: expectedFrom,
-                to: expectedPos
-            });
-
-            expect(mockEditor.commands.insertContentAt).toHaveBeenCalledWith(
-                expectedPos,
+            expect(mockEditor.commands.insertContent).toHaveBeenCalledWith(
                 {
                     type: 'text',
                     text: 'New content',
@@ -275,24 +266,12 @@ describe('EditorAdapter', () => {
             );
         });
 
-        it('clamps selection start to zero when document is short', async () => {
-            mockEditor.state.doc.content.size = 20;
-
-            await mockAdapter.insertText('Short doc content');
-
-            expect(mockEditor.commands.setTextSelection).toHaveBeenCalledWith({
-                from: 0,
-                to: 20
-            });
-        });
-
         it('should handle empty marks when inserting', async () => {
             mockEditor.commands.getSelectionMarks = vi.fn().mockReturnValue([]);
 
             await mockAdapter.insertText('Plain text');
 
-            expect(mockEditor.commands.insertContentAt).toHaveBeenCalledWith(
-                expect.any(Number),
+            expect(mockEditor.commands.insertContent).toHaveBeenCalledWith(
                 {
                     type: 'text',
                     text: 'Plain text',

--- a/packages/superdoc-ai/src/editor-adapter.ts
+++ b/packages/superdoc-ai/src/editor-adapter.ts
@@ -114,11 +114,8 @@ export class EditorAdapter {
 
     // Insert operations
     async insertText(suggestedText: string): Promise<void> {
-        const pos: number = this.editor.state.doc.content.size;
-        const from: number = Math.max(0, pos - 50);
-        this.editor.commands.setTextSelection({ from, to: pos });
         const marks = this.editor.commands.getSelectionMarks() as MarkType[];
-        this.editor.commands.insertContentAt(pos, {
+        this.editor.commands.insertContent({
             type: 'text',
             text: suggestedText,
             marks: marks.map((mark: MarkType) => ({

--- a/packages/superdoc-ai/src/types.ts
+++ b/packages/superdoc-ai/src/types.ts
@@ -59,6 +59,8 @@ export type StreamOptions = {
     providerOptions?: Record<string, unknown>;
     /** Document identifier for tracking */
     documentId?: string;
+    /** Force streaming (true) or disable it (false). Defaults to true when supported. */
+    stream?: boolean;
 }
 
 /**
@@ -70,6 +72,8 @@ export type CompletionOptions = StreamOptions;
  * Interface that all AI providers must implement
  */
 export type AIProvider = {
+    /** Indicates whether the provider prefers streaming responses by default */
+    streamResults?: boolean;
     /** Stream completion with incremental results */
     streamCompletion(messages: AIMessage[], options?: StreamOptions): AsyncGenerator<string, void, unknown>;
     /** Get complete response in one call */


### PR DESCRIPTION
In this PR I'm adding a new option to our superdoc-ai where the results can be streamed back if the user pass streamResults: true. this is not just making the provider stream the results but receiving the results format it and stream it to the UI as well.  
When streamResults is true SuperDoc AI will pass stream: true to the provider and the actions: insertContent, and summarize will stream the results back
