### PR TITLE
fix: return null instead of blank num definition when not found

### DIFF
--- a/packages/super-editor/src/core/helpers/list-numbering-helpers.js
+++ b/packages/super-editor/src/core/helpers/list-numbering-helpers.js
@@ -162,7 +162,7 @@ export const hasListDefinition = (editor, numId, ilvl) => {
  */
 export const changeNumIdSameAbstract = (numId, level, listType, editor) => {
   const newId = getNewListId(editor, 'definitions');
-  const { abstract } = ListHelpers.getListDefinitionDetails({ numId, level, listType, editor });
+  const { abstract } = ListHelpers.getListDefinitionDetails({ numId, level, listType, editor }) || {};
 
   const numbering = editor.converter.numbering;
   const newNumbering = { ...numbering };
@@ -243,7 +243,7 @@ export const getNewListId = (editor, grouping = 'definitions') => {
  * @param {import("prosemirror-model").NodeType} [params.listType] - The type of the list (e.g., 'orderedList', 'bulletList'). Required when generating new definitions
  * @param {Object} params.editor - The editor instance containing converter and numbering data
  * @param {number} [params.tries=0] - The number of recursion attempts to avoid infinite loops (max 1)
- * @returns {Object} The list definition details
+ * @returns {Object | null} The list definition details or null if not found
  */
 export const getListDefinitionDetails = ({ numId, level, listType, editor, tries = 0 }) => {
   const { definitions, abstracts } = editor.converter.numbering;
@@ -263,17 +263,7 @@ export const getListDefinitionDetails = ({ numId, level, listType, editor, tries
 
   const abstract = abstracts[abstractId];
   if (!abstract) {
-    return {
-      start: null,
-      numFmt: null,
-      lvlText: null,
-      listNumberingType: null,
-      suffix: null,
-      justification: null,
-      customFormat: null,
-      abstract: null,
-      abstractId,
-    };
+    return null;
   }
 
   // Handle style link recursion (max 1 retry)
@@ -304,17 +294,7 @@ export const getListDefinitionDetails = ({ numId, level, listType, editor, tries
   );
 
   if (!listDefinition) {
-    return {
-      start: null,
-      numFmt: null,
-      lvlText: null,
-      suffix: null,
-      justification: null,
-      listNumberingType: null,
-      customFormat: null,
-      abstract,
-      abstractId,
-    };
+    return null;
   }
 
   // Extract level properties safely

--- a/packages/super-editor/src/core/helpers/list-numbering-helpers.test.js
+++ b/packages/super-editor/src/core/helpers/list-numbering-helpers.test.js
@@ -290,20 +290,10 @@ describe('getListDefinitionDetails', () => {
         editor: mockEditor,
       });
 
-      expect(result).toEqual({
-        start: null,
-        numFmt: null,
-        lvlText: null,
-        listNumberingType: null,
-        customFormat: null,
-        justification: null,
-        suffix: null,
-        abstract: null,
-        abstractId: 'nonexistent', // The function correctly returns the abstractId even when abstract is not found
-      });
+      expect(result).toBeNull();
     });
 
-    it('should return partial data when abstract exists but level definition is missing', () => {
+    it('should return null when abstract exists but level definition is missing', () => {
       mockDefinitions[1] = {
         elements: [
           {
@@ -329,17 +319,7 @@ describe('getListDefinitionDetails', () => {
         editor: mockEditor,
       });
 
-      expect(result).toEqual({
-        start: null,
-        numFmt: null,
-        lvlText: null,
-        suffix: null,
-        justification: null,
-        listNumberingType: null,
-        customFormat: null,
-        abstract: mockAbstracts['abstract1'],
-        abstractId: 'abstract1',
-      });
+      expect(result).toBeNull();
     });
   });
 
@@ -464,8 +444,7 @@ describe('getListDefinitionDetails', () => {
       });
 
       // Should not recurse, should return null values since no level definition exists
-      expect(result.abstract).toBe(mockAbstracts['abstract1']);
-      expect(result.start).toBe(null);
+      expect(result).toBeNull();
     });
 
     it('should handle missing style definition gracefully', () => {
@@ -495,8 +474,7 @@ describe('getListDefinitionDetails', () => {
         editor: mockEditor,
       });
 
-      expect(result.abstract).toBe(mockAbstracts['abstract1']);
-      expect(result.start).toBe(null);
+      expect(result).toBeNull();
     });
 
     it('should handle incomplete style definition chain', () => {
@@ -539,8 +517,7 @@ describe('getListDefinitionDetails', () => {
         editor: mockEditor,
       });
 
-      expect(result.abstract).toBe(mockAbstracts['abstract1']);
-      expect(result.start).toBe(null);
+      expect(result).toBeNull();
     });
 
     it('should handle style definition with missing nested elements', () => {
@@ -582,8 +559,7 @@ describe('getListDefinitionDetails', () => {
         editor: mockEditor,
       });
 
-      expect(result.abstract).toBe(mockAbstracts['abstract1']);
-      expect(result.start).toBe(null);
+      expect(result).toBeNull();
     });
   });
 
@@ -643,8 +619,7 @@ describe('getListDefinitionDetails', () => {
         editor: mockEditor,
       });
 
-      expect(result.abstract).toBe(mockAbstracts['abstract1']);
-      expect(result.start).toBe(null);
+      expect(result).toBeNull();
     });
 
     it('should handle undefined editor or numbering data', () => {
@@ -663,17 +638,7 @@ describe('getListDefinitionDetails', () => {
         editor: emptyEditor,
       });
 
-      expect(result).toEqual({
-        start: null,
-        numFmt: null,
-        lvlText: null,
-        justification: null,
-        suffix: null,
-        listNumberingType: null,
-        customFormat: null,
-        abstract: null,
-        abstractId: undefined,
-      });
+      expect(result).toBeNull();
     });
   });
 
@@ -865,7 +830,13 @@ describe('getListDefinitionDetails', () => {
       };
       mockEditor.converter.numbering.abstracts['10'] = {
         attributes: { 'w:abstractNumId': '10' },
-        elements: [],
+        elements: [
+          {
+            name: 'w:lvl',
+            attributes: { 'w:ilvl': '0' },
+            elements: [{ name: 'w:numFmt', attributes: { 'w:val': 'decimal' } }],
+          },
+        ],
       };
 
       const newNumId = ListHelpers.changeNumIdSameAbstract(1, 0, 'orderedList', mockEditor);


### PR DESCRIPTION
- During the computation of a list item's properties in the numberingPlugin, if the `numId` was not found, a numbering definition with null properties was returned which could cause issues further ahead.
- This was changed so that `null` is returned instead and the definition is ignored.