### PR TITLE
fix: guarding against component init when ref is null

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -763,6 +763,9 @@ const initializeData = async () => {
 const getExtensions = () => getStarterExtensions();
 
 const initEditor = async ({ content, media = {}, mediaFiles = {}, fonts = {} } = {}) => {
+  // component may have unmounted during async init
+  if (!editorElem.value) return;
+
   const { editorCtor, ...editorOptions } = props.options || {};
   const EditorCtor = editorCtor ?? Editor;
   clearSelectedImage();


### PR DESCRIPTION
On quick component mount/unmount (like with HMR), the element ref may be null, but the init function may still be waiting to fire using a null ref. This one-liner guards against that with an early return.