### PR TITLE
SD-1401 - Bug: Tab on first line + hanging indent renders with second line wrapping prematurely

### DIFF
--- a/packages/layout-engine/layout-bridge/src/remeasure.ts
+++ b/packages/layout-engine/layout-bridge/src/remeasure.ts
@@ -660,13 +660,16 @@ export function remeasureParagraph(
   const attrs = block.attrs as ParagraphBlockAttrs | undefined;
   const indent = attrs?.indent;
   const wordLayout = attrs?.wordLayout;
-  const indentLeft = Math.max(0, indent?.left ?? 0);
-  const indentRight = Math.max(0, indent?.right ?? 0);
+  const rawIndentLeft = indent?.left ?? 0;
+  const rawIndentRight = indent?.right ?? 0;
+  const indentLeft = Math.max(0, rawIndentLeft);
+  const indentRight = Math.max(0, rawIndentRight);
   const indentFirstLine = Math.max(0, indent?.firstLine ?? 0);
   const indentHanging = Math.max(0, indent?.hanging ?? 0);
   const baseFirstLineOffset = firstLineIndent || indentFirstLine - indentHanging;
   const clampedFirstLineOffset = Math.max(0, baseFirstLineOffset);
-  const allowNegativeFirstLineOffset = !wordLayout?.marker && baseFirstLineOffset < 0;
+  const hasNegativeIndent = rawIndentLeft < 0 || rawIndentRight < 0;
+  const allowNegativeFirstLineOffset = !wordLayout?.marker && !hasNegativeIndent && baseFirstLineOffset < 0;
   const effectiveFirstLineOffset = allowNegativeFirstLineOffset ? baseFirstLineOffset : clampedFirstLineOffset;
   const contentWidth = Math.max(1, maxWidth - indentLeft - indentRight);
   // Some producers provide `marker.textStartX` without setting top-level `textStartPx`.

--- a/packages/layout-engine/layout-bridge/test/remeasure.test.ts
+++ b/packages/layout-engine/layout-bridge/test/remeasure.test.ts
@@ -416,6 +416,21 @@ describe('remeasureParagraph', () => {
       expect(firstLineChars).toBeLessThan(secondLineChars);
     });
 
+    it('expands first line width for hanging indents without negative indents', () => {
+      const maxWidth = 200;
+      const indentLeft = 40;
+      const hanging = 20;
+      const block = createBlock([textRun('A'.repeat(40))], {
+        indent: { left: indentLeft, hanging },
+      });
+      const measure = remeasureParagraph(block, maxWidth);
+
+      expect(measure.lines.length).toBeGreaterThan(1);
+      const contentWidth = maxWidth - indentLeft;
+      expect(measure.lines[0].maxWidth).toBe(contentWidth + hanging);
+      expect(measure.lines[1].maxWidth).toBe(contentWidth);
+    });
+
     it('increases subsequent line widths with hanging indent', () => {
       // Hanging indent means first line has REDUCED width (negative offset from hanging)
       // Subsequent lines have MORE width (hanging indent adds to available space)
@@ -468,6 +483,18 @@ describe('remeasureParagraph', () => {
       // Should treat negative values as 0, so full width is available
       expect(measure.lines).toHaveLength(1);
       expect(measure.lines[0].width).toBe(5 * CHAR_WIDTH);
+    });
+
+    it('avoids widening first line when negative indents are present with hanging', () => {
+      const maxWidth = 200;
+      const block = createBlock([textRun('A'.repeat(40))], {
+        indent: { left: -20, right: -30, hanging: 20 },
+      });
+      const measure = remeasureParagraph(block, maxWidth);
+
+      expect(measure.lines.length).toBeGreaterThan(1);
+      expect(measure.lines[0].maxWidth).toBe(maxWidth);
+      expect(measure.lines[1].maxWidth).toBe(maxWidth);
     });
 
     it('respects firstLineIndent parameter for list markers', () => {

--- a/packages/layout-engine/measuring/dom/src/index.test.ts
+++ b/packages/layout-engine/measuring/dom/src/index.test.ts
@@ -229,6 +229,33 @@ describe('measureBlock', () => {
       expect(measure.lines[0].maxWidth).toBe(maxWidth - textStartX);
     });
 
+    it('expands first-line width for hanging indents on non-list paragraphs', async () => {
+      const maxWidth = 400;
+      const indentLeft = 48;
+      const hanging = 24;
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'hanging-indent-non-list',
+        runs: [
+          {
+            text: 'This paragraph uses a hanging indent with enough text to wrap onto multiple lines for testing.',
+            fontFamily: 'Arial',
+            fontSize: 16,
+          },
+        ],
+        attrs: {
+          indent: { left: indentLeft, hanging },
+        },
+      };
+
+      const measure = expectParagraphMeasure(await measureBlock(block, maxWidth));
+      expect(measure.lines.length).toBeGreaterThan(1);
+
+      const contentWidth = maxWidth - indentLeft;
+      expect(measure.lines[0].maxWidth).toBe(contentWidth + hanging);
+      expect(measure.lines[1].maxWidth).toBe(contentWidth);
+    });
+
     it('measures empty block correctly', async () => {
       const block: FlowBlock = {
         kind: 'paragraph',

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -687,7 +687,9 @@ async function measureParagraphBlock(block: ParagraphBlock, maxWidth: number): P
   // so keep the same available width as body lines. For normal paragraphs we must honor
   // negative offsets (hanging indent) so the first line can extend into the hanging region.
   const clampedFirstLineOffset = Math.max(0, rawFirstLineOffset);
-  const allowNegativeFirstLineOffset = !isWordLayoutList && rawFirstLineOffset < 0;
+  const hasNegativeIndent = indentLeft < 0 || indentRight < 0;
+  // Avoid widening the first line when negative indents already expand fragment width.
+  const allowNegativeFirstLineOffset = !isWordLayoutList && !hasNegativeIndent && rawFirstLineOffset < 0;
   const firstLineOffset = isWordLayoutList
     ? 0
     : allowNegativeFirstLineOffset

--- a/packages/layout-engine/measuring/dom/src/negativeIndent.test.ts
+++ b/packages/layout-engine/measuring/dom/src/negativeIndent.test.ts
@@ -645,5 +645,34 @@ describe('negative indent measurement', () => {
       // Body lines also use full contentWidth - hanging affects position, not available width
       expect(measure.lines[1].maxWidth).toBe(maxWidth + Math.abs(negativeLeft));
     });
+
+    it('keeps first-line width aligned when negative left/right indents include hanging', async () => {
+      const maxWidth = 468;
+      const negativeLeft = -36;
+      const negativeRight = -54;
+      const hanging = 24;
+
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'para-neg-left-right-hanging',
+        runs: [
+          {
+            text: 'This paragraph uses negative left and right indents with a hanging indent to ensure the first line does not expand beyond the body line width.',
+            fontFamily: 'Arial',
+            fontSize: 12,
+          },
+        ],
+        attrs: {
+          indent: { left: negativeLeft, right: negativeRight, hanging },
+        },
+      };
+
+      const measure = expectParagraphMeasure(await measureBlock(block, maxWidth));
+      expect(measure.lines.length).toBeGreaterThan(1);
+
+      const contentWidth = maxWidth + Math.abs(negativeLeft) + Math.abs(negativeRight);
+      expect(measure.lines[0].maxWidth).toBe(contentWidth);
+      expect(measure.lines[1].maxWidth).toBe(contentWidth);
+    });
   });
 });


### PR DESCRIPTION
**Issue:** Word lets the first visual line extend into the hanging indent region, so it uses that extra horizontal space even when there’s no list marker, so it can stay on one line. Our measurer always clamped `firstLine` - hanging to zero unless the paragraph was a list, so that first line only saw the smaller body width and wrapped prematurely.

**Fix:** Let negative first-line offsets be used for non-list paragraphs so the first line inherits the same width Word uses. Mirror the same logic in the remeasure piece so updated documents behave identically. With the first-line width now matching Word, the line stays intact and the measurements remain stable across saves.


**Before:**
<img width="2188" height="495" alt="Screenshot 2026-01-09 at 17 51 23" src="https://github.com/user-attachments/assets/4ce69b5e-7119-44fc-af33-85ba975efbc0" />

**After:** 

<img width="2164" height="378" alt="Screenshot 2026-01-09 at 17 51 41" src="https://github.com/user-attachments/assets/9ccc3aaa-73eb-4d9a-8da8-0821553ba100" />
