### PR TITLE
test(layout-bridge): migrate mocking tests from vitest to bun

### DIFF
--- a/packages/layout-engine/layout-bridge/test/cacheInvalidation.test.ts
+++ b/packages/layout-engine/layout-bridge/test/cacheInvalidation.test.ts
@@ -4,7 +4,7 @@
  * Tests for cache invalidation logic for headers/footers and body content.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, spyOn } from 'bun:test';
 import type { FlowBlock, ParagraphBlock, SectionMetadata } from '@superdoc/contracts';
 import type { HeaderFooterConstraints } from '../../layout-engine';
 import {
@@ -420,7 +420,7 @@ describe('Cache Invalidation', () => {
     });
 
     it('should invalidate cache when content changes', () => {
-      const invalidateSpy = vi.spyOn(cache, 'invalidate');
+      const invalidateSpy = spyOn(cache, 'invalidate');
 
       const blocks1 = {
         default: [
@@ -452,7 +452,7 @@ describe('Cache Invalidation', () => {
     });
 
     it('should invalidate cache when constraints change', () => {
-      const invalidateSpy = vi.spyOn(cache, 'invalidate');
+      const invalidateSpy = spyOn(cache, 'invalidate');
 
       const blocks = {
         default: [
@@ -485,7 +485,7 @@ describe('Cache Invalidation', () => {
     });
 
     it('should invalidate cache when section metadata changes', () => {
-      const invalidateSpy = vi.spyOn(cache, 'invalidate');
+      const invalidateSpy = spyOn(cache, 'invalidate');
 
       const blocks = {
         default: [
@@ -522,7 +522,7 @@ describe('Cache Invalidation', () => {
     });
 
     it('should not invalidate when nothing has changed', () => {
-      const invalidateSpy = vi.spyOn(cache, 'invalidate');
+      const invalidateSpy = spyOn(cache, 'invalidate');
 
       const blocks = {
         default: [
@@ -550,7 +550,7 @@ describe('Cache Invalidation', () => {
     });
 
     it('should invalidate cache when overflowBaseHeight changes', () => {
-      const invalidateSpy = vi.spyOn(cache, 'invalidate');
+      const invalidateSpy = spyOn(cache, 'invalidate');
 
       const blocks = {
         default: [

--- a/packages/layout-engine/layout-bridge/test/footnoteColumnPlacement.test.ts
+++ b/packages/layout-engine/layout-bridge/test/footnoteColumnPlacement.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect,  mock } from 'bun:test';
 import type { FlowBlock, Measure } from '@superdoc/contracts';
 import { incrementalLayout } from '../src/incrementalLayout';
 
@@ -34,7 +34,7 @@ describe('Footnotes in columns', () => {
     const footnoteOne = makeParagraph('footnote-1-0-paragraph', 'Footnote one', 0);
     const footnoteTwo = makeParagraph('footnote-2-0-paragraph', 'Footnote two', 0);
 
-    const measureBlock = vi.fn(async (block: FlowBlock) => {
+    const measureBlock = mock(async (block: FlowBlock) => {
       if (block.kind === 'columnBreak') {
         return { kind: 'columnBreak' } as Measure;
       }

--- a/packages/layout-engine/layout-bridge/test/footnoteSeparatorSpacing.test.ts
+++ b/packages/layout-engine/layout-bridge/test/footnoteSeparatorSpacing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect,  mock } from 'bun:test';
 import type { FlowBlock, Measure } from '@superdoc/contracts';
 import { incrementalLayout } from '../src/incrementalLayout';
 
@@ -43,7 +43,7 @@ const buildLayout = async ({
   const dividerHeight = 1;
   const topPadding = 4;
 
-  const measureBlock = vi.fn(async (block: FlowBlock) => {
+  const measureBlock = mock(async (block: FlowBlock) => {
     if (block.id.startsWith('footnote-')) {
       return makeMeasure(footnoteLineHeight);
     }

--- a/packages/layout-engine/layout-bridge/test/headerFooterIntegration.test.ts
+++ b/packages/layout-engine/layout-bridge/test/headerFooterIntegration.test.ts
@@ -7,7 +7,7 @@
  * 3. Integration with incrementalLayout
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect,  mock } from 'bun:test';
 import type { FlowBlock, Measure, ParagraphBlock, TextRun, SectionMetadata } from '@superdoc/contracts';
 import { incrementalLayout } from '../src/incrementalLayout';
 import type { HeaderFooterBatch } from '../src/layoutHeaderFooter';
@@ -79,7 +79,7 @@ describe('End-to-End Header/Footer Token Resolution', () => {
     ];
 
     // Mock measureBlock function
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     // Run incremental layout with headers
     const result = await incrementalLayout(
@@ -133,7 +133,7 @@ describe('End-to-End Header/Footer Token Resolution', () => {
       default: [makePageNumberParagraph('header-large-doc')],
     };
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     const result = await incrementalLayout(
       [],
@@ -187,7 +187,7 @@ describe('End-to-End Header/Footer Token Resolution', () => {
       default: [makePageNumberParagraph('footer-default')],
     };
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     const result = await incrementalLayout(
       [],
@@ -239,7 +239,7 @@ describe('End-to-End Header/Footer Token Resolution', () => {
       default: [originalHeaderBlock],
     };
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     await incrementalLayout(
       [],
@@ -278,7 +278,7 @@ describe('End-to-End Header/Footer Token Resolution', () => {
       },
     ];
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     const result = await incrementalLayout(
       [],
@@ -315,7 +315,7 @@ describe('End-to-End Header/Footer Token Resolution', () => {
       default: [makePageNumberParagraph('header-single')],
     };
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     const result = await incrementalLayout(
       [],
@@ -345,7 +345,7 @@ describe('End-to-End Header/Footer Token Resolution', () => {
       makeTextParagraph(`body-${i}`, `Content ${i + 1}`),
     );
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     const result = await incrementalLayout(
       [],

--- a/packages/layout-engine/layout-bridge/test/instrumentation.test.ts
+++ b/packages/layout-engine/layout-bridge/test/instrumentation.test.ts
@@ -4,16 +4,16 @@
  * Tests for debug logging and metrics collection.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { PageTokenLogger, HeaderFooterCacheLogger, MetricsCollector } from '../src/instrumentation';
 
 describe('Instrumentation', () => {
-  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof spyOn>;
+  let consoleWarnSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
-    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/packages/layout-engine/layout-bridge/test/layout-coordinator.test.ts
+++ b/packages/layout-engine/layout-bridge/test/layout-coordinator.test.ts
@@ -2,7 +2,7 @@
  * Tests for LayoutCoordinator
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, mock, spyOn } from 'bun:test';
 import { LayoutCoordinator, type LayoutResult } from '../src/layout-coordinator';
 import { Priority } from '../src/layout-scheduler';
 import { LayoutVersionManager } from '../src/layout-version-manager';
@@ -10,9 +10,9 @@ import { LayoutVersionManager } from '../src/layout-version-manager';
 describe('LayoutCoordinator', () => {
   let coordinator: LayoutCoordinator;
   let versionManager: LayoutVersionManager;
-  let executeP0: ReturnType<typeof vi.fn>;
-  let executeP1: ReturnType<typeof vi.fn>;
-  let executeWorker: ReturnType<typeof vi.fn>;
+  let executeP0: ReturnType<typeof mock>;
+  let executeP1: ReturnType<typeof mock>;
+  let executeWorker: ReturnType<typeof mock>;
 
   const mockLayout = { pages: [], pageSize: { w: 612, h: 792 } };
 
@@ -28,9 +28,9 @@ describe('LayoutCoordinator', () => {
       aborted: false,
     };
 
-    executeP0 = vi.fn().mockReturnValue(mockResult);
-    executeP1 = vi.fn().mockResolvedValue(mockResult);
-    executeWorker = vi.fn().mockResolvedValue(mockResult);
+    executeP0 = mock(() => mockResult);
+    executeP1 = mock(() => Promise.resolve(mockResult));
+    executeWorker = mock(() => Promise.resolve(mockResult));
 
     coordinator = new LayoutCoordinator({
       layoutVersionManager: versionManager,
@@ -144,7 +144,7 @@ describe('LayoutCoordinator', () => {
 
   describe('version management integration', () => {
     it('should notify version manager on P0 completion', () => {
-      const spy = vi.spyOn(versionManager, 'onLayoutComplete');
+      const spy = spyOn(versionManager, 'onLayoutComplete');
 
       coordinator.scheduleLayout(1, Priority.P0, { scope: 'paragraph' });
 
@@ -152,7 +152,7 @@ describe('LayoutCoordinator', () => {
     });
 
     it('should notify version manager on async completion', async () => {
-      const spy = vi.spyOn(versionManager, 'onLayoutComplete');
+      const spy = spyOn(versionManager, 'onLayoutComplete');
 
       coordinator.scheduleLayout(1, Priority.P1, { scope: 'viewport' });
 

--- a/packages/layout-engine/layout-bridge/test/layoutHeaderFooterBucketing.test.ts
+++ b/packages/layout-engine/layout-bridge/test/layoutHeaderFooterBucketing.test.ts
@@ -10,7 +10,7 @@
  * - Backward compatibility with legacy API
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect,  mock } from 'bun:test';
 import type { FlowBlock, Measure, ParagraphBlock, TextRun } from '@superdoc/contracts';
 import {
   layoutHeaderFooterWithCache,
@@ -148,7 +148,7 @@ describe('layoutHeaderFooterWithCache - Backward Compatibility', () => {
       default: [makeBlock('header-1', 'Header text')],
     };
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
     const result = await layoutHeaderFooterWithCache(
       sections,
       { width: 400, height: 80 },
@@ -168,7 +168,7 @@ describe('layoutHeaderFooterWithCache - Backward Compatibility', () => {
       default: [makePageTokenBlock('header-with-tokens')],
     };
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
     const result = await layoutHeaderFooterWithCache(
       sections,
       { width: 400, height: 80 },
@@ -196,7 +196,7 @@ describe('layoutHeaderFooterWithCache - No-Token Fast Path', () => {
       totalPages: 150,
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
     const result = await layoutHeaderFooterWithCache(
       sections,
       { width: 400, height: 80 },
@@ -222,7 +222,7 @@ describe('layoutHeaderFooterWithCache - No-Token Fast Path', () => {
       totalPages: 50,
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
     const result = await layoutHeaderFooterWithCache(
       sections,
       { width: 400, height: 80 },
@@ -248,7 +248,7 @@ describe('layoutHeaderFooterWithCache - Per-Page Resolution (Small Docs)', () =>
       totalPages: 50, // < 100 pages
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
     const result = await layoutHeaderFooterWithCache(
       sections,
       { width: 400, height: 80 },
@@ -275,7 +275,7 @@ describe('layoutHeaderFooterWithCache - Per-Page Resolution (Small Docs)', () =>
       totalPages: 10,
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
     const result = await layoutHeaderFooterWithCache(
       sections,
       { width: 400, height: 80 },
@@ -306,7 +306,7 @@ describe('layoutHeaderFooterWithCache - Digit Bucketing (Large Docs)', () => {
       totalPages: 150, // >= 100 pages
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
     const result = await layoutHeaderFooterWithCache(
       sections,
       { width: 400, height: 80 },
@@ -337,7 +337,7 @@ describe('layoutHeaderFooterWithCache - Digit Bucketing (Large Docs)', () => {
       totalPages: 1500, // All 4 buckets needed
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
     const result = await layoutHeaderFooterWithCache(
       sections,
       { width: 400, height: 80 },
@@ -367,7 +367,7 @@ describe('layoutHeaderFooterWithCache - Digit Bucketing (Large Docs)', () => {
       totalPages: 250, // Only d1, d2, d3 needed
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
     const result = await layoutHeaderFooterWithCache(
       sections,
       { width: 400, height: 80 },
@@ -412,7 +412,7 @@ describe('layoutHeaderFooterWithCache - Section-Aware Token Resolution', () => {
       };
     };
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
     const result = await layoutHeaderFooterWithCache(
       sections,
       { width: 400, height: 80 },
@@ -441,7 +441,7 @@ describe('layoutHeaderFooterWithCache - Section-Aware Token Resolution', () => {
       };
     };
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
     const result = await layoutHeaderFooterWithCache(
       sections,
       { width: 400, height: 80 },
@@ -468,7 +468,7 @@ describe('layoutHeaderFooterWithCache - Cache Behavior', () => {
       totalPages: 50,
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     // First call
     await layoutHeaderFooterWithCache(
@@ -514,7 +514,7 @@ describe('layoutHeaderFooterWithCache - Cache Behavior', () => {
       totalPages: 10,
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     // First call
     await layoutHeaderFooterWithCache(
@@ -562,7 +562,7 @@ describe('layoutHeaderFooterWithCache - Per-Variant Cloning', () => {
       totalPages: 5,
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     await layoutHeaderFooterWithCache(
       sections,
@@ -588,7 +588,7 @@ describe('layoutHeaderFooterWithCache - Per-Variant Cloning', () => {
     });
 
     const capturedBlocks: FlowBlock[][] = [];
-    const measureBlock = vi.fn(async (block: FlowBlock) => {
+    const measureBlock = mock(async (block: FlowBlock) => {
       capturedBlocks.push([block]);
       return makeMeasure(20);
     });
@@ -624,7 +624,7 @@ describe('layoutHeaderFooterWithCache - Multiple Variants', () => {
       totalPages: 20,
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     const result = await layoutHeaderFooterWithCache(
       sections,
@@ -657,7 +657,7 @@ describe('layoutHeaderFooterWithCache - Multiple Variants', () => {
       totalPages: 50,
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     const result = await layoutHeaderFooterWithCache(
       sections,
@@ -685,7 +685,7 @@ describe('layoutHeaderFooterWithCache - Edge Cases', () => {
       totalPages: 10,
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     const result = await layoutHeaderFooterWithCache(
       sections,
@@ -710,7 +710,7 @@ describe('layoutHeaderFooterWithCache - Edge Cases', () => {
       totalPages: 1,
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     const result = await layoutHeaderFooterWithCache(
       sections,
@@ -735,7 +735,7 @@ describe('layoutHeaderFooterWithCache - Edge Cases', () => {
       totalPages: 10000, // Very large document
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     const result = await layoutHeaderFooterWithCache(
       sections,
@@ -764,7 +764,7 @@ describe('layoutHeaderFooterWithCache - Edge Cases', () => {
       totalPages: 5,
     });
 
-    const measureBlock = vi.fn(async () => makeMeasure(20));
+    const measureBlock = mock(async () => makeMeasure(20));
 
     const result = await layoutHeaderFooterWithCache(
       sections,


### PR DESCRIPTION
Test results:                                                                                                                               
- Bun: 925 tests, 38 files, 942ms                                                                                                           
- Vitest: 273 tests, 14 files, 3.9s   