### PR TITLE
fix(ci): use pull_request_target for secrets access in contributor workflow

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,7 +1,7 @@
 name: Update README Contributors
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
 


### PR DESCRIPTION
## Summary

- Fixes the `update-contributors` workflow failing with `appId option is required` by switching from `pull_request` to `pull_request_target`
- `pull_request` events from forks don't have access to repository secrets; `pull_request_target` runs in the base repo context and does

## Test plan

- [ ] Merge a PR from a non-org contributor and verify the workflow runs successfully