### PR TITLE
fix(tracked-changes): fix suggested insertions from paste failures

### DIFF
--- a/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/replaceStep.js
+++ b/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/replaceStep.js
@@ -40,11 +40,15 @@ export const replaceStep = ({ state, tr, step, newTr, map, user, date, originalS
     }
   }
 
+  // When pasting into a textblock, try the open slice first so content merges inline
+  // instead of creating new paragraphs (prevents inserting block nodes into non-textblocks).
   const baseParentIsTextblock = trTemp.doc.resolve(positionTo).parent?.isTextblock;
   const shouldPreferInlineInsertion = step.from === step.to && baseParentIsTextblock;
 
   const tryInsert = (slice) => {
     const tempTr = state.apply(newTr).tr;
+    // Empty slices represent pure deletions (no content to insert).
+    // Detecting them ensures deletion tracking runs even if `tempTr` doesn't change.
     const isEmptySlice = slice?.content?.size === 0;
     try {
       tempTr.replaceRange(positionTo, positionTo, slice);

--- a/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/replaceStep.test.js
+++ b/packages/super-editor/src/extensions/track-changes/trackChangesHelpers/replaceStep.test.js
@@ -300,6 +300,45 @@ describe('trackChangesHelpers replaceStep', () => {
     expect(insertedText).toContain('Plain Paste');
   });
 
+  it('tracks paste replacement over selected existing text', () => {
+    const doc = schema.nodes.doc.create(
+      {},
+      schema.nodes.paragraph.create({}, schema.nodes.run.create({}, [schema.text('Hello World')])),
+    );
+    let state = createState(doc);
+
+    const worldPos = findTextPos(state.doc, 'Hello World');
+    expect(worldPos).toBeTypeOf('number');
+    const from = worldPos + 'Hello '.length;
+    const to = from + 'World'.length;
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, from, to)));
+
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = '<p>Pasted</p>';
+    const parsedDoc = PMDOMParser.fromSchema(schema).parse(tempDiv);
+    const slice = new Slice(parsedDoc.content, 0, 0);
+
+    let tr = state.tr.replaceSelection(slice);
+    tr.setMeta('inputType', 'insertFromPaste');
+    const tracked = trackedTransaction({ tr, state, user });
+    const meta = tracked.getMeta(TrackChangesBasePluginKey);
+    const finalState = state.apply(tracked);
+
+    let insertedText = '';
+    let deletedText = '';
+    finalState.doc.descendants((node) => {
+      if (!node.isText) return;
+      if (node.marks.some((mark) => mark.type.name === TrackInsertMarkName)) insertedText += node.text;
+      if (node.marks.some((mark) => mark.type.name === TrackDeleteMarkName)) deletedText += node.text;
+    });
+
+    expect(insertedText).toContain('Pasted');
+    expect(deletedText).toContain('World');
+    expect(meta?.insertedMark).toBeDefined();
+    expect(meta?.deletionMark).toBeDefined();
+    expect(meta.insertedMark.attrs.id).toBe(meta.deletionMark.attrs.id);
+  });
+
   it('prefers original paste slice before maxOpen fallback for collapsed insertions', () => {
     const doc = schema.nodes.doc.create(
       {},


### PR DESCRIPTION
- insertion using a more flexible method (replaceRange) in a temporary transaction
- handle complex pasted content correctly
- ensure paste is inline and on the line we expect