### PR TITLE
[stable] fix: block keyboard, paste, and drop events in view mode during collab

### DIFF
--- a/packages/super-editor/src/core/extensions/editable.js
+++ b/packages/super-editor/src/core/extensions/editable.js
@@ -1,16 +1,56 @@
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { Extension } from '../Extension.js';
 
+/**
+ * Editable extension controls whether the editor accepts user input.
+ *
+ * When editable is false, all user interactions are blocked:
+ * - Text input via beforeinput events
+ * - Mouse interactions via mousedown
+ * - Focus via automatic blur
+ * - Click, double-click, and triple-click events
+ * - Keyboard shortcuts via handleKeyDown
+ * - Paste and drop events
+ */
 export const Editable = Extension.create({
   name: 'editable',
 
   addPmPlugins() {
+    const editor = this.editor;
     const editablePlugin = new Plugin({
       key: new PluginKey('editable'),
       props: {
-        editable: () => {
-          return this.editor.options.editable;
+        editable: () => editor.options.editable,
+        handleDOMEvents: {
+          beforeinput: (_view, event) => {
+            if (!editor.options.editable) {
+              event.preventDefault();
+              return true;
+            }
+            return false;
+          },
+          mousedown: (_view, event) => {
+            if (!editor.options.editable) {
+              event.preventDefault();
+              return true;
+            }
+            return false;
+          },
+          focus: (view, event) => {
+            if (!editor.options.editable) {
+              event.preventDefault();
+              view.dom.blur();
+              return true;
+            }
+            return false;
+          },
         },
+        handleClick: () => !editor.options.editable,
+        handleDoubleClick: () => !editor.options.editable,
+        handleTripleClick: () => !editor.options.editable,
+        handleKeyDown: () => !editor.options.editable,
+        handlePaste: () => !editor.options.editable,
+        handleDrop: () => !editor.options.editable,
       },
     });
 


### PR DESCRIPTION
Stable version of this PR: https://github.com/Harbour-Enterprises/SuperDoc/pull/1460