### PR TITLE
ci: add automatic PR risk-level labeling (SD-1925)

### DIFF
--- a/.github/scripts/risk-label.mjs
+++ b/.github/scripts/risk-label.mjs
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+
+// --- Path Classification ---
+// Order matters: critical is checked first, then sensitive, then low.
+// When in doubt, a path is classified higher (critical > sensitive > low).
+
+const CRITICAL_PATHS = [
+  'packages/layout-engine/style-engine/',
+  'packages/layout-engine/layout-engine/',
+  'packages/layout-engine/pm-adapter/',
+  'packages/layout-engine/layout-bridge/',
+  'packages/layout-engine/measuring/',
+  'packages/layout-engine/painters/',
+  'packages/super-editor/src/core/super-converter/',
+  'packages/super-editor/src/core/presentation-editor/',
+  'packages/superdoc/src/core/',
+  'packages/word-layout/',
+];
+
+const SENSITIVE_PATHS = [
+  'packages/super-editor/src/extensions/',
+  'packages/super-editor/src/core/',
+  'packages/layout-engine/contracts/',
+  'packages/esign/',
+];
+
+const TEST_PATTERNS = [
+  /__tests__\//,
+  /\/test-fixtures\//,
+  /\.(test|spec)\.[^/]+$/,
+  /^tests\//,
+  /^e2e-tests\//,
+];
+
+// --- Helpers ---
+
+function isTestFile(file) {
+  return TEST_PATTERNS.some((p) => p.test(file));
+}
+
+function classifyFile(file) {
+  for (const prefix of CRITICAL_PATHS) {
+    if (file.startsWith(prefix)) return 'critical';
+  }
+  for (const prefix of SENSITIVE_PATHS) {
+    if (file.startsWith(prefix)) return 'sensitive';
+  }
+  return 'low';
+}
+
+// --- Main Classification ---
+
+export function classify(files) {
+  if (!files.length) {
+    return { level: 'low', downgraded: false };
+  }
+
+  const entries = files.map((file) => ({
+    file,
+    risk: classifyFile(file),
+    test: isTestFile(file),
+  }));
+
+  // Highest risk wins
+  let level = 'low';
+  if (entries.some((e) => e.risk === 'critical')) level = 'critical';
+  else if (entries.some((e) => e.risk === 'sensitive')) level = 'sensitive';
+
+  // Downgrade if ALL risky files are test-only
+  const riskyFiles = entries.filter((e) => e.risk !== 'low');
+  let downgraded = false;
+  if (riskyFiles.length > 0 && riskyFiles.every((e) => e.test)) {
+    if (level === 'critical') level = 'sensitive';
+    else if (level === 'sensitive') level = 'low';
+    downgraded = true;
+  }
+
+  return { level, downgraded };
+}
+
+// --- CLI ---
+
+if (process.argv[1]?.endsWith('risk-label.mjs')) {
+  let files;
+  if (process.argv.length > 2) {
+    files = process.argv.slice(2);
+  } else {
+    const input = readFileSync('/dev/stdin', 'utf-8');
+    files = input.trim().split('\n').filter(Boolean);
+  }
+
+  const result = classify(files);
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/.github/scripts/risk-label.test.mjs
+++ b/.github/scripts/risk-label.test.mjs
@@ -1,0 +1,155 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { classify } from './risk-label.mjs';
+
+describe('classify', () => {
+  it('empty file list returns low', () => {
+    assert.equal(classify([]).level, 'low');
+  });
+
+  it('low-risk files only', () => {
+    const result = classify([
+      'apps/docs/guides/foo.mdx',
+      'packages/react/src/SuperDocEditor.tsx',
+      'shared/utils/helpers.js',
+      '.github/workflows/ci.yml',
+    ]);
+    assert.equal(result.level, 'low');
+    assert.equal(result.downgraded, false);
+  });
+
+  it('sensitive: extensions', () => {
+    assert.equal(
+      classify(['packages/super-editor/src/extensions/bold/bold.ts']).level,
+      'sensitive',
+    );
+  });
+
+  it('sensitive: esign', () => {
+    assert.equal(classify(['packages/esign/src/foo.ts']).level, 'sensitive');
+  });
+
+  it('sensitive: contracts', () => {
+    assert.equal(
+      classify(['packages/layout-engine/contracts/src/index.ts']).level,
+      'sensitive',
+    );
+  });
+
+  it('critical: style-engine', () => {
+    assert.equal(
+      classify(['packages/layout-engine/style-engine/src/resolve.js']).level,
+      'critical',
+    );
+  });
+
+  it('critical: super-converter', () => {
+    assert.equal(
+      classify([
+        'packages/super-editor/src/core/super-converter/v2/importer/foo.js',
+      ]).level,
+      'critical',
+    );
+  });
+
+  it('critical: layout-engine core', () => {
+    assert.equal(
+      classify(['packages/layout-engine/layout-engine/src/index.ts']).level,
+      'critical',
+    );
+  });
+
+  it('critical: pm-adapter', () => {
+    assert.equal(
+      classify(['packages/layout-engine/pm-adapter/src/foo.js']).level,
+      'critical',
+    );
+  });
+
+  it('critical: painters', () => {
+    assert.equal(
+      classify(['packages/layout-engine/painters/dom/src/renderer.ts']).level,
+      'critical',
+    );
+  });
+
+  it('critical: superdoc core', () => {
+    assert.equal(
+      classify(['packages/superdoc/src/core/SuperDoc.js']).level,
+      'critical',
+    );
+  });
+
+  it('critical: presentation-editor', () => {
+    assert.equal(
+      classify([
+        'packages/super-editor/src/core/presentation-editor/PresentationEditor.ts',
+      ]).level,
+      'critical',
+    );
+  });
+
+  it('critical: layout-bridge', () => {
+    assert.equal(
+      classify(['packages/layout-engine/layout-bridge/src/foo.ts']).level,
+      'critical',
+    );
+  });
+
+  it('critical: measuring', () => {
+    assert.equal(
+      classify(['packages/layout-engine/measuring/src/foo.ts']).level,
+      'critical',
+    );
+  });
+
+  it('highest risk wins when mixed', () => {
+    const result = classify([
+      'packages/layout-engine/style-engine/src/resolve.js',
+      'packages/super-editor/src/extensions/bold/bold.ts',
+      'apps/docs/guides/foo.mdx',
+    ]);
+    assert.equal(result.level, 'critical');
+  });
+
+  it('super-editor/src/core/ non-critical subpath is sensitive', () => {
+    assert.equal(
+      classify(['packages/super-editor/src/core/helpers/utils.js']).level,
+      'sensitive',
+    );
+  });
+
+  it('downgrade: critical test-only becomes sensitive', () => {
+    const result = classify([
+      'packages/layout-engine/style-engine/__tests__/resolve.test.js',
+      'packages/super-editor/src/core/super-converter/__tests__/import.test.js',
+    ]);
+    assert.equal(result.level, 'sensitive');
+    assert.equal(result.downgraded, true);
+  });
+
+  it('downgrade: sensitive test-only becomes low', () => {
+    const result = classify([
+      'packages/super-editor/src/extensions/bold/bold.test.ts',
+    ]);
+    assert.equal(result.level, 'low');
+    assert.equal(result.downgraded, true);
+  });
+
+  it('no downgrade when mix of test and source in risky paths', () => {
+    const result = classify([
+      'packages/layout-engine/style-engine/src/resolve.js',
+      'packages/layout-engine/style-engine/__tests__/resolve.test.js',
+    ]);
+    assert.equal(result.level, 'critical');
+    assert.equal(result.downgraded, false);
+  });
+
+  it('test directories are recognized as low risk', () => {
+    assert.equal(
+      classify(['tests/visual/tests/behavior/bold.spec.ts']).level,
+      'low',
+    );
+    assert.equal(classify(['e2e-tests/foo.test.ts']).level, 'low');
+  });
+});

--- a/.github/workflows/risk-label.yml
+++ b/.github/workflows/risk-label.yml
@@ -1,0 +1,87 @@
+name: PR Risk Label
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: risk-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get changed files and classify risk
+        id: risk
+        run: |
+          gh pr diff ${{ github.event.pull_request.number }} --name-only \
+            | node .github/scripts/risk-label.mjs > /tmp/risk.json
+          echo "level=$(node -e "console.log(JSON.parse(require('fs').readFileSync('/tmp/risk.json','utf-8')).level)")" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply risk label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const level = '${{ steps.risk.outputs.level }}';
+
+            const LABELS = {
+              critical: { name: 'risk: critical', color: 'd73a4a' },
+              sensitive: { name: 'risk: sensitive', color: 'fbca04' },
+              low: { name: 'risk: low', color: '0e8a16' },
+            };
+
+            const prNumber = context.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Ensure all risk labels exist
+            for (const label of Object.values(LABELS)) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label.name });
+              } catch {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label.name,
+                  color: label.color,
+                });
+              }
+            }
+
+            // Remove stale risk labels, add current one
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: prNumber,
+            });
+
+            const riskLabels = currentLabels.filter((l) => l.name.startsWith('risk: '));
+            for (const label of riskLabels) {
+              if (label.name !== LABELS[level].name) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  name: label.name,
+                });
+              }
+            }
+
+            const hasCorrectLabel = riskLabels.some((l) => l.name === LABELS[level].name);
+            if (!hasCorrectLabel) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [LABELS[level].name],
+              });
+            }


### PR DESCRIPTION
Classifies PRs as critical/sensitive/low based on changed file paths and applies a colored label. Test-only changes in critical paths get downgraded one level.