### PR TITLE
refactor: remove node schema check in structured content commands

### DIFF
--- a/packages/super-editor/src/extensions/structured-content/structured-content-commands.js
+++ b/packages/super-editor/src/extensions/structured-content/structured-content-commands.js
@@ -223,12 +223,6 @@ export const StructuredContentCommands = Extension.create({
             }
 
             const updatedNode = node.type.create({ ...node.attrs, ...options.attrs }, content, node.marks);
-            try {
-              updatedNode.check();
-            } catch {
-              console.error('Updated node does not conform to the schema');
-              return false;
-            }
 
             tr.replaceWith(posFrom, posTo, updatedNode);
           }


### PR DESCRIPTION
on the frontend proseMirror can handle multiple marks by itself, when in the headless mode that is causing an error and requires additional sanitizations. 