### PR TITLE
SD-1591 - fix: handling absolute paths for relationships

### DIFF
--- a/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
@@ -1,6 +1,6 @@
 import { getInitialJSON } from '../docxHelper.js';
 import { carbonCopy } from '../../../utilities/carbonCopy.js';
-import { twipsToInches } from '../../helpers.js';
+import { twipsToInches, resolveOpcTargetPath } from '../../helpers.js';
 import { DEFAULT_LINKED_STYLES } from '../../exporter-docx-defs.js';
 import { drawingNodeHandlerEntity } from './imageImporter.js';
 import { trackChangeNodeHandlerEntity } from './trackChangesImporter.js';
@@ -755,7 +755,8 @@ const findSectPr = (obj, result = []) => {
 const getHeaderFooterSectionData = (sectionData, docx) => {
   const rId = sectionData.attributes.Id;
   const target = sectionData.attributes.Target;
-  const referenceFile = docx[`word/${target}`];
+  const filePath = resolveOpcTargetPath(target, 'word');
+  const referenceFile = filePath ? docx[filePath] : undefined;
   const currentFileName = target;
   return {
     rId,

--- a/packages/super-editor/src/core/super-validator/validators/xml/relationships/relationships-validator.js
+++ b/packages/super-editor/src/core/super-validator/validators/xml/relationships/relationships-validator.js
@@ -1,3 +1,5 @@
+import { resolveOpcTargetPath } from '@converter/helpers.js';
+
 /**
  * Creates a validator for Word document relationships (word/_rels/document.xml.rels)
  *
@@ -209,22 +211,15 @@ function processRelationships(root, convertedXml, results) {
 
     // Handle image relationships
     if (isImageType(type)) {
-      const relPath = `word/${target.replace(/^\.?\//, '')}`;
-      if (/^media\/.+\.bin$/i.test(target) && relPath in convertedXml) {
+      const relPath = resolveOpcTargetPath(target, 'word');
+      if (relPath && /^media\/.+\.bin$/i.test(target) && relPath in convertedXml) {
         binMediaTargets.add(`/${relPath}`);
       }
     }
 
     // Validate internal target files exist
     if (targetMode.toLowerCase() !== 'external' && !looksExternal(target)) {
-      // Handle relative paths that go UP from word/ directory (e.g., ../customXml/item1.xml)
-      let likelyPath;
-      if (target.startsWith('../')) {
-        // Resolve relative path: ../customXml/item1.xml -> customXml/item1.xml
-        likelyPath = target.replace(/^\.\.\//, '');
-      } else {
-        likelyPath = `word/${target.replace(/^\.?\//, '')}`;
-      }
+      const likelyPath = resolveOpcTargetPath(target, 'word');
 
       if (!(likelyPath in convertedXml)) {
         if (!isImageType(type)) {


### PR DESCRIPTION
- Abs. paths are supported by the OPC, and seem to be used by other docx generators.
- We were checking for relative paths only, leading to incorrect loading via paths like word/word/styles.xml
- This should follow the spec here: https://datatracker.ietf.org/doc/html/rfc3986#section-5