### PR TITLE
fix: pass user data in collaborative comment helpers, remove global superdoc

### DIFF
--- a/packages/superdoc/src/core/collaboration/collaboration-comments.js
+++ b/packages/superdoc/src/core/collaboration/collaboration-comments.js
@@ -1,6 +1,6 @@
 import { Map as YMap } from 'yjs';
 
-export const addYComment = (yArray, ydoc, event) => {
+export const addYComment = (yArray, ydoc, event, user) => {
   const { comment } = event;
   const yComment = new YMap(Object.entries(comment));
 
@@ -8,11 +8,11 @@ export const addYComment = (yArray, ydoc, event) => {
     () => {
       yArray.push([yComment]);
     },
-    { user: superdoc.user },
+    { user },
   );
 };
 
-export const updateYComment = (yArray, ydoc, event) => {
+export const updateYComment = (yArray, ydoc, event, user) => {
   const { comment } = event;
   const yComment = new YMap(Object.entries(comment));
   const commentIndex = getCommentIndex(yArray, comment);
@@ -23,11 +23,11 @@ export const updateYComment = (yArray, ydoc, event) => {
       yArray.delete(commentIndex, 1);
       yArray.insert(commentIndex, [yComment]);
     },
-    { user: superdoc.user },
+    { user },
   );
 };
 
-export const deleteYComment = (yArray, ydoc, event) => {
+export const deleteYComment = (yArray, ydoc, event, user) => {
   const { comment } = event;
   const commentIndex = getCommentIndex(yArray, comment);
   if (commentIndex === -1) return;
@@ -36,7 +36,7 @@ export const deleteYComment = (yArray, ydoc, event) => {
     () => {
       yArray.delete(commentIndex, 1);
     },
-    { user: superdoc.user },
+    { user },
   );
 };
 

--- a/packages/superdoc/src/core/collaboration/collaboration.test.js
+++ b/packages/superdoc/src/core/collaboration/collaboration.test.js
@@ -325,27 +325,29 @@ describe('collaboration helpers', () => {
 });
 
 describe('collaboration comments primitives', () => {
+  const testUser = { name: 'Test User', email: 'test@example.com' };
+
   it('manages Yjs comment array operations', () => {
     const ydoc = new MockYDoc();
     const yArray = ydoc.getArray('comments');
     const baseComment = { commentId: 'c1', body: 'Hello' };
 
-    addYComment(yArray, ydoc, { comment: baseComment });
+    addYComment(yArray, ydoc, { comment: baseComment }, testUser);
     expect(yArray.toJSON()).toEqual([baseComment]);
-    expect(ydoc._lastMeta.user).toEqual(globalThis.superdoc.user);
+    expect(ydoc._lastMeta.user).toEqual(testUser);
 
     const updatedComment = { commentId: 'c1', body: 'Updated' };
-    updateYComment(yArray, ydoc, { comment: updatedComment });
+    updateYComment(yArray, ydoc, { comment: updatedComment }, testUser);
     expect(yArray.toJSON()).toEqual([updatedComment]);
 
-    deleteYComment(yArray, ydoc, { comment: updatedComment });
+    deleteYComment(yArray, ydoc, { comment: updatedComment }, testUser);
     expect(yArray.toJSON()).toEqual([]);
   });
 
   it('getCommentIndex finds matching comment ids', () => {
     const ydoc = new MockYDoc();
     const yArray = ydoc.getArray('comments');
-    addYComment(yArray, ydoc, { comment: { commentId: 'c5', body: 'Test' } });
+    addYComment(yArray, ydoc, { comment: { commentId: 'c5', body: 'Test' } }, testUser);
     expect(getCommentIndex(yArray, { commentId: 'missing' })).toBe(-1);
     expect(getCommentIndex(yArray, { commentId: 'c5' })).toBe(0);
   });
@@ -363,6 +365,7 @@ describe('syncCommentsToClients routing', () => {
       ydoc,
       isCollaborative: true,
       config: {
+        user: { name: 'Test User', email: 'test@example.com' },
         modules: { comments: true },
       },
     };

--- a/packages/superdoc/src/core/collaboration/helpers.js
+++ b/packages/superdoc/src/core/collaboration/helpers.js
@@ -118,19 +118,20 @@ export const syncCommentsToClients = (superdoc, event) => {
   if (!superdoc.isCollaborative || !superdoc.config.modules.comments) return;
 
   const yArray = superdoc.ydoc.getArray('comments');
+  const user = superdoc.config.user;
 
   switch (event.type) {
     case 'add':
-      addYComment(yArray, superdoc.ydoc, event);
+      addYComment(yArray, superdoc.ydoc, event, user);
       break;
     case 'update':
-      updateYComment(yArray, superdoc.ydoc, event);
+      updateYComment(yArray, superdoc.ydoc, event, user);
       break;
     case 'resolved':
-      updateYComment(yArray, superdoc.ydoc, event);
+      updateYComment(yArray, superdoc.ydoc, event, user);
       break;
     case 'deleted':
-      deleteYComment(yArray, superdoc.ydoc, event);
+      deleteYComment(yArray, superdoc.ydoc, event, user);
       break;
   }
 };


### PR DESCRIPTION
interesting: originally getting superdoc from window via DOM element. If missing DOM element, would get superdoc undefined