### PR TITLE
feat: disable telemetry in visual testing harness configuration

### DIFF
--- a/tests/visual/harness/main.ts
+++ b/tests/visual/harness/main.ts
@@ -26,6 +26,7 @@ function init(file?: File) {
   const config: any = {
     selector: '#editor',
     useLayoutEngine: layout,
+    telemetry: { enabled: false },
     onReady: ({ superdoc }: any) => {
       (window as any).superdoc = superdoc;
       superdoc.activeEditor.on('create', ({ editor }: any) => {


### PR DESCRIPTION
visual testing config is used from the main branch only. So, if telemetry is not disabled for the main branch - it affects all the PRs. 
This is a small patch to unblock other CI/CD workflows