### PR TITLE
docs: require pnpm for development setup in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,21 +69,21 @@ Documentation is crucial for our project. You can help by:
    cd SuperDoc
    ```
 
-2. **Install Dependencies**:
+2. **Install Dependencies** (pnpm required):
 
    ```bash
-   npm install
+   pnpm install
    ```
 
 3. **Set Up Development Environment**:
 
    ```bash
-   npm run dev
+   pnpm run dev
    ```
 
 4. **Run Tests**:
    ```bash
-   npm test
+   pnpm test
    ```
 
 ## Pull Request Process


### PR DESCRIPTION
Hi SuperDoc team 👋🏽

I was trying to run SuperDoc locally and got this error when running `npm install`

```
  npm install
  npm error code EUNSUPPORTEDPROTOCOL
  npm error Unsupported URL Type "catalog:": catalog:
  npm error A complete log of this run can be found in: /Users/icarominka/.npm/_logs/2026-01-15T16_06_39_737Z-
  debug-0.log
```

I noticed it's because you're using pnpm, so I updated this doc.