### PR TITLE
fix: preserve line spacing and indentation on Google Docs paste

### DIFF
--- a/packages/super-editor/src/extensions/paragraph/helpers/parseAttrs.js
+++ b/packages/super-editor/src/extensions/paragraph/helpers/parseAttrs.js
@@ -1,4 +1,4 @@
-const CSS_LENGTH_TO_PT = { pt: 1, px: 1 / 1.333, in: 72, cm: 28.3465, mm: 2.83465 };
+const CSS_LENGTH_TO_PT = { pt: 1, px: 72 / 96, in: 72, cm: 28.3465, mm: 2.83465 };
 
 /**
  * Parse a CSS length value and return { points, unit }.
@@ -39,9 +39,9 @@ export function parseAttrs(node) {
     } else if (attr.name === 'data-spacing') {
       try {
         spacing = JSON.parse(attr.value);
-        // Ensure numeric values
+        // Ensure numeric values (skip lineRule which is a string like 'auto')
         Object.keys(spacing).forEach((key) => {
-          spacing[key] = Number(spacing[key]);
+          if (key !== 'lineRule') spacing[key] = Number(spacing[key]);
         });
       } catch {
         // ignore invalid spacing value
@@ -61,6 +61,8 @@ export function parseAttrs(node) {
       if (lh.unit === '' || lh.unit === '%') {
         // Unitless (1.5) or percentage (115%) → auto multiplier
         const multiplier = lh.unit === '%' ? lh.points / 100 : lh.points;
+        // Invert pm-adapter's normalizeLineValue (value * 1.15 / 240) so
+        // values round-trip correctly through import → render → export.
         cssSpacing.line = Math.round((multiplier * 240) / 1.15);
         cssSpacing.lineRule = 'auto';
       } else {

--- a/packages/super-editor/src/extensions/paragraph/helpers/parseAttrs.test.js
+++ b/packages/super-editor/src/extensions/paragraph/helpers/parseAttrs.test.js
@@ -20,7 +20,7 @@ describe('parseAttrs', () => {
       const result = parseAttrs(node);
       expect(result.paragraphProperties.spacing).toEqual({
         line: 360,
-        lineRule: NaN, // string values get Number() applied
+        lineRule: 'auto',
         before: 120,
         after: 80,
       });
@@ -94,7 +94,7 @@ describe('parseAttrs', () => {
       const node = createMockNode({}, { marginTop: '16px' });
       const result = parseAttrs(node);
       // 16px / 1.333 = ~12pt, * 20 = ~240 twips
-      const expectedPt = 16 / 1.333;
+      const expectedPt = 16 * 72 / 96;
       expect(result.paragraphProperties.spacing.before).toBe(Math.round(expectedPt * 20));
     });
 
@@ -108,7 +108,7 @@ describe('parseAttrs', () => {
     it('extracts marginLeft in px and converts to twips', () => {
       const node = createMockNode({}, { marginLeft: '48px' });
       const result = parseAttrs(node);
-      const expectedPt = 48 / 1.333;
+      const expectedPt = 48 * 72 / 96;
       expect(result.paragraphProperties.indent.left).toBe(Math.round(expectedPt * 20));
     });
 
@@ -133,7 +133,7 @@ describe('parseAttrs', () => {
       const node = createMockNode({}, { lineHeight: '24px' });
       const result = parseAttrs(node);
       // 24px / 1.333 ≈ 18pt, * 20 = 360 twips
-      expect(result.paragraphProperties.spacing.line).toBe(Math.round((24 / 1.333) * 20));
+      expect(result.paragraphProperties.spacing.line).toBe(Math.round((24 * 72 / 96) * 20));
       expect(result.paragraphProperties.spacing.lineRule).toBe('exact');
     });
 


### PR DESCRIPTION
## Summary

- Add CSS inline style fallback in `parseAttrs.js` so line spacing (`lineHeight`), paragraph spacing (`marginTop`/`marginBottom`), indentation (`marginLeft`), and first-line/hanging indent (`textIndent`) are preserved when pasting from Google Docs or other sources that use inline CSS instead of SuperDoc's `data-*` attributes
- Use a single `parseCssLength` helper backed by a `CSS_LENGTH_TO_PT` conversion map supporting `pt`, `px`, `in`, `cm`, `mm` — unrecognized units (`em`, `rem`, etc.) are safely ignored
- Use exact `72 / 96` ratio for px→pt conversion, matching `PX_PER_PT` in pm-adapter
- Correctly parse CSS `line-height` units: unitless and `%` values are stored as auto multipliers, while absolute lengths are stored as exact line spacing in twips
- Line spacing formula inverts pm-adapter's `normalizeLineValue` (`value * 1.15 / 240`) so values round-trip correctly
- Map positive `text-indent` to `indent.firstLine` and negative `text-indent` to `indent.hanging`
- Preserve explicit zero margins (`margin-top: 0`) as `0` twips to prevent the style-engine from applying non-zero defaults
- Fix pre-existing bug: skip `Number()` coercion for `lineRule` in `data-spacing` parsing to preserve the `'auto'` string value
- Data attributes still take priority, so existing DOCX paste behavior is unchanged

Closes #2151

## Test plan

- [ ] Paste from Google Docs with different line spacings (single, 1.5, double) and verify they are preserved
- [ ] Paste indented paragraphs from Google Docs and verify indentation is preserved
- [ ] Paste HTML with first-line and hanging indentation and verify correct rendering
- [ ] Paste HTML with percentage/px/pt/in/cm/mm values and verify correct conversion
- [ ] Paste HTML with explicit zero margins and verify no unintended spacing appears
- [ ] Paste from Word and verify existing `data-spacing`/`data-indent` behavior is unchanged
- [x] Run `pnpm test` — all parseAttrs tests pass (28/28)