### PR TITLE
refactor: move node specific functions from exporter.js

### DIFF
--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -1,16 +1,12 @@
 import { SuperConverter } from './SuperConverter.js';
 import { inchesToTwips, linesToTwips, rgbToHex } from './helpers.js';
-import { generateDocxRandomId } from '@helpers/generateDocxRandomId.js';
 import { DEFAULT_DOCX_DEFS } from './exporter-docx-defs.js';
-import { carbonCopy } from '../utilities/carbonCopy.js';
 import { translateChildNodes } from './v2/exporter/helpers/index.js';
 import { translator as wBrNodeTranslator } from './v3/handlers/w/br/br-translator.js';
 import { translator as wHighlightTranslator } from './v3/handlers/w/highlight/highlight-translator.js';
 import { translator as wTabNodeTranslator } from './v3/handlers/w/tab/tab-translator.js';
 import { translator as wPNodeTranslator } from './v3/handlers/w/p/p-translator.js';
-import { translator as wPPrNodeTranslator } from './v3/handlers/w/pPr/pPr-translator.js';
 import { translator as wRNodeTranslator } from './v3/handlers/w/r/r-translator.js';
-import { translator as wRPrNodeTranslator } from './v3/handlers/w/rpr/rpr-translator.js';
 import { translator as wTcNodeTranslator } from './v3/handlers/w/tc/tc-translator';
 import { translator as wTrNodeTranslator } from './v3/handlers/w/tr/tr-translator.js';
 import { translator as wSdtNodeTranslator } from './v3/handlers/w/sdt/sdt-translator';
@@ -28,9 +24,6 @@ import { translator as sdTableOfContentsTranslator } from '@converter/v3/handler
 import { translator as pictTranslator } from './v3/handlers/w/pict/pict-translator';
 import { translateVectorShape, translateShapeGroup } from '@converter/v3/handlers/wp/helpers/decode-image-node-helpers';
 import { translator as wTextTranslator } from '@converter/v3/handlers/w/t';
