### PR TITLE
docs: document stable block addressing for headless workflows (SD-2069)

### DIFF
--- a/apps/docs/document-api/common-workflows.mdx
+++ b/apps/docs/document-api/common-workflows.mdx
@@ -133,7 +133,7 @@ if (caps.global.trackChanges.enabled) {
 
 ## Cross-session block addressing
 
-When you load a DOCX, close the editor, and load the same file again, `sdBlockId` values change — they're regenerated on every open. The Document API's `find` operation returns addresses with stable IDs derived from the DOCX-native `paraId`, which survives round-trips.
+When you load a DOCX, close the editor, and load the same file again, `sdBlockId` values change — they're regenerated on every open. The Document API's `find` operation returns addresses whose `nodeId` prefers DOCX-native `paraId`, which is usually stable when reopening the same unchanged DOCX.
 
 This pattern is common in headless pipelines: extract block references in one session, then apply edits in another.
 
@@ -150,7 +150,7 @@ const result = editor1.doc.find({
   includeNodes: true,
 });
 
-// Save addresses — nodeId is the stable paraId from the DOCX file
+// Save addresses — for DOCX-imported blocks, nodeId uses paraId when available
 const addresses = result.items.map((item) => ({
   address: item.address,
   text: item.node?.text,
@@ -162,7 +162,7 @@ editor1.destroy();
 const editor2 = await Editor.open(docx);
 const saved = JSON.parse(await readFile('./blocks.json', 'utf-8'));
 
-// Addresses from session 1 still resolve — same DOCX, same paraId values
+// Addresses from session 1 usually resolve when reloading the same unchanged DOCX
 for (const { address } of saved) {
   const node = editor2.doc.getNode(address); // works across sessions
 }
@@ -170,8 +170,12 @@ editor2.destroy();
 ```
 
 <Info>
-`nodeId` stability depends on the ID source. For DOCX-imported content, `nodeId` comes from the file's `paraId` and is stable. For nodes created at runtime, it falls back to `sdBlockId` which is volatile. See [Node addressing](/document-api/overview#node-addressing) for details.
+`nodeId` stability depends on the ID source. For DOCX-imported content, `nodeId` comes from `paraId` when available and is best-effort stable across loads. For nodes created at runtime, it falls back to `sdBlockId`, which is volatile.
 </Info>
+
+<Warning>
+No ID is guaranteed to survive all Microsoft Word round-trips. Re-extract addresses after major external edits or transformations, since Word (or other tools) may rewrite paragraph IDs and SuperDoc may rewrite duplicate IDs on import.
+</Warning>
 
 ## Dry-run preview
 

--- a/apps/docs/document-api/overview.mdx
+++ b/apps/docs/document-api/overview.mdx
@@ -31,16 +31,19 @@ Every block in a document has a `nodeId` — a string that uniquely identifies i
 
 ### Stable IDs across loads
 
-For DOCX documents, `nodeId` is derived from the file's native `w14:paraId` attribute. This ID is part of the DOCX file itself, so it stays the same every time you open the document — even across separate editor sessions, different machines, or headless CLI pipelines.
+For DOCX documents, `nodeId` is derived from the file's native `w14:paraId` attribute. In practice, this is usually stable when you reopen the same unchanged DOCX across separate editor sessions, machines, or headless CLI pipelines.
 
-For nodes created at runtime (not imported from DOCX), `nodeId` falls back to `sdBlockId`, a UUID generated when the editor opens. This fallback is volatile — it changes on every load.
+For nodes created at runtime (not imported from DOCX), `nodeId` falls back to `sdBlockId`, a UUID generated when the editor opens. This fallback is volatile and changes on every load.
 
 | ID source | Stable across loads? | When used |
 |-----------|---------------------|-----------|
-| `paraId` (from DOCX) | Yes | Paragraphs, tables, rows, cells imported from DOCX |
-| `sdBlockId` (runtime) | No | Nodes created programmatically before first export |
+| `paraId` (from DOCX) | Best effort (usually stable for unchanged DOCX blocks) | Paragraphs, tables, rows, cells imported from DOCX |
+| `sdBlockId` (runtime) | No (session-scoped) | Nodes created programmatically before first export |
 
 <Tip>
-If you need to reference blocks across separate editor sessions, use `editor.doc.find()` to get addresses — don't read `node.attrs.sdBlockId` directly. The Document API resolves the stable `paraId` automatically. See [Cross-session block addressing](/document-api/common-workflows#cross-session-block-addressing) for a worked example.
+If you need to reference blocks across separate editor sessions, use `editor.doc.find()` to get addresses — don't read `node.attrs.sdBlockId` directly. The Document API resolves `paraId` first for DOCX-imported content.
 </Tip>
 
+<Warning>
+No block ID is guaranteed to survive all Microsoft Word round-trips or external document rewrites. Word and other tools may regenerate `w14:paraId` during structural changes (for example split/merge/rebuild operations), and SuperDoc may rewrite duplicate IDs on import to keep block targeting deterministic.
+</Warning>

--- a/apps/docs/getting-started/ai-agents.mdx
+++ b/apps/docs/getting-started/ai-agents.mdx
@@ -92,9 +92,9 @@ const result = editor.doc.find({
   includeNodes: true,
 });
 
-// Each item has an address with a stable nodeId
+// Each item has an address with a best-effort stable nodeId
 const blocks = result.items.map((item) => ({
-  id: item.address.nodeId,     // stable across loads for DOCX content
+  id: item.address.nodeId,     // usually stable across loads for unchanged DOCX content
   type: item.address.nodeType,
   text: item.node?.text,
 }));
@@ -115,9 +115,9 @@ const result = editor.doc.find({
   includeNodes: true,
 });
 
-// Each item has an address with a stable nodeId
+// Each item has an address with a best-effort stable nodeId
 const blocks = result.items.map((item) => ({
-  id: item.address.nodeId,     // stable across loads for DOCX content
+  id: item.address.nodeId,     // usually stable across loads for unchanged DOCX content
   type: item.address.nodeType,
   text: item.node?.text,
 }));
@@ -127,7 +127,7 @@ const blocks = result.items.map((item) => ({
 </CodeGroup>
 
 <Info>
-Block addresses from `doc.find()` use DOCX-native IDs that survive round-trips. Don't read `node.attrs.sdBlockId` directly — it's regenerated on every load. See [Cross-session block addressing](/document-api/common-workflows#cross-session-block-addressing) for the full pattern.
+Block addresses from `doc.find()` prefer DOCX-native IDs (`paraId`) for imported blocks. This is the best available cross-session anchor, but no ID is guaranteed to survive all Word round-trips. Don't read `node.attrs.sdBlockId` directly — it's regenerated on every load.
 </Info>
 
 ## LLM quick reference

--- a/apps/docs/snippets/extensions/block-node.mdx
+++ b/apps/docs/snippets/extensions/block-node.mdx
@@ -125,7 +125,7 @@ Every block-level node (paragraphs, headings, etc.) automatically receives a uni
 4. **Programmatic updates** - Update document structure via APIs
 
 <Warning>
-`sdBlockId` is regenerated on every document load. If you need stable block references across separate editor sessions (e.g., headless CLI pipelines, multi-step AI workflows), use the [Document API](/document-api/overview) instead. `editor.doc.find()` returns addresses with stable IDs derived from the DOCX-native `paraId`, which survives round-trips. See [Cross-session block addressing](/document-api/common-workflows#cross-session-block-addressing) for a worked example.
+`sdBlockId` is regenerated on every document load. If you need cross-session block references (e.g., headless CLI pipelines, multi-step AI workflows), use the [Document API](/document-api/overview) instead. `editor.doc.find()` returns addresses whose `nodeId` prefers DOCX-native `paraId` for imported blocks. This is best-effort stable, not a permanent global ID: Word or other tools can rewrite IDs during structural changes, and SuperDoc may rewrite duplicates on import.
 </Warning>
 
 ## Use case


### PR DESCRIPTION
The Document API already resolves `paraId`-first (stable across loads) over `sdBlockId` (volatile), but nothing in the docs told users this. Add node addressing docs, cross-session workflow example, warn about `sdBlockId` volatility in Block Node docs, and reference Document API from the AI Agents page.