### PR TITLE
fix: add typesVersions for TypeScript subpath exports

### DIFF
--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -46,6 +46,16 @@
     "./style.css": "./dist/style.css"
   },
   "types": "./dist/superdoc/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "super-editor": [
+        "./dist/super-editor/src/index.d.ts"
+      ],
+      "types": [
+        "./dist/types.d.ts"
+      ]
+    }
+  },
   "main": "./dist/superdoc.umd.js",
   "module": "./dist/superdoc.es.js",
   "scripts": {


### PR DESCRIPTION
TypeScript users with moduleResolution "node" couldn't resolve types for superdoc/super-editor subpath. Added typesVersions to package.json to support legacy module resolution.