### PR TITLE
fix(react): use semantic-release-pnpm to resolve workspace deps on publish

### DIFF
--- a/packages/react/.releaserc.cjs
+++ b/packages/react/.releaserc.cjs
@@ -11,7 +11,7 @@ const config = {
     'semantic-release-commit-filter',
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    ['@semantic-release/npm', { npmPublish: true }],
+    ['semantic-release-pnpm', { npmPublish: true }],
   ],
 };
 


### PR DESCRIPTION
## Summary

- Switches `@superdoc-dev/react` release config from `@semantic-release/npm` to `semantic-release-pnpm` (already used by the `superdoc` package)
- `@semantic-release/npm` runs `npm publish` which does **not** resolve pnpm `workspace:*` references — this caused v1.0.0-canary.2 to ship with `"superdoc": "workspace:*"`, breaking `npm install` for consumers
- `semantic-release-pnpm` runs `pnpm publish` which properly resolves workspace protocols to actual version numbers


Closes SD-1908

## Test plan

- [x] Verify `semantic-release-pnpm` is already a root dependency (it is — used by superdoc)
- [x] Verify the next react release publishes with resolved dependency versions
- [x] Manually update `@latest` dist-tag to point to a working version