### PR TITLE
fix: ignore sdBlockId when pasting content

### DIFF
--- a/packages/super-editor/src/core/InputRule.js
+++ b/packages/super-editor/src/core/InputRule.js
@@ -392,9 +392,12 @@ export function sanitizeHtml(html, forbiddenTags = ['meta', 'svg', 'script', 'st
         continue;
       }
 
-      // Remove linebreaktype here - we don't want it when pasting HTML
+      // Internal/runtime-only attributes must not be preserved across paste.
       if (child.hasAttribute('linebreaktype')) {
         child.removeAttribute('linebreaktype');
+      }
+      if (child.hasAttribute('data-sd-block-id')) {
+        child.removeAttribute('data-sd-block-id');
       }
 
       walkAndClean(child);

--- a/packages/super-editor/src/core/InputRule.test.js
+++ b/packages/super-editor/src/core/InputRule.test.js
@@ -80,11 +80,15 @@ describe('InputRule helpers', () => {
   });
 
   it('sanitizes forbidden tags and attributes', () => {
-    const sanitized = sanitizeHtml('<div linebreaktype="soft"><script>bad()</script><span>ok</span></div>');
+    const sanitized = sanitizeHtml(
+      '<div linebreaktype="soft"><p data-sd-block-id="block-1"><script>bad()</script><span>ok</span></p></div>',
+    );
 
     expect(sanitized.querySelector('script')).toBeNull();
     const div = sanitized.querySelector('div');
     expect(div?.hasAttribute('linebreaktype')).toBe(false);
+    const paragraph = sanitized.querySelector('p');
+    expect(paragraph?.hasAttribute('data-sd-block-id')).toBe(false);
     expect(div?.querySelector('span')?.textContent).toBe('ok');
   });
 

--- a/packages/super-editor/src/core/inputRules/docx-paste/docx-paste.js
+++ b/packages/super-editor/src/core/inputRules/docx-paste/docx-paste.js
@@ -31,6 +31,7 @@ export const handleDocxPaste = (html, editor, view) => {
 
   const tempDiv = document.createElement('div');
   tempDiv.innerHTML = cleanedHtml;
+  tempDiv.querySelectorAll('[data-sd-block-id]').forEach((node) => node.removeAttribute('data-sd-block-id'));
 
   const data = tempDiv.querySelectorAll('p, li, ' + [1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => `h${n}`).join(', '));
 

--- a/packages/super-editor/src/core/inputRules/docx-paste/docx-paste.test.js
+++ b/packages/super-editor/src/core/inputRules/docx-paste/docx-paste.test.js
@@ -103,7 +103,7 @@ describe('handleDocxPaste', () => {
               <span style="font-size:13pt;font-family:Calibri">First item</span>
             </li>
           </ol>
-          <p class="MsoListParagraph" style="mso-list:l0 level1 lfo1;font-size:13pt;font-family:Calibri">
+          <p class="MsoListParagraph" data-sd-block-id="copied-block-id" style="mso-list:l0 level1 lfo1;font-size:13pt;font-family:Calibri">
             <!--[if !supportLists]--><span style="font-family:Arial;font-size:12pt">2.</span><!--[endif]-->
             Second item
           </p>
@@ -133,6 +133,7 @@ describe('handleDocxPaste', () => {
     const parsedNode = parseSpy.mock.calls[0][0];
     const generatedParagraphs = Array.from(parsedNode.querySelectorAll('p[data-list-level]'));
     expect(generatedParagraphs).toHaveLength(2);
+    expect(parsedNode.querySelector('[data-sd-block-id]')).toBeNull();
     expect(generatedParagraphs[0].getAttribute('data-num-id')).toBe('200');
     expect(generatedParagraphs[0].getAttribute('data-list-level')).toBe('[1]');
     expect(generatedParagraphs[1].getAttribute('data-list-level')).toBe('[2]');


### PR DESCRIPTION
- When copying and pasting text inside the editor, the pasted nodes would have the same `sdBlockId` attributes, causing issues during rendering by the layout engine.
- Now the `sdBlockId` attribute is ignored during pasting so that it is auto-generated.