-import { combineRunProperties, decodeRPrFromMarks } from '@converter/styles.js';
-
-const RUN_LEVEL_WRAPPERS = new Set(['w:hyperlink', 'w:ins', 'w:del']);
 
 const DEFAULT_SECTION_PROPS_TWIPS = Object.freeze({
   pageSize: Object.freeze({ width: '12240', height: '15840' }),
@@ -104,59 +97,6 @@ export const isLineBreakOnlyRun = (node) => {
   if (!runContent.length) return false;
   return runContent.every((child) => child?.type === 'lineBreak' || child?.type === 'hardBreak');
 };
-
-/**
- * Convert SDT child elements into Word run elements.
- * @param {Array<Object>|Object} elements
- * @returns {Array<Object>}
- */
-export function convertSdtContentToRuns(elements) {
-  const normalized = Array.isArray(elements) ? elements : [elements];
-  const runs = [];
-
-  normalized.forEach((element) => {
-    if (!element) return;
-
-    if (element.name === 'w:sdtPr') {
-      return;
-    }
-
-    if (element.name === 'w:r') {
-      runs.push(element);
-      return;
-    }
-
-    if (element.name === 'w:sdt') {
-      // Recursively flatten nested SDTs into the surrounding run sequence, skipping property bags.
-      const sdtContent = (element.elements || []).find((child) => child?.name === 'w:sdtContent');
-      if (sdtContent?.elements) {
-        runs.push(...convertSdtContentToRuns(sdtContent.elements));
-      }
-      return;
-    }
-
-    if (RUN_LEVEL_WRAPPERS.has(element.name)) {
-      const wrapperElements = convertSdtContentToRuns(element.elements || []);
-      if (wrapperElements.length) {
-        runs.push({
-          ...element,
-          elements: wrapperElements,
-        });
-      }
-      return;
-    }
-
-    if (element.name) {
-      runs.push({
-        name: 'w:r',
-        type: 'element',
-        elements: element.elements || [element],
-      });
-    }
-  });
-
-  return runs.filter((run) => Array.isArray(run.elements) && run.elements.length > 0);
-}
 
 /**
  * @typedef {Object} ExportParams
@@ -341,85 +281,7 @@ function translateHeadingNode(params) {
   };
 
   // Use existing paragraph translator with the modified node
-  return translateParagraphNode({ ...params, node: paragraphNode });
-}
-
-/**
- * Translate a paragraph node
- *
- * @param {ExportParams} node A prose mirror paragraph node
- * @returns {XmlReadyNode} JSON of the XML-ready paragraph node
- */
-export function translateParagraphNode(params) {
-  const elements = translateChildNodes(params);
-
-  // Replace current paragraph with content of html annotation
-  const htmlAnnotationChild = elements.find((element) => element.name === 'htmlAnnotation');
-  if (htmlAnnotationChild) {
-    return htmlAnnotationChild.elements;
-  }
-
-  // Insert paragraph properties at the beginning of the elements array
-  const pPr = generateParagraphProperties(params);
-  if (pPr) elements.unshift(pPr);
-
-  let attributes = {};
-  if (params.node.attrs?.rsidRDefault) {
-    attributes['w:rsidRDefault'] = params.node.attrs.rsidRDefault;
-  }
-
-  const result = {
-    name: 'w:p',
-    elements,
-    attributes,
-  };
-
-  return result;
-}
-
-/**
- * Generate the w:pPr props for a paragraph node
- *
- * @param {SchemaNode} node
- * @returns {XmlReadyNode} The paragraph properties node
- */
-export function generateParagraphProperties(params) {
-  const { node } = params;
-  const { attrs = {} } = node;
-
-  const paragraphProperties = carbonCopy(attrs.paragraphProperties || {});
-  if (attrs.styleId !== paragraphProperties.styleId) {
-    paragraphProperties.styleId = attrs.styleId;
-  }
-
-  // Check which properties have changed
-  ['borders', 'styleId', 'indent', 'textAlign', 'keepLines', 'keepNext', 'spacing', 'tabStops'].forEach((key) => {
-    let propKey = key === 'textAlign' ? 'justification' : key;
-    if (JSON.stringify(paragraphProperties[propKey]) !== JSON.stringify(attrs[key])) {
-      paragraphProperties[key] = attrs[key];
-    }
-  });
-
-  const framePr = attrs.dropcap;
-  if (framePr) {
-    framePr.dropCap = framePr.type;
-    delete framePr.type;
-  }
-  if (JSON.stringify(paragraphProperties.framePr) !== JSON.stringify(framePr)) {
-    paragraphProperties.framePr = framePr;
-  }
-
-  // Get run properties from marksAttrs
-  const marksProps = decodeRPrFromMarks(attrs.marksAttrs || []);
-  const finalRunProps = combineRunProperties([paragraphProperties.runProperties || {}, marksProps]);
-  paragraphProperties.runProperties = finalRunProps;
-
-  const pPr = wPPrNodeTranslator.decode({ node: { ...node, attrs: { paragraphProperties } } });
-  const sectPr = node.attrs?.paragraphProperties?.sectPr;
-  if (sectPr) {
-    pPr.elements.push(sectPr);
-  }
-  return pPr;
+  return wPNodeTranslator.decode({ ...params, node: paragraphNode });
 }
 
 /**
@@ -442,79 +304,6 @@ function translateDocumentNode(params) {
   };
 
   return [node, params];
-}
-
-/**
- * Helper function to be used for text node translation
- * Also used for transforming text annotations for the final submit
- *
- * @param {String} text Text node's content
- * @param {Object[]} marks The marks to add to the run properties
- * @returns {XmlReadyNode} The translated text node
- */
-
-export function getTextNodeForExport(text, marks, params) {
-  const hasLeadingOrTrailingSpace = /^\s|\s$/.test(text);
-  const space = hasLeadingOrTrailingSpace ? 'preserve' : null;
-  const nodeAttrs = space ? { 'xml:space': space } : null;
-  const textNodes = [];
-
-  const textRunProperties = decodeRPrFromMarks(marks || []);
-  const parentRunProperties = params.extraParams?.runProperties || {};
-  const combinedRunProperties = combineRunProperties([parentRunProperties, textRunProperties]);
-  const rPrNode = wRPrNodeTranslator.decode({ node: { attrs: { runProperties: combinedRunProperties } } });
-
-  textNodes.push({
-    name: 'w:t',
-    elements: [{ text, type: 'text' }],
-    attributes: nodeAttrs,
-  });
-
-  // For custom mark export, we need to add a bookmark start and end tag
-  // And store attributes in the bookmark name
-  if (params) {
-    const { editor } = params;
-    const customMarks = editor.extensionService.extensions.filter((e) => e.isExternal === true);
-
-    marks.forEach((mark) => {
-      const isCustomMark = customMarks.some((customMark) => {
-        const customMarkName = customMark.name;
-        return mark.type === customMarkName;
-      });
-
-      if (!isCustomMark) return;
-
-      let attrsString = '';
-      Object.entries(mark.attrs).forEach(([key, value]) => {
-        if (value) {
-          attrsString += `${key}=${value};`;
-        }
-      });
-
-      if (isCustomMark) {
-        textNodes.unshift({
-          type: 'element',
-          name: 'w:bookmarkStart',
-          attributes: {
-            'w:id': '5000',
-            'w:name': mark.type + ';' + attrsString,
-          },
-        });
-        textNodes.push({
-          type: 'element',
-          name: 'w:bookmarkEnd',
-          attributes: {
-            'w:id': '5000',
-          },
-        });
-      }
-    });
-  }
-
-  return {
-    name: 'w:r',
-    elements: rPrNode ? [rPrNode, ...textNodes] : textNodes,
-  };
 }
 
 /**
@@ -567,79 +356,6 @@ export function processOutputMarks(marks = []) {
       return translateMark(mark);
     }
   });
-}
-
-export function processLinkContentNode(node) {
-  if (!node) return node;
-
-  const contentNode = carbonCopy(node);
-  if (!contentNode) return contentNode;
-
-  const hyperlinkStyle = {
-    name: 'w:rStyle',
-    attributes: { 'w:val': 'Hyperlink' },
-  };
-  const color = {
-    name: 'w:color',
-    attributes: { 'w:val': '467886' },
-  };
-  const underline = {
-    name: 'w:u',
-    attributes: {
-      'w:val': 'none',
-    },
-  };
-
-  if (contentNode.name === 'w:r') {
-    const runProps = contentNode.elements.find((el) => el.name === 'w:rPr');
-
-    if (runProps) {
-      const foundColor = runProps.elements.find((el) => el.name === 'w:color');
-      const foundHyperlinkStyle = runProps.elements.find((el) => el.name === 'w:rStyle');
-      const underlineMark = runProps.elements.find((el) => el.name === 'w:u');
-      if (!foundColor) runProps.elements.unshift(color);
-      if (!foundHyperlinkStyle) runProps.elements.unshift(hyperlinkStyle);
-      if (!underlineMark) runProps.elements.unshift(underline);
-    } else {
-      // we don't add underline by default
-      const runProps = {
-        name: 'w:rPr',
-        elements: [hyperlinkStyle, color],
-      };
-
-      contentNode.elements.unshift(runProps);
-    }
-  }
-
-  return contentNode;
-}
-
-/**
- * Create a new link relationship and add it to the relationships array
- *
- * @param {ExportParams} params
- * @param {string} link The URL of this link
- * @returns {string} The new relationship ID
- */
-export function addNewLinkRelationship(params, link) {
-  const newId = 'rId' + generateDocxRandomId();
-
-  if (!params.relationships || !Array.isArray(params.relationships)) {
-    params.relationships = [];
-  }
-
-  params.relationships.push({
-    type: 'element',
-    name: 'Relationship',
-    attributes: {
-      Id: newId,
-      Type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink',
-      Target: link,
-      TargetMode: 'External',
-    },
-  });
-
-  return newId;
 }
 
 /**
@@ -766,24 +482,6 @@ function translateMark(mark) {
   }
 
   return markElement;
-}
-
-export function translateHardBreak(params) {
-  const { node = {} } = params;
-  const { attrs = {} } = node;
-  const { pageBreakSource } = attrs;
-  if (pageBreakSource === 'sectPr') return null;
-
-  return {
-    name: 'w:r',
-    elements: [
-      {
-        name: 'w:br',
-        type: 'element',
-        attributes: { 'w:type': 'page' },
-      },
-    ],
-  };
 }
 
 export class DocxExporter {

--- a/packages/super-editor/src/core/super-converter/v2/exporter/commentsExporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/exporter/commentsExporter.js
@@ -1,4 +1,4 @@
-import { translateParagraphNode } from '../../exporter.js';
+import { translator as wPTranslator } from '@converter/v3/handlers/w/p';
 import { carbonCopy } from '../../../utilities/carbonCopy.js';
 import { COMMENT_REF, COMMENTS_XML_DEFINITIONS } from '../../exporter-docx-defs.js';
 import { generateRandom32BitHex } from '../../../helpers/generateDocxRandomId.js';
@@ -26,7 +26,7 @@ export const prepareCommentParaIds = (comment) => {
  * @returns {Object} The w:comment node for the comment
  */
 export const getCommentDefinition = (comment, commentId, allComments, editor) => {
-  const translatedText = translateParagraphNode({ editor, node: comment.commentJSON });
+  const translatedText = wPTranslator.decode({ editor, node: comment.commentJSON });
   const attributes = {
     'w:id': String(commentId),
     'w:author': comment.creatorName || comment.importedAuthor?.name,

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/hyperlink/hyperlink-translator.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/hyperlink/hyperlink-translator.js
@@ -158,13 +158,13 @@ function _addNewLinkRelationship(params, link) {
     type: 'element',
     name: 'Relationship',
     attributes: {
-      Id: id,
+      Id: `rId${id}`,
       Type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink',
       Target: link,
       TargetMode: 'External',
     },
   });
-  return id;
+  return `rId${id}`;
 }
 
 /** @type {import('@translator').NodeTranslatorConfig} */

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/hyperlink/hyperlink-translator.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/hyperlink/hyperlink-translator.test.js
@@ -241,8 +241,8 @@ describe('w:hyperlink translator', () => {
 
       const result = translator.decode(params);
 
-      expect(result.attributes['r:id']).toBe('new-random-id');
-      expect(params.relationships[0].attributes.Id).toBe('new-random-id');
+      expect(result.attributes['r:id']).toBe('rIdnew-random-id');
+      expect(params.relationships[0].attributes.Id).toBe('rIdnew-random-id');
       expect(generateDocxRandomId).toHaveBeenCalled();
     });
 

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/p/helpers/generate-paragraph-properties.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/p/helpers/generate-paragraph-properties.js
@@ -1,0 +1,48 @@
+import { carbonCopy } from '@core/utilities/carbonCopy.js';
+import { combineRunProperties, decodeRPrFromMarks } from '@converter/styles.js';
+import { translator as wPPrNodeTranslator } from '../../pPr/pPr-translator.js';
+
+/**
+ * Generate the w:pPr props for a paragraph node
+ *
+ * @param {SchemaNode} node
+ * @returns {XmlReadyNode} The paragraph properties node
+ */
+export function generateParagraphProperties(params) {
+  const { node } = params;
+  const { attrs = {} } = node;
+
+  const paragraphProperties = carbonCopy(attrs.paragraphProperties || {});
+  if (attrs.styleId !== paragraphProperties.styleId) {
+    paragraphProperties.styleId = attrs.styleId;
+  }
+
+  // Check which properties have changed
+  ['borders', 'styleId', 'indent', 'textAlign', 'keepLines', 'keepNext', 'spacing', 'tabStops'].forEach((key) => {
+    let propKey = key === 'textAlign' ? 'justification' : key;
+    if (JSON.stringify(paragraphProperties[propKey]) !== JSON.stringify(attrs[key])) {
+      paragraphProperties[propKey] = attrs[key];
+    }
+  });
+
+  const framePr = attrs.dropcap;
+  if (framePr) {
+    framePr.dropCap = framePr.type;
+    delete framePr.type;
+  }
+  if (JSON.stringify(paragraphProperties.framePr) !== JSON.stringify(framePr)) {
+    paragraphProperties.framePr = framePr;
+  }
+
+  // Get run properties from marksAttrs
+  const marksProps = decodeRPrFromMarks(attrs.marksAttrs || []);
+  const finalRunProps = combineRunProperties([paragraphProperties.runProperties || {}, marksProps]);
+  paragraphProperties.runProperties = finalRunProps;
+
+  const pPr = wPPrNodeTranslator.decode({ node: { ...node, attrs: { paragraphProperties } } });
+  const sectPr = node.attrs?.paragraphProperties?.sectPr;
+  if (sectPr) {
+    pPr.elements.push(sectPr);
+  }
+  return pPr;
+}

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/p/helpers/generate-paragraph-properties.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/p/helpers/generate-paragraph-properties.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { generateParagraphProperties } from './generate-paragraph-properties.js';
+
+describe('generateParagraphProperties indent', () => {
+  it('includes zero-value indents when explicitly provided', () => {
+    const node = {
+      type: 'paragraph',
+      attrs: {
+        indent: {
+          left: 0,
+          right: 0,
+          firstLine: 0,
+          hanging: 0,
+          explicitLeft: true,
+          explicitRight: true,
+          explicitFirstLine: true,
+          explicitHanging: true,
+        },
+      },
+    };
+
+    const result = generateParagraphProperties({ node });
+    const indentElement = result.elements.find((el) => el.name === 'w:ind');
+
+    expect(indentElement).toBeDefined();
+    expect(indentElement.attributes['w:left']).toBe('0');
+    expect(indentElement.attributes['w:right']).toBe('0');
+    expect(indentElement.attributes['w:firstLine']).toBe('0');
+    expect(indentElement.attributes['w:hanging']).toBe('0');
+  });
+});
+
+describe('generateParagraphProperties', () => {
+  it('updates changed attrs, merges run props and keeps original paragraph properties untouched', () => {
+    const originalParagraphProperties = {
+      styleId: 'Body',
+      indent: { left: 100 },
+      runProperties: { color: { val: '111111' } },
+    };
+    const params = {
+      node: {
+        type: 'paragraph',
+        attrs: {
+          styleId: 'Heading1',
+          textAlign: 'center',
+          indent: { left: 240 },
+          marksAttrs: [
+            { type: 'textStyle', attrs: { color: '#FF0000' } },
+            { type: 'italic', attrs: { value: true } },
+          ],
+          paragraphProperties: originalParagraphProperties,
+        },
+      },
+    };
+    const result = generateParagraphProperties(params);
+    const getElement = (name) => result.elements.find((el) => el.name === name);
+
+    const styleElement = getElement('w:pStyle');
+    expect(styleElement?.attributes?.['w:val']).toBe('Heading1');
+
+    const justificationElement = getElement('w:jc');
+    expect(justificationElement?.attributes?.['w:val']).toBe('center');
+
+    const indentElement = getElement('w:ind');
+    expect(indentElement?.attributes?.['w:left']).toBe('240');
+
+    const runPropertiesElement = getElement('w:rPr');
+    expect(runPropertiesElement).toBeDefined();
+    const colorElement = runPropertiesElement.elements.find((el) => el.name === 'w:color');
+    expect(colorElement?.attributes?.['w:val']).toBe('FF0000');
+    const italicElement = runPropertiesElement.elements.find((el) => el.name === 'w:i');
+    expect(italicElement?.attributes).toEqual({});
+
+    expect(originalParagraphProperties).toEqual({
+      styleId: 'Body',
+      indent: { left: 100 },
+      runProperties: { color: { val: '111111' } },
+    });
+  });
+
+  it('transforms dropcap to framePr and appends sectPr to decoded elements', () => {
+    const sectPr = { name: 'w:sectPr', type: 'element', attributes: { id: 'sect-1' }, elements: [] };
+
+    const params = {
+      node: {
+        type: 'paragraph',
+        attrs: {
+          dropcap: { type: 'drop', lines: 2 },
+          paragraphProperties: {
+            framePr: { wrap: 'around' },
+            sectPr,
+          },
+        },
+      },
+    };
+
+    const result = generateParagraphProperties(params);
+
+    const framePrElement = result.elements.find((el) => el.name === 'w:framePr');
+    expect(framePrElement?.attributes?.['w:dropCap']).toBe('drop');
+    expect(framePrElement?.attributes?.['w:lines']).toBe('2');
+    expect(result.elements[result.elements.length - 1]).toBe(sectPr);
+  });
+});

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/p/helpers/translate-paragraph-node.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/p/helpers/translate-paragraph-node.js
@@ -1,0 +1,35 @@
+import { translateChildNodes } from '@converter/v2/exporter/helpers/index.js';
+import { generateParagraphProperties } from './generate-paragraph-properties.js';
+
+/**
+ * Translate a paragraph node
+ *
+ * @param {ExportParams} node A prose mirror paragraph node
+ * @returns {XmlReadyNode} JSON of the XML-ready paragraph node
+ */
+export function translateParagraphNode(params) {
+  const elements = translateChildNodes(params);
+
+  // Replace current paragraph with content of html annotation
+  const htmlAnnotationChild = elements.find((element) => element.name === 'htmlAnnotation');
+  if (htmlAnnotationChild) {
+    return htmlAnnotationChild.elements;
+  }
+
+  // Insert paragraph properties at the beginning of the elements array
+  const pPr = generateParagraphProperties(params);
+  if (pPr) elements.unshift(pPr);
+
+  let attributes = {};
+  if (params.node.attrs?.rsidRDefault) {
+    attributes['w:rsidRDefault'] = params.node.attrs.rsidRDefault;
+  }
+
+  const result = {
+    name: 'w:p',
+    elements,
+    attributes,
+  };
+
+  return result;
+}

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/p/helpers/translate-paragraph-node.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/p/helpers/translate-paragraph-node.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { translateChildNodes } from '@converter/v2/exporter/helpers/index.js';
+import { generateParagraphProperties } from './generate-paragraph-properties.js';
+
+vi.mock('@converter/v2/exporter/helpers/index.js', () => ({
+  translateChildNodes: vi.fn(),
+}));
+
+vi.mock('./generate-paragraph-properties.js', () => ({
+  generateParagraphProperties: vi.fn(),
+}));
+
+import { translateParagraphNode } from './translate-paragraph-node.js';
+
+const baseParams = () => ({
+  node: { attrs: {} },
+});
+
+describe('translateParagraphNode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns html annotation elements when present', () => {
+    const params = baseParams();
+    const annotationElements = [{ name: 'w:r', elements: [{ text: 'rich html' }] }];
+    translateChildNodes.mockReturnValue([
+      { name: 'w:r', elements: [] },
+      { name: 'htmlAnnotation', elements: annotationElements },
+      { name: 'w:bookmarkStart' },
+    ]);
+
+    const result = translateParagraphNode(params);
+
+    expect(result).toBe(annotationElements);
+    expect(translateChildNodes).toHaveBeenCalledWith(params);
+    expect(generateParagraphProperties).not.toHaveBeenCalled();
+  });
+
+  it('prepends generated paragraph properties when html annotation is absent', () => {
+    const params = baseParams();
+    const paragraphProperties = { name: 'w:pPr', elements: [{ name: 'w:spacing' }] };
+    const childElements = [{ name: 'w:r', elements: [{ text: 'content' }] }];
+    translateChildNodes.mockReturnValue([...childElements]);
+    generateParagraphProperties.mockReturnValue(paragraphProperties);
+
+    const result = translateParagraphNode(params);
+
+    expect(result).toEqual({
+      name: 'w:p',
+      elements: [paragraphProperties, ...childElements],
+      attributes: {},
+    });
+    expect(translateChildNodes).toHaveBeenCalledWith(params);
+    expect(generateParagraphProperties).toHaveBeenCalledWith(params);
+  });
+
+  it('adds rsid default attribute when provided and leaves children untouched when no paragraph properties exist', () => {
+    const params = {
+      node: { attrs: { rsidRDefault: '00DE1' } },
+    };
+    const childElements = [{ name: 'w:r', elements: [] }];
+    translateChildNodes.mockReturnValue(childElements);
+    generateParagraphProperties.mockReturnValue(null);
+
+    const result = translateParagraphNode(params);
+
+    expect(result).toEqual({
+      name: 'w:p',
+      elements: childElements,
+      attributes: { 'w:rsidRDefault': '00DE1' },
+    });
+    expect(translateChildNodes).toHaveBeenCalledWith(params);
+    expect(generateParagraphProperties).toHaveBeenCalledWith(params);
+  });
+});

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/p/p-translator.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/p/p-translator.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { NodeTranslator } from '@translator';
 import { handleParagraphNode as legacyHandleParagraphNode } from './helpers/legacy-handle-paragraph-node.js';
