### PR TITLE
chore: add SDT round-trip preservation for DOCX import/export

### DIFF
--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-annotation-node.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-annotation-node.js
@@ -71,7 +71,7 @@ export function handleAnnotationNode(params) {
   }
 
   const { attrs: marksAsAttrs, marks } = parseAnnotationMarks(sdtContent);
-  const allAttrs = { ...attrs, ...marksAsAttrs };
+  const allAttrs = { ...attrs, ...marksAsAttrs, ...(sdtPr && { sdtPr }) }; // Include sdtPr for round-trip passthrough only if it exists
   if (!allAttrs.hash) allAttrs.hash = generateDocxRandomId(4);
 
   // Some w:sdt nodes have attrs.fieldId (coming from GoogleDocs) so we need a secondary check

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-doc-part-obj.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-doc-part-obj.js
@@ -13,24 +13,32 @@ export function handleDocPartObj(params) {
   const sdtPr = node.elements.find((el) => el.name === 'w:sdtPr');
   const docPartObj = sdtPr?.elements.find((el) => el.name === 'w:docPartObj');
   const docPartGallery = docPartObj?.elements.find((el) => el.name === 'w:docPartGallery');
-  const docPartGalleryType = docPartGallery?.attributes['w:val'];
-
-  if (!docPartGalleryType || !validGalleryTypeMap[docPartGalleryType]) {
-    // TODO: Handle catching unkown gallery types
-    return null;
-  }
+  const docPartGalleryType = docPartGallery?.attributes?.['w:val'] ?? null;
 
   const content = node?.elements.find((el) => el.name === 'w:sdtContent');
-  const handler = validGalleryTypeMap[docPartGalleryType];
+
+  // Use specific handler if available, otherwise fall back to generic handler
+  const handler = validGalleryTypeMap[docPartGalleryType] || genericDocPartHandler;
   const result = handler({
     ...params,
     nodes: [content],
-    extraParams: { ...(params.extraParams || {}), sdtPr },
+    extraParams: { ...(params.extraParams || {}), sdtPr, docPartGalleryType },
   });
 
   return result;
 }
 
