### PR TITLE
feat: run linters and tests on each push, not just on open PRs

### DIFF
--- a/.github/workflows/commit-validation.yml
+++ b/.github/workflows/commit-validation.yml
@@ -1,15 +1,13 @@
-name: PR Validation [auto]
+name: Commit Validation [auto]
 
 permissions:
   contents: read
 
-on:
-  pull_request:
-    branches: [main, 'release/**']
+on: push
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   validate-commits:
@@ -18,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # Pinned commit hash for @v4
 
@@ -44,17 +42,17 @@ jobs:
       
       - name: Validate commits
         run: |
-          BASE=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+          BASE=$(git merge-base ${{ github.sha }} ${{ github.sha }})
           pnpx commitlint \
             --from "$BASE" \
-            --to ${{ github.event.pull_request.head.sha }}
+            --to ${{ github.sha }}
           
   run-unit-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # Pinned commit hash for @v4
 
@@ -96,7 +94,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # Pinned commit hash for @v4
 
@@ -161,7 +159,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # Pinned commit hash for @v4
 

--- a/cicd.md
+++ b/cicd.md
@@ -31,9 +31,9 @@ main (next) → stable (latest) → X.x (maintenance)
 
 ### Core Workflows
 
-#### 1. PR Validation (`pr-validation.yml`)
+#### 1. Commit Validation (`commit-validation.yml`)
 
-**Triggers**: All pull requests
+**Triggers**: All pushes
 
 **Checks**:
 
@@ -44,7 +44,7 @@ main (next) → stable (latest) → X.x (maintenance)
 - Visual regression tests
 - E2E tests (main branch only)
 
-**Required to pass before merge**.
+**Required to pass before PR merge**.
 
 #### 2. Release (`release.yml`)
 


### PR DESCRIPTION
Rename GitHub workflow from `pr-validation` to `commit-validation`, and run on all pushes to all branches, rather than only running for open PRs.

Concurrency is configured to cancel earlier builds on branches except for main.
