### PR TITLE
fix: add null checks to list numbering functions

### DIFF
--- a/shared/common/list-numbering/index.ts
+++ b/shared/common/list-numbering/index.ts
@@ -49,7 +49,8 @@ export const generateOrderedListIndex = ({
   return handler ? handler(listLevel, lvlText, customFormat) : null;
 };
 
-const createNumbering = (values: string[], lvlText: string): string => {
+const createNumbering = (values: string[], lvlText: string | null): string | null => {
+  if (lvlText == null) return null;
   return values.reduce<string>((acc, value, index) => {
     return Number(value) > 9
       ? acc.replace(/^0/, '').replace(`%${index + 1}`, value)
@@ -57,7 +58,8 @@ const createNumbering = (values: string[], lvlText: string): string => {
   }, lvlText);
 };
 
-const generateNumbering = (path: number[], lvlText: string, formatter: NumberFormatter): string => {
+const generateNumbering = (path: number[], lvlText: string | null, formatter: NumberFormatter): string | null => {
+  if (lvlText == null) return null;
   const formattedValues = path.map((entry, idx) => formatter(entry, idx));
   return createNumbering(formattedValues, lvlText);
 };
@@ -74,7 +76,8 @@ const decimalZeroFormatter: NumberFormatter = (value, idx) => {
   return `0${value}`;
 };
 
-const generateFromCustom = (path: number[], lvlText: string, customFormat: string): string => {
+const generateFromCustom = (path: number[], lvlText: string | null, customFormat: string): string | null => {
+  if (lvlText == null) return null;
   if (customFormat.match(/(?:[0]+\d,\s){3}\.{3}/) == null) {
     return generateNumbering(path, lvlText, numberToStringFormatter);
   }


### PR DESCRIPTION
## Summary

Added null safety to the list numbering functions in `shared/common/list-numbering/index.ts` to prevent runtime errors when `lvlText` is null or undefined.

## Changes

- Updated `createNumbering` to accept `lvlText: string | null` and return early if null
- Updated `generateNumbering` to accept `lvlText: string | null` with null guard
- Updated `generateFromCustom` to accept `lvlText: string | null` with null guard
- Updated return types to `string | null` to reflect nullable returns

## Why

When `lvlText` is null, calling `.replace()` on it causes a runtime error. This fix ensures graceful handling by returning null early.

## Test Plan

- [X] Existing unit tests pass
- [ ] Verify list numbering still works correctly with valid `lvlText` values
- [ ] Verify null `lvlText` returns null without throwing errors

## Breaking Changes

None - this is a backwards-compatible fix. Functions that previously crashed on null input will now return null.