### PR TITLE
feat: add CLAUDE.md/AGENTS.md navigation files for AI tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,6 @@ dist-types
 .env
 .npmrc
 .eslintcache
-CLAUDE.md
-
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
@@ -66,7 +64,6 @@ reports/
 # Planning and progress tracking documents
 **/plan/progress.md
 
-AGENTS.md
 codex.config.json
 perf-baseline-results.json
 .claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# SuperDoc
+
+A document editing and rendering library for the web.
+
+## Architecture: Dual Rendering System
+
+SuperDoc has **two separate rendering systems** that work independently:
+
+| Mode | Package | How it works |
+|------|---------|--------------|
+| **Editing** | `super-editor` | ProseMirror-based, uses decorations for visual styling |
+| **Presentation** | `layout-engine` | Virtualized DOM rendering via DomPainter class |
+
+**Key insight**: Visual changes often need to be implemented in BOTH systems.
+
+### State Communication
+
+State flows from super-editor → Layout Engine via:
+- `PresentationEditor.ts` listens to editor events (`super-editor/src/core/presentation-editor/`)
+- Calls DomPainter methods to update state
+- DomPainter re-renders with new state
+
+## Project Structure
+
+```
+packages/
+  superdoc/          Main entry point (npm: superdoc)
+  super-editor/      ProseMirror editor (@superdoc/super-editor)
+  layout-engine/     Layout & pagination pipeline
+    contracts/       - Shared type definitions
+    pm-adapter/      - ProseMirror → Layout bridge
+    layout-engine/   - Pagination algorithms
+    layout-bridge/   - Pipeline orchestration
+    painters/dom/    - DOM rendering
+    style-engine/    - OOXML style resolution
+  ai/                AI integration
+  collaboration-yjs/ Collaboration server
+shared/              Internal utilities
+e2e-tests/           Playwright tests
+```
+
+## Where to Look
+
+| Task | Location |
+|------|----------|
+| Editing features | `super-editor/src/extensions/` |
+| Presentation mode visuals | `layout-engine/painters/dom/src/renderer.ts` |
+| DOCX import/export | `super-editor/src/core/super-converter/` |
+| Style resolution | `layout-engine/style-engine/` |
+| Main entry point | `superdoc/src/SuperDoc.vue` |
+
+## When to Modify Which System
+
+- **Editing-only**: Modify super-editor decorations/plugins
+- **Viewing-only**: Modify DomPainter in layout-engine
+- **Both modes**: Modify both and bridge via PresentationEditor
+
+## Commands
+
+- `pnpm build` - Build all packages
+- `pnpm test` - Run tests
+- `pnpm dev` - Start dev server (from examples/)

--- a/packages/layout-engine/AGENTS.md
+++ b/packages/layout-engine/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/layout-engine/CLAUDE.md
+++ b/packages/layout-engine/CLAUDE.md
@@ -1,0 +1,70 @@
+# Layout Engine
+
+Pagination and rendering pipeline for SuperDoc's presentation/viewing mode.
+
+## Pipeline Overview
+
+```
+ProseMirror Doc → pm-adapter → FlowBlock[] → layout-engine → Layout[] → painter-dom → DOM
+```
+
+## Sub-packages
+
+| Package | Purpose | Key Entry |
+|---------|---------|-----------|
+| `contracts/` | Shared types (FlowBlock, Layout, etc.) | `src/index.ts` |
+| `pm-adapter/` | PM document → FlowBlocks conversion | `src/internal.ts` |
+| `layout-engine/` | Pagination algorithms | `src/index.ts` |
+| `layout-bridge/` | Pipeline orchestration | `src/layout-pipeline.ts` |
+| `painters/dom/` | DOM rendering | `src/renderer.ts` |
+| `style-engine/` | OOXML style resolution | `src/index.ts` |
+| `geometry-utils/` | Math utilities for layout | `src/index.ts` |
+
+## Key Insight: DomPainter is "Dumb"
+
+DomPainter receives pre-computed `Layout` with positioned fragments and renders them.
+It does NOT do layout logic - that's in `layout-engine/`.
+
+## Common Tasks
+
+| Task | Where to look |
+|------|---------------|
+| Change how element renders | `painters/dom/src/renderer.ts` |
+| Change pagination/layout | `layout-engine/src/index.ts` |
+| Add new block type | `pm-adapter/src/converters/` + `painters/dom/` |
+| Change style resolution | `style-engine/` |
+| Change text measurement | `measuring-dom/` |
+
+## Important Patterns
+
+### Virtualization (`painters/dom/src/renderer.ts`)
+
+Page virtualization in vertical mode - sliding window of mounted pages.
+Only visible pages are in DOM.
+
+### Active State (comments, track changes)
+
+State changes trigger layout version bump → full DOM rebuild:
+```javascript
+setActiveComment(commentId) → increments layoutVersion → clears pageIndexToState
+```
+
+### Block Lookup
+
+Maps block IDs to entries for change detection. Only changed pages re-render.
+See `blockIdToEntry` in `painters/dom/src/renderer.ts`.
+
+## Entry Points
+
+- `painters/dom/src/renderer.ts` - Main DOM rendering (large file)
+- `painters/dom/src/styles.ts` - CSS class definitions
+- `layout-bridge/src/layout-pipeline.ts` - Pipeline orchestration
+- `pm-adapter/src/internal.ts` - PM → FlowBlock conversion
+
+## Cross-References
+
+Visual changes in **editing mode** → modify super-editor decorations
+Visual changes in **viewing mode** → modify renderer.ts
+Changes to **both modes** → modify both and bridge via PresentationEditor (`super-editor/src/core/presentation-editor/`)
+
+See root CLAUDE.md for dual rendering system explanation.

