### PR TITLE
feat: add legacy .doc file conversion support

### DIFF
--- a/examples/conversion-server/.dockerignore
+++ b/examples/conversion-server/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+.DS_Store
+README.md
+*.log
+.env
+.env.*

--- a/examples/conversion-server/.gitignore
+++ b/examples/conversion-server/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+*.log

--- a/examples/conversion-server/Dockerfile
+++ b/examples/conversion-server/Dockerfile
@@ -1,0 +1,46 @@
+# SuperDoc Conversion Server
+# Includes LibreOffice for .doc to .docx conversion
+
+FROM node:20-slim
+
+# Install LibreOffice and required dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libreoffice \
+    libreoffice-writer \
+    fonts-liberation \
+    fonts-dejavu \
+    fonts-freefont-ttf \
+    fontconfig \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && fc-cache -f -v
+
+# Create app directory
+WORKDIR /app
+
+# Copy package files
+COPY package.json ./
+
+# Install dependencies
+RUN npm install --omit=dev
+
+# Copy server code
+COPY server.js ./
+
+# Create temp directory for conversions
+RUN mkdir -p /tmp/superdoc-conversions
+
+# Expose port
+EXPOSE 3001
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD node -e "fetch('http://localhost:3001/health').then(r => process.exit(r.ok ? 0 : 1))" || exit 1
+
+# Run as non-root user for security
+RUN useradd -m -s /bin/bash appuser && \
+    chown -R appuser:appuser /app /tmp/superdoc-conversions
+USER appuser
+
+# Start server
+CMD ["node", "server.js"]

--- a/examples/conversion-server/README.md
+++ b/examples/conversion-server/README.md
@@ -1,0 +1,233 @@
+# SuperDoc Conversion Server
+
+A simple Node.js server for converting legacy `.doc` files to `.docx` format using LibreOffice.
+
+## Quick Start with Docker (Recommended)
+
+The easiest way to run the conversion server is with Docker - no need to install LibreOffice manually.
+
+### Using Docker Compose
+
+```bash
+cd conversion-server
+docker-compose up -d
+```
+
+### Using Docker directly
+
+```bash
+cd conversion-server
+
+# Build the image
+docker build -t superdoc-conversion-server .
+
+# Run the container
+docker run -d -p 3001:3001 --name superdoc-conversion superdoc-conversion-server
+```
+
+The server will be available at `http://localhost:3001`.
+
+### Docker Commands
+
+```bash
+# View logs
+docker-compose logs -f
+
+# Stop the server
+docker-compose down
+
+# Rebuild after changes
+docker-compose up -d --build
+```
+
+---
+
+## Manual Setup (Without Docker)
+
+If you prefer to run without Docker, you'll need to install LibreOffice manually.
+
+## Prerequisites
+
+### LibreOffice Installation
+
+This server requires LibreOffice to be installed on your system.
+
+#### macOS
+
+**Option 1: Direct Download**
+- Download from: https://www.libreoffice.org/download/download/
+
+**Option 2: Homebrew**
+```bash
+brew install --cask libreoffice
+```
+
+#### Linux
+
+**Ubuntu/Debian:**
+```bash
+sudo apt update
+sudo apt install libreoffice
+```
+
+**Fedora:**
+```bash
+sudo dnf install libreoffice
+```
+
+**Arch Linux:**
+```bash
+sudo pacman -S libreoffice-fresh
+```
+
+#### Windows
+
+Download from: https://www.libreoffice.org/download/download/
+
+## Setup
+
+1. Navigate to the conversion-server folder:
+   ```bash
+   cd conversion-server
+   ```
+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+   Or for development with auto-reload:
+   ```bash
+   npm run dev
+   ```
+
+The server will start on `http://localhost:3001`.
+
+## API Endpoints
+
+### `GET /health`
+Health check endpoint.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "message": "Conversion server is running"
+}
+```
+
+### `GET /check-libreoffice`
+Check if LibreOffice is properly installed.
+
+**Response (success):**
+```json
+{
+  "status": "ok",
+  "message": "LibreOffice is installed",
+  "path": "/Applications/LibreOffice.app/Contents/MacOS/soffice"
+}
+```
+
+**Response (error):**
+```json
+{
+  "status": "error",
+  "message": "LibreOffice not found. Please install it.",
+  "instructions": {
+    "os": "macOS",
+    "methods": [
+      "Download from: https://www.libreoffice.org/download/download/",
+      "Or via Homebrew: brew install --cask libreoffice"
+    ]
+  }
+}
+```
+
+### `POST /convert`
+Convert a `.doc` file to `.docx` format.
+
+**Request:**
+- Content-Type: `multipart/form-data`
+- Body: `file` - The `.doc` file to convert
+
+**Response:**
+- Content-Type: `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
+- Body: The converted `.docx` file
+
+**Example using curl:**
+```bash
+curl -X POST -F "file=@document.doc" http://localhost:3001/convert -o document.docx
+```
+
+## Usage with SuperDoc Dev
+
+1. Start the conversion server:
+   ```bash
+   cd conversion-server
+   npm start
+   ```
+
+2. In another terminal, start SuperDoc dev:
+   ```bash
+   npm run dev
+   ```
+
+3. Open http://localhost:9094 in your browser
+
+4. Upload a `.doc` file - a dialog will appear offering to convert it
+
+5. Click "Convert & Edit" to convert and load the document
+
+## Configuration
+
+### Port
+
+Set the `PORT` environment variable to change the server port:
+```bash
+PORT=3002 npm start
+```
+
+### CORS
+
+By default, the server allows requests from:
+- `http://localhost:9094`
+- `http://localhost:9096`
+- `http://127.0.0.1:9094`
+
+To modify allowed origins, edit the `cors` configuration in `server.js`.
+
+## Troubleshooting
+
+### "LibreOffice not found"
+
+1. Verify LibreOffice is installed:
+   ```bash
+   # macOS
+   ls /Applications/LibreOffice.app
+
+   # Linux
+   which soffice
+   ```
+
+2. If installed in a non-standard location, add the path to the `possiblePaths` array in `server.js`.
+
+### "Conversion failed"
+
+1. Check the server console for error details
+2. Ensure the `.doc` file is not corrupted
+3. Try converting the file manually with LibreOffice to verify it works
+
+### CORS errors
+
+If you're running the dev server on a different port, add it to the CORS `origin` array in `server.js`.
+
+## Security Notes
+
+- This server is designed for local development
+- For production use, add authentication and rate limiting
+- Files are temporarily stored in the system temp directory and deleted after conversion