+/**
+ * Handler for Table of Contents docPartGallery type.
+ * Processes ToC content and preserves sdtPr for round-trip.
+ * @param {Object} params - The handler parameters
+ * @param {Array} params.nodes - Array containing the w:sdtContent node
+ * @param {Object} params.nodeListHandler - Handler for processing child nodes
+ * @param {Object} params.extraParams - Extra parameters containing sdtPr
+ * @param {Object} params.extraParams.sdtPr - The original sdtPr element for passthrough
+ * @param {Array} [params.path] - Current processing path for nested nodes
+ * @returns {Object} Document part object node configured for Table of Contents
+ */
 export const tableOfContentsHandler = (params) => {
   const node = params.nodes[0];
   const translatedContent = params.nodeListHandler.handler({
@@ -40,6 +48,9 @@ export const tableOfContentsHandler = (params) => {
   });
   const sdtPr = params.extraParams.sdtPr;
   const id = sdtPr.elements?.find((el) => el.name === 'w:id')?.attributes['w:val'] || '';
+  const docPartObj = sdtPr?.elements.find((el) => el.name === 'w:docPartObj');
+  // Per OOXML spec: presence of w:docPartUnique element = true, absence = false
+  const docPartUnique = docPartObj?.elements.some((el) => el.name === 'w:docPartUnique') ?? false;
 
   const result = {
     type: 'documentPartObject',
@@ -47,7 +58,51 @@ export const tableOfContentsHandler = (params) => {
     attrs: {
       id,
       docPartGallery: 'Table of Contents',
-      docPartUnique: true,
+      docPartUnique,
+      sdtPr, // Passthrough for round-trip preservation
+    },
+  };
+  return result;
+};
+
+/**
+ * Generic handler for unknown docPartGallery types.
+ * Translates content for display but preserves full sdtPr for round-trip preservation.
+ * @param {Object} params - The handler parameters
+ * @param {Array} params.nodes - Array containing the w:sdtContent node
+ * @param {Object} params.nodeListHandler - Handler for processing child nodes
+ * @param {Object} params.extraParams - Extra parameters containing sdtPr and docPartGalleryType
+ * @param {Object} params.extraParams.sdtPr - The original sdtPr element for passthrough
+ * @param {string} params.extraParams.docPartGalleryType - The type of document part gallery
+ * @param {Array} [params.path] - Current processing path for nested nodes
+ * @returns {Object} Document part object node with content, type, and attrs including sdtPr passthrough
+ */
+export const genericDocPartHandler = (params) => {
+  const node = params.nodes[0];
+  const translatedContent = params.nodeListHandler.handler({
+    ...params,
+    nodes: node.elements,
+    path: [...(params.path || []), node],
+  });
+  const sdtPr = params.extraParams.sdtPr;
+  const docPartGalleryType = params.extraParams.docPartGalleryType;
+  const id = sdtPr?.elements?.find((el) => el.name === 'w:id')?.attributes['w:val'] || '';
+  const docPartObj = sdtPr?.elements.find((el) => el.name === 'w:docPartObj');
+  const docPartGallery =
+    docPartGalleryType ??
+    docPartObj?.elements?.find((el) => el.name === 'w:docPartGallery')?.attributes?.['w:val'] ??
+    null;
+  // Per OOXML spec: presence of w:docPartUnique element = true, absence = false
+  const docPartUnique = docPartObj?.elements.some((el) => el.name === 'w:docPartUnique') ?? false;
+
+  const result = {
+    type: 'documentPartObject',
+    content: translatedContent,
+    attrs: {
+      id,
+      docPartGallery,
+      docPartUnique,
+      sdtPr, // Passthrough for round-trip preservation of all sdtPr elements
     },
   };
   return result;

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-doc-part-obj.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-doc-part-obj.test.js
@@ -44,11 +44,16 @@ describe('handleDocPartObj', () => {
     expect(result).toBeNull();
   });
 
-  it('should return null if docPartGalleryType is not supported', () => {
+  it('should use generic handler for unsupported docPartGalleryType', () => {
     const node = createSdtNode('UnsupportedType');
-    const params = { nodes: [node] };
+    const params = { nodes: [node], nodeListHandler: mockNodeListHandler, path: [] };
     const result = handleDocPartObj(params);
-    expect(result).toBeNull();
+
+    // Generic handler processes unsupported types for round-trip preservation
+    expect(result.type).toEqual('documentPartObject');
+    expect(result.attrs.docPartGallery).toEqual('UnsupportedType');
+    expect(result.attrs.sdtPr).toBeDefined(); // Passthrough for round-trip
+    expect(result.attrs.sdtPr).toHaveProperty('elements');
   });
 
   it('should call the correct handler for a supported docPartGalleryType', () => {
@@ -56,15 +61,36 @@ describe('handleDocPartObj', () => {
     const params = { nodes: [node], nodeListHandler: mockNodeListHandler, path: [] };
     const result = handleDocPartObj(params);
     expect(mockNodeListHandler.handler).toHaveBeenCalled();
-    expect(result).toEqual({
-      type: 'documentPartObject',
-      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'TOC Content' }] }],
-      attrs: {
-        id: '123',
-        docPartGallery: 'Table of Contents',
-        docPartUnique: true,
-      },
-    });
+    expect(result.type).toEqual('documentPartObject');
+    expect(result.content).toEqual([{ type: 'paragraph', content: [{ type: 'text', text: 'TOC Content' }] }]);
+    expect(result.attrs.id).toEqual('123');
+    expect(result.attrs.docPartGallery).toEqual('Table of Contents');
+    expect(result.attrs.docPartUnique).toEqual(false); // No w:docPartUnique element in mock
+    expect(result.attrs.sdtPr).toBeDefined(); // Passthrough for round-trip
+    expect(result.attrs.sdtPr).toHaveProperty('elements');
+  });
+
+  it('should set docPartGallery to null when missing and preserve sdtPr', () => {
+    const node = {
+      name: 'w:sdt',
+      elements: [
+        {
+          name: 'w:sdtPr',
+          elements: [
+            { name: 'w:docPartObj', elements: [] },
+            { name: 'w:id', attributes: { 'w:val': '123' } },
+          ],
+        },
+        { name: 'w:sdtContent', elements: [{ name: 'w:p', elements: [] }] },
+      ],
+    };
+
+    const params = { nodes: [node], nodeListHandler: mockNodeListHandler, path: [] };
+    const result = handleDocPartObj(params);
+
+    expect(result.attrs.docPartGallery).toBeNull();
+    expect(result.attrs.sdtPr).toBeDefined();
+    expect(result.attrs.sdtPr.elements.find((el) => el.name === 'w:docPartObj')).toBeDefined();
   });
 });
 
@@ -76,7 +102,16 @@ describe('tableOfContentsHandler', () => {
   it('should process a Table of Contents node correctly', () => {
     const sdtPr = {
       name: 'w:sdtPr',
-      elements: [{ name: 'w:id', attributes: { 'w:val': '456' } }],
+      elements: [
+        { name: 'w:id', attributes: { 'w:val': '456' } },
+        {
+          name: 'w:docPartObj',
+          elements: [
+            { name: 'w:docPartGallery', attributes: { 'w:val': 'Table of Contents' } },
+            { name: 'w:docPartUnique' },
+          ],
+        },
+      ],
     };
     const contentNode = {
       name: 'w:sdtContent',
@@ -96,14 +131,60 @@ describe('tableOfContentsHandler', () => {
       nodes: contentNode.elements,
       path: [contentNode],
     });
-    expect(result).toEqual({
-      type: 'documentPartObject',
-      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'TOC Content' }] }],
-      attrs: {
-        id: '456',
-        docPartGallery: 'Table of Contents',
-        docPartUnique: true,
-      },
-    });
+    expect(result.type).toEqual('documentPartObject');
+    expect(result.content).toEqual([{ type: 'paragraph', content: [{ type: 'text', text: 'TOC Content' }] }]);
+    expect(result.attrs.id).toEqual('456');
+    expect(result.attrs.docPartGallery).toEqual('Table of Contents');
+    expect(result.attrs.docPartUnique).toEqual(true);
+    expect(result.attrs.sdtPr).toBeDefined(); // Passthrough for round-trip
+    expect(result.attrs.sdtPr).toHaveProperty('elements');
+  });
+
+  it('should handle empty sdtPr.elements array', () => {
+    const sdtPr = {
+      name: 'w:sdtPr',
+      elements: [],
+    };
+    const contentNode = {
+      name: 'w:sdtContent',
+      elements: [{ name: 'w:p', elements: [] }],
+    };
+    const params = {
+      nodes: [contentNode],
+      nodeListHandler: mockNodeListHandler,
+      extraParams: { sdtPr },
+      path: [],
+    };
+
+    const result = tableOfContentsHandler(params);
+
+    expect(result.type).toEqual('documentPartObject');
+    expect(result.attrs.id).toEqual('');
+    expect(result.attrs.docPartUnique).toEqual(false); // Default to false per OOXML spec
+    expect(result.attrs.sdtPr).toBeDefined();
+  });
+
+  it('should handle null/undefined docPartObj gracefully', () => {
+    const sdtPr = {
+      name: 'w:sdtPr',
+      elements: [{ name: 'w:id', attributes: { 'w:val': '789' } }],
+    };
+    const contentNode = {
+      name: 'w:sdtContent',
+      elements: [{ name: 'w:p', elements: [] }],
+    };
+    const params = {
+      nodes: [contentNode],
+      nodeListHandler: mockNodeListHandler,
+      extraParams: { sdtPr },
+      path: [],
+    };
+
+    const result = tableOfContentsHandler(params);
+
+    expect(result.type).toEqual('documentPartObject');
+    expect(result.attrs.id).toEqual('789');
+    expect(result.attrs.docPartUnique).toEqual(false); // Default to false when docPartObj is missing
+    expect(result.attrs.sdtPr).toBeDefined();
   });
 });

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-document-section-node.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-document-section-node.js
@@ -24,6 +24,12 @@ export function handleDocumentSectionNode(params) {
   const title = titleTag?.attributes?.['w:val'] || tagValue.title || null;
 
   const { description } = tagValue;
+
+  // Parse w:lock element for section locking
+  const lockTag = sdtPr?.elements.find((el) => el.name === 'w:lock');
+  const lockValue = lockTag?.attributes?.['w:val'];
+  const isLocked = lockValue === 'sdtContentLocked';
+
   const sdtContent = node.elements.find((el) => el.name === 'w:sdtContent');
   const translatedContent = nodeListHandler.handler({
     ...params,
@@ -38,6 +44,8 @@ export function handleDocumentSectionNode(params) {
       id,
       title,
       description,
+      isLocked,
+      ...(sdtPr && { sdtPr }), // Passthrough for round-trip preservation of unknown elements only if it exists
     },
   };
 

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-document-section-node.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/handle-document-section-node.test.js
@@ -88,15 +88,14 @@ describe('handleDocumentSectionNode', () => {
       nodes: [{ name: 'w:p', text: 'content' }],
       path: [node],
     });
-    expect(result).toEqual({
-      type: 'documentSection',
-      content: [{ type: 'paragraph', text: 'test content' }],
-      attrs: {
-        id: 'section-123',
-        title: 'Section Title',
-        description: 'Section description',
-      },
-    });
+    expect(result.type).toEqual('documentSection');
+    expect(result.content).toEqual([{ type: 'paragraph', text: 'test content' }]);
+    expect(result.attrs.id).toEqual('section-123');
+    expect(result.attrs.title).toEqual('Section Title');
+    expect(result.attrs.description).toEqual('Section description');
+    expect(result.attrs.isLocked).toEqual(false);
+    expect(result.attrs.sdtPr).toBeDefined(); // Passthrough for round-trip
+    expect(result.attrs.sdtPr).toHaveProperty('elements');
   });
 
   it('uses values from parsed JSON when element attributes are missing', () => {
@@ -116,11 +115,12 @@ describe('handleDocumentSectionNode', () => {
 
     const result = handleDocumentSectionNode(params);
 
-    expect(result.attrs).toEqual({
-      id: 'json-id',
-      title: 'JSON Title',
-      description: 'JSON description',
-    });
+    expect(result.attrs.id).toEqual('json-id');
+    expect(result.attrs.title).toEqual('JSON Title');
+    expect(result.attrs.description).toEqual('JSON description');
+    expect(result.attrs.isLocked).toEqual(false);
+    expect(result.attrs.sdtPr).toBeDefined();
+    expect(result.attrs.sdtPr).toHaveProperty('elements');
   });
 
   it('prioritizes element attributes over JSON values', () => {
@@ -144,10 +144,94 @@ describe('handleDocumentSectionNode', () => {
 
     const result = handleDocumentSectionNode(params);
 
-    expect(result.attrs).toEqual({
-      id: 'element-id',
-      title: 'Element Title',
-      description: 'JSON description',
+    expect(result.attrs.id).toEqual('element-id');
+    expect(result.attrs.title).toEqual('Element Title');
+    expect(result.attrs.description).toEqual('JSON description');
+    expect(result.attrs.isLocked).toEqual(false);
+    expect(result.attrs.sdtPr).toBeDefined();
+    expect(result.attrs.sdtPr).toHaveProperty('elements');
+  });
+
+  it('parses w:lock element and sets isLocked to true when sdtContentLocked', () => {
+    const createLock = (value) => ({
+      name: 'w:lock',
+      attributes: { 'w:val': value },
     });
+
+    const node = createNode([
+      createTag('{"type": "documentSection"}'),
+      createId('section-123'),
+      createLock('sdtContentLocked'),
+    ]);
+
+    const params = {
+      nodes: [node],
+      nodeListHandler: mockNodeListHandler,
+    };
+
+    parseTagValueJSON.mockReturnValue({
+      type: 'documentSection',
+    });
+
+    const result = handleDocumentSectionNode(params);
+
+    expect(result.attrs.isLocked).toEqual(true);
+  });
+
+  it('handles null sdtPr gracefully without adding it to attrs', () => {
+    const node = {
+      name: 'w:sdt',
+      elements: [
+        {
+          name: 'w:sdtContent',
+          elements: [],
+        },
+      ],
+    };
+
+    const params = {
+      nodes: [node],
+      nodeListHandler: mockNodeListHandler,
+    };
+
+    parseTagValueJSON.mockReturnValue({
+      type: 'documentSection',
+    });
+
+    const result = handleDocumentSectionNode(params);
+
+    expect(result.attrs).toBeDefined();
+    expect(result.attrs.sdtPr).toBeUndefined();
+  });
+
+  it('handles empty sdtPr.elements array correctly', () => {
+    const node = {
+      name: 'w:sdt',
+      elements: [
+        {
+          name: 'w:sdtPr',
+          elements: [],
+        },
+        {
+          name: 'w:sdtContent',
+          elements: [],
+        },
+      ],
+    };
+
+    const params = {
+      nodes: [node],
+      nodeListHandler: mockNodeListHandler,
+    };
+
+    parseTagValueJSON.mockReturnValue({
+      type: 'documentSection',
+    });
+
+    const result = handleDocumentSectionNode(params);
+
+    expect(result.attrs).toBeDefined();
+    expect(result.attrs.sdtPr).toBeDefined();
+    expect(result.attrs.sdtPr.elements).toEqual([]);
   });
 });

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-document-part-obj.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-document-part-obj.js
@@ -11,37 +11,11 @@ export function translateDocumentPartObj(params) {
 
   const childContent = translateChildNodes({ ...params, nodes: node.content });
 
-  // We build the sdt node elements here, and re-add passthrough sdtPr node
+  // Build sdtPr with passthrough support
+  const sdtPr = generateSdtPrForDocPartObj(attrs);
+
   const nodeElements = [
-    {
-      name: 'w:sdtPr',
-      elements: [
-        {
-          name: 'w:id',
-          attributes: {
-            'w:val': attrs.id,
-          },
-        },
-        {
-          name: 'w:docPartObj',
-          elements: [
-            {
-              name: 'w:docPartGallery',
-              attributes: {
-                'w:val': attrs.docPartGallery,
-              },
-            },
-            ...(attrs.docPartUnique
-              ? [
-                  {
-                    name: 'w:docPartUnique',
-                  },
-                ]
-              : []),
-          ],
-        },
-      ],
-    },
+    sdtPr,
     {
       name: 'w:sdtContent',
       elements: childContent,
@@ -54,4 +28,90 @@ export function translateDocumentPartObj(params) {
   };
 
   return result;
+}
+
+/**
+ * Generate sdtPr element for document part object with passthrough support.
+ * Builds core w:id and w:docPartObj elements, then appends any additional
+ * elements from the original sdtPr that are not explicitly managed.
+ * @param {Object} attrs - The node attributes
+ * @param {string} attrs.id - Document part ID
+ * @param {string} attrs.docPartGallery - Gallery type (e.g., "Table of Contents")
+ * @param {boolean} attrs.docPartUnique - Whether document part is unique
+ * @param {Object} [attrs.sdtPr] - Original sdtPr element for passthrough preservation
+ * @returns {Object} The complete sdtPr element with name and elements array
+ */
+function generateSdtPrForDocPartObj(attrs) {
+  const existingDocPartObj = attrs.sdtPr?.elements?.find((el) => el.name === 'w:docPartObj');
+  const existingDocPartGallery = existingDocPartObj?.elements?.find((el) => el.name === 'w:docPartGallery')
+    ?.attributes?.['w:val'];
+  const docPartGallery = attrs.docPartGallery ?? existingDocPartGallery ?? null;
+  const id = attrs.id ?? attrs.sdtPr?.elements?.find((el) => el.name === 'w:id')?.attributes?.['w:val'] ?? '';
+  // Per OOXML spec: presence of w:docPartUnique element = true, absence = false
+  const docPartUnique =
+    attrs.docPartUnique ?? existingDocPartObj?.elements?.some((el) => el.name === 'w:docPartUnique') ?? false;
+
+  // If we do not know the gallery type, prefer full passthrough to avoid emitting invalid XML
+  if (docPartGallery === null) {
+    if (attrs.sdtPr) {
+      return attrs.sdtPr;
+    }
+    return {
+      name: 'w:sdtPr',
+      elements: [
+        {
+          name: 'w:id',
+          attributes: {
+            'w:val': id,
+          },
+        },
+        {
+          name: 'w:docPartObj',
+          elements: [],
+        },
+      ],
+    };
+  }
+
+  // Build the core w:docPartObj element
+  const docPartObjElements = [
+    {
+      name: 'w:docPartGallery',
+      attributes: {
+        'w:val': docPartGallery,
+      },
+    },
+  ];
+
+  if (docPartUnique) {
+    docPartObjElements.push({ name: 'w:docPartUnique' });
+  }
+
+  // Start with explicitly managed elements
+  const sdtPrElements = [
+    {
+      name: 'w:id',
+      attributes: {
+        'w:val': id,
+      },
+    },
+    {
+      name: 'w:docPartObj',
+      elements: docPartObjElements,
+    },
+  ];
+
+  // Passthrough: preserve any sdtPr elements not explicitly managed
+  if (attrs.sdtPr?.elements && Array.isArray(attrs.sdtPr.elements)) {
+    const elementsToExclude = ['w:id', 'w:docPartObj'];
+    const passthroughElements = attrs.sdtPr.elements.filter(
+      (el) => el && el.name && !elementsToExclude.includes(el.name),
+    );
+    sdtPrElements.push(...passthroughElements);
+  }
+
+  return {
+    name: 'w:sdtPr',
+    elements: sdtPrElements,
+  };
 }

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-document-part-obj.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-document-part-obj.test.js
@@ -1,0 +1,36 @@
+// @ts-check
+import { describe, it, expect } from 'vitest';
+import { translateDocumentPartObj } from './translate-document-part-obj.js';
+
+describe('translateDocumentPartObj', () => {
+  it('reuses passthrough sdtPr when docPartGallery is missing to avoid invalid XML', () => {
+    const passthroughSdtPr = {
+      name: 'w:sdtPr',
+      elements: [
+        { name: 'w:id', attributes: { 'w:val': '123' } },
+        { name: 'w:docPartObj', elements: [] },
+        { name: 'w:foo', attributes: { 'w:val': 'bar' } },
+      ],
+    };
+
+    const node = {
+      type: 'documentPartObject',
+      content: [],
+      attrs: {
+        id: '123',
+        docPartGallery: null,
+        docPartUnique: true,
+        sdtPr: passthroughSdtPr,
+      },
+    };
+
+    const result = translateDocumentPartObj({ node });
+
+    expect(result.elements[0]).toEqual(passthroughSdtPr);
+    expect(
+      result.elements[0].elements.find(
+        (el) => el.name === 'w:docPartGallery' && el.attributes?.['w:val'] === 'undefined',
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-field-annotation.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/sdt/helpers/translate-field-annotation.js
@@ -69,16 +69,28 @@ export function translateFieldAnnotation(params) {
   };
   const annotationAttrsJson = JSON.stringify(annotationAttrs);
 
+  // Build sdtPr elements with passthrough support
+  const sdtPrElements = [
+    { name: 'w:alias', attributes: { 'w:val': attrs.displayLabel } },
+    { name: 'w:tag', attributes: { 'w:val': annotationAttrsJson } },
+    { name: 'w:id', attributes: { 'w:val': id } },
+  ];
+
+  // Passthrough: preserve any sdtPr elements not explicitly managed
+  if (attrs.sdtPr?.elements && Array.isArray(attrs.sdtPr.elements)) {
+    const elementsToExclude = ['w:alias', 'w:tag', 'w:id'];
+    const passthroughElements = attrs.sdtPr.elements.filter(
+      (el) => el && el.name && !elementsToExclude.includes(el.name),
+    );
+    sdtPrElements.push(...passthroughElements);
+  }
+
   const result = {
     name: 'w:sdt',
     elements: [
       {
         name: 'w:sdtPr',
-        elements: [
-          { name: 'w:alias', attributes: { 'w:val': attrs.displayLabel } },
-          { name: 'w:tag', attributes: { 'w:val': annotationAttrsJson } },
-          { name: 'w:id', attributes: { 'w:val': id } },
-        ],
+        elements: sdtPrElements,
       },
       {
         name: 'w:sdtContent',


### PR DESCRIPTION
  ## Summary

  - Add round-trip preservation for Structured Document Tags (SDT) to prevent data loss during DOCX import/export cycles
  - Preserve unknown/unmanaged `w:sdtPr` elements through the conversion pipeline for field annotations, document part objects, and document sections
  - Fix `docPartUnique` boolean logic to match OOXML spec (element presence = true, absence = false)
  - Add null safety checks for `sdtPr` passthrough in all SDT handlers