-import { translateParagraphNode } from '../../../../exporter.js';
+import { translateParagraphNode } from './helpers/translate-paragraph-node.js';
 import validXmlAttributes from './attributes/index.js';
 
 /** @type {import('@translator').XmlNodeName} */

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/p/p-translator.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/p/p-translator.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { translateParagraphNode } from './helpers/translate-paragraph-node.js';
 
 // Mock attribute handlers before importing the SUT so the config captures them.
 // Define everything inside the factory to avoid hoisting issues.
@@ -54,7 +55,7 @@ vi.mock('./helpers/legacy-handle-paragraph-node.js', () => ({
 }));
 
 // Mock exporter decode function used by decode
-vi.mock('../../../../exporter.js', () => ({
+vi.mock('./helpers/translate-paragraph-node.js', () => ({
   translateParagraphNode: vi.fn(() => ({
     name: 'w:p',
     elements: [],
@@ -66,7 +67,6 @@ vi.mock('../../../../exporter.js', () => ({
 import { translator, config } from './p-translator.js';
 import { NodeTranslator } from '@translator';
 import { handleParagraphNode } from './helpers/legacy-handle-paragraph-node.js';
-import { translateParagraphNode } from '../../../../exporter.js';
 
 describe('w/p p-translator', () => {
   afterEach(() => {

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/convert-sdt-content-to-runs.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/convert-sdt-content-to-runs.js
@@ -1,0 +1,54 @@
+const RUN_LEVEL_WRAPPERS = new Set(['w:hyperlink', 'w:ins', 'w:del']);
+
+/**
+ * Convert SDT child elements into Word run elements.
+ * @param {Array<Object>|Object} elements
+ * @returns {Array<Object>}
+ */
+export function convertSdtContentToRuns(elements) {
+  const normalized = Array.isArray(elements) ? elements : [elements];
+  const runs = [];
+
+  normalized.forEach((element) => {
+    if (!element) return;
+
+    if (element.name === 'w:sdtPr') {
+      return;
+    }
+
+    if (element.name === 'w:r') {
+      runs.push(element);
+      return;
+    }
+
+    if (element.name === 'w:sdt') {
+      // Recursively flatten nested SDTs into the surrounding run sequence, skipping property bags.
+      const sdtContent = (element.elements || []).find((child) => child?.name === 'w:sdtContent');
+      if (sdtContent?.elements) {
+        runs.push(...convertSdtContentToRuns(sdtContent.elements));
+      }
+      return;
+    }
+
+    if (RUN_LEVEL_WRAPPERS.has(element.name)) {
+      const wrapperElements = convertSdtContentToRuns(element.elements || []);
+      if (wrapperElements.length) {
+        runs.push({
+          ...element,
+          elements: wrapperElements,
+        });
+      }
+      return;
+    }
+
+    if (element.name) {
+      runs.push({
+        name: 'w:r',
+        type: 'element',
+        elements: element.elements || [element],
+      });
+    }
+  });
+
+  return runs.filter((run) => Array.isArray(run.elements) && run.elements.length > 0);
+}

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/convert-sdt-content-to-runs.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/convert-sdt-content-to-runs.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { convertSdtContentToRuns } from './convert-sdt-content-to-runs.js';
+
+describe('convertSdtContentToRuns', () => {
+  it('wraps non-run elements into w:r nodes and ignores w:sdtPr', () => {
+    const textElement = { name: 'w:t', text: 'Hello' };
+    const existingRun = { name: 'w:r', elements: [{ name: 'w:t', text: 'World' }] };
+
+    const result = convertSdtContentToRuns([{ name: 'w:sdtPr' }, textElement, existingRun]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      name: 'w:r',
+      type: 'element',
+      elements: [textElement],
+    });
+    expect(result[1]).toBe(existingRun);
+  });
+
+  it('flattens nested SDTs and preserves run-level wrappers', () => {
+    const nestedRun = {
+      name: 'w:r',
+      elements: [{ name: 'w:t', text: 'Inner' }],
+    };
+    const nestedSdt = {
+      name: 'w:sdt',
+      elements: [{ name: 'w:sdtContent', elements: [nestedRun] }],
+    };
+    const hyperlink = {
+      name: 'w:hyperlink',
+      attributes: { 'r:id': 'rId1' },
+      elements: [nestedSdt],
+    };
+    const root = {
+      name: 'w:sdt',
+      elements: [
+        { name: 'w:sdtPr' },
+        {
+          name: 'w:sdtContent',
+          elements: [hyperlink, { name: 'w:t', text: 'Tail' }],
+        },
+      ],
+    };
+
+    const result = convertSdtContentToRuns(root);
+
+    expect(result).toHaveLength(2);
+
+    const hyperlinkResult = result[0];
+    expect(hyperlinkResult.name).toBe('w:hyperlink');
+    expect(hyperlinkResult.attributes).toEqual({ 'r:id': 'rId1' });
+    expect(hyperlinkResult.elements).toHaveLength(1);
+    expect(hyperlinkResult.elements[0]).toEqual(nestedRun);
+
+    const tailRun = result[1];
+    expect(tailRun.name).toBe('w:r');
+    expect(tailRun.elements[0]).toEqual({ name: 'w:t', text: 'Tail' });
+  });
+
+  it('filters runs without child elements', () => {
+    const emptyElement = { name: 'w:none', elements: [] };
+    const result = convertSdtContentToRuns(emptyElement);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-field-annotation.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-field-annotation.js
@@ -5,8 +5,9 @@ import { translator as wDrawingNodeTranslator } from '@converter/v3/handlers/w/d
 import { ListHelpers } from '@helpers/list-numbering-helpers';
 import { generateDocxRandomId, generateRandomSigned32BitIntStrId } from '@helpers/generateDocxRandomId';
 import { sanitizeHtml } from '@core/InputRule';
-import { getTextNodeForExport, processLinkContentNode, addNewLinkRelationship } from '@converter/exporter';
+import { getTextNodeForExport } from '@converter/v3/handlers/w/t/helpers/translate-text-node.js';
 import he from 'he';
+import { translator as wHyperlinkTranslator } from '@converter/v3/handlers/w/hyperlink/index.js';
 
 /**
  * Translate a field annotation node
@@ -229,20 +230,32 @@ export function prepareUrlAnnotation(params) {
 
   if (!attrs.linkUrl) return prepareTextAnnotation(params);
 
-  const newId = addNewLinkRelationship(params, attrs.linkUrl);
-
-  const linkTextNode = getTextNodeForExport(attrs.linkUrl, marks, params);
-  const contentNode = processLinkContentNode(linkTextNode);
-
-  return {
-    name: 'w:hyperlink',
-    type: 'element',
-    attributes: {
-      'r:id': newId,
-      'w:history': 1,
-    },
-    elements: [contentNode],
+  const linkTextNode = {
+    type: 'text',
+    text: attrs.linkUrl,
+    marks: [
+      ...marks,
+      {
+        type: 'link',
+        attrs: {
+          href: attrs.linkUrl,
+          history: true,
+          text: attrs.linkUrl,
+        },
+      },
+      {
+        type: 'textStyle',
+        attrs: {
+          color: '#467886',
+        },
+      },
+    ],
   };
+
+  return wHyperlinkTranslator.decode({
+    ...params,
+    node: linkTextNode,
+  });
 }
 
 export function translateFieldAttrsToMarks(attrs = {}) {

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-structured-content.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-structured-content.js
@@ -1,5 +1,5 @@
 import { translateChildNodes } from '@converter/v2/exporter/helpers/translateChildNodes';
-import { convertSdtContentToRuns } from '@converter/exporter';
+import { convertSdtContentToRuns } from './convert-sdt-content-to-runs.js';
 
 /**
  * @param {Object} params - The parameters for translation.

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/t/helpers/translate-text-node.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/t/helpers/translate-text-node.js
@@ -1,0 +1,74 @@
+/**
+ * Helper function to be used for text node translation
+ * Also used for transforming text annotations for the final submit
+ *
+ * @param {String} text Text node's content
+ * @param {Object[]} marks The marks to add to the run properties
+ * @returns {XmlReadyNode} The translated text node
+ */
+import { translator as wRPrNodeTranslator } from '../../rpr/rpr-translator.js';
+import { combineRunProperties, decodeRPrFromMarks } from '@converter/styles.js';
+
+export function getTextNodeForExport(text, marks, params) {
+  const hasLeadingOrTrailingSpace = /^\s|\s$/.test(text);
+  const space = hasLeadingOrTrailingSpace ? 'preserve' : null;
+  const nodeAttrs = space ? { 'xml:space': space } : null;
+  const textNodes = [];
+
+  const textRunProperties = decodeRPrFromMarks(marks || []);
+  const parentRunProperties = params.extraParams?.runProperties || {};
+  const combinedRunProperties = combineRunProperties([parentRunProperties, textRunProperties]);
+  const rPrNode = wRPrNodeTranslator.decode({ node: { attrs: { runProperties: combinedRunProperties } } });
+
+  textNodes.push({
+    name: 'w:t',
+    elements: [{ text, type: 'text' }],
+    attributes: nodeAttrs,
+  });
+
+  // For custom mark export, we need to add a bookmark start and end tag
+  // And store attributes in the bookmark name
+  if (params) {
+    const { editor } = params;
+    const customMarks = editor.extensionService.extensions.filter((e) => e.isExternal === true);
+
+    marks.forEach((mark) => {
+      const isCustomMark = customMarks.some((customMark) => {
+        const customMarkName = customMark.name;
+        return mark.type === customMarkName;
+      });
+
+      if (!isCustomMark) return;
+
+      let attrsString = '';
+      Object.entries(mark.attrs).forEach(([key, value]) => {
+        if (value) {
+          attrsString += `${key}=${value};`;
+        }
+      });
+
+      if (isCustomMark) {
+        textNodes.unshift({
+          type: 'element',
+          name: 'w:bookmarkStart',
+          attributes: {
+            'w:id': '5000',
+            'w:name': mark.type + ';' + attrsString,
+          },
+        });
+        textNodes.push({
+          type: 'element',
+          name: 'w:bookmarkEnd',
+          attributes: {
+            'w:id': '5000',
+          },
+        });
+      }
+    });
+  }
+
+  return {
+    name: 'w:r',
+    elements: rPrNode ? [rPrNode, ...textNodes] : textNodes,
+  };
+}

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/t/t-translator.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/t/t-translator.js
@@ -4,7 +4,7 @@ import { createAttributeHandler } from '@converter/v3/handlers/utils.js';
 import { translator as wDelTranslator } from '@converter/v3/handlers/w/del/index.js';
 import { translator as wInsTranslator } from '@converter/v3/handlers/w/ins/index.js';
 import { translator as wHyperlinkTranslator } from '@converter/v3/handlers/w/hyperlink/index.js';
-import { getTextNodeForExport } from '@converter/exporter.js';
+import { getTextNodeForExport } from '@converter/v3/handlers/w/t/helpers/translate-text-node.js';
 
 /** @type {import('@translator').XmlNodeName} */
 const XML_NODE_NAME = 'w:t';

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/t/t-translator.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/t/t-translator.test.js
@@ -1,13 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import { config, translator } from './t-translator.js';
 import { NodeTranslator } from '@translator';
-import { getTextNodeForExport } from '@converter/exporter.js';
+import { getTextNodeForExport } from '@converter/v3/handlers/w/t/helpers/translate-text-node.js';
 import { translator as wDelTranslator } from '@converter/v3/handlers/w/del/index.js';
 import { translator as wInsTranslator } from '@converter/v3/handlers/w/ins/index.js';
 import { translator as wHyperlinkTranslator } from '@converter/v3/handlers/w/hyperlink/index.js';
 
 // Mocks
-vi.mock('@converter/exporter.js', () => ({
+vi.mock('@converter/v3/handlers/w/t/helpers/translate-text-node.js', () => ({
   getTextNodeForExport: vi.fn(),
 }));
 

--- a/packages/super-editor/src/tests/export/exporter-utils.test.js
+++ b/packages/super-editor/src/tests/export/exporter-utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isLineBreakOnlyRun, generateParagraphProperties, processOutputMarks } from '@converter/exporter.js';
+import { isLineBreakOnlyRun, processOutputMarks } from '@converter/exporter.js';
 
 describe('isLineBreakOnlyRun', () => {
   it('returns true for a run containing only line break nodes', () => {
@@ -43,34 +43,5 @@ describe('processOutputMarks', () => {
         attributes: { 'w:val': 'auto' },
       },
     ]);
-  });
-});
-
-describe('generateParagraphProperties', () => {
-  it('includes zero-value indents when explicitly provided', () => {
-    const node = {
-      type: 'paragraph',
-      attrs: {
-        indent: {
-          left: 0,
-          right: 0,
-          firstLine: 0,
-          hanging: 0,
-          explicitLeft: true,
-          explicitRight: true,
-          explicitFirstLine: true,
-          explicitHanging: true,
-        },
-      },
-    };
-
-    const result = generateParagraphProperties({ node });
-    const indentElement = result.elements.find((el) => el.name === 'w:ind');
-
-    expect(indentElement).toBeDefined();
-    expect(indentElement.attributes['w:left']).toBe('0');
-    expect(indentElement.attributes['w:right']).toBe('0');
-    expect(indentElement.attributes['w:firstLine']).toBe('0');
-    expect(indentElement.attributes['w:hanging']).toBe('0');
   });
 });

--- a/packages/super-editor/src/tests/export/lists/miscOrderedListExport.test.js
+++ b/packages/super-editor/src/tests/export/lists/miscOrderedListExport.test.js
@@ -69,7 +69,8 @@ describe('[custom_list1.docx] interrupted ordered list tests', async () => {
     const firstList = body.elements[0];
     const firstListPprList = firstList.elements.filter((n) => (n.name = 'w:pPr' && n.elements.length));
     const firstListPpr = firstListPprList[0];
-    expect(firstListPpr.elements.length).toBe(6);
+
+    expect(firstListPpr.elements.length).toBe(7);
 
     const numPr = firstListPpr.elements.find((n) => n.name === 'w:numPr');
     const numIdTag = numPr.elements.find((n) => n.name === 'w:numId');

--- a/packages/super-editor/src/tests/export/structured-content-exporter.test.js
+++ b/packages/super-editor/src/tests/export/structured-content-exporter.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { convertSdtContentToRuns } from '@converter/exporter.js';
+import { convertSdtContentToRuns } from '@converter/v3/handlers/w/sdt/helpers/convert-sdt-content-to-runs.js';
 
 describe('convertSdtContentToRuns', () => {
   it('returns existing runs unchanged', () => {

--- a/packages/super-editor/src/tests/export/tabStopsExporter.test.js
+++ b/packages/super-editor/src/tests/export/tabStopsExporter.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
-import { translateParagraphNode } from '@converter/exporter.js';
+import { translator as wPTranslator } from '@converter/v3/handlers/w/p';
 
 describe('Tab Stops Export Tests', () => {
   // Create a minimal editor mock that has the required extensions property
@@ -43,7 +43,7 @@ describe('Tab Stops Export Tests', () => {
       content: [],
     };
 
-    const result = translateParagraphNode({
+    const result = wPTranslator.decode({
       editor: mockEditor,
       node: mockParagraphNode,
     });
@@ -91,7 +91,7 @@ describe('Tab Stops Export Tests', () => {
       content: [],
     };
 
-    const result = translateParagraphNode({
+    const result = wPTranslator.decode({
       editor: mockEditor,
       node: mockParagraphNode,
     });
@@ -119,7 +119,7 @@ describe('Tab Stops Export Tests', () => {
       content: [],
     };
 
-    const result = translateParagraphNode({
+    const result = wPTranslator.decode({
       editor: mockEditor,
       node: mockParagraphNode,
     });
@@ -154,7 +154,7 @@ describe('Tab Stops Export Tests', () => {
       content: [],
     };
 
-    const result = translateParagraphNode({
+    const result = wPTranslator.decode({
       editor: mockEditor,
       node: mockParagraphNode,
     });
@@ -194,7 +194,7 @@ describe('Tab Stops Export Tests', () => {
       content: [],
     };
 
-    const result = translateParagraphNode({
+    const result = wPTranslator.decode({
       editor: mockEditor,
       node: mockParagraphNode,
     });
@@ -231,7 +231,7 @@ describe('Tab Stops Export Tests', () => {
       content: [],
     };
 
-    const result = translateParagraphNode({
+    const result = wPTranslator.decode({
       editor: mockEditor,
       node: mockParagraphNode,
     });

--- a/packages/super-editor/src/tests/import-export/tabStopsRoundTrip.test.js
+++ b/packages/super-editor/src/tests/import-export/tabStopsRoundTrip.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'vitest';
 import { handleParagraphNode } from '@converter/v2/importer/paragraphNodeImporter.js';
 import { defaultNodeListHandler } from '@converter/v2/importer/docxImporter.js';
-import { translateParagraphNode } from '@converter/exporter.js';
+import { translator as wPTranslator } from '@converter/v3/handlers/w/p';
 
 describe('Tab Stops Round Trip Tests', () => {
   // Create a minimal editor mock that has the required extensions property
@@ -85,7 +85,7 @@ describe('Tab Stops Round Trip Tests', () => {
 
     // Step 2: Export the imported node back to DOCX
     const mockEditor = createMockEditor();
-    const exportedResult = translateParagraphNode({
+    const exportedResult = wPTranslator.decode({
       editor: mockEditor,
       node: importedNode,
     });
@@ -146,7 +146,7 @@ describe('Tab Stops Round Trip Tests', () => {
 
     // Step 2: Export the imported node back to DOCX
     const mockEditor = createMockEditor();
-    const exportedResult = translateParagraphNode({
+    const exportedResult = wPTranslator.decode({
       editor: mockEditor,
       node: importedNode,
     });
@@ -206,7 +206,7 @@ describe('Tab Stops Round Trip Tests', () => {
 
     // Step 2: Export the imported node back to DOCX
     const mockEditor = createMockEditor();
-    const exportedResult = translateParagraphNode({
+    const exportedResult = wPTranslator.decode({
       editor: mockEditor,
       node: importedNode,
     });
@@ -255,7 +255,7 @@ describe('Tab Stops Round Trip Tests', () => {
     expect(importedNode.attrs.tabStops[0].tab.pos).toBe(1234);
 
     const mockEditor = createMockEditor();
-    const exportedResult = translateParagraphNode({
+    const exportedResult = wPTranslator.decode({
       editor: mockEditor,
       node: importedNode,
     });
@@ -319,7 +319,7 @@ describe('Tab Stops Round Trip Tests', () => {
 
     // Step 2: Export the imported node back to DOCX
     const mockEditor = createMockEditor();
-    const exportedResult = translateParagraphNode({
+    const exportedResult = wPTranslator.decode({
       editor: mockEditor,
       node: importedNode,
     });


### PR DESCRIPTION
This PR is ment to refactor exporter.js:
1. Use hyperlink translator for annotations and get rid of separate helper
2. Move node specific methods into v3 folder
3. Write more tests for helpers functions