--- a/examples/conversion-server/docker-compose.yml
+++ b/examples/conversion-server/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  conversion-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: superdoc-conversion-server
+    ports:
+      - "3001:3001"
+    environment:
+      - PORT=3001
+      - NODE_ENV=production
+    restart: unless-stopped
+    # Resource limits
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 512M
+    # Health check
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3001/health').then(r => process.exit(r.ok ? 0 : 1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s

--- a/examples/conversion-server/package.json
+++ b/examples/conversion-server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "superdoc-conversion-server",
+  "version": "1.0.0",
+  "description": "Server for converting legacy .doc files to .docx format",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "multer": "^1.4.5-lts.1"
+  }
+}

--- a/examples/conversion-server/server.js
+++ b/examples/conversion-server/server.js
@@ -1,0 +1,259 @@
+import express from 'express';
+import cors from 'cors';
+import multer from 'multer';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import crypto from 'crypto';
+
+const execAsync = promisify(exec);
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+// Configure CORS for local development
+app.use(cors({
+  origin: ['http://localhost:9094', 'http://localhost:9096', 'http://127.0.0.1:9094'],
+  methods: ['POST', 'GET', 'OPTIONS'],
+  allowedHeaders: ['Content-Type'],
+}));
+
+// Configure multer for file uploads
+const storage = multer.diskStorage({
+  destination: async (req, file, cb) => {
+    const tempDir = path.join(os.tmpdir(), 'superdoc-conversions');
+    await fs.mkdir(tempDir, { recursive: true });
+    cb(null, tempDir);
+  },
+  filename: (req, file, cb) => {
+    // Generate unique filename to avoid collisions
+    const uniqueId = crypto.randomBytes(8).toString('hex');
+    const ext = path.extname(file.originalname);
+    cb(null, `${uniqueId}${ext}`);
+  },
+});
+
+const upload = multer({
+  storage,
+  limits: {
+    fileSize: 50 * 1024 * 1024, // 50MB limit
+  },
+  fileFilter: (req, file, cb) => {
+    const allowedExtensions = ['.doc', '.DOC'];
+    const ext = path.extname(file.originalname);
+    if (allowedExtensions.includes(ext)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only .doc files are allowed'));
+    }
+  },
+});
+
+// Health check endpoint
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', message: 'Conversion server is running' });
+});
+
+// Check LibreOffice installation
+app.get('/check-libreoffice', async (req, res) => {
+  try {
+    const libreOfficePath = await findLibreOffice();
+    res.json({
+      status: 'ok',
+      message: 'LibreOffice is installed',
+      path: libreOfficePath
+    });
+  } catch (error) {
+    res.status(500).json({
+      status: 'error',
+      message: 'LibreOffice not found. Please install it.',
+      instructions: getInstallInstructions()
+    });
+  }
+});
+
+// Main conversion endpoint
+app.post('/convert', upload.single('file'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+
+  const inputPath = req.file.path;
+  const outputDir = path.dirname(inputPath);
+  const baseName = path.basename(inputPath, path.extname(inputPath));
+  const expectedOutputPath = path.join(outputDir, `${baseName}.docx`);
+
+  try {
+    // Find LibreOffice
+    const libreOfficePath = await findLibreOffice();
+
+    // Convert using LibreOffice
+    console.log(`Converting: ${inputPath}`);
+    const command = `"${libreOfficePath}" --headless --convert-to docx --outdir "${outputDir}" "${inputPath}"`;
+
+    await execAsync(command, { timeout: 60000 }); // 60 second timeout
+
+    // Check if output file exists
+    try {
+      await fs.access(expectedOutputPath);
+    } catch {
+      throw new Error('Conversion completed but output file not found');
+    }
+
+    // Read the converted file
+    const convertedFile = await fs.readFile(expectedOutputPath);
+
+    // Set response headers
+    const originalName = req.file.originalname.replace(/\.doc$/i, '.docx');
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+    res.setHeader('Content-Disposition', `attachment; filename="${originalName}"`);
+    res.setHeader('Content-Length', convertedFile.length);
+
+    // Send the file
+    res.send(convertedFile);
+
+    // Cleanup files
+    await cleanupFiles([inputPath, expectedOutputPath]);
+
+  } catch (error) {
+    console.error('Conversion error:', error);
+
+    // Cleanup input file on error
+    await cleanupFiles([inputPath, expectedOutputPath]).catch(() => {});
+
+    if (error.message.includes('not found') || error.message.includes('ENOENT')) {
+      return res.status(500).json({
+        error: 'LibreOffice not found',
+        instructions: getInstallInstructions()
+      });
+    }
+
+    res.status(500).json({
+      error: 'Conversion failed',
+      details: error.message
+    });
+  }
+});
+
+// Find LibreOffice installation
+async function findLibreOffice() {
+  const possiblePaths = [
+    // macOS
+    '/Applications/LibreOffice.app/Contents/MacOS/soffice',
+    '/opt/homebrew/bin/soffice',
+    '/usr/local/bin/soffice',
+    // Linux
+    '/usr/bin/soffice',
+    '/usr/bin/libreoffice',
+    '/usr/lib/libreoffice/program/soffice',
+    '/snap/bin/libreoffice',
+    // Windows (WSL)
+    '/mnt/c/Program Files/LibreOffice/program/soffice.exe',
+  ];
+
+  for (const p of possiblePaths) {
+    try {
+      await fs.access(p, fs.constants.X_OK);
+      return p;
+    } catch {
+      // Continue to next path
+    }
+  }
+
+  // Try to find via command line
+  try {
+    const { stdout } = await execAsync('which soffice');
+    const path = stdout.trim();
+    if (path) return path;
+  } catch {
+    // Not found via which
+  }
+
+  throw new Error('LibreOffice not found');
+}
+
+// Get installation instructions based on OS
+function getInstallInstructions() {
+  const platform = os.platform();
+
+  if (platform === 'darwin') {
+    return {
+      os: 'macOS',
+      methods: [
+        'Download from: https://www.libreoffice.org/download/download/',
+        'Or via Homebrew: brew install --cask libreoffice'
+      ]
+    };
+  } else if (platform === 'linux') {
+    return {
+      os: 'Linux',
+      methods: [
+        'Ubuntu/Debian: sudo apt install libreoffice',
+        'Fedora: sudo dnf install libreoffice',
+        'Arch: sudo pacman -S libreoffice-fresh'
+      ]
+    };
+  } else {
+    return {
+      os: 'Windows',
+      methods: [
+        'Download from: https://www.libreoffice.org/download/download/'
+      ]
+    };
+  }
+}
+
+// Cleanup temporary files
+async function cleanupFiles(files) {
+  for (const file of files) {
+    try {
+      await fs.unlink(file);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+// Error handling middleware
+app.use((err, req, res, next) => {
+  console.error('Server error:', err);
+
+  if (err instanceof multer.MulterError) {
+    if (err.code === 'LIMIT_FILE_SIZE') {
+      return res.status(400).json({ error: 'File too large. Maximum size is 50MB.' });
+    }
+    return res.status(400).json({ error: err.message });
+  }
+
+  res.status(500).json({ error: err.message || 'Internal server error' });
+});
+
+// Start server
+app.listen(PORT, () => {
+  console.log(`
+  ========================================
+    SuperDoc Conversion Server
+  ========================================
+
+  Server running at: http://localhost:${PORT}
+
+  Endpoints:
+    GET  /health           - Health check
+    GET  /check-libreoffice - Check LibreOffice installation
+    POST /convert          - Convert .doc to .docx
+
+  Make sure LibreOffice is installed!
+  ========================================
+  `);
+
+  // Check LibreOffice on startup
+  findLibreOffice()
+    .then(path => console.log(`  LibreOffice found at: ${path}\n`))
+    .catch(() => {
+      console.log(`  WARNING: LibreOffice not found!`);
+      console.log(`  Install instructions:`, getInstallInstructions());
+      console.log('');
+    });
+});

--- a/packages/superdoc/src/core/helpers/documentConverter.js
+++ b/packages/superdoc/src/core/helpers/documentConverter.js
@@ -1,0 +1,161 @@
+/* global FormData, AbortController, AbortSignal */
+import { DOC, DOCX } from '@superdoc/common';
+
+/**
+ * @typedef {Object} ConversionConfig
+ * @property {string} [serverUrl] - URL of the conversion server (e.g., 'http://localhost:3001')
+ * @property {boolean} [enabled] - Whether conversion is enabled (default: true if serverUrl is provided)
+ * @property {number} [timeout] - Request timeout in milliseconds (default: 60000)
+ */
+
+/**
+ * @typedef {Object} ConversionResult
+ * @property {boolean} success - Whether the conversion succeeded
+ * @property {File} [file] - The converted .docx file
+ * @property {Error} [error] - Error if conversion failed
+ */
+
+/**
+ * Check if a file is a legacy .doc file that needs conversion
+ * @param {File|Blob} file - The file to check
+ * @returns {boolean}
+ */
+export const isDocFile = (file) => {
+  if (!file) return false;
+
+  // Check by MIME type
+  if (file.type === DOC || file.type === 'application/msword') {
+    return true;
+  }
+
+  // Check by extension (fallback for files without proper MIME type)
+  const name = file.name || '';
+  return name.toLowerCase().endsWith('.doc') && !name.toLowerCase().endsWith('.docx');
+};
+
+/**
+ * Check if a filename indicates a .doc file
+ * @param {string} filename - The filename to check
+ * @returns {boolean}
+ */
+export const isDocFilename = (filename) => {
+  if (!filename) return false;
+  const lower = filename.toLowerCase();
+  return lower.endsWith('.doc') && !lower.endsWith('.docx');
+};
+
+/**
+ * Convert a .doc file to .docx using the conversion server
+ * @param {File|Blob} file - The .doc file to convert
+ * @param {ConversionConfig} config - Conversion configuration
+ * @returns {Promise<ConversionResult>}
+ */
+export const convertDocToDocx = async (file, config) => {
+  const { serverUrl, timeout = 60000 } = config || {};
+
+  if (!serverUrl) {
+    return {
+      success: false,
+      error: new Error('Conversion server URL not configured. Set modules.conversion.serverUrl in SuperDoc config.'),
+    };
+  }
+
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    const response = await fetch(`${serverUrl}/convert`, {
+      method: 'POST',
+      body: formData,
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.error || `Conversion failed with status ${response.status}`);
+    }
+
+    const blob = await response.blob();
+    const originalName = file.name || 'document.doc';
+    const newName = originalName.replace(/\.doc$/i, '.docx');
+
+    const convertedFile = new File([blob], newName, { type: DOCX });
+
+    return {
+      success: true,
+      file: convertedFile,
+    };
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      return {
+        success: false,
+        error: new Error('Conversion timed out. The file may be too large or the server is unavailable.'),
+      };
+    }
+
+    return {
+      success: false,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+};
+
+/**
+ * Check if the conversion server is available
+ * @param {string} serverUrl - The conversion server URL
+ * @returns {Promise<boolean>}
+ */
+export const isConversionServerAvailable = async (serverUrl) => {
+  if (!serverUrl) return false;
+
+  try {
+    const response = await fetch(`${serverUrl}/health`, {
+      method: 'GET',
+      signal: AbortSignal.timeout(5000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Get conversion server status including LibreOffice availability
+ * @param {string} serverUrl - The conversion server URL
+ * @returns {Promise<{available: boolean, libreOfficeInstalled: boolean, message: string}>}
+ */
+export const getConversionServerStatus = async (serverUrl) => {
+  if (!serverUrl) {
+    return {
+      available: false,
+      libreOfficeInstalled: false,
+      message: 'No conversion server URL configured',
+    };
+  }
+
+  try {
+    const response = await fetch(`${serverUrl}/check-libreoffice`, {
+      method: 'GET',
+      signal: AbortSignal.timeout(5000),
+    });
+
+    const data = await response.json();
+
+    return {
+      available: true,
+      libreOfficeInstalled: response.ok,
+      message: data.message || (response.ok ? 'Ready' : 'LibreOffice not installed'),
+    };
+  } catch {
+    return {
+      available: false,
+      libreOfficeInstalled: false,
+      message: 'Conversion server unavailable',
+    };
+  }
+};

--- a/packages/superdoc/src/core/helpers/file.js
+++ b/packages/superdoc/src/core/helpers/file.js
@@ -1,4 +1,4 @@
-import { DOCX, PDF, HTML } from '@superdoc/common';
+import { DOC, DOCX, HTML, PDF } from '@superdoc/common';
 
 /**
  * @typedef {Object} UploadWrapper
@@ -60,6 +60,7 @@ export const extractBrowserFile = (input) => {
 const inferTypeFromName = (name = '') => {
   const lower = String(name).toLowerCase();
   if (lower.endsWith('.docx')) return DOCX;
+  if (lower.endsWith('.doc')) return DOC;
   if (lower.endsWith('.pdf')) return PDF;
   if (lower.endsWith('.html') || lower.endsWith('.htm')) return HTML;
   if (lower.endsWith('.md') || lower.endsWith('.markdown')) return 'text/markdown';

--- a/packages/superdoc/src/dev/components/SuperdocDev.vue
+++ b/packages/superdoc/src/dev/components/SuperdocDev.vue
@@ -1,18 +1,15 @@
 <script setup>
 import '@superdoc/common/styles/common-styles.css';
-import { nextTick, onMounted, onBeforeUnmount, provide, ref, shallowRef, computed } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef } from 'vue';
 
-import { SuperDoc } from '@superdoc/index.js';
-import { DOCX, PDF, HTML } from '@superdoc/common';
-import { getFileObject } from '@superdoc/common';
-import { createPdfPainter } from '@superdoc/painter-pdf';
+import { DOCX, getFileObject } from '@superdoc/common';
 import BasicUpload from '@superdoc/common/components/BasicUpload.vue';
-import SuperdocLogo from '../../../../layout-engine/v1-beta-demo/src/assets/superdoc-logo.webp?url';
-import { fieldAnnotationHelpers } from '@harbour-enterprises/super-editor';
-import { toolbarIcons } from '../../../../super-editor/src/components/toolbar/toolbarIcons';
 import BlankDOCX from '@superdoc/common/data/blank.docx?url';
+import { SuperDoc } from '@superdoc/index.js';
+import { createPdfPainter } from '@superdoc/painter-pdf';
 import * as pdfjsLib from 'pdfjs-dist/build/pdf.mjs';
 import * as pdfjsViewer from 'pdfjs-dist/web/pdf_viewer.mjs';
+import SuperdocLogo from '../../../../layout-engine/v1-beta-demo/src/assets/superdoc-logo.webp?url';
 import { getWorkerSrcFromCDN } from '../../components/PdfViewer/pdf/pdf-adapter.js';
 
 // Or set worker globally outside the component.
@@ -61,6 +58,13 @@ const commentPermissionResolver = ({ permission, comment, defaultDecision, curre
   return defaultDecision;
 };
 
+// .doc conversion state (used by SuperDoc's automatic conversion events)
+const isConverting = ref(false);
+const conversionError = ref(null);
+
+// Conversion server URL - adjust if running on different port
+const CONVERSION_SERVER_URL = 'http://localhost:3001';
+
 const handleNewFile = async (file) => {
   uploadedFileName.value = file?.name || '';
   // Generate a file url
@@ -70,6 +74,9 @@ const handleNewFile = async (file) => {
   const fileExtension = file.name.split('.').pop()?.toLowerCase();
   const isMarkdown = fileExtension === 'md';
   const isHtml = fileExtension === 'html' || fileExtension === 'htm';
+
+  // Note: .doc files are now handled automatically by SuperDoc via the
+  // modules.conversion config. They will be converted to .docx before loading.
 
   if (isMarkdown || isHtml) {
     // For text-based files, read the content and use a blank DOCX as base
@@ -83,7 +90,8 @@ const handleNewFile = async (file) => {
       currentFile.value.htmlContent = content;
     }
   } else {
-    // For binary files (DOCX, PDF), use as-is
+    // For binary files (DOCX, PDF, DOC), use as-is
+    // .doc files will be converted by SuperDoc if conversion server is configured
     currentFile.value = await getFileObject(url, file.name, file.type);
   }
 
@@ -162,6 +170,11 @@ const init = async () => {
     // cspNonce: 'testnonce123',
     useLayoutEngine: useLayoutEngine.value,
     modules: {
+      // .doc to .docx conversion server
+      conversion: {
+        serverUrl: CONVERSION_SERVER_URL,
+        timeout: 60000,
+      },
       comments: {
         // comments: sampleComments,
         // overflow: true,
@@ -309,6 +322,23 @@ const init = async () => {
         textLayerMode: 1,
       },
     },
+
+    // Conversion event handlers
+    onConversionStart: ({ fileName }) => {
+      console.log(`🔄 Converting .doc file: ${fileName}`);
+      isConverting.value = true;
+      conversionError.value = null;
+    },
+    onConversionComplete: ({ fileName, convertedFile }) => {
+      console.log(`✅ Conversion complete: ${fileName} → ${convertedFile.name}`);
+      isConverting.value = false;
+    },
+    onConversionError: ({ fileName, error }) => {
+      console.error(`❌ Conversion failed for ${fileName}:`, error.message);
+      isConverting.value = false;
+      conversionError.value = error.message;
+    },
+
     onEditorCreate,
     onContentError,
     // handleImageUpload: async (file) => url,
@@ -621,6 +651,36 @@ const closeExportMenu = () => {
               <div id="superdoc"></div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Conversion Status Indicator (shown when converting .doc files) -->
+    <div v-if="isConverting" class="doc-conversion-overlay">
+      <div class="doc-conversion-dialog">
+        <div class="doc-conversion-header">
+          <h3>Converting Document</h3>
+        </div>
+        <div class="doc-conversion-body">
+          <div class="doc-conversion-progress">Converting .doc file to .docx... Please wait.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Conversion Error Dialog -->
+    <div v-if="conversionError" class="doc-conversion-overlay">
+      <div class="doc-conversion-dialog">
+        <div class="doc-conversion-header">
+          <h3>Conversion Failed</h3>
+        </div>
+        <div class="doc-conversion-body">
+          <div class="doc-conversion-error">
+            {{ conversionError }}
+          </div>
+          <p style="margin-top: 12px">Make sure the conversion server is running at {{ CONVERSION_SERVER_URL }}</p>
+        </div>
+        <div class="doc-conversion-actions">
+          <button class="doc-conversion-btn doc-conversion-btn--primary" @click="conversionError = null">Close</button>
         </div>
       </div>
     </div>
@@ -1024,5 +1084,117 @@ const closeExportMenu = () => {
   display: grid;
   overflow-y: auto;
   scrollbar-width: none;
+}
+
+/* .doc Conversion Dialog Styles */
+.doc-conversion-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.doc-conversion-dialog {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  max-width: 480px;
+  width: 90%;
+  overflow: hidden;
+}
+
+.doc-conversion-header {
+  background: #0f172a;
+  color: #fff;
+  padding: 16px 20px;
+}
+
+.doc-conversion-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.doc-conversion-body {
+  padding: 20px;
+  color: #333;
+  line-height: 1.6;
+}
+
+.doc-conversion-body p {
+  margin: 0 0 12px;
+}
+
+.doc-conversion-body p:last-child {
+  margin-bottom: 0;
+}
+
+.doc-conversion-error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #dc2626;
+  padding: 12px;
+  border-radius: 8px;
+  margin-top: 12px;
+  font-size: 14px;
+}
+
+.doc-conversion-progress {
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #2563eb;
+  padding: 12px;
+  border-radius: 8px;
+  margin-top: 12px;
+  font-size: 14px;
+  text-align: center;
+}
+
+.doc-conversion-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 16px 20px;
+  background: #f8fafc;
+  border-top: 1px solid #e2e8f0;
+}
+
+.doc-conversion-btn {
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.doc-conversion-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.doc-conversion-btn--secondary {
+  background: #fff;
+  border: 1px solid #d1d5db;
+  color: #374151;
+}
+
+.doc-conversion-btn--secondary:hover:not(:disabled) {
+  background: #f3f4f6;
+  border-color: #9ca3af;
+}
+
+.doc-conversion-btn--primary {
+  background: #3b82f6;
+  border: 1px solid #3b82f6;
+  color: #fff;
+}
+
+.doc-conversion-btn--primary:hover:not(:disabled) {
+  background: #2563eb;
+  border-color: #2563eb;
 }
 </style>

--- a/shared/common/components/BasicUpload.vue
+++ b/shared/common/components/BasicUpload.vue
@@ -8,7 +8,7 @@ const props = withDefaults(
     accept?: string;
   }>(),
   {
-    accept: '.docx, .pdf, .html, .md',
+    accept: '.docx, .pdf, .html, .md, .doc',
   },
 );
 

--- a/shared/common/document-types.ts
+++ b/shared/common/document-types.ts
@@ -1,11 +1,13 @@
 export const DOCX = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' as const;
+export const DOC = 'application/msword' as const;
 export const PDF = 'application/pdf' as const;
 export const HTML = 'text/html' as const;
 
 export const documentTypes = {
   docx: DOCX,
+  doc: DOC,
   pdf: PDF,
   html: HTML,
 } as const;
 
-export type DocumentType = typeof DOCX | typeof PDF | typeof HTML;
+export type DocumentType = typeof DOCX | typeof DOC | typeof PDF | typeof HTML;


### PR DESCRIPTION
## Summary

Add support for converting legacy `.doc` files to `.docx` format using a conversion server powered by LibreOffice. This enables SuperDoc to open and edit legacy Word documents seamlessly.

- Add `DOC` type constant to `document-types.ts`
- Create `documentConverter.js` helper module with conversion logic
- Update `SuperDoc.js` with automatic `.doc` detection and conversion
- Add conversion events (`onConversionStart`, `onConversionComplete`, `onConversionError`)
- Add `modules.conversion` config option for server URL
- Update `file.js` to detect `.doc` files by extension
- Update `BasicUpload.vue` to accept `.doc` files
- Add `conversion-server` example with Docker support

## Demo

https://github.com/user-attachments/assets/015f7c60-6edb-49a2-95cd-b6459479f96d



## Usage

```javascript
const superdoc = new SuperDoc({
  document: docFile, // Can be .doc or .docx
  modules: {
    conversion: {
      serverUrl: 'http://localhost:3001',
      timeout: 60000, // optional
    },
  },
  onConversionStart: ({ fileName }) => console.log(`Converting: ${fileName}`),
  onConversionComplete: ({ convertedFile }) => console.log(`Done: ${convertedFile.name}`),
  onConversionError: ({ error }) => console.error(error),
});
```

## Conversion Server

A Docker-based conversion server is included in `examples/conversion-server/`:

```bash
cd examples/conversion-server
docker-compose up -d
```

The server uses LibreOffice for reliable `.doc` to `.docx` conversion.

## Test plan

- [ ] Upload a `.doc` file and verify it converts and loads correctly
- [ ] Verify conversion events fire appropriately
- [ ] Test error handling when conversion server is unavailable
- [ ] Test with various `.doc` files (different Word versions)
- [ ] Verify `.docx` files continue to work normally (no regression)

Closes #1019