### PR TITLE
fix: allow override row borders

### DIFF
--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tbl/tbl-translator.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tbl/tbl-translator.test.js
@@ -156,9 +156,9 @@ describe('w:tbl translator', () => {
 
       // Check borders (merged from style and inline)
       expect(result.attrs.borders).toEqual({
-        top: { size: 0.5 }, // from style
-        insideH: { size: 0.25 }, // from style
-        bottom: { size: 1 }, // from inline
+        top: { size: 0.5, val: 'single' }, // from style
+        insideH: { size: 0.25, val: 'dashed' }, // from style
+        bottom: { size: 1, val: 'double' }, // from inline
       });
     });
 
@@ -351,7 +351,7 @@ describe('w:tbl translator', () => {
       expect(styles.justification).toBe('right');
       expect(styles.fonts).toEqual({ ascii: 'Calibri', hAnsi: undefined, cs: undefined });
       expect(styles.fontSize).toBe('11pt');
-      expect(styles.borders).toEqual({ top: { size: 1 } });
+      expect(styles.borders).toEqual({ top: { size: 1, val: 'single' } });
       expect(styles.cellMargins).toEqual({
         marginLeft: { value: 108, type: 'dxa' },
         marginRight: undefined,
@@ -393,7 +393,6 @@ describe('w:tbl translator', () => {
       expect(styles).toBeDefined();
       expect(styles?.name).toBeDefined();
       expect(styles?.borders).toBeUndefined();
-      expect(styles?.rowBorders).toBeUndefined();
       expect(styles?.cellMargins).toBeUndefined();
     });
   });

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tc/helpers/legacy-handle-table-cell-node.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tc/helpers/legacy-handle-table-cell-node.js
@@ -251,14 +251,14 @@ const processInlineCellBorders = (borders, rowBorders) => {
     const borderAttrs = borders[direction];
     const rowBorderAttrs = rowBorders[direction];
 
-    if (borderAttrs && borderAttrs['val'] !== 'nil') {
+    if (borderAttrs && borderAttrs['val'] !== 'none') {
       const color = borderAttrs['color'];
       let size = borderAttrs['size'];
       if (size) size = eighthPointsToPixels(size);
       acc[direction] = { color, size, val: borderAttrs['val'] };
       return acc;
     }
-    if (borderAttrs && borderAttrs['val'] === 'nil') {
+    if (borderAttrs && borderAttrs['val'] === 'none') {
       const border = Object.assign({}, rowBorderAttrs || {});
       if (!Object.keys(border).length) {
         return acc;

--- a/packages/super-editor/src/extensions/table/table.js
+++ b/packages/super-editor/src/extensions/table/table.js
@@ -353,17 +353,6 @@ export const Table = Node.create({
        */
       borders: {
         default: {},
-        renderDOM({ borders }) {
-          if (!borders) return {};
-
-          const style = Object.entries(borders).reduce((acc, [key, { size, color }]) => {
-            return `${acc}border-${key}: ${Math.ceil(size)}px solid ${color || 'black'};`;
-          }, '');
-
-          return {
-            style,
-          };
-        },
       },
 
       /**


### PR DESCRIPTION
1. Apply borders on cells instead of the whole table to make disabling row borders possible
2. Support w:tblPrEx overrides for borders