### PR TITLE
fix(paste): detect heading levels from Google Docs styled paragraphs

### DIFF
--- a/packages/super-editor/src/core/inputRules/google-docs-paste/google-docs-paste.js
+++ b/packages/super-editor/src/core/inputRules/google-docs-paste/google-docs-paste.js
@@ -5,7 +5,8 @@ import { createSingleItemList } from '../html/html-helpers.js';
 import { getLvlTextForGoogleList, googleNumDefMap } from '../../helpers/pasteListHelpers.js';
 import { wrapTextsInRuns } from '../docx-paste/docx-paste.js';
 
-// Ordered largest → smallest; first match wins.
+// Match Google Docs default heading sizes (H1=20pt, H2=18pt, H3=14pt, H4=12pt, H5=11pt).
+// Descending order so oversized fonts (e.g. 24pt) still resolve to closest heading.
 const headingSizeMap = [
   { minPt: 20, tag: 'h1' },
   { minPt: 16, tag: 'h2' },

--- a/packages/super-editor/src/core/inputRules/google-docs-paste/google-docs-paste.test.js
+++ b/packages/super-editor/src/core/inputRules/google-docs-paste/google-docs-paste.test.js
@@ -187,6 +187,22 @@ describe('handleGoogleDocsHtml', () => {
       expect(dom.querySelector('h1')?.textContent?.trim()).toBe('Bold p, size on span');
     });
 
+    it('does not convert when one span is missing a font-size', () => {
+      const html = `
+        <p><span style="font-size:20pt;font-weight:700">A</span><span style="font-weight:700">B</span></p>
+      `;
+      const dom = parseHeadings(html);
+      expect(dom.querySelector('h1,h2,h3,h4,h5')).toBeNull();
+    });
+
+    it('does not convert when spans have inconsistent font sizes', () => {
+      const html = `
+        <p><span style="font-size:20pt;font-weight:700">A</span><span style="font-size:14pt;font-weight:700">B</span></p>
+      `;
+      const dom = parseHeadings(html);
+      expect(dom.querySelector('h1,h2,h3,h4,h5')).toBeNull();
+    });
+
     it('converts when font-size is on <p> but font-weight is only on the child <span>', () => {
       const html = `
         <p style="font-size:20pt"><span style="font-weight:700">Split style heading</span></p>


### PR DESCRIPTION
# Problem

> When pasting content with H1, H3-H6 headings from Google Docs, they lose their heading level and paste as plain paragraphs. Only H2 is reliably preserved as a heading tag.

Closes #2152

<img width="100%" alt="SuperDoc with pasted Google Docs headings after the fix is applied" src="https://github.com/user-attachments/assets/85636cf5-6bd2-4138-aa6d-9b6b7ced7350" />

# Cause

Google Docs converts most heading levels to `<p>` tags with inline `font-size`/`font-weight` styling instead of semantic `<h1>`–`<h6>` tags. ProseMirror's `paragraph.parseDOM` has rules for `h1`–`h6` but they never fire for these styled `<p>` elements, so the heading level is silently dropped.

# Fix

- Added `convertStyledHeadings` to the Google Docs paste pipeline, running before ProseMirror parses the pasted DOM
- Detects `<p>` elements carrying bold + a recognised font-size (checked on both the `<p>` itself and its first child `<span>`, covering both Google Docs style placements) and replaces them with the corresponding `<h1>`–`<h5>` element
- Font-size thresholds accommodate the default Google Docs theme and alternate themes (e.g. 20 pt and 24 pt both resolve to `h1`)
