### PR TITLE
Preserving annotation field marks for text sdts

### DIFF
--- a/packages/super-editor/src/extensions/structured-content/structured-content-commands.test.js
+++ b/packages/super-editor/src/extensions/structured-content/structured-content-commands.test.js
@@ -463,8 +463,8 @@ describe('updateStructuredContentByGroup', () => {
         json: invalidJSON,
       });
 
-      // The command should return true (it continues processing) but nodes won't be updated
-      expect(didUpdate).toBe(true);
+      // The command should return false due to validation failure (all-or-nothing behavior)
+      expect(didUpdate).toBe(false);
 
       // Verify that console.error was called with validation error
       expect(consoleErrorSpy).toHaveBeenCalled();


### PR DESCRIPTION
- Introduced `keepTextNodeStyles` property to preserve text node styles during updates.
- Enhanced `updateStructuredContentById` and `updateStructuredContentByGroup` commands to utilize this new option.
- Implemented validation checks before applying updates to ensure content integrity. (SD-897)
- Added comprehensive tests for the new functionality, covering various scenarios including validation failures and style preservation.