### PR TITLE
feat: add displayMarginsOverride, used only when pagination is off [main]

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -59,6 +59,9 @@ const contextMenuDisabled = computed(() => {
   return active?.options ? Boolean(active.options.disableContextMenu) : Boolean(props.options.disableContextMenu);
 });
 
+const isFlowEditor = computed(() => props.options?.editorCtor !== PresentationEditor);
+const shouldRelaxMinSize = computed(() => isFlowEditor.value && Boolean(props.options?.displayMarginsOverride));
+
 /**
  * Reactive ruler visibility state.
  * Uses a ref with a deep watcher to ensure proper reactivity when options.rulers changes.
@@ -783,7 +786,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="super-editor-container">
+  <div class="super-editor-container" :class="{ 'no-min-height': shouldRelaxMinSize }">
     <!-- Ruler: teleport to external container if specified, otherwise render inline -->
     <Teleport v-if="options.rulerContainer && rulersVisible && !!activeEditor" :to="options.rulerContainer">
       <Ruler class="ruler superdoc-ruler" :editor="activeEditor" @margin-change="handleMarginChange" />
@@ -883,6 +886,12 @@ onBeforeUnmount(() => {
   position: relative;
   display: flex;
   flex-direction: column;
+}
+
+.super-editor-container.no-min-height {
+  width: 100%;
+  min-height: 0;
+  min-width: 0;
 }
 
 .ruler {

--- a/packages/super-editor/src/core/Editor.displayMarginsOverride.test.js
+++ b/packages/super-editor/src/core/Editor.displayMarginsOverride.test.js
@@ -1,0 +1,525 @@
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { initTestEditor, loadTestDataForEditorTests } from '../tests/helpers/helpers.js';
+
+describe('Editor displayMarginsOverride', () => {
+  let docx;
+  let media;
+  let mediaFiles;
+  let fonts;
+
+  beforeAll(async () => {
+    ({ docx, media, mediaFiles, fonts } = await loadTestDataForEditorTests('blank-doc.docx'));
+  });
+
+  describe('Input Validation', () => {
+    afterEach((context) => {
+      context.editor?.destroy();
+    });
+
+    it('accepts valid positive numbers for all margin properties', (context) => {
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+        displayMarginsOverride: {
+          top: 100,
+          bottom: 50,
+          left: 75,
+          right: 25,
+        },
+      });
+      context.editor = editor;
+
+      expect(editor.options.displayMarginsOverride).toEqual({
+        top: 100,
+        bottom: 50,
+        left: 75,
+        right: 25,
+      });
+    });
+
+    it('accepts zero values for margin properties', (context) => {
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+        displayMarginsOverride: {
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+        },
+      });
+      context.editor = editor;
+
+      expect(editor.options.displayMarginsOverride).toEqual({
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+      });
+    });
+
+    it('accepts partial displayMarginsOverride with only some properties set', (context) => {
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+        displayMarginsOverride: {
+          top: 50,
+          left: 75,
+        },
+      });
+      context.editor = editor;
+
+      expect(editor.options.displayMarginsOverride).toEqual({
+        top: 50,
+        left: 75,
+      });
+    });
+
+    it('rejects negative values and warns', (context) => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+        displayMarginsOverride: {
+          top: -10,
+          bottom: 50,
+        },
+      });
+      context.editor = editor;
+
+      expect(editor.options.displayMarginsOverride).toEqual({
+        bottom: 50,
+      });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid displayMarginsOverride.top'));
+
+      warnSpy.mockRestore();
+    });
+
+    it('rejects NaN values and warns', (context) => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+        displayMarginsOverride: {
+          top: NaN,
+          bottom: 50,
+        },
+      });
+      context.editor = editor;
+
+      expect(editor.options.displayMarginsOverride).toEqual({
+        bottom: 50,
+      });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid displayMarginsOverride.top'));
+
+      warnSpy.mockRestore();
+    });
+
+    it('rejects Infinity values and warns', (context) => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+        displayMarginsOverride: {
+          top: Infinity,
+          bottom: 50,
+        },
+      });
+      context.editor = editor;
+
+      expect(editor.options.displayMarginsOverride).toEqual({
+        bottom: 50,
+      });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid displayMarginsOverride.top'));
+
+      warnSpy.mockRestore();
+    });
+
+    it('rejects string values and warns', (context) => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+        displayMarginsOverride: {
+          // @ts-expect-error - invalid input on purpose
+          top: '100',
+          bottom: 50,
+        },
+      });
+      context.editor = editor;
+
+      expect(editor.options.displayMarginsOverride).toEqual({
+        bottom: 50,
+      });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid displayMarginsOverride.top'));
+
+      warnSpy.mockRestore();
+    });
+
+    it('sets displayMarginsOverride to null if all values are invalid', (context) => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+        displayMarginsOverride: {
+          // @ts-expect-error - invalid inputs on purpose
+          top: -10,
+          bottom: 'invalid',
+          left: NaN,
+          right: Infinity,
+        },
+      });
+      context.editor = editor;
+
+      expect(editor.options.displayMarginsOverride).toBeNull();
+      expect(warnSpy).toHaveBeenCalledTimes(4);
+
+      warnSpy.mockRestore();
+    });
+
+    it('handles null and undefined values gracefully', (context) => {
+      const { editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+        displayMarginsOverride: {
+          top: 100,
+          // @ts-expect-error - invalid input on purpose
+          bottom: null,
+          left: undefined,
+          right: 50,
+        },
+      });
+      context.editor = editor;
+
+      expect(editor.options.displayMarginsOverride).toEqual({
+        top: 100,
+        right: 50,
+      });
+    });
+  });
+
+  describe('getMaxContentSize()', () => {
+    let editor;
+
+    beforeEach(() => {
+      ({ editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+      }));
+    });
+
+    afterEach(() => {
+      editor?.destroy();
+      editor = null;
+    });
+
+    it('returns empty object when converter is not available', () => {
+      const editorWithoutConverter = { converter: null };
+      const result = editor.getMaxContentSize.call(editorWithoutConverter);
+
+      expect(result).toEqual({});
+    });
+
+    it('returns empty object when page size is not available', () => {
+      editor.converter.pageStyles = {};
+
+      const result = editor.getMaxContentSize();
+
+      expect(result).toEqual({});
+    });
+
+    it('calculates max content size with default margins when layout engine is enabled', () => {
+      editor.presentationEditor = {};
+      editor.options.displayMarginsOverride = null;
+      editor.converter.pageStyles = {
+        pageSize: { width: 8.5, height: 11 },
+        pageMargins: { top: 1, bottom: 1, left: 1, right: 1 },
+      };
+
+      const result = editor.getMaxContentSize();
+
+      // (8.5 * 96 - 1*96 - 1*96 - 20) = 604
+      // (11 * 96 - 1*96 - 1*96 - 50) = 814
+      expect(result.width).toBe(604);
+      expect(result.height).toBe(814);
+    });
+
+    it('applies displayMarginsOverride when layout engine is disabled', () => {
+      editor.presentationEditor = null;
+      editor.options.displayMarginsOverride = {
+        top: 50,
+        bottom: 50,
+        left: 100,
+        right: 100,
+      };
+      editor.converter.pageStyles = {
+        pageSize: { width: 8.5, height: 11 },
+        pageMargins: { top: 1, bottom: 1, left: 1, right: 1 },
+      };
+
+      const result = editor.getMaxContentSize();
+
+      // (8.5 * 96 - 100 - 100 - 20) = 596
+      // (11 * 96 - 50 - 50 - 50) = 906
+      expect(result.width).toBe(596);
+      expect(result.height).toBe(906);
+    });
+
+    it('uses partial displayMarginsOverride and falls back to document margins', () => {
+      editor.presentationEditor = null;
+      editor.options.displayMarginsOverride = {
+        top: 50,
+        left: 100,
+      };
+      editor.converter.pageStyles = {
+        pageSize: { width: 8.5, height: 11 },
+        pageMargins: { top: 1, bottom: 1, left: 1, right: 1 },
+      };
+
+      const result = editor.getMaxContentSize();
+
+      // width: (8.5 * 96 - 100 - 1*96 - 20) = 600
+      // height: (11 * 96 - 50 - 1*96 - 50) = 860
+      expect(result.width).toBe(600);
+      expect(result.height).toBe(860);
+    });
+
+    it('ignores displayMarginsOverride when layout engine is enabled', () => {
+      editor.presentationEditor = {};
+      editor.options.displayMarginsOverride = {
+        top: 50,
+        bottom: 50,
+        left: 100,
+        right: 100,
+      };
+      editor.converter.pageStyles = {
+        pageSize: { width: 8.5, height: 11 },
+        pageMargins: { top: 1, bottom: 1, left: 1, right: 1 },
+      };
+
+      const result = editor.getMaxContentSize();
+
+      expect(result.width).toBe(604);
+      expect(result.height).toBe(814);
+    });
+
+    it('handles zero values in displayMarginsOverride', () => {
+      editor.presentationEditor = null;
+      editor.options.displayMarginsOverride = {
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+      };
+      editor.converter.pageStyles = {
+        pageSize: { width: 8.5, height: 11 },
+        pageMargins: { top: 1, bottom: 1, left: 1, right: 1 },
+      };
+
+      const result = editor.getMaxContentSize();
+
+      expect(result.width).toBe(796);
+      expect(result.height).toBe(1006);
+    });
+
+    it('handles missing page margins gracefully', () => {
+      editor.presentationEditor = null;
+      editor.options.displayMarginsOverride = {
+        top: 50,
+      };
+      editor.converter.pageStyles = {
+        pageSize: { width: 8.5, height: 11 },
+        pageMargins: {},
+      };
+
+      const result = editor.getMaxContentSize();
+
+      expect(result.width).toBe(796);
+      expect(result.height).toBe(956);
+    });
+  });
+
+  describe('updateEditorStyles()', () => {
+    let editor;
+    let element;
+    let proseMirror;
+
+    beforeEach(() => {
+      ({ editor } = initTestEditor({
+        content: docx,
+        media,
+        mediaFiles,
+        fonts,
+      }));
+
+      element = {
+        style: {},
+        setAttribute: vi.fn(),
+        classList: {
+          contains: vi.fn(() => false),
+        },
+      };
+      proseMirror = {
+        style: {},
+        setAttribute: vi.fn(),
+        classList: {
+          remove: vi.fn(),
+        },
+      };
+
+      editor.converter.pageStyles = {
+        pageSize: { width: 8.5, height: 11 },
+        pageMargins: { top: 1, bottom: 1, left: 1, right: 1 },
+      };
+    });
+
+    afterEach(() => {
+      editor?.destroy();
+      editor = null;
+    });
+
+    it('returns early if proseMirror is null', () => {
+      editor.updateEditorStyles(element, null);
+
+      expect(element.style.width).toBeUndefined();
+    });
+
+    it('returns early if element is null', () => {
+      editor.updateEditorStyles(null, proseMirror);
+
+      expect(proseMirror.style.paddingTop).toBeUndefined();
+    });
+
+    it('applies displayMarginsOverride padding when layout engine is disabled', () => {
+      editor.presentationEditor = null;
+      editor.options.displayMarginsOverride = {
+        top: 50,
+        bottom: 75,
+        left: 100,
+        right: 125,
+      };
+
+      editor.updateEditorStyles(element, proseMirror);
+
+      expect(element.style.width).toBe('100%');
+      expect(element.style.paddingLeft).toBe('100px');
+      expect(element.style.paddingRight).toBe('125px');
+      expect(proseMirror.style.paddingTop).toBe('50px');
+      expect(proseMirror.style.paddingBottom).toBe('75px');
+    });
+
+    it('applies default padding when layout engine is disabled without override', () => {
+      editor.presentationEditor = null;
+      editor.options.displayMarginsOverride = null;
+
+      editor.updateEditorStyles(element, proseMirror);
+
+      expect(element.style.width).toBe('8.5in');
+      expect(element.style.minWidth).toBe('8.5in');
+      expect(element.style.minHeight).toBe('11in');
+      expect(element.style.paddingLeft).toBe('1in');
+      expect(element.style.paddingRight).toBe('1in');
+      expect(proseMirror.style.paddingTop).toBe('0');
+      expect(proseMirror.style.paddingBottom).toBe('0');
+    });
+
+    it('does not apply displayMarginsOverride when layout engine is enabled', () => {
+      editor.presentationEditor = {};
+      editor.options.displayMarginsOverride = {
+        top: 50,
+        bottom: 75,
+        left: 100,
+        right: 125,
+      };
+
+      editor.updateEditorStyles(element, proseMirror);
+
+      expect(element.style.width).toBe('8.5in');
+      expect(element.style.paddingLeft).toBe('1in');
+      expect(element.style.paddingRight).toBe('1in');
+      expect(proseMirror.style.paddingTop).toBe('1in');
+      expect(proseMirror.style.paddingBottom).toBe('0');
+    });
+
+    it('applies partial displayMarginsOverride', () => {
+      editor.presentationEditor = null;
+      editor.options.displayMarginsOverride = {
+        left: 100,
+        top: 50,
+      };
+
+      editor.updateEditorStyles(element, proseMirror);
+
+      expect(element.style.width).toBe('100%');
+      expect(element.style.paddingLeft).toBe('100px');
+      expect(element.style.paddingRight).toBeUndefined();
+      expect(proseMirror.style.paddingTop).toBe('50px');
+      expect(proseMirror.style.paddingBottom).toBe('96px');
+    });
+
+    it('treats presentation-editor__hidden-host as layout-engine context', () => {
+      editor.presentationEditor = null;
+      editor.options.displayMarginsOverride = {
+        top: 50,
+        bottom: 75,
+        left: 100,
+        right: 125,
+      };
+      editor.options.element = element;
+      element.classList.contains.mockImplementation((className) => className === 'presentation-editor__hidden-host');
+
+      editor.updateEditorStyles(element, proseMirror);
+
+      expect(element.style.width).toBe('8.5in');
+      expect(element.style.minWidth).toBe('8.5in');
+      expect(element.style.minHeight).toBe('11in');
+      expect(element.style.paddingLeft).toBe('1in');
+      expect(element.style.paddingRight).toBe('1in');
+      expect(proseMirror.style.paddingTop).toBe('1in');
+      expect(proseMirror.style.paddingBottom).toBe('0');
+    });
+
+    it('removes minHeight when displayMarginsOverride is active', () => {
+      editor.presentationEditor = null;
+      editor.options.displayMarginsOverride = { top: 50 };
+
+      editor.updateEditorStyles(element, proseMirror);
+
+      expect(element.style.minHeight).toBe('');
+    });
+
+    it('sets minHeight when displayMarginsOverride is not active', () => {
+      editor.presentationEditor = {};
+      editor.options.displayMarginsOverride = null;
+
+      editor.updateEditorStyles(element, proseMirror);
+
+      expect(element.style.minHeight).toBe('11in');
+    });
+  });
+});

--- a/packages/super-editor/src/core/types/EditorConfig.ts
+++ b/packages/super-editor/src/core/types/EditorConfig.ts
@@ -54,6 +54,17 @@ export interface DocxFileEntry {
 }
 
 /**
+ * Override visual margins for non-layout-engine mode.
+ * Values are in pixels and only apply when PresentationEditor is not used.
+ */
+export interface DisplayMarginsOverride {
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+}
+
+/**
  * Awareness interface - matches y-protocols Awareness.
  * All properties optional to support various provider implementations.
  */
