### PR TITLE
SD-1468 - validating int ID for structured content for early failure

### DIFF
--- a/packages/super-editor/src/extensions/structured-content/structured-content-commands.js
+++ b/packages/super-editor/src/extensions/structured-content/structured-content-commands.js
@@ -268,6 +268,11 @@ export const StructuredContentCommands = Extension.create({
       updateStructuredContentById:
         (id, options = {}) =>
         ({ editor, dispatch, state, tr }) => {
+          // Validate ID is an integer (required for MS Word compatibility)
+          if (options.attrs?.id !== undefined && !isValidIntegerId(options.attrs.id)) {
+            throw new Error('Invalid structured content id - must be an integer, got: ' + options.attrs.id);
+          }
+
           const structuredContentTags = getStructuredContentTagsById(id, state);
 
           if (!structuredContentTags.length) {
@@ -429,6 +434,11 @@ export const StructuredContentCommands = Extension.create({
       updateStructuredContentByGroup:
         (group, options = {}) =>
         ({ editor, dispatch, state, tr }) => {
+          // Validate ID is an integer (required for MS Word compatibility)
+          if (options.attrs?.id !== undefined && !isValidIntegerId(options.attrs.id)) {
+            throw new Error('Invalid structured content id - must be an integer, got: ' + options.attrs.id);
+          }
+
           const structuredContentTags = getStructuredContentByGroup(group, state);
 
           if (!structuredContentTags.length) {

--- a/packages/super-editor/src/extensions/structured-content/structured-content-commands.test.js
+++ b/packages/super-editor/src/extensions/structured-content/structured-content-commands.test.js
@@ -165,6 +165,14 @@ describe('updateStructuredContentById', () => {
     schema = null;
   });
 
+  it('throws error when updating ID with a non-integer value', () => {
+    expect(() => {
+      editor.commands.updateStructuredContentById(INLINE_ID, {
+        attrs: { id: 'abc-123' },
+      });
+    }).toThrow('Invalid structured content id - must be an integer, got: abc-123');
+  });
+
   describe('keepTextNodeStyles option', () => {
     it('preserves marks from the first text node when keepTextNodeStyles is true', () => {
       const didUpdate = editor.commands.updateStructuredContentById(INLINE_ID, {
@@ -405,6 +413,14 @@ describe('updateStructuredContentByGroup', () => {
     editor?.destroy();
     editor = null;
     schema = null;
+  });
+
+  it('throws error when updating ID with a non-integer value', () => {
+    expect(() => {
+      editor.commands.updateStructuredContentByGroup(GROUP_NAME, {
+        attrs: { id: 'abc-123' },
+      });
+    }).toThrow('Invalid structured content id - must be an integer, got: abc-123');
   });
 
   describe('keepTextNodeStyles option', () => {


### PR DESCRIPTION
Structured content with non-integer IDs produces documents that Word cannot open. ([documentation here](https://docs.superdoc.dev/extensions/structured-content#param-id)).
This adds early validation to catch the error before export.