### PR TITLE
fix: load alternative style definitions when main one is missing (SD-920)

### DIFF
--- a/packages/super-editor/src/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/core/super-converter/SuperConverter.js
@@ -269,6 +269,14 @@ class SuperConverter {
         this.convertedXml[file.name] = addDefaultStylesIfMissing(this.convertedXml[file.name]);
       }
     });
+    if (!this.convertedXml['word/styles.xml']) {
+      for (let i = 1; i <= 5; i += 1) {
+        if (this.convertedXml[`word/styles${i}.xml`] != null) {
+          this.convertedXml['word/styles.xml'] = addDefaultStylesIfMissing(this.convertedXml[`word/styles${i}.xml`]);
+          break;
+        }
+      }
+    }
     this.initialJSON = this.convertedXml['word/document.xml'];
 
     if (!this.initialJSON) this.initialJSON = this.parseXmlToJson(this.xml);


### PR DESCRIPTION
- Sometimes the docx file may be missing the `word/styles.xml` file but contain alternative files like `word/styles2.xml`. This PR makes SD fall back to the alternative files if the main one is missing.