### PR TITLE
fix: handle fldSimple syntax for page number fields

### DIFF
--- a/packages/super-editor/src/core/super-converter/field-references/preProcessPageFieldsOnly.js
+++ b/packages/super-editor/src/core/super-converter/field-references/preProcessPageFieldsOnly.js
@@ -28,6 +28,33 @@ export const preProcessPageFieldsOnly = (nodes = [], depth = 0) => {
     const fldCharEl = node.elements?.find((el) => el.name === 'w:fldChar');
     const fldType = fldCharEl?.attributes?.['w:fldCharType'];
 
+    // Check if this node IS a fldSimple (simple field syntax)
+    // fldSimple has the instruction in an attribute, not nested elements
+    if (node.name === 'w:fldSimple') {
+      const instrAttr = node.attributes?.['w:instr'] || '';
+      const fieldType = instrAttr.trim().split(/\s+/)[0];
+
+      if (fieldType === 'PAGE' || fieldType === 'NUMPAGES') {
+        const preprocessor = fieldType === 'PAGE' ? preProcessPageInstruction : preProcessNumPagesInstruction;
+
+        // Extract rPr from child elements (content nodes inside fldSimple)
+        const contentNodes = node.elements || [];
+        let fieldRunRPr = null;
+        for (const child of contentNodes) {
+          const rPr = child.elements?.find((el) => el.name === 'w:rPr');
+          if (rPr) {
+            fieldRunRPr = rPr;
+            break;
+          }
+        }
+
+        const processedField = preprocessor(contentNodes, instrAttr.trim(), fieldRunRPr);
+        processedNodes.push(...processedField);
+        i++;
+        continue;
+      }
+    }
+
     if (fldType === 'begin') {
       // Scan ahead to find the field type and end marker
       const fieldInfo = scanFieldSequence(nodes, i);

--- a/packages/super-editor/src/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
+++ b/packages/super-editor/src/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
@@ -1,0 +1,193 @@
+// @ts-check
+import { describe, it, expect } from 'vitest';
+import { preProcessPageFieldsOnly } from './preProcessPageFieldsOnly.js';
+
+describe('preProcessPageFieldsOnly', () => {
+  describe('complex field syntax (w:fldChar)', () => {
+    it('should process PAGE field with fldChar syntax', () => {
+      const nodes = [
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: ' PAGE ' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0].name).toBe('sd:autoPageNumber');
+    });
+
+    it('should process NUMPAGES field with fldChar syntax', () => {
+      const nodes = [
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: ' NUMPAGES ' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:t', elements: [{ type: 'text', text: '5' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0].name).toBe('sd:totalPageNumber');
+    });
+  });
+
+  describe('simple field syntax (w:fldSimple)', () => {
+    it('should process PAGE field with fldSimple syntax', () => {
+      const nodes = [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': ' PAGE ' },
+          elements: [
+            {
+              name: 'w:r',
+              elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1' }] }],
+            },
+          ],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0].name).toBe('sd:autoPageNumber');
+    });
+
+    it('should process NUMPAGES field with fldSimple syntax', () => {
+      const nodes = [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': ' NUMPAGES  \\* MERGEFORMAT ' },
+          elements: [
+            {
+              name: 'w:r',
+              elements: [
+                { name: 'w:rPr', elements: [{ name: 'w:noProof' }] },
+                { name: 'w:t', elements: [{ type: 'text', text: '2' }] },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0].name).toBe('sd:totalPageNumber');
+    });
+
+    it('should preserve rPr styling from fldSimple content', () => {
+      const nodes = [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': 'NUMPAGES' },
+          elements: [
+            {
+              name: 'w:r',
+              elements: [
+                { name: 'w:rPr', elements: [{ name: 'w:b' }, { name: 'w:sz', attributes: { 'w:val': '24' } }] },
+                { name: 'w:t', elements: [{ type: 'text', text: '10' }] },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0].name).toBe('sd:totalPageNumber');
+      expect(result.processedNodes[0].elements).toBeDefined();
+      expect(result.processedNodes[0].elements[0].name).toBe('w:rPr');
+    });
+
+    it('should pass through fldSimple with non-page field types', () => {
+      const nodes = [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': ' AUTHOR ' },
+          elements: [
+            {
+              name: 'w:r',
+              elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'John Doe' }] }],
+            },
+          ],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      // Should pass through unchanged (processed recursively)
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0].name).toBe('w:fldSimple');
+    });
+  });
+
+  describe('nested content', () => {
+    it('should recursively process fldSimple inside table cells', () => {
+      const nodes = [
+        {
+          name: 'w:tc',
+          elements: [
+            {
+              name: 'w:p',
+              elements: [
+                {
+                  name: 'w:fldSimple',
+                  attributes: { 'w:instr': 'NUMPAGES' },
+                  elements: [
+                    {
+                      name: 'w:r',
+                      elements: [{ name: 'w:t', elements: [{ type: 'text', text: '5' }] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      // Navigate to the processed field
+      const tc = result.processedNodes[0];
+      const p = tc.elements[0];
+      expect(p.elements).toHaveLength(1);
+      expect(p.elements[0].name).toBe('sd:totalPageNumber');
+    });
+  });
+});


### PR DESCRIPTION
Previously:
<img width="826" height="206" alt="image" src="https://github.com/user-attachments/assets/b151eddd-0f35-49f3-9af0-ad2432b74a88" />

Now:
<img width="831" height="168" alt="image" src="https://github.com/user-attachments/assets/b97f921a-3235-4a6b-9401-8a9a0e51d7f0" />
