### PR TITLE
fix: context menu clicks would change selection position (SD-1634)

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -987,7 +987,7 @@ const handleMarginClick = (event) => {
   if (target?.classList?.contains('ProseMirror')) return;
 
   // Causes issues with node selection.
-  if (target?.closest?.('.presentation-editor, .superdoc-layout')) {
+  if (target?.closest?.('.presentation-editor, .superdoc-layout, .slash-menu')) {
     return;
   }
 


### PR DESCRIPTION
- Fixes an issue where a click in one of the context menu options would modify the editor's selection, causing tables to be inserted in the wrong place.