### PR TITLE
fix(react): use pnpm publish for workspace dependency resolution (SD-1908)

### DIFF
--- a/packages/react/.releaserc.cjs
+++ b/packages/react/.releaserc.cjs
@@ -11,7 +11,8 @@ const config = {
     'semantic-release-commit-filter',
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    ['semantic-release-pnpm', { npmPublish: true }],
+    ['semantic-release-pnpm', { npmPublish: false }],
+    '../../scripts/publish-react.cjs',
   ],
 };
 

--- a/scripts/publish-react.cjs
+++ b/scripts/publish-react.cjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '..');
+const reactDir = path.join(rootDir, 'packages', 'react');
+
+module.exports = {
+  publish: async (_pluginConfig, context) => {
+    const { nextRelease, logger = console } = context;
+    const distTag = (nextRelease && nextRelease.channel) || 'latest';
+
+    logger.log(`Publishing @superdoc-dev/react with dist-tag "${distTag}"...`);
+    execFileSync(
+      'pnpm',
+      ['publish', '--access', 'public', '--tag', distTag, '--no-git-checks'],
+      { stdio: 'inherit', cwd: reactDir }
+    );
+  },
+};


### PR DESCRIPTION
## Summary

- Switches `@superdoc-dev/react` release from `@semantic-release/npm` to `semantic-release-pnpm` + custom publish script
- `@semantic-release/npm` runs `npm publish` which does **not** resolve pnpm `workspace:*` references — this caused v1.0.0-canary.2 to ship with `"superdoc": "workspace:*"`, breaking `npm install` for consumers
- Follows the same pattern as the `superdoc` package: `semantic-release-pnpm` for version bumping (`npmPublish: false`) + `scripts/publish-react.cjs` calling `pnpm publish` directly
- Also avoids the `--userconfig` flag incompatibility between `semantic-release-pnpm` and pnpm v10

**Note:** The `@latest` dist-tag has already been fixed via CI to point to `1.0.0-rc.2`.

Closes SD-1908

## Test plan

- [ ] Merge and verify next react release publishes successfully with resolved dependency versions