### PR TITLE
feat: add displayMarginsOverride, used only when pagination is off [stable]

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -46,12 +46,11 @@ const editor = shallowRef(null);
 const message = useMessage();
 
 /**
- * Computed property that determines if displayMarginsOverride is active.
- * The override is only active when pagination is disabled and an override is provided.
- * @returns {boolean} True if displayMarginsOverride should be applied
+ * Computed property that determines if responsive layout mode is active.
+ * @returns {boolean} True if layoutMode is 'responsive'
  */
-const hasDisplayMarginsOverride = computed(() => {
-  return !props.options.pagination && !!props.options.displayMarginsOverride;
+const isResponsiveMode = computed(() => {
+  return props.options.layoutMode === 'responsive';
 });
 
 const editorWrapper = ref(null);
@@ -317,7 +316,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="super-editor-container" :class="{ 'no-min-height': hasDisplayMarginsOverride }">
+  <div class="super-editor-container" :class="{ 'no-min-height': isResponsiveMode }">
     <Ruler class="ruler" v-if="options.rulers && !!editor" :editor="editor" @margin-change="handleMarginChange" />
 
     <div

--- a/packages/super-editor/src/core/Editor.js
+++ b/packages/super-editor/src/core/Editor.js
@@ -147,7 +147,8 @@ const MAX_WIDTH_BUFFER_PX = 20;
  * @property {string} [html] - HTML content to initialize the editor with
  * @property {string} [markdown] - Markdown content to initialize the editor with
  * @property {boolean} [isDebug=false] - Whether to enable debug mode
- * @property {{top?: number, bottom?: number, left?: number, right?: number}} [displayMarginsOverride] - Override visual margins (values in pixels, only applies when pagination is disabled)
+ * @property {'responsive' | 'paginated'} [layoutMode='paginated'] - Document layout mode ('paginated' for fixed page width, 'responsive' for fluid width)
+ * @property {{top?: number, bottom?: number, left?: number, right?: number}} [layoutMargins] - Custom margins in pixels for responsive layout mode
  * @property {(params: {
  *   permission: string,
  *   role?: string,
@@ -242,7 +243,8 @@ export class Editor extends EventEmitter {
     lastSelection: null,
     suppressDefaultDocxStyles: false,
     jsonOverride: null,
-    displayMarginsOverride: null,
+    layoutMode: 'paginated',
+    layoutMargins: null,
     onBeforeCreate: () => null,
     onCreate: () => null,
     onUpdate: () => null,
@@ -294,7 +296,7 @@ export class Editor extends EventEmitter {
 
     this.#initContainerElement(options);
     this.#checkHeadless(options);
-    this.#validateDisplayMarginsOverride(options);
+    this.#validateLayoutMargins(options);
     this.setOptions(options);
 
     let modes = {
@@ -520,45 +522,45 @@ export class Editor extends EventEmitter {
   }
 
   /**
-   * Validate displayMarginsOverride option values
+   * Validate layoutMargins option values
    * @param {EditorOptions} options - Editor options
    * @returns {void}
    */
-  #validateDisplayMarginsOverride(options) {
-    if (!options.displayMarginsOverride) return;
+  #validateLayoutMargins(options) {
+    if (!options.layoutMargins) return;
 
-    const override = options.displayMarginsOverride;
-    const validatedOverride = {};
+    const margins = options.layoutMargins;
+    const validatedMargins = {};
     let hasValidValues = false;
 
     for (const key of ['top', 'bottom', 'left', 'right']) {
-      if (override[key] !== undefined && override[key] !== null) {
-        const value = override[key];
+      if (margins[key] !== undefined && margins[key] !== null) {
+        const value = margins[key];
 
         // Validate that value is a positive finite number
         if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
-          validatedOverride[key] = value;
+          validatedMargins[key] = value;
           hasValidValues = true;
         } else {
           console.warn(
-            `[SuperDoc] Invalid displayMarginsOverride.${key}: ${value}. ` +
+            `[SuperDoc] Invalid layoutMargins.${key}: ${value}. ` +
               `Value must be a positive finite number. Ignoring this property.`,
           );
         }
       }
     }
 
-    // Replace the override with the validated version, or null if no valid values
-    options.displayMarginsOverride = hasValidValues ? validatedOverride : null;
+    // Replace the margins with the validated version, or null if no valid values
+    options.layoutMargins = hasValidValues ? validatedMargins : null;
   }
 
   /**
-   * Check if displayMarginsOverride should be applied
-   * @returns {boolean} True if pagination is disabled and displayMarginsOverride is set
+   * Check if responsive layout mode is enabled
+   * @returns {boolean} True if layoutMode is 'responsive'
    * @private
    */
-  #shouldApplyMarginsOverride() {
-    return !this.options.pagination && !!this.options.displayMarginsOverride;
+  #isResponsiveMode() {
+    return this.options.layoutMode === 'responsive';
   }
 
   /**
@@ -1279,16 +1281,18 @@ export class Editor extends EventEmitter {
   getMaxContentSize() {
     if (!this.converter) return {};
     const { pageSize = {}, pageMargins = {} } = this.converter.pageStyles ?? {};
-    const { displayMarginsOverride } = this.options;
+    const { layoutMargins } = this.options;
     const { width, height } = pageSize;
 
-    // displayMarginsOverride only applies when pagination is disabled
-    // Override values are in pixels, document margins are in inches
-    const shouldApplyMarginsOverride = this.#shouldApplyMarginsOverride();
+    // In responsive mode: use layoutMargins (pixels) or defaults (1in = 96px)
+    // In paginated mode: use document margins (inches converted to pixels)
+    const isResponsive = this.#isResponsiveMode();
 
     const getMarginPx = (side) => {
-      const defaultPx = (pageMargins?.[side] ?? 0) * PIXELS_PER_INCH;
-      return shouldApplyMarginsOverride ? (displayMarginsOverride?.[side] ?? defaultPx) : defaultPx;
+      if (isResponsive) {
+        return layoutMargins?.[side] ?? PIXELS_PER_INCH;
+      }
+      return (pageMargins?.[side] ?? 0) * PIXELS_PER_INCH;
     };
 
     const topPx = getMarginPx('top');
@@ -1316,11 +1320,10 @@ export class Editor extends EventEmitter {
    */
   updateEditorStyles(element, proseMirror, hasPaginationEnabled = true) {
     const { pageSize, pageMargins } = this.converter.pageStyles ?? {};
-    const { displayMarginsOverride, pagination } = this.options;
+    const { layoutMargins, pagination } = this.options;
 
-    // displayMarginsOverride only applies when pagination is disabled
-    // Check this.options.pagination directly since hasPaginationEnabled parameter may not reflect config
-    const shouldApplyMarginsOverride = this.#shouldApplyMarginsOverride();
+    // Responsive mode uses 100% width and custom margins
+    const isResponsive = this.#isResponsiveMode();
 
     if (!proseMirror || !element) {
       return;
@@ -1334,22 +1337,20 @@ export class Editor extends EventEmitter {
 
     // Set fixed dimensions and padding that won't change with scaling
     if (pageSize?.width != null) {
-      element.style.width = shouldApplyMarginsOverride ? '100%' : `${pageSize.width}in`;
-      element.style.minWidth = shouldApplyMarginsOverride ? '' : `${pageSize.width}in`;
+      element.style.width = isResponsive ? '100%' : `${pageSize.width}in`;
+      element.style.minWidth = isResponsive ? '' : `${pageSize.width}in`;
     }
 
     if (pageSize?.height != null) {
-      element.style.minHeight = shouldApplyMarginsOverride ? '' : `${pageSize.height}in`;
+      element.style.minHeight = isResponsive ? '' : `${pageSize.height}in`;
     }
 
-    // Apply left/right margins - use displayMarginsOverride (in pixels) if provided and pagination disabled
-    if (shouldApplyMarginsOverride) {
-      if (displayMarginsOverride.left != null) {
-        element.style.paddingLeft = displayMarginsOverride.left + 'px';
-      }
-      if (displayMarginsOverride.right != null) {
-        element.style.paddingRight = displayMarginsOverride.right + 'px';
-      }
+    // Apply left/right margins
+    // In responsive mode: use layoutMargins (pixels) or defaults (1in = 96px)
+    // In paginated mode: use document margins (inches)
+    if (isResponsive) {
+      element.style.paddingLeft = (layoutMargins?.left ?? PIXELS_PER_INCH) + 'px';
+      element.style.paddingRight = (layoutMargins?.right ?? PIXELS_PER_INCH) + 'px';
     } else if (pageMargins) {
       element.style.paddingLeft = pageMargins.left + 'in';
       element.style.paddingRight = pageMargins.right + 'in';
@@ -1383,16 +1384,16 @@ export class Editor extends EventEmitter {
     const defaultLineHeight = 1.2;
     proseMirror.style.lineHeight = defaultLineHeight;
 
-    // If we are not using pagination, we still need to add some padding for header/footer
-    // Use displayMarginsOverride (in pixels) for top/bottom if provided, otherwise default to 1in
-    if (!pagination) {
-      if (shouldApplyMarginsOverride) {
-        proseMirror.style.paddingTop = (displayMarginsOverride.top ?? PIXELS_PER_INCH) + 'px'; // Default to 1in
-        proseMirror.style.paddingBottom = (displayMarginsOverride.bottom ?? PIXELS_PER_INCH) + 'px';
-      } else {
-        proseMirror.style.paddingTop = '1in';
-        proseMirror.style.paddingBottom = '1in';
-      }
+    // Top/bottom padding
+    // In responsive mode: use layoutMargins (pixels) or defaults (1in = 96px)
+    // In paginated mode with pagination disabled: use 1in
+    // In paginated mode with pagination enabled: no padding (pages handle it)
+    if (isResponsive) {
+      proseMirror.style.paddingTop = (layoutMargins?.top ?? PIXELS_PER_INCH) + 'px';
+      proseMirror.style.paddingBottom = (layoutMargins?.bottom ?? PIXELS_PER_INCH) + 'px';
+    } else if (!pagination) {
+      proseMirror.style.paddingTop = '1in';
+      proseMirror.style.paddingBottom = '1in';
     } else {
       proseMirror.style.paddingTop = '0';
       proseMirror.style.paddingBottom = '0';
@@ -1420,12 +1421,18 @@ export class Editor extends EventEmitter {
   /**
    * Initializes responsive styles for mobile devices.
    * Sets up scaling based on viewport width and handles orientation changes.
+   * Note: Scaling is skipped in responsive layout mode since content reflows naturally.
    *
    * @param {HTMLElement|void} element - The DOM element to apply mobile styles to
    * @returns {void}
    */
   initMobileStyles(element) {
     if (!element) {
+      return;
+    }
+
+    // In responsive mode, content reflows naturally - no scaling needed
+    if (this.#isResponsiveMode()) {
       return;
     }
 
@@ -1539,6 +1546,11 @@ export class Editor extends EventEmitter {
    */
   async #initPagination() {
     if (this.options.isHeadless || !this.extensionService || this.options.isHeaderOrFooter) {
+      return;
+    }
+
+    // Responsive mode disables pagination - content reflows naturally
+    if (this.#isResponsiveMode()) {
       return;
     }
 

--- a/packages/super-editor/src/core/Editor.layoutMode.test.js
+++ b/packages/super-editor/src/core/Editor.layoutMode.test.js
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { initTestEditor, loadTestDataForEditorTests } from '../tests/helpers/helpers.js';
 
-describe('Editor displayMarginsOverride', () => {
+describe('Editor layoutMode', () => {
   let docx;
   let media;
   let mediaFiles;
@@ -22,8 +22,8 @@ describe('Editor displayMarginsOverride', () => {
         media,
         mediaFiles,
         fonts,
-        pagination: false,
-        displayMarginsOverride: {
+        layoutMode: 'responsive',
+        layoutMargins: {
           top: 100,
           bottom: 50,
           left: 75,
@@ -32,7 +32,7 @@ describe('Editor displayMarginsOverride', () => {
       });
       context.editor = editor;
 
-      expect(editor.options.displayMarginsOverride).toEqual({
+      expect(editor.options.layoutMargins).toEqual({
         top: 100,
         bottom: 50,
         left: 75,
@@ -46,8 +46,8 @@ describe('Editor displayMarginsOverride', () => {
         media,
         mediaFiles,
         fonts,
-        pagination: false,
-        displayMarginsOverride: {
+        layoutMode: 'responsive',
+        layoutMargins: {
           top: 0,
           bottom: 0,
           left: 0,
@@ -56,7 +56,7 @@ describe('Editor displayMarginsOverride', () => {
       });
       context.editor = editor;
 
-      expect(editor.options.displayMarginsOverride).toEqual({
+      expect(editor.options.layoutMargins).toEqual({
         top: 0,
         bottom: 0,
         left: 0,
@@ -64,21 +64,21 @@ describe('Editor displayMarginsOverride', () => {
       });
     });
 
-    it('accepts partial displayMarginsOverride with only some properties set', (context) => {
+    it('accepts partial layoutMargins with only some properties set', (context) => {
       const { editor } = initTestEditor({
         content: docx,
         media,
         mediaFiles,
         fonts,
-        pagination: false,
-        displayMarginsOverride: {
+        layoutMode: 'responsive',
+        layoutMargins: {
           top: 50,
           left: 75,
         },
       });
       context.editor = editor;
 
-      expect(editor.options.displayMarginsOverride).toEqual({
+      expect(editor.options.layoutMargins).toEqual({
         top: 50,
         left: 75,
       });
@@ -92,18 +92,18 @@ describe('Editor displayMarginsOverride', () => {
         media,
         mediaFiles,
         fonts,
-        pagination: false,
-        displayMarginsOverride: {
+        layoutMode: 'responsive',
+        layoutMargins: {
           top: -10,
           bottom: 50,
         },
       });
       context.editor = editor;
 
-      expect(editor.options.displayMarginsOverride).toEqual({
+      expect(editor.options.layoutMargins).toEqual({
         bottom: 50,
       });
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid displayMarginsOverride.top'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid layoutMargins.top'));
 
       warnSpy.mockRestore();
     });
@@ -116,18 +116,18 @@ describe('Editor displayMarginsOverride', () => {
         media,
         mediaFiles,
         fonts,
-        pagination: false,
-        displayMarginsOverride: {
+        layoutMode: 'responsive',
+        layoutMargins: {
           top: NaN,
           bottom: 50,
         },
       });
       context.editor = editor;
 
-      expect(editor.options.displayMarginsOverride).toEqual({
+      expect(editor.options.layoutMargins).toEqual({
         bottom: 50,
       });
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid displayMarginsOverride.top'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid layoutMargins.top'));
 
       warnSpy.mockRestore();
     });
@@ -140,18 +140,18 @@ describe('Editor displayMarginsOverride', () => {
         media,
         mediaFiles,
         fonts,
-        pagination: false,
-        displayMarginsOverride: {
+        layoutMode: 'responsive',
+        layoutMargins: {
           top: Infinity,
           bottom: 50,
         },
       });
       context.editor = editor;
 
-      expect(editor.options.displayMarginsOverride).toEqual({
+      expect(editor.options.layoutMargins).toEqual({
         bottom: 50,
       });
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid displayMarginsOverride.top'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid layoutMargins.top'));
 
       warnSpy.mockRestore();
     });
@@ -164,23 +164,23 @@ describe('Editor displayMarginsOverride', () => {
         media,
         mediaFiles,
         fonts,
-        pagination: false,
-        displayMarginsOverride: {
+        layoutMode: 'responsive',
+        layoutMargins: {
           top: '100',
           bottom: 50,
         },
       });
       context.editor = editor;
 
-      expect(editor.options.displayMarginsOverride).toEqual({
+      expect(editor.options.layoutMargins).toEqual({
         bottom: 50,
       });
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid displayMarginsOverride.top'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid layoutMargins.top'));
 
       warnSpy.mockRestore();
     });
 
-    it('sets displayMarginsOverride to null if all values are invalid', (context) => {
+    it('sets layoutMargins to null if all values are invalid', (context) => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const { editor } = initTestEditor({
@@ -188,8 +188,8 @@ describe('Editor displayMarginsOverride', () => {
         media,
         mediaFiles,
         fonts,
-        pagination: false,
-        displayMarginsOverride: {
+        layoutMode: 'responsive',
+        layoutMargins: {
           top: -10,
           bottom: 'invalid',
           left: NaN,
@@ -198,7 +198,7 @@ describe('Editor displayMarginsOverride', () => {
       });
       context.editor = editor;
 
-      expect(editor.options.displayMarginsOverride).toBeNull();
+      expect(editor.options.layoutMargins).toBeNull();
       expect(warnSpy).toHaveBeenCalledTimes(4);
 
       warnSpy.mockRestore();
@@ -210,8 +210,8 @@ describe('Editor displayMarginsOverride', () => {
         media,
         mediaFiles,
         fonts,
-        pagination: false,
-        displayMarginsOverride: {
+        layoutMode: 'responsive',
+        layoutMargins: {
           top: 100,
           bottom: null,
           left: undefined,
@@ -220,10 +220,52 @@ describe('Editor displayMarginsOverride', () => {
       });
       context.editor = editor;
 
-      expect(editor.options.displayMarginsOverride).toEqual({
+      expect(editor.options.layoutMargins).toEqual({
         top: 100,
         right: 50,
       });
+    });
+
+    it('defaults to paginated layout mode', (context) => {
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+      });
+      context.editor = editor;
+
+      expect(editor.options.layoutMode).toBe('paginated');
+    });
+
+    it('accepts responsive layout mode', (context) => {
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+        layoutMode: 'responsive',
+      });
+      context.editor = editor;
+
+      expect(editor.options.layoutMode).toBe('responsive');
+    });
+
+    it('responsive mode takes precedence over pagination: true', (context) => {
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+        layoutMode: 'responsive',
+        pagination: true,
+      });
+      context.editor = editor;
+
+      // layoutMode: 'responsive' should work even if pagination: true is set
+      expect(editor.options.layoutMode).toBe('responsive');
+      // The editor should still treat this as responsive mode
+      expect(editor.options.pagination).toBe(true); // Option preserved, but behavior overridden
     });
   });
 
@@ -261,9 +303,9 @@ describe('Editor displayMarginsOverride', () => {
       expect(result).toEqual({});
     });
 
-    it('calculates max content size with default margins when pagination is enabled', () => {
-      editor.options.pagination = true;
-      editor.options.displayMarginsOverride = null;
+    it('calculates max content size with default margins when in paginated mode', () => {
+      editor.options.layoutMode = 'paginated';
+      editor.options.layoutMargins = null;
       editor.converter.pageStyles = {
         pageSize: { width: 8.5, height: 11 },
         pageMargins: { top: 1, bottom: 1, left: 1, right: 1 },
@@ -277,9 +319,9 @@ describe('Editor displayMarginsOverride', () => {
       expect(result.height).toBe(814);
     });
 
-    it('applies displayMarginsOverride when pagination is disabled', () => {
-      editor.options.pagination = false;
-      editor.options.displayMarginsOverride = {
+    it('applies layoutMargins in responsive mode', () => {
+      editor.options.layoutMode = 'responsive';
+      editor.options.layoutMargins = {
         top: 50,
         bottom: 50,
         left: 100,
@@ -298,9 +340,9 @@ describe('Editor displayMarginsOverride', () => {
       expect(result.height).toBe(906);
     });
 
-    it('uses partial displayMarginsOverride and falls back to document margins', () => {
-      editor.options.pagination = false;
-      editor.options.displayMarginsOverride = {
+    it('uses partial layoutMargins and falls back to document margins', () => {
+      editor.options.layoutMode = 'responsive';
+      editor.options.layoutMargins = {
         top: 50,
         left: 100,
       };
@@ -317,9 +359,9 @@ describe('Editor displayMarginsOverride', () => {
       expect(result.height).toBe(860);
     });
 
-    it('ignores displayMarginsOverride when pagination is enabled', () => {
-      editor.options.pagination = true;
-      editor.options.displayMarginsOverride = {
+    it('ignores layoutMargins in paginated mode', () => {
+      editor.options.layoutMode = 'paginated';
+      editor.options.layoutMargins = {
         top: 50,
         bottom: 50,
         left: 100,
@@ -339,9 +381,9 @@ describe('Editor displayMarginsOverride', () => {
       expect(result.height).toBe(814);
     });
 
-    it('handles zero values in displayMarginsOverride', () => {
-      editor.options.pagination = false;
-      editor.options.displayMarginsOverride = {
+    it('handles zero values in layoutMargins', () => {
+      editor.options.layoutMode = 'responsive';
+      editor.options.layoutMargins = {
         top: 0,
         bottom: 0,
         left: 0,
@@ -361,8 +403,8 @@ describe('Editor displayMarginsOverride', () => {
     });
 
     it('handles missing page margins gracefully', () => {
-      editor.options.pagination = false;
-      editor.options.displayMarginsOverride = {
+      editor.options.layoutMode = 'responsive';
+      editor.options.layoutMargins = {
         top: 50,
       };
       editor.converter.pageStyles = {
@@ -372,10 +414,11 @@ describe('Editor displayMarginsOverride', () => {
 
       const result = editor.getMaxContentSize();
 
-      // Expected: (8.5 * 96 - 0 - 0 - 20) = 796 (left/right use 0 when margins missing)
-      // Expected: (11 * 96 - 50 - 0 - 50) = 956 (top override, bottom uses 0)
-      expect(result.width).toBe(796);
-      expect(result.height).toBe(956);
+      // In responsive mode, missing layoutMargins default to 96px (1in)
+      // Expected: (8.5 * 96 - 96 - 96 - 20) = 604 (left/right default to 96px)
+      // Expected: (11 * 96 - 50 - 96 - 50) = 860 (top override, bottom defaults to 96px)
+      expect(result.width).toBe(604);
+      expect(result.height).toBe(860);
     });
   });
 
@@ -430,9 +473,9 @@ describe('Editor displayMarginsOverride', () => {
       expect(proseMirror.style.paddingTop).toBeUndefined();
     });
 
-    it('applies displayMarginsOverride padding when pagination is disabled', () => {
-      editor.options.pagination = false;
-      editor.options.displayMarginsOverride = {
+    it('applies layoutMargins padding in responsive mode', () => {
+      editor.options.layoutMode = 'responsive';
+      editor.options.layoutMargins = {
         top: 50,
         bottom: 75,
         left: 100,
@@ -447,21 +490,23 @@ describe('Editor displayMarginsOverride', () => {
       expect(proseMirror.style.paddingBottom).toBe('75px');
     });
 
-    it('applies default padding when pagination is disabled without override', () => {
-      editor.options.pagination = false;
-      editor.options.displayMarginsOverride = null;
+    it('applies default padding in responsive mode without layoutMargins', () => {
+      editor.options.layoutMode = 'responsive';
+      editor.options.layoutMargins = null;
 
       editor.updateEditorStyles(element, proseMirror, false);
 
-      expect(element.style.paddingLeft).toBe('1in');
-      expect(element.style.paddingRight).toBe('1in');
-      expect(proseMirror.style.paddingTop).toBe('1in');
-      expect(proseMirror.style.paddingBottom).toBe('1in');
+      // Uses default 1in (96px) for all sides in responsive mode without layoutMargins
+      expect(element.style.paddingLeft).toBe('96px');
+      expect(element.style.paddingRight).toBe('96px');
+      expect(proseMirror.style.paddingTop).toBe('96px');
+      expect(proseMirror.style.paddingBottom).toBe('96px');
     });
 
-    it('does not apply displayMarginsOverride when pagination is enabled', () => {
+    it('does not apply layoutMargins in paginated mode', () => {
+      editor.options.layoutMode = 'paginated';
       editor.options.pagination = true;
-      editor.options.displayMarginsOverride = {
+      editor.options.layoutMargins = {
         top: 50,
         bottom: 75,
         left: 100,
@@ -477,9 +522,9 @@ describe('Editor displayMarginsOverride', () => {
       expect(proseMirror.style.paddingBottom).toBe('0');
     });
 
-    it('applies partial displayMarginsOverride with fallback to document margins', () => {
-      editor.options.pagination = false;
-      editor.options.displayMarginsOverride = {
+    it('applies partial layoutMargins with fallback to default', () => {
+      editor.options.layoutMode = 'responsive';
+      editor.options.layoutMargins = {
         left: 100,
         top: 50,
       };
@@ -487,27 +532,46 @@ describe('Editor displayMarginsOverride', () => {
       editor.updateEditorStyles(element, proseMirror, false);
 
       expect(element.style.paddingLeft).toBe('100px');
-      expect(element.style.paddingRight).toBeUndefined(); // Not set by override, uses document margin
+      expect(element.style.paddingRight).toBe('96px'); // Falls back to 1in = 96px
       expect(proseMirror.style.paddingTop).toBe('50px');
       expect(proseMirror.style.paddingBottom).toBe('96px'); // Falls back to 1in = 96px
     });
 
-    it('removes minHeight when displayMarginsOverride is active', () => {
-      editor.options.pagination = false;
-      editor.options.displayMarginsOverride = { top: 50 };
+    it('removes minHeight in responsive mode', () => {
+      editor.options.layoutMode = 'responsive';
+      editor.options.layoutMargins = { top: 50 };
 
       editor.updateEditorStyles(element, proseMirror, false);
 
       expect(element.style.minHeight).toBe('');
     });
 
-    it('sets minHeight when displayMarginsOverride is not active', () => {
+    it('sets minHeight in paginated mode', () => {
+      editor.options.layoutMode = 'paginated';
       editor.options.pagination = true;
-      editor.options.displayMarginsOverride = null;
+      editor.options.layoutMargins = null;
 
       editor.updateEditorStyles(element, proseMirror, true);
 
       expect(element.style.minHeight).toBe('11in');
+    });
+
+    it('sets width to 100% in responsive mode', () => {
+      editor.options.layoutMode = 'responsive';
+
+      editor.updateEditorStyles(element, proseMirror, false);
+
+      expect(element.style.width).toBe('100%');
+      expect(element.style.minWidth).toBe('');
+    });
+
+    it('sets fixed width in paginated mode', () => {
+      editor.options.layoutMode = 'paginated';
+
+      editor.updateEditorStyles(element, proseMirror, true);
+
+      expect(element.style.width).toBe('8.5in');
+      expect(element.style.minWidth).toBe('8.5in');
     });
   });
 });

--- a/packages/superdoc/src/SuperDoc.vue
+++ b/packages/superdoc/src/SuperDoc.vue
@@ -327,7 +327,8 @@ const editorOptions = (doc) => {
     suppressDefaultDocxStyles: proxy.$superdoc.config.suppressDefaultDocxStyles,
     disableContextMenu: proxy.$superdoc.config.disableContextMenu,
     jsonOverride: proxy.$superdoc.config.jsonOverride,
-    displayMarginsOverride: proxy.$superdoc.config.displayMarginsOverride,
+    layoutMode: proxy.$superdoc.config.layoutMode,
+    layoutMargins: proxy.$superdoc.config.layoutMargins,
     permissionResolver: (payload = {}) =>
       proxy.$superdoc.canPerformPermission({
         role: proxy.$superdoc.config.role,

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -112,10 +112,15 @@ export class SuperDoc extends EventEmitter {
     // Disable context menus (slash and right-click) globally
     disableContextMenu: false,
 
-    // Override visual margins for the editor (values in pixels)
-    // Only applies when pagination is disabled
+    // Document layout mode: 'paginated' (default) or 'responsive'
+    // 'paginated': Fixed page width, shows page breaks like a real document
+    // 'responsive': 100% width, text reflows to fit the container (useful for mobile/accessibility)
+    layoutMode: 'paginated',
+
+    // Custom margins for responsive layout mode (values in pixels)
+    // Only applies when layoutMode is 'responsive'
     // Example: { top: 48, bottom: 48, left: 48, right: 48 }
-    displayMarginsOverride: null,
+    layoutMargins: null,
   };
 
   /**

--- a/packages/superdoc/src/core/types/index.js
+++ b/packages/superdoc/src/core/types/index.js
@@ -97,12 +97,19 @@
  */
 
 /**
- * @typedef {Object} DisplayMarginsOverride
+ * @typedef {'responsive' | 'paginated'} LayoutMode
+ * Determines how the document is displayed:
+ * - 'paginated' (default): Fixed page width, shows page breaks like a real document
+ * - 'responsive': 100% width, text reflows to fit the container (useful for mobile/accessibility)
+ */
+
+/**
+ * @typedef {Object} LayoutMargins
  * @property {number} [top] Override for the top margin in pixels
  * @property {number} [bottom] Override for the bottom margin in pixels
  * @property {number} [left] Override for the left margin in pixels
  * @property {number} [right] Override for the right margin in pixels
- * @description Only applies when pagination is disabled. Values are in pixels.
+ * @description Custom margins for responsive layout mode. Values are in pixels. Defaults to 96px (1 inch) if not specified.
  */
 
 /**
@@ -164,7 +171,8 @@
  * @property {string} [html] HTML content to initialize the editor with
  * @property {string} [markdown] Markdown content to initialize the editor with
  * @property {boolean} [isDebug=false] Whether to enable debug mode
- * @property {DisplayMarginsOverride} [displayMarginsOverride] Override visual margins for the editor (values in pixels, only applies when pagination is disabled)
+ * @property {LayoutMode} [layoutMode='paginated'] Document layout mode ('paginated' for fixed page width, 'responsive' for fluid width)
+ * @property {LayoutMargins} [layoutMargins] Custom margins in pixels for responsive layout mode
  */
 
 export {};

--- a/packages/superdoc/src/dev/components/SuperdocDev.vue
+++ b/packages/superdoc/src/dev/components/SuperdocDev.vue
@@ -131,9 +131,10 @@ const init = async () => {
     rulers: false,
     annotations: true,
 
-    // Override visual margins (values in pixels) - uncomment to test
-    pagination: true,
-    // displayMarginsOverride: { top: 10, bottom: 10, left: 10, right: 10 }, // Pagination must be false for this to do anything
+    // Document layout mode: 'paginated' (default) or 'responsive'
+    // 'responsive' enables 100% width and custom margins - useful for mobile/accessibility
+    // layoutMode: 'responsive',
+    // layoutMargins: { top: 10, bottom: 10, left: 10, right: 10 },
 
     isInternal,
     telemetry: false,


### PR DESCRIPTION
- add displayMarginsOverride config key (only active if pagination: false is also set)
- prevents min-height of editor when displayMarginsOverride
- used for "semantic" display of content