### PR TITLE
fix(converter): handle absolute paths in header/footer relationship targets

### DIFF
--- a/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
@@ -759,7 +759,10 @@ const getHeaderFooterSectionData = (sectionData, docx) => {
   const target = sectionData.attributes.Target;
   const filePath = resolveOpcTargetPath(target, 'word');
   const referenceFile = filePath ? docx[filePath] : undefined;
-  const currentFileName = target;
+  // Extract just the filename for relationship file lookup.
+  // This handles both absolute paths (/word/header1.xml -> header1.xml)
+  // and relative paths (header1.xml -> header1.xml) per ECMA-376 OPC spec.
+  const currentFileName = filePath ? filePath.split('/').pop() : target.split('/').pop();
   return {
     rId,
     referenceFile,


### PR DESCRIPTION
## Summary

Fixes SD-1786: Image in header does not render until resaving document in Word

- Documents created by tools like Google Docs may use absolute paths (e.g., `/word/header1.xml`) in relationship target attributes instead of relative paths
- This caused the relationship file lookup to construct invalid paths, resulting in images in headers not rendering
- The fix extracts just the filename from the resolved path, handling both absolute and relative paths correctly per ECMA-376 OPC spec

## Root Cause

In `getHeaderFooterSectionData`, the `currentFileName` was set to the raw target path:

```javascript
// Before (bug)
const currentFileName = target;  // "/word/header1.xml"

// This caused invalid lookup path:
// word/_rels//word/header1.xml.rels ❌
```

## Fix

Extract just the filename from the resolved path:

```javascript
// After (fix)
const currentFileName = filePath.split('/').pop();  // "header1.xml"

// Correct lookup path:
// word/_rels/header1.xml.rels ✅
```

## Test plan

- [x] Added regression test for absolute paths in image relationship targets
- [x] All 5,381 existing tests pass
- [x] Verified fix works with the original problematic document

🔗 [Linear ticket](https://linear.app/superdocworkspace/issue/SD-1786)