@@ -186,6 +197,12 @@ export interface EditorOptions {
 
   /** Editor scale/zoom */
   scale?: number;
+
+  /**
+   * Override visual margins (values in pixels).
+   * Only applies when PresentationEditor (layout engine) is disabled.
+   */
+  displayMarginsOverride?: DisplayMarginsOverride | null;
 
   /** Whether annotations are enabled */
   annotations?: boolean;

--- a/packages/superdoc/src/SuperDoc.vue
+++ b/packages/superdoc/src/SuperDoc.vue
@@ -450,6 +450,7 @@ const editorOptions = (doc) => {
     suppressDefaultDocxStyles: proxy.$superdoc.config.suppressDefaultDocxStyles,
     disableContextMenu: proxy.$superdoc.config.disableContextMenu,
     jsonOverride: proxy.$superdoc.config.jsonOverride,
+    displayMarginsOverride: useLayoutEngine ? null : proxy.$superdoc.config.displayMarginsOverride,
     layoutEngineOptions: useLayoutEngine
       ? {
           ...(proxy.$superdoc.config.layoutEngineOptions || {}),
@@ -785,7 +786,15 @@ watch(getFloatingComments, () => {
 </script>
 
 <template>
-  <div class="superdoc" :class="{ 'superdoc--with-sidebar': showCommentsSidebar, 'high-contrast': isHighContrastMode }">
+  <div
+    class="superdoc"
+    :class="{
+      'superdoc--with-sidebar': showCommentsSidebar,
+      'superdoc--flow':
+        proxy.$superdoc.config.useLayoutEngine === false && Boolean(proxy.$superdoc.config.displayMarginsOverride),
+      'high-contrast': isHighContrastMode,
+    }"
+  >
     <div class="superdoc__layers layers" ref="layers" role="group">
       <!-- Floating tools menu (shows up when user has text selection)-->
       <div v-if="showToolsFloatingMenu" class="superdoc__tools tools" :style="toolsMenuPosition">
@@ -919,6 +928,11 @@ watch(getFloatingComments, () => {
 <style scoped>
 .superdoc {
   display: flex;
+}
+
+.superdoc.superdoc--flow .superdoc__layers {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .right-sidebar {

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -110,6 +110,11 @@ export class SuperDoc extends EventEmitter {
     // Disable context menus (slash and right-click) globally
     disableContextMenu: false,
 
+    // Override visual margins for the flow editor (values in pixels)
+    // Only applies when layout engine is disabled (useLayoutEngine: false)
+    // Example: { top: 48, bottom: 48, left: 48, right: 48 }
+    displayMarginsOverride: null,
+
     // Internal: toggle layout-engine-powered PresentationEditor in dev shells
     useLayoutEngine: true,
   };

--- a/packages/superdoc/src/core/types/index.js
+++ b/packages/superdoc/src/core/types/index.js
@@ -97,6 +97,15 @@
  */
 
 /**
+ * @typedef {Object} DisplayMarginsOverride
+ * @property {number} [top] Override for the top margin in pixels
+ * @property {number} [bottom] Override for the bottom margin in pixels
+ * @property {number} [left] Override for the left margin in pixels
+ * @property {number} [right] Override for the right margin in pixels
+ * @description Only applies when the layout engine is disabled. Values are in pixels.
+ */
+
+/**
  * @typedef {Object} Config
  * @property {string} [superdocId] The ID of the SuperDoc
  * @property {string | HTMLElement} selector The selector or element to mount the SuperDoc into
@@ -156,6 +165,7 @@
  * @property {string} [html] HTML content to initialize the editor with
  * @property {string} [markdown] Markdown content to initialize the editor with
  * @property {boolean} [isDebug=false] Whether to enable debug mode
+ * @property {DisplayMarginsOverride} [displayMarginsOverride] Override visual margins for the flow editor (values in pixels, only applies when useLayoutEngine is false)
  */
 
 export {};

--- a/packages/superdoc/src/dev/components/SuperdocDev.vue
+++ b/packages/superdoc/src/dev/components/SuperdocDev.vue
@@ -135,7 +135,6 @@ const init = async () => {
     role: userRole,
     documentMode: 'editing',
     toolbarGroups: ['left', 'center', 'right'],
-    pagination: useLayoutEngine.value,
     rulers: true,
     rulerContainer: '#ruler-container',
     annotations: true,
@@ -160,7 +159,10 @@ const init = async () => {
     //   },
     // ],
     // cspNonce: 'testnonce123',
+
     useLayoutEngine: useLayoutEngine.value,
+    // displayMarginsOverride: { top: 10, bottom: 10, left: 10, right: 10 }, // useLayoutEngine must be false for this to apply
+
     modules: {
       comments: {
         // comments: sampleComments,


### PR DESCRIPTION
add displayMarginsOverride config key (only active if pagination: false is also set)
prevents min-height of editor when displayMarginsOverride
used for "semantic" display of content