### PR TITLE
fix: close toolbar dropdowns when clicking in editor area

### DIFF
--- a/packages/super-editor/src/components/toolbar/ButtonGroup.vue
+++ b/packages/super-editor/src/components/toolbar/ButtonGroup.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, h } from 'vue';
+import { computed, ref, h, onMounted, onBeforeUnmount } from 'vue';
 import ToolbarButton from './ToolbarButton.vue';
 import ToolbarSeparator from './ToolbarSeparator.vue';
 import OverflowMenu from './OverflowMenu.vue';
@@ -203,6 +203,21 @@ const handleFocus = (e) => {
     firstButton.focus();
   }
 };
+
+const handleDocumentPointerDown = (event) => {
+  if (!currentItem.value?.expand) return;
+  const target = event.target;
+  if (target?.closest?.('[data-editor-ui-surface]') || target?.closest?.('.n-dropdown')) return;
+  closeDropdowns();
+};
+
+onMounted(() => {
+  document.addEventListener('pointerdown', handleDocumentPointerDown, true);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', handleDocumentPointerDown, true);
+});
 
 const handleDropdownUpdateShow = (open) => {
   if (!open) {


### PR DESCRIPTION
## Summary

Fixes #2169

- Toolbar dropdowns (font family, font size, table edit, etc.) now close when clicking in the editor area
- Root cause: `EditorInputManager` calls `preventDefault()` on `pointerdown` in the editor viewport, which suppresses `mousedown`/`click` per the Pointer Events spec. Naive UI's `NDropdown` relies on `mousedown` for click-outside detection, so it never sees the click.
- Fix: Add a `pointerdown`-based click-outside listener in `ButtonGroup.vue` that closes open dropdowns when clicking outside the toolbar UI surface. `pointerdown` always fires regardless of `preventDefault()` calls.

## Test plan

- [ ] Open a document
- [ ] Open a toolbar dropdown (font family, font size, etc.)
- [ ] Click in the editor area — dropdown should close
- [ ] Open the dropdown again, click inside the dropdown to select an option — should work normally
- [ ] Open the dropdown again, press Escape — should still close (existing behavior)