### PR TITLE
fix(comments): undo of last tracked-change suggestion leaves orphan comment (IT-601)

### DIFF
--- a/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
@@ -3351,13 +3351,12 @@ export class PresentationEditor extends EventEmitter {
 
       // Emit fresh comment positions after layout completes.
       // This ensures positions are always in sync with the current document and layout.
+      // Always emit — even when empty — so the store can clear stale positions
+      // (e.g. when undo removes the last tracked-change mark).
       const allowViewingCommentPositions = this.#layoutOptions.emitCommentPositionsInViewing === true;
       if (this.#documentMode !== 'viewing' || allowViewingCommentPositions) {
         const commentPositions = this.#collectCommentPositions();
-        const positionKeys = Object.keys(commentPositions);
-        if (positionKeys.length > 0) {
-          this.emit('commentPositions', { positions: commentPositions });
-        }
+        this.emit('commentPositions', { positions: commentPositions });
       }
 
       this.#selectionSync.requestRender({ immediate: true });


### PR DESCRIPTION
PresentationEditor skipped emitting commentPositions when positions were empty, so undoing the last tracked-change mark never signaled the store to clear stale position data. Additionally, getFloatingComments treated tracked-change comments (which lack selection.source) as non-editor comments that bypass position filtering, and handleEditorLocationsUpdate blocked all empty position updates regardless of lifecycle state.

- Always emit commentPositions from PresentationEditor, even when empty
- Use isEditorBackedComment() in getFloatingComments instead of naive source check so tracked-change comments require live positions
- Add hasReceivedPositions flag to distinguish initial-load guard from legitimate undo cleanup in handleEditorLocationsUpdate

 fixed #2186