### PR TITLE
fix: preserve text selection highlight on right-click

### DIFF
--- a/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
@@ -3369,7 +3369,7 @@ export class PresentationEditor extends EventEmitter {
     const activeEditor = this.getActiveEditor();
     const hasFocus = activeEditor?.view?.hasFocus?.() ?? false;
     // Keep selection visible when context menu (SlashMenu) is open
-    const slashMenuOpen = !!SlashMenuPluginKey.getState(activeEditor?.state)?.open;
+    const slashMenuOpen = activeEditor?.state ? !!SlashMenuPluginKey.getState(activeEditor.state)?.open : false;
 
     if (!hasFocus && !slashMenuOpen) {
       try {


### PR DESCRIPTION
## Summary
  - Selection highlight no longer disappears when right-clicking to open context menu
  - Fixed by checking SlashMenu open state before clearing selection overlay in PresentationEditor
  - Reproduced in both Chrome and Firefox (pagination mode)

## Before

https://github.com/user-attachments/assets/ff7587dd-1dcc-4b41-919c-a0da6202d4e9

## After

https://github.com/user-attachments/assets/67381ad0-ba1e-46ea-ba56-ccb48ef49297


## Test plan
  - [x] Select text in pagination mode
  - [x] Right-click on selected text
  - [x] Verify blue highlight stays visible while context menu is open

Fixes #1764