### PR TITLE
fix: use DEFLATE compression for docx export instead of STORE

### DIFF
--- a/packages/super-editor/src/core/DocxZipper.js
+++ b/packages/super-editor/src/core/DocxZipper.js
@@ -262,7 +262,7 @@ class DocxZipper {
     return zip;
   }
 
-  async updateZip({ docx, updatedDocs, originalDocxFile, media, fonts, isHeadless }) {
+  async updateZip({ docx, updatedDocs, originalDocxFile, media, fonts, isHeadless, compression = 'DEFLATE' }) {
     // We use a different re-zip process if we have the original docx vs the docx xml metadata
     let zip;
 
@@ -274,7 +274,11 @@ class DocxZipper {
 
     // If we are headless we don't have 'blob' support, so export as 'nodebuffer'
     const exportType = isHeadless ? 'nodebuffer' : 'blob';
-    return await zip.generateAsync({ type: exportType });
+    return await zip.generateAsync({
+      type: exportType,
+      compression,
+      compressionOptions: compression === 'DEFLATE' ? { level: 6 } : undefined,
+    });
   }
 
   /**

--- a/packages/super-editor/src/core/Editor.ts
+++ b/packages/super-editor/src/core/Editor.ts
@@ -138,6 +138,9 @@ export interface SaveOptions {
 
   /** Highlight color for fields */
   fieldsHighlightColor?: string | null;
+
+  /** ZIP compression method for docx export. Defaults to 'DEFLATE'. Use 'STORE' for faster exports without compression. */
+  compression?: 'DEFLATE' | 'STORE';
 }
 
 /**
@@ -2484,6 +2487,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
     comments,
     getUpdatedDocs = false,
     fieldsHighlightColor = null,
+    compression,
   }: {
     isFinalDoc?: boolean;
     commentsType?: string;
@@ -2492,6 +2496,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
     comments?: Comment[];
     getUpdatedDocs?: boolean;
     fieldsHighlightColor?: string | null;
+    compression?: 'DEFLATE' | 'STORE';
   } = {}): Promise<Blob | ArrayBuffer | Buffer | Record<string, string> | ProseMirrorJSON | string | undefined> {
     try {
       // Use provided comments, or fall back to imported comments from converter
@@ -2623,6 +2628,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
         media,
         fonts: this.options.fonts,
         isHeadless: this.options.isHeadless,
+        compression,
       });
 
       return result;
@@ -2893,6 +2899,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
       commentsType: options?.commentsType,
       comments: options?.comments,
       fieldsHighlightColor: options?.fieldsHighlightColor,
+      compression: options?.compression,
     });
 
     return result as Blob | Buffer;


### PR DESCRIPTION
## Summary

- Default `DocxZipper.updateZip` to use DEFLATE compression instead of JSZip's default of STORE (no compression), reducing exported `.docx` file sizes by ~10x
- Make the compression method configurable via the `compression` option on `exportDocument()` / `save()` / `saveTo()`, so callers can opt into STORE for faster exports if needed
- Add tests verifying DEFLATE produces smaller output than STORE and that the option is respected

## Context

JSZip defaults to `STORE` (no compression) when `compression` isn't specified in `generateAsync()`. Since Word and other editors use DEFLATE, a round-trip through SuperDoc was inflating file sizes significantly (e.g., a 27KB input becoming 260KB after export).

## Test plan

- [x] Existing `DocxZipper` tests pass
- [x] New test: DEFLATE (default) produces smaller output than STORE
- [x] New test: explicit `compression: 'STORE'` is respected
- [x] Pre-commit hooks pass (format, lint, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)