--- a/packages/super-editor/AGENTS.md
+++ b/packages/super-editor/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/super-editor/CLAUDE.md
+++ b/packages/super-editor/CLAUDE.md
@@ -1,0 +1,64 @@
+# Super Editor
+
+ProseMirror-based document editor for SuperDoc.
+
+## Quick Navigation
+
+| Area | Path | Purpose |
+|------|------|---------|
+| Extensions | `src/extensions/` | Feature modules (bold, table, comment, etc.) |
+| Core | `src/core/Editor.ts` | Main editor class and lifecycle |
+| Commands | `src/core/commands/` | Low-level transformation operations |
+| Converter | `src/core/super-converter/` | DOCX import/export |
+| Helpers | `src/core/helpers/` | DOM/schema utilities |
+| Schema | `src/schema/` | Document schema definitions |
+
+## Extension Pattern
+
+Extensions use a fluent builder pattern:
+
+```javascript
+export const MyExtension = Mark.create({
+  name: 'my-extension',
+  addOptions() { return { /* config */ }; },
+  addAttributes() { /* DOM mappings */ },
+  parseHTML() { /* HTML → PM */ },
+  renderHTML() { /* PM → HTML */ },
+  addCommands() { return { /* editor.commands.* */ }; },
+  addPmPlugins() { /* state/behavior */ },
+});
+```
+
+**Example to follow**: `src/extensions/bold/` for marks, `src/extensions/paragraph/` for nodes
+
+## Key Concepts
+
+| Concept | Description | Stored in Document? |
+|---------|-------------|---------------------|
+| **Mark** | Inline formatting (bold, color) | Yes |
+| **Node** | Block or inline element (paragraph, image) | Yes |
+| **Decoration** | Visual-only overlay (highlights, selections) | No |
+| **Plugin** | State and transaction handlers | N/A |
+
+## Common Tasks
+
+| Task | Where to look |
+|------|---------------|
+| Add inline formatting | Create mark extension in `src/extensions/` |
+| Add block element | Create node extension in `src/extensions/` |
+| Add keyboard shortcut | Use `addShortcuts()` in extension |
+| Add visual decoration | Use `addPmPlugins()` with DecorationSet |
+| Support new DOCX element | Add handler in `super-converter/v3/handlers/w/` |
+
+## Entry Points
+
+- `src/extensions/index.js` - All registered extensions
+- `src/core/Editor.ts` - Main editor class
+- `src/core/CommandService.js` - Command execution
+- `src/core/super-converter/SuperConverter.js` - DOCX conversion
+
+## Testing
+
+Tests are co-located: `feature.test.js` next to `feature.js`
+
+Run: `pnpm test` from package root

--- a/packages/superdoc/AGENTS.md
+++ b/packages/superdoc/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/superdoc/CLAUDE.md
+++ b/packages/superdoc/CLAUDE.md
@@ -1,0 +1,63 @@
+# SuperDoc Package
+
+Main library entry point. Published as `superdoc` on npm.
+
+## Overview
+
+This package provides the `SuperDoc` Vue component that combines:
+- `super-editor` for editing mode
+- `layout-engine` for presentation/viewing mode
+
+## Quick Navigation
+
+| Area | Path | Purpose |
+|------|------|---------|
+| Main component | `src/SuperDoc.vue` | Primary Vue component |
+| Core setup | `src/core/SuperDoc.js` | Instance creation and configuration |
+| Stores | `src/stores/` | Vue stores for state management |
+| Composables | `src/composables/` | Vue composition utilities |
+| Helpers | `src/helpers/` | Utility functions |
+
+## Entry Points
+
+- `src/SuperDoc.vue` - Main Vue component
+- `src/index.js` - Public API exports
+- `src/core/SuperDoc.js` - Core instance logic
+
+## Public API
+
+```javascript
+import { SuperDoc } from 'superdoc';
+
+// Create instance
+const superdoc = new SuperDoc({
+  selector: '#editor',
+  document: docxArrayBuffer,
+  mode: 'edit', // or 'view'
+  // ... options
+});
+
+// Key methods
+superdoc.setMode('view');
+superdoc.getDocument();
+superdoc.destroy();
+```
+
+## Integration Patterns
+
+### Edit Mode
+Uses `super-editor` for full document editing with ProseMirror.
+
+### View/Presentation Mode
+Uses `layout-engine` for virtualized rendering with pagination.
+
+### Mode Switching
+`PresentationEditor.ts` bridges state between modes.
+See `super-editor/src/core/presentation-editor/` for implementation.
+
+## Testing
+
+- Unit tests: `src/SuperDoc.test.js`
+- Integration tests: `src/tests/`
+
+Run: `pnpm test` from package root


### PR DESCRIPTION
Add hierarchical CLAUDE.md files to help AI coding tools (Claude Code, Cursor, GitHub Copilot, Aider, etc.) navigate the SuperDoc codebase effectively.