### PR TITLE
fix: block keyboard, paste, and drop events in view mode during collab

### DIFF
--- a/packages/super-editor/src/core/extensions/editable.js
+++ b/packages/super-editor/src/core/extensions/editable.js
@@ -9,6 +9,8 @@ import { Extension } from '../Extension.js';
  * - Mouse interactions via mousedown
  * - Focus via automatic blur
  * - Click, double-click, and triple-click events
+ * - Keyboard shortcuts via handleKeyDown
+ * - Paste and drop events
  */
 export const Editable = Extension.create({
   name: 'editable',
@@ -46,6 +48,9 @@ export const Editable = Extension.create({
         handleClick: () => !editor.options.editable,
         handleDoubleClick: () => !editor.options.editable,
         handleTripleClick: () => !editor.options.editable,
+        handleKeyDown: () => !editor.options.editable,
+        handlePaste: () => !editor.options.editable,
+        handleDrop: () => !editor.options.editable,
       },
     });
 


### PR DESCRIPTION

 - Added `handleKeyDown`, `handlePaste`, `handleDrop` to editable extension
  - Blocks all local input when user switches to view mode during collaboration
  - Fixes issue where view-mode users could see their own local edits until refresh