### PR TITLE
feat(template-builder): add cspNonce support

### DIFF
--- a/packages/superdoc/src/core/types/index.js
+++ b/packages/superdoc/src/core/types/index.js
@@ -192,6 +192,7 @@
  * @property {string} [markdown] Markdown content to initialize the editor with
  * @property {boolean} [isDebug=false] Whether to enable debug mode
  * @property {ViewOptions} [viewOptions] Document view options (OOXML ST_View compatible)
+ * @property {string} [cspNonce] Content Security Policy nonce for dynamically injected styles
  */
 
 export {};

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -112,6 +112,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
       menu = {},
       list = {},
       toolbar,
+      cspNonce,
       onReady,
       onTrigger,
       onFieldInsert,
@@ -468,6 +469,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
           documentMode: document?.mode || 'editing',
           modules,
           toolbar: toolbarSettings?.selector,
+          cspNonce,
           onReady: handleReady,
         });
 
@@ -489,7 +491,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
 
         superdocRef.current = null;
       };
-    }, [document?.source, document?.mode, trigger, discoverFields, onReady, onTrigger, toolbarSettings]);
+    }, [document?.source, document?.mode, trigger, discoverFields, onReady, onTrigger, toolbarSettings, cspNonce]);
 
     const handleMenuSelect = useCallback(
       async (field: Types.FieldDefinition) => {

--- a/packages/template-builder/src/types.ts
+++ b/packages/template-builder/src/types.ts
@@ -110,6 +110,9 @@ export interface SuperDocTemplateBuilderProps {
   list?: ListConfig;
   toolbar?: boolean | string | ToolbarConfig;
 
+  /** Content Security Policy nonce for dynamically injected styles */
+  cspNonce?: string;
+
   // Events
   onReady?: () => void;
   onTrigger?: (event: TriggerEvent) => void;


### PR DESCRIPTION
Forward the cspNonce prop from SuperDocTemplateBuilder to the underlying SuperDoc instance for Content Security Policy compliance.