### PR TITLE
feat: remove naive ui

### DIFF
--- a/packages/super-editor/package.json
+++ b/packages/super-editor/package.json
@@ -108,7 +108,6 @@
   },
   "peerDependencies": {
     "@floating-ui/dom": "^1.7.0",
-    "naive-ui": "^2.38.2",
     "tippy.js": "^6.3.7",
     "y-prosemirror": "catalog:",
     "yjs": "catalog:"

--- a/packages/super-editor/src/assets/styles/elements/toolbar.css
+++ b/packages/super-editor/src/assets/styles/elements/toolbar.css
@@ -3,12 +3,14 @@
   height: 100%;
   display: block;
   fill: currentColor;
+  pointer-events: none;
+
   path {
     stroke: currentColor;
   }
 }
 
-.sd-editor-toolbar-dropdown .n-dropdown-option .dropdown-select-icon {
+.sd-editor-toolbar-dropdown .toolbar-dropdown-option .dropdown-select-icon {
   display: flex;
   width: 12px;
   height: 12px;

--- a/packages/super-editor/src/components/EditorSkeleton.vue
+++ b/packages/super-editor/src/components/EditorSkeleton.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="placeholder-editor">
+    <div class="placeholder-title">
+      <div class="placeholder-line placeholder-line--60"></div>
+    </div>
+
+    <div class="placeholder-block">
+      <div v-for="n in 7" :key="`p-1-${n}`" class="placeholder-line"></div>
+      <div class="placeholder-line placeholder-line--60"></div>
+    </div>
+
+    <div class="placeholder-block placeholder-block--narrow">
+      <div v-for="n in 6" :key="`p-2-${n}`" class="placeholder-line placeholder-line--30"></div>
+    </div>
+
+    <div class="placeholder-block">
+      <div class="placeholder-line placeholder-line--60"></div>
+      <div v-for="n in 7" :key="`p-3-${n}`" class="placeholder-line"></div>
+      <div class="placeholder-line placeholder-line--30"></div>
+    </div>
+
+    <div class="placeholder-block placeholder-block--tail">
+      <div v-for="n in 8" :key="`p-4-${n}`" class="placeholder-line"></div>
+      <div class="placeholder-line placeholder-line--70"></div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.placeholder-editor {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 5;
+  border-radius: 8px;
+  background-color: #fff;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 1in;
+}
+
+.placeholder-title {
+  display: flex;
+  justify-content: center;
+}
+
+.placeholder-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.placeholder-line {
+  width: 100%;
+  height: 16px;
+  border-radius: 2px;
+  background-color: #ebebeb;
+}
+
+.placeholder-line--30 {
+  width: 30%;
+}
+
+.placeholder-line--60 {
+  width: 60%;
+}
+
+.placeholder-line--70 {
+  width: 70%;
+}
+</style>

--- a/packages/super-editor/src/components/SuperEditor.test.js
+++ b/packages/super-editor/src/components/SuperEditor.test.js
@@ -1,12 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 
-const messageApi = vi.hoisted(() => ({
-  error: vi.fn(),
-  info: vi.fn(),
-  success: vi.fn(),
-}));
-
 const onMarginClickCursorChangeMock = vi.hoisted(() => vi.fn());
 const checkNodeSpecificClicksMock = vi.hoisted(() => vi.fn());
 const getFileObjectMock = vi.hoisted(() =>
@@ -30,11 +24,6 @@ const EditorConstructor = vi.hoisted(() => {
 
   return MockEditor;
 });
-
-vi.mock('naive-ui', () => ({
-  NSkeleton: { name: 'NSkeleton', render: () => null },
-  useMessage: () => messageApi,
-}));
 
 // pagination legacy removed; no pagination helpers
 
@@ -85,16 +74,19 @@ import SuperEditor from './SuperEditor.vue';
 
 const getEditorInstance = () => EditorConstructor.mock.results.at(-1)?.value;
 let consoleDebugSpy;
+let consoleWarnSpy;
 
 describe('SuperEditor.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.useRealTimers();
     consoleDebugSpy?.mockRestore();
+    consoleWarnSpy?.mockRestore();
     vi.clearAllMocks();
   });
 
@@ -519,7 +511,7 @@ describe('SuperEditor.vue', () => {
     await flushPromises();
 
     expect(onException).toHaveBeenCalledWith({ error, editor: null });
-    expect(messageApi.error).toHaveBeenCalledWith(
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
       'Unable to load the file. Please verify the .docx is valid and not password protected.',
     );
     expect(getFileObjectMock).toHaveBeenCalledWith('blank-docx-url', 'blank.docx', DOCX_MIME);

--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { NSkeleton, useMessage } from 'naive-ui';
 import 'tippy.js/dist/tippy.css';
 import { ref, onMounted, onBeforeUnmount, shallowRef, reactive, markRaw, computed, watch, nextTick } from 'vue';
 import { Editor } from '@superdoc/super-editor';
@@ -9,6 +8,7 @@ import ContextMenu from './context-menu/ContextMenu.vue';
 import { onMarginClickCursorChange } from './cursor-helpers.js';
 import Ruler from './rulers/Ruler.vue';
 import GenericPopover from './popovers/GenericPopover.vue';
+import EditorSkeleton from './EditorSkeleton.vue';
 import LinkInput from './toolbar/LinkInput.vue';
 import TableResizeOverlay from './TableResizeOverlay.vue';
 import ImageResizeOverlay from './ImageResizeOverlay.vue';
@@ -23,6 +23,8 @@ import { DOM_CLASS_NAMES, buildImagePmSelector, buildInlineImagePmSelector } fro
 const emit = defineEmits(['editor-ready', 'editor-click', 'editor-keydown', 'comments-loaded', 'selection-update']);
 
 const DOCX = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+const FILE_LOAD_ERROR_MESSAGE = 'Unable to load the file. Please verify the .docx is valid and not password protected.';
+
 const props = defineProps({
   documentId: {
     type: String,
@@ -264,8 +266,6 @@ const setupRulerObservers = () => {
     rulerContainerResizeObserver.observe(rulerHost);
   }
 };
-
-const message = useMessage();
 
 const editorWrapper = ref(null);
 const editorElem = ref(null);
@@ -780,12 +780,17 @@ const waitForCollaborativeFragmentSettling = async (ydoc, maxWaitMs = 200) => {
   return fragment;
 };
 
+const notifyFileLoadError = () => {
+  console.warn(FILE_LOAD_ERROR_MESSAGE);
+};
+
 const initializeData = async () => {
   // If we have the file, initialize immediately from file
   if (props.fileSource) {
     let fileData = await loadNewFileData();
     if (!fileData) {
-      message.error('Unable to load the file. Please verify the .docx is valid and not password protected.');
+      // TODO: show a visible error to the user (toast removed with naive-ui)
+      notifyFileLoadError();
       await setDefaultBlankFile();
       fileData = await loadNewFileData();
     }
@@ -1196,23 +1201,7 @@ onBeforeUnmount(() => {
       />
     </div>
 
-    <div class="placeholder-editor" v-if="!editorReady">
-      <div class="placeholder-title">
-        <n-skeleton text style="width: 60%" />
-      </div>
-
-      <n-skeleton text :repeat="6" />
-      <n-skeleton text style="width: 60%" />
-
-      <n-skeleton text :repeat="6" style="width: 30%; display: block; margin: 20px" />
-      <n-skeleton text style="width: 60%" />
-      <n-skeleton text :repeat="5" />
-      <n-skeleton text style="width: 30%" />
-
-      <n-skeleton text style="margin-top: 50px" />
-      <n-skeleton text :repeat="6" />
-      <n-skeleton text style="width: 70%" />
-    </div>
+    <EditorSkeleton v-if="!editorReady" />
 
     <GenericPopover
       v-if="activeEditor"
@@ -1288,24 +1277,5 @@ onBeforeUnmount(() => {
   color: initial;
   overflow: hidden;
   position: relative;
-}
-
-.placeholder-editor {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border-radius: 8px;
-  padding: 1in;
-  z-index: 5;
-  background-color: white;
-  box-sizing: border-box;
-}
-
-.placeholder-title {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 40px;
 }
 </style>

--- a/packages/super-editor/src/components/toolbar/ButtonGroup.test.js
+++ b/packages/super-editor/src/components/toolbar/ButtonGroup.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { h, ref } from 'vue';
+import ButtonGroup from './ButtonGroup.vue';
+
+const createDropdownItem = (selectedKey) => ({
+  type: 'dropdown',
+  id: ref('btn-test'),
+  name: ref('test'),
+  isNarrow: ref(false),
+  isWide: ref(false),
+  disabled: ref(false),
+  expand: ref(false),
+  tooltip: ref('Test'),
+  dropdownStyles: ref({}),
+  dropdownValueKey: ref('key'),
+  selectedValue: ref(selectedKey),
+  attributes: ref({ ariaLabel: 'Test dropdown' }),
+  nestedOptions: ref([
+    {
+      key: 'render-match',
+      type: 'render',
+      render: () => h('div', 'render option'),
+      props: {},
+    },
+    {
+      key: 'plain-match',
+      label: 'Plain option',
+      props: {},
+    },
+  ]),
+});
+
+const mountWithItem = (item) =>
+  shallowMount(ButtonGroup, {
+    props: {
+      toolbarItems: [item],
+      overflowItems: [],
+    },
+  });
+
+describe('ButtonGroup dropdownOptions selected class', () => {
+  it('does not mark render option as selected even when selectedValue matches', () => {
+    const wrapper = mountWithItem(createDropdownItem('render-match'));
+    const options = wrapper.findComponent({ name: 'ToolbarDropdown' }).props('options');
+
+    expect(options[0].type).toBe('render');
+    expect(options[0].props.class).toBe('');
+  });
+
+  it('marks non-render option as selected when selectedValue matches', () => {
+    const wrapper = mountWithItem(createDropdownItem('plain-match'));
+    const options = wrapper.findComponent({ name: 'ToolbarDropdown' }).props('options');
+
+    expect(options[1].type).toBeUndefined();
+    expect(options[1].props.class).toBe('selected');
+  });
+});

--- a/packages/super-editor/src/components/toolbar/ButtonGroup.vue
+++ b/packages/super-editor/src/components/toolbar/ButtonGroup.vue
@@ -1,12 +1,14 @@
 <script setup>
-import { computed, ref, h, watch, onBeforeUnmount } from 'vue';
+import { computed, getCurrentInstance, ref, watch, onBeforeUnmount } from 'vue';
 import ToolbarButton from './ToolbarButton.vue';
 import ToolbarSeparator from './ToolbarSeparator.vue';
 import OverflowMenu from './OverflowMenu.vue';
-import { NDropdown, NTooltip } from 'naive-ui';
+import ToolbarDropdown from './ToolbarDropdown.vue';
+import SdTooltip from './SdTooltip.vue';
 import { useHighContrastMode } from '../../composables/use-high-contrast-mode';
 
 const emit = defineEmits(['command', 'item-clicked', 'dropdown-update-show']);
+const { proxy } = getCurrentInstance();
 
 const toolbarItemRefs = ref([]);
 const buttonGroupRef = ref(null);
@@ -67,11 +69,39 @@ const isButton = (item) => item.type === 'button';
 const isDropdown = (item) => item.type === 'dropdown';
 const isSeparator = (item) => item.type === 'separator';
 const isOverflow = (item) => item.type === 'overflow';
+
+const getExpanded = (item) => {
+  return Boolean(item?.expand?.value);
+};
+
+const setExpanded = (item, open) => {
+  if (!item?.expand) return;
+  item.expand.value = open;
+};
+
 const handleToolbarButtonClick = (item, argument = null) => {
-  emit('item-clicked');
-  currentItem.value = item;
-  currentItem.value.expand = !currentItem.value.expand;
   if (item.disabled.value) return;
+
+  if (isOverflow(item)) {
+    const willOpen = !getExpanded(item);
+    if (willOpen) {
+      closeDropdowns();
+    }
+    setExpanded(item, willOpen);
+    currentItem.value = willOpen ? item : null;
+    emit('item-clicked');
+    return;
+  }
+
+  if (isDropdown(item)) {
+    return;
+  }
+
+  if (currentItem.value && isDropdown(currentItem.value) && getExpanded(currentItem.value)) {
+    closeDropdowns();
+  }
+
+  emit('item-clicked');
   emit('command', { item, argument });
 };
 
@@ -82,8 +112,17 @@ const handleToolbarButtonTextSubmit = (item, argument) => {
 };
 
 const closeDropdowns = () => {
-  if (!currentItem.value) return;
-  currentItem.value.expand = false;
+  const toolbarItems = proxy?.$toolbar?.toolbarItems || [];
+  const overflowItems = proxy?.$toolbar?.overflowItems || [];
+  const allItems = [...toolbarItems, ...overflowItems];
+
+  const itemsToClose = allItems.length ? allItems : props.toolbarItems;
+  itemsToClose.forEach((toolbarItem) => {
+    const shouldCloseOverflow = isOverflow(toolbarItem) && !props.fromOverflow;
+    if (isDropdown(toolbarItem) || shouldCloseOverflow) {
+      setExpanded(toolbarItem, false);
+    }
+  });
   currentItem.value = null;
 };
 
@@ -97,11 +136,12 @@ const handleSelect = (item, option) => {
 const dropdownOptions = (item) => {
   if (!item.nestedOptions?.value?.length) return [];
   return item.nestedOptions.value.map((option) => {
+    const isSelected = option?.type !== 'render' && item.selectedValue.value === option.key;
     return {
       ...option,
       props: {
         ...option.props,
-        class: item.selectedValue.value === option.key ? 'selected' : '',
+        class: isSelected ? 'selected' : '',
       },
     };
   });
@@ -205,21 +245,30 @@ const handleFocus = (e) => {
   }
 };
 
-const handleDropdownUpdateShow = (open) => {
+const handleDropdownUpdateShowForItem = (open, item) => {
+  emit('item-clicked');
+
   if (!open) {
     closeDropdowns();
+    emit('dropdown-update-show', false);
+    return;
   }
-  emit('dropdown-update-show', open);
+
+  closeDropdowns();
+  currentItem.value = item;
+  setExpanded(item, true);
+
+  emit('dropdown-update-show', true);
 };
 
 const handleDocumentPointerDown = (event) => {
   if (!currentItem.value) return;
 
   const target = event.target;
-  if (!(target instanceof HTMLElement)) return;
+  if (!(target instanceof Element)) return;
 
-  // Naive UI dropdown content is rendered in a portal outside the toolbar group.
-  // Treat it as "inside" so option clicks do not close the menu before selection.
+  // Dropdown content is teleported outside the toolbar group.
+  // Treat menu clicks as "inside" so option clicks do not close before selection.
   if (target.closest('.sd-toolbar-dropdown-menu')) return;
   if (buttonGroupRef.value?.contains(target)) return;
 
@@ -227,10 +276,7 @@ const handleDocumentPointerDown = (event) => {
 };
 
 const isCurrentItemExpanded = () => {
-  if (!currentItem.value) return false;
-  const { expand } = currentItem.value;
-  if (typeof expand === 'object' && expand !== null) return Boolean(expand.value);
-  return Boolean(expand);
+  return getExpanded(currentItem.value);
 };
 
 watch(
@@ -270,45 +316,48 @@ onBeforeUnmount(() => {
       <ToolbarSeparator v-if="isSeparator(item)" style="width: 20px" />
 
       <!-- Toolbar button -->
-      <n-dropdown
+      <ToolbarDropdown
         v-if="isDropdown(item) && item.nestedOptions?.value?.length"
         :options="dropdownOptions(item)"
-        :trigger="item.disabled.value ? null : 'click'"
-        :show="item.expand.value"
+        :disabled="item.disabled.value"
+        :show="getExpanded(item)"
         :content-style="{ fontFamily: props.uiFontFamily }"
-        size="medium"
         placement="bottom-start"
-        class="toolbar-button toolbar-dropdown sd-editor-toolbar-dropdown"
-        :class="{ 'high-contrast': isHighContrastMode }"
+        class="toolbar-button sd-editor-toolbar-dropdown"
         @select="(key, option) => handleSelect(item, option)"
-        @update-show="handleDropdownUpdateShow"
+        @update:show="(open) => handleDropdownUpdateShowForItem(open, item)"
         :style="item.dropdownStyles.value"
         :menu-props="
           () => ({
             role: 'menu',
             style: { fontFamily: props.uiFontFamily },
-            class: 'sd-toolbar-dropdown-menu',
+            class: ['sd-toolbar-dropdown-menu', { 'high-contrast': isHighContrastMode }],
           })
         "
         :node-props="(option) => getDropdownAttributes(option, item)"
       >
-        <n-tooltip trigger="hover" :disabled="!item.tooltip?.value" :content-style="{ fontFamily: props.uiFontFamily }">
-          <template #trigger>
-            <ToolbarButton
-              :toolbar-item="item"
-              :disabled="item.disabled.value"
-              @textSubmit="handleToolbarButtonTextSubmit(item, $event)"
-              @buttonClick="handleToolbarButtonClick(item)"
-            />
-          </template>
-          <div>
-            {{ item.tooltip }}
-            <span v-if="item.disabled.value">(disabled)</span>
-          </div>
-        </n-tooltip>
-      </n-dropdown>
+        <template #trigger>
+          <SdTooltip
+            trigger="hover"
+            :disabled="!item.tooltip?.value"
+            :content-style="{ fontFamily: props.uiFontFamily }"
+          >
+            <template #trigger>
+              <ToolbarButton
+                :toolbar-item="item"
+                :disabled="item.disabled.value"
+                @textSubmit="handleToolbarButtonTextSubmit(item, $event)"
+              />
+            </template>
+            <div>
+              {{ item.tooltip }}
+              <span v-if="item.disabled.value">(disabled)</span>
+            </div>
+          </SdTooltip>
+        </template>
+      </ToolbarDropdown>
 
-      <n-tooltip
+      <SdTooltip
         trigger="hover"
         v-else-if="isButton(item)"
         class="sd-editor-toolbar-tooltip"
@@ -326,7 +375,7 @@ onBeforeUnmount(() => {
           {{ item.tooltip }}
           <span v-if="item.disabled.value">(disabled)</span>
         </div>
-      </n-tooltip>
+      </SdTooltip>
 
       <!-- Overflow menu -->
       <OverflowMenu
@@ -339,65 +388,6 @@ onBeforeUnmount(() => {
     </div>
   </div>
 </template>
-
-<style lang="postcss">
-.sd-editor-toolbar-dropdown {
-  border-radius: 8px;
-  min-width: 80px;
-  cursor: pointer;
-}
-
-.sd-editor-toolbar-dropdown {
-  &.high-contrast {
-    .n-dropdown-option-body {
-      &:hover {
-        &::before,
-        &::after {
-          background-color: #000 !important;
-        }
-      }
-
-      &.selected[data-item='btn-fontFamily-option'],
-      &.selected[data-item='btn-fontSize-option'] {
-        &::before,
-        &::after {
-          background-color: #000 !important;
-        }
-      }
-
-      &__label {
-        &:hover {
-          color: #fff !important;
-        }
-      }
-    }
-  }
-
-  .n-dropdown-option-body {
-    &:hover {
-      &::before,
-      &::after {
-        background-color: #d8dee5 !important;
-      }
-    }
-
-    &.selected[data-item='btn-fontFamily-option'],
-    &.selected[data-item='btn-fontSize-option'] {
-      &::before,
-      &::after {
-        background-color: #d8dee5 !important;
-      }
-    }
-  }
-}
-
-.sd-editor-toolbar-tooltip,
-.sd-editor-toolbar-tooltip.n-popover {
-  background-color: #333333 !important;
-  font-size: 14px;
-  border-radius: 8px !important;
-}
-</style>
 
 <style lang="postcss" scoped>
 .button-group {

--- a/packages/super-editor/src/components/toolbar/SdTooltip.vue
+++ b/packages/super-editor/src/components/toolbar/SdTooltip.vue
@@ -1,0 +1,262 @@
+<script setup>
+import { computed, nextTick, onBeforeUnmount, ref, useAttrs, watch } from 'vue';
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+const props = defineProps({
+  trigger: {
+    type: String,
+    default: 'hover',
+  },
+  delay: {
+    type: Number,
+    default: 100,
+  },
+  duration: {
+    type: Number,
+    default: 100,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  contentStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const attrs = useAttrs();
+
+const isOpen = ref(false);
+const triggerRef = ref(null);
+const contentRef = ref(null);
+const position = ref({ top: '0px', left: '0px' });
+
+let closeTimeout = null;
+let openTimeout = null;
+
+const mergedContentClass = computed(() => ['sd-tooltip-content', attrs.class]);
+const contentStyle = computed(() => ({
+  ...props.contentStyle,
+  ...(attrs.style || {}),
+  position: 'fixed',
+  top: position.value.top,
+  left: position.value.left,
+  zIndex: 2100,
+}));
+
+const clearCloseTimeout = () => {
+  if (closeTimeout) {
+    window.clearTimeout(closeTimeout);
+    closeTimeout = null;
+  }
+};
+
+const clearOpenTimeout = () => {
+  if (openTimeout) {
+    window.clearTimeout(openTimeout);
+    openTimeout = null;
+  }
+};
+
+const updatePosition = () => {
+  if (!triggerRef.value || !contentRef.value) return;
+
+  const triggerRect = triggerRef.value.getBoundingClientRect();
+  const contentWidth = contentRef.value.offsetWidth;
+  const contentHeight = contentRef.value.offsetHeight;
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+  const gutter = 8;
+
+  let left = triggerRect.left + triggerRect.width / 2 - contentWidth / 2;
+  left = Math.max(gutter, Math.min(left, viewportWidth - contentWidth - gutter));
+
+  position.value = {
+    top: `${triggerRect.top - contentHeight - 10}px`,
+    left: `${left}px`,
+  };
+};
+
+const open = async () => {
+  if (props.disabled) return;
+  clearCloseTimeout();
+  clearOpenTimeout();
+  if (isOpen.value) return;
+  isOpen.value = true;
+  await nextTick();
+  updatePosition();
+};
+
+const close = () => {
+  clearOpenTimeout();
+  clearCloseTimeout();
+  if (!isOpen.value) return;
+  isOpen.value = false;
+};
+
+const openWithDelay = () => {
+  clearCloseTimeout();
+  clearOpenTimeout();
+  if (isOpen.value) return;
+  if (props.delay === 0) {
+    void open();
+    return;
+  }
+  openTimeout = window.setTimeout(() => {
+    openTimeout = null;
+    void open();
+  }, props.delay);
+};
+
+const closeWithDelay = () => {
+  clearOpenTimeout();
+  clearCloseTimeout();
+  if (!isOpen.value) return;
+  if (props.duration === 0) {
+    close();
+    return;
+  }
+  closeTimeout = window.setTimeout(() => {
+    closeTimeout = null;
+    close();
+  }, props.duration);
+};
+
+const handleTriggerMouseEnter = () => {
+  if (props.trigger !== 'hover') return;
+  openWithDelay();
+};
+
+const handleTriggerMouseLeave = () => {
+  if (props.trigger !== 'hover') return;
+  closeWithDelay();
+};
+
+const handleContentMouseEnter = () => {
+  clearOpenTimeout();
+  clearCloseTimeout();
+};
+const handleContentMouseLeave = () => {
+  closeWithDelay();
+};
+
+const handleEscape = (event) => {
+  if (event.key === 'Escape') close();
+};
+
+watch(
+  () => props.disabled,
+  (disabled) => {
+    if (disabled) close();
+  },
+);
+
+watch(isOpen, (openState) => {
+  if (openState) {
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    document.addEventListener('keydown', handleEscape, true);
+  } else {
+    window.removeEventListener('resize', updatePosition);
+    window.removeEventListener('scroll', updatePosition, true);
+    document.removeEventListener('keydown', handleEscape, true);
+  }
+});
+
+onBeforeUnmount(() => {
+  clearOpenTimeout();
+  clearCloseTimeout();
+  window.removeEventListener('resize', updatePosition);
+  window.removeEventListener('scroll', updatePosition, true);
+  document.removeEventListener('keydown', handleEscape, true);
+});
+</script>
+
+<template>
+  <span
+    ref="triggerRef"
+    class="sd-tooltip-trigger"
+    @mouseenter="handleTriggerMouseEnter"
+    @mouseleave="handleTriggerMouseLeave"
+    @focusin="handleTriggerMouseEnter"
+    @focusout="handleTriggerMouseLeave"
+  >
+    <slot name="trigger" />
+  </span>
+
+  <Teleport to="body">
+    <Transition name="fade-in-scale-up-transition">
+      <div
+        v-if="isOpen && !disabled"
+        ref="contentRef"
+        :class="mergedContentClass"
+        :style="contentStyle"
+        @mouseenter="handleContentMouseEnter"
+        @mouseleave="handleContentMouseLeave"
+      >
+        <span class="sd-tooltip-arrow" aria-hidden="true" />
+        <slot />
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.sd-tooltip-trigger {
+  display: inline-flex;
+}
+
+.sd-tooltip-content {
+  background-color: #262626;
+  color: #fff;
+  font-size: 14px;
+  line-height: 1.3;
+  border-radius: 6px;
+  padding: 8px 14px;
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.28);
+  pointer-events: auto;
+  white-space: nowrap;
+}
+
+.sd-tooltip-arrow {
+  position: absolute;
+  left: 50%;
+  bottom: -5px;
+  width: 10px;
+  height: 10px;
+  background-color: #262626;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.fade-in-scale-up-transition-enter-active,
+.fade-in-scale-up-transition-leave-active {
+  transform-origin: bottom center;
+}
+
+.fade-in-scale-up-transition-enter-active {
+  transition:
+    opacity 0.2s cubic-bezier(0, 0, 0.2, 1),
+    transform 0.2s cubic-bezier(0, 0, 0.2, 1);
+}
+
+.fade-in-scale-up-transition-leave-active {
+  transition:
+    opacity 0.2s cubic-bezier(0.4, 0, 1, 1),
+    transform 0.2s cubic-bezier(0.4, 0, 1, 1);
+}
+
+.fade-in-scale-up-transition-enter-from,
+.fade-in-scale-up-transition-leave-to {
+  opacity: 0;
+  transform: scale(0.9);
+}
+
+.fade-in-scale-up-transition-leave-from,
+.fade-in-scale-up-transition-enter-to {
+  opacity: 1;
+  transform: scale(1);
+}
+</style>

--- a/packages/super-editor/src/components/toolbar/Toolbar.vue
+++ b/packages/super-editor/src/components/toolbar/Toolbar.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { NConfigProvider } from 'naive-ui';
 import { ref, getCurrentInstance, onMounted, onDeactivated, nextTick, computed } from 'vue';
 import { throttle } from './helpers.js';
 import ButtonGroup from './ButtonGroup.vue';
@@ -82,37 +81,35 @@ const restoreSelection = () => {
 
 <template>
   <div class="superdoc-toolbar" :key="toolbarKey" role="toolbar" aria-label="Toolbar" data-editor-ui-surface>
-    <n-config-provider abstract preflight-style-disabled>
-      <ButtonGroup
-        tabindex="0"
-        v-if="showLeftSide"
-        :toolbar-items="getFilteredItems('left')"
-        :ui-font-family="uiFontFamily"
-        position="left"
-        @command="handleCommand"
-        @item-clicked="restoreSelection"
-        class="superdoc-toolbar-group-side"
-      />
-      <ButtonGroup
-        tabindex="0"
-        :toolbar-items="getFilteredItems('center')"
-        :overflow-items="proxy.$toolbar.overflowItems"
-        :ui-font-family="uiFontFamily"
-        position="center"
-        @command="handleCommand"
-        @item-clicked="restoreSelection"
-      />
-      <ButtonGroup
-        tabindex="0"
-        v-if="showRightSide"
-        :toolbar-items="getFilteredItems('right')"
-        :ui-font-family="uiFontFamily"
-        position="right"
-        @command="handleCommand"
-        @item-clicked="restoreSelection"
-        class="superdoc-toolbar-group-side"
-      />
-    </n-config-provider>
+    <ButtonGroup
+      tabindex="0"
+      v-if="showLeftSide"
+      :toolbar-items="getFilteredItems('left')"
+      :ui-font-family="uiFontFamily"
+      position="left"
+      @command="handleCommand"
+      @item-clicked="restoreSelection"
+      class="superdoc-toolbar-group-side"
+    />
+    <ButtonGroup
+      tabindex="0"
+      :toolbar-items="getFilteredItems('center')"
+      :overflow-items="proxy.$toolbar.overflowItems"
+      :ui-font-family="uiFontFamily"
+      position="center"
+      @command="handleCommand"
+      @item-clicked="restoreSelection"
+    />
+    <ButtonGroup
+      tabindex="0"
+      v-if="showRightSide"
+      :toolbar-items="getFilteredItems('right')"
+      :ui-font-family="uiFontFamily"
+      position="right"
+      @command="handleCommand"
+      @item-clicked="restoreSelection"
+      class="superdoc-toolbar-group-side"
+    />
   </div>
 </template>
 

--- a/packages/super-editor/src/components/toolbar/ToolbarDropdown.vue
+++ b/packages/super-editor/src/components/toolbar/ToolbarDropdown.vue
@@ -1,0 +1,476 @@
+<script setup>
+import { computed, defineComponent, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+
+const props = defineProps({
+  options: {
+    type: Array,
+    default: () => [],
+  },
+  show: {
+    type: Boolean,
+    required: true,
+  },
+  placement: {
+    type: String,
+    default: 'bottom-start',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  contentStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+  menuProps: {
+    type: Function,
+    default: null,
+  },
+  nodeProps: {
+    type: Function,
+    default: null,
+  },
+});
+
+const emit = defineEmits(['update:show', 'select']);
+
+const triggerRef = ref(null);
+const menuRef = ref(null);
+const menuPosition = ref({ top: '0px', left: '0px' });
+const optionRefs = ref([]);
+const keyboardIndex = ref(-1);
+
+const isOpen = computed(() => Boolean(props.show));
+const hasRenderOptions = computed(() => props.options.some((option) => option?.type === 'render'));
+
+const computedMenuProps = computed(() => {
+  if (typeof props.menuProps !== 'function') return {};
+  return props.menuProps() || {};
+});
+
+const computedMenuAttrs = computed(() => {
+  const { class: _class, style: _style, ...rest } = computedMenuProps.value;
+  return rest;
+});
+
+const mergedMenuClass = computed(() => {
+  const fromProps = computedMenuProps.value.class;
+  const onlyRenderOptions =
+    props.options.length > 0 && props.options.every((option) => option && option.type === 'render');
+  return ['toolbar-dropdown-menu', fromProps, { 'toolbar-dropdown-menu--render-only': onlyRenderOptions }];
+});
+
+const mergedMenuStyle = computed(() => {
+  const fromProps = computedMenuProps.value.style || {};
+  return { ...props.contentStyle, ...fromProps };
+});
+
+const menuStyle = computed(() => {
+  return {
+    ...mergedMenuStyle.value,
+    position: 'fixed',
+    top: menuPosition.value.top,
+    left: menuPosition.value.left,
+    zIndex: 2000,
+  };
+});
+
+const setOpen = (value) => {
+  emit('update:show', value);
+};
+
+const close = () => {
+  if (!isOpen.value) return;
+  setOpen(false);
+};
+
+const updateMenuPosition = () => {
+  if (!triggerRef.value) return;
+  const rect = triggerRef.value.getBoundingClientRect();
+  const menuEl = menuRef.value;
+  const menuWidth = menuEl?.offsetWidth ?? 0;
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+  const gutter = 8;
+  let left = rect.left;
+
+  if (props.placement === 'bottom-end') {
+    left = rect.right - menuWidth;
+  }
+
+  // Prevent horizontal overflow outside viewport.
+  const maxLeft = Math.max(gutter, viewportWidth - menuWidth - gutter);
+  left = Math.min(Math.max(gutter, left), maxLeft);
+
+  menuPosition.value = {
+    top: `${rect.bottom + 4}px`,
+    left: `${left}px`,
+  };
+};
+
+const onTriggerClick = () => {
+  if (props.disabled) return;
+  setOpen(!isOpen.value);
+};
+
+const getNodeProps = (option) => {
+  if (typeof props.nodeProps !== 'function') return {};
+  return props.nodeProps(option) || {};
+};
+
+const onOptionClick = (option) => {
+  if (option?.disabled) return;
+  if (option?.type === 'render') return;
+  emit('select', option?.key, option);
+  close();
+};
+
+const isRenderOption = (option) => option?.type === 'render';
+const isOptionNavigable = (option) => !option?.disabled && option?.type !== 'render';
+const hasIcon = (option) => typeof option?.icon === 'function' || Boolean(option?.icon);
+const renderIcon = (option) => {
+  if (typeof option?.icon === 'function') return option.icon(option);
+  return option?.icon || null;
+};
+
+const classHasSelected = (value) => {
+  if (!value) return false;
+  if (typeof value === 'string') {
+    return value.split(/\s+/).includes('selected');
+  }
+  if (Array.isArray(value)) {
+    return value.some(classHasSelected);
+  }
+  if (typeof value === 'object') {
+    return Boolean(value.selected);
+  }
+  return false;
+};
+
+const isOptionSelected = (option) => {
+  return classHasSelected(option?.props?.class) || classHasSelected(option?.class);
+};
+
+const getNavigableIndexes = () => {
+  return props.options.map((option, index) => (isOptionNavigable(option) ? index : -1)).filter((index) => index >= 0);
+};
+
+const getInitialKeyboardIndex = () => {
+  const selectedIndex = props.options.findIndex((option) => isOptionNavigable(option) && isOptionSelected(option));
+  if (selectedIndex >= 0) return selectedIndex;
+  return getNavigableIndexes()[0] ?? -1;
+};
+
+const setOptionRef = (el, index) => {
+  if (!el) {
+    delete optionRefs.value[index];
+    return;
+  }
+  optionRefs.value[index] = el;
+};
+
+const focusKeyboardIndex = () => {
+  optionRefs.value.forEach((el, index) => {
+    if (!el) return;
+    el.setAttribute('tabindex', index === keyboardIndex.value ? '0' : '-1');
+  });
+
+  const target = optionRefs.value[keyboardIndex.value];
+  if (target && typeof target.focus === 'function') {
+    target.focus();
+  }
+};
+
+const moveKeyboardIndex = (direction) => {
+  const navigableIndexes = getNavigableIndexes();
+  if (!navigableIndexes.length) {
+    keyboardIndex.value = -1;
+    return;
+  }
+
+  const currentPosition = navigableIndexes.indexOf(keyboardIndex.value);
+  if (currentPosition < 0) {
+    keyboardIndex.value = direction > 0 ? navigableIndexes[0] : navigableIndexes[navigableIndexes.length - 1];
+    return;
+  }
+
+  const nextPosition = (currentPosition + direction + navigableIndexes.length) % navigableIndexes.length;
+  keyboardIndex.value = navigableIndexes[nextPosition];
+};
+
+const selectKeyboardOption = () => {
+  let option = props.options[keyboardIndex.value];
+  if (!isOptionNavigable(option)) {
+    const firstIndex = getNavigableIndexes()[0];
+    option = firstIndex === undefined ? null : props.options[firstIndex];
+  }
+  if (!option) return;
+  onOptionClick(option);
+};
+
+const RenderOption = defineComponent({
+  name: 'ToolbarDropdownRenderOption',
+  props: {
+    option: {
+      type: Object,
+      required: true,
+    },
+  },
+  setup(componentProps) {
+    return () => {
+      if (typeof componentProps.option.render !== 'function') return null;
+      return componentProps.option.render();
+    };
+  },
+});
+
+const OptionIcon = defineComponent({
+  name: 'ToolbarDropdownOptionIcon',
+  props: {
+    option: {
+      type: Object,
+      required: true,
+    },
+  },
+  setup(componentProps) {
+    return () => renderIcon(componentProps.option);
+  },
+});
+
+const handlePointerDown = (event) => {
+  if (!isOpen.value) return;
+
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+
+  const insideTrigger = triggerRef.value?.contains(target);
+  const insideMenu = menuRef.value?.contains(target);
+  if (insideTrigger || insideMenu) return;
+
+  close();
+};
+
+const handleKeyDown = (event) => {
+  if (!isOpen.value) return;
+
+  const { key } = event;
+  const supportedKeys = ['Escape', 'ArrowDown', 'ArrowUp', 'Enter'];
+  if (!supportedKeys.includes(key)) return;
+
+  if (key === 'Escape') {
+    close();
+    return;
+  }
+
+  if (hasRenderOptions.value) return;
+
+  event.preventDefault();
+
+  if (key === 'ArrowDown') {
+    moveKeyboardIndex(1);
+    focusKeyboardIndex();
+    return;
+  }
+
+  if (key === 'ArrowUp') {
+    moveKeyboardIndex(-1);
+    focusKeyboardIndex();
+    return;
+  }
+
+  if (key === 'Enter') {
+    selectKeyboardOption();
+  }
+};
+
+watch(
+  isOpen,
+  async (open) => {
+    if (!open) {
+      keyboardIndex.value = -1;
+      optionRefs.value = [];
+      return;
+    }
+
+    await nextTick();
+    updateMenuPosition();
+
+    if (hasRenderOptions.value) return;
+
+    keyboardIndex.value = getInitialKeyboardIndex();
+    focusKeyboardIndex();
+  },
+  { immediate: true },
+);
+
+watch(
+  isOpen,
+  (open) => {
+    if (open) {
+      document.addEventListener('pointerdown', handlePointerDown, true);
+      document.addEventListener('keydown', handleKeyDown, true);
+      window.addEventListener('resize', updateMenuPosition);
+      window.addEventListener('scroll', updateMenuPosition, true);
+    } else {
+      document.removeEventListener('pointerdown', handlePointerDown, true);
+      document.removeEventListener('keydown', handleKeyDown, true);
+      window.removeEventListener('resize', updateMenuPosition);
+      window.removeEventListener('scroll', updateMenuPosition, true);
+    }
+  },
+  { immediate: true },
+);
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', handlePointerDown, true);
+  document.removeEventListener('keydown', handleKeyDown, true);
+  window.removeEventListener('resize', updateMenuPosition);
+  window.removeEventListener('scroll', updateMenuPosition, true);
+});
+</script>
+
+<template>
+  <div class="toolbar-dropdown">
+    <div ref="triggerRef" class="toolbar-dropdown-trigger" @click="onTriggerClick">
+      <slot name="trigger" />
+    </div>
+
+    <Teleport to="body">
+      <Transition name="fade-in-scale-up-transition">
+        <div v-if="isOpen" ref="menuRef" :class="mergedMenuClass" :style="menuStyle" v-bind="computedMenuAttrs">
+          <div
+            v-for="(option, index) in options"
+            :key="option.key"
+            :ref="(el) => setOptionRef(el, index)"
+            class="toolbar-dropdown-option"
+            :class="[option.class, option.props?.class, { disabled: option.disabled, render: isRenderOption(option) }]"
+            tabindex="-1"
+            @click="onOptionClick(option)"
+            v-bind="{ ...option.props, ...getNodeProps(option) }"
+          >
+            <RenderOption v-if="isRenderOption(option)" :option="option" />
+            <template v-else>
+              <span v-if="hasIcon(option)" class="toolbar-dropdown-option__icon">
+                <OptionIcon :option="option" />
+              </span>
+              <span class="toolbar-dropdown-option__label">{{ option.label }}</span>
+            </template>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+  </div>
+</template>
+
+<style scoped>
+.toolbar-dropdown {
+  display: inline-flex;
+}
+
+.toolbar-dropdown-trigger {
+  display: inline-flex;
+}
+
+.toolbar-dropdown-menu {
+  min-width: 80px;
+  padding: 4px;
+  border-radius: 8px;
+  background: #fff;
+  border: 1px solid #e4e6eb;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+  box-sizing: border-box;
+}
+
+.toolbar-dropdown-menu.toolbar-dropdown-menu--render-only {
+  padding: 0;
+}
+
+.toolbar-dropdown-option {
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s ease-out;
+  box-sizing: border-box;
+}
+
+.toolbar-dropdown-option__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  min-width: 14px;
+  height: 14px;
+  margin-right: 6px;
+}
+
+.toolbar-dropdown-option__icon :deep(.dropdown-select-icon) {
+  display: flex;
+  width: 12px;
+  height: 12px;
+}
+
+.toolbar-dropdown-option:hover {
+  background: #d8dee5;
+}
+
+.toolbar-dropdown-option.selected {
+  background: #d8dee5;
+}
+
+.toolbar-dropdown-menu.high-contrast .toolbar-dropdown-option:not(.render):hover {
+  background: #000;
+  color: #fff;
+}
+
+.toolbar-dropdown-menu.high-contrast .toolbar-dropdown-option:not(.render).selected {
+  background: #000;
+  color: #fff;
+}
+
+.toolbar-dropdown-option.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.toolbar-dropdown-option.render {
+  padding: 0;
+  cursor: default;
+}
+
+.toolbar-dropdown-option.render:hover {
+  background: transparent;
+  color: inherit;
+}
+
+.fade-in-scale-up-transition-enter-active,
+.fade-in-scale-up-transition-leave-active {
+  transform-origin: top left;
+}
+
+.fade-in-scale-up-transition-enter-active {
+  transition:
+    opacity 0.2s cubic-bezier(0, 0, 0.2, 1),
+    transform 0.2s cubic-bezier(0, 0, 0.2, 1);
+}
+
+.fade-in-scale-up-transition-leave-active {
+  transition:
+    opacity 0.2s cubic-bezier(0.4, 0, 1, 1),
+    transform 0.2s cubic-bezier(0.4, 0, 1, 1);
+}
+
+.fade-in-scale-up-transition-enter-from,
+.fade-in-scale-up-transition-leave-to {
+  opacity: 0;
+  transform: scale(0.9);
+}
+
+.fade-in-scale-up-transition-leave-from,
+.fade-in-scale-up-transition-enter-to {
+  opacity: 1;
+  transform: scale(1);
+}
+</style>

--- a/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
@@ -4230,11 +4230,13 @@ export class PresentationEditor extends EventEmitter {
     // Keep selection visible when context menu is open.
     const contextMenuOpen = activeEditor?.state ? !!ContextMenuPluginKey.getState(activeEditor.state)?.open : false;
 
-    // Keep selection visible when focus is on editor UI surfaces (toolbar, dropdowns).
-    // Naive-UI portals dropdown content under .v-binder-follower-content at <body> level,
-    // so it won't be inside [data-editor-ui-surface]. Check both.
+    // Keep selection visible when focus is on editor UI surfaces (toolbar, dropdowns, tooltips).
+    // Dropdown/tooltip content is portaled under <body>, so it won't be inside
+    // [data-editor-ui-surface]. Check both in-surface and portaled SD UI roots.
     const activeEl = document.activeElement;
-    const isOnEditorUi = !!(activeEl as Element)?.closest?.('[data-editor-ui-surface], .v-binder-follower-content');
+    const isOnEditorUi = !!(activeEl as Element)?.closest?.(
+      '[data-editor-ui-surface], .sd-toolbar-dropdown-menu, .toolbar-dropdown-menu',
+    );
 
     if (!hasFocus && !contextMenuOpen && !isOnEditorUi) {
       try {

--- a/packages/super-editor/src/dev/components/DeveloperPlayground.vue
+++ b/packages/super-editor/src/dev/components/DeveloperPlayground.vue
@@ -3,7 +3,6 @@ import '@superdoc/super-editor/style.css';
 import '@superdoc/common/styles/common-styles.css';
 
 import { ref, computed, onMounted } from 'vue';
-import { NMessageProvider } from 'naive-ui';
 import { SuperEditor } from '@superdoc/super-editor';
 import { PresentationEditor } from '@core/presentation-editor/index.js';
 import { getFileObject } from '@superdoc/common/helpers/get-file-object';
@@ -223,9 +222,7 @@ const toggleLayoutEngine = () => {
           </div>
 
           <div class="dev-app__content" v-if="currentFile">
-            <n-message-provider>
-              <SuperEditor :file-source="currentFile" :options="editorOptions" />
-            </n-message-provider>
+            <SuperEditor :file-source="currentFile" :options="editorOptions" />
           </div>
         </div>
       </div>

--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -81,7 +81,6 @@
     "eventemitter3": "catalog:",
     "jsdom": "catalog:",
     "konva": "catalog:",
-    "naive-ui": "catalog:",
     "pinia": "catalog:",
     "rollup-plugin-copy": "catalog:",
     "uuid": "catalog:",

--- a/packages/superdoc/src/SuperDoc.test.js
+++ b/packages/superdoc/src/SuperDoc.test.js
@@ -141,26 +141,6 @@ vi.mock('@superdoc/components/CommentsLayer/CommentsLayer.vue', () => ({
   default: CommentsLayerStub,
 }));
 
-vi.mock('naive-ui', () => ({
-  NConfigProvider: defineComponent({
-    name: 'NConfigProvider',
-    props: {
-      abstract: Boolean,
-      preflightStyleDisabled: Boolean,
-      styleMountTarget: Object,
-    },
-    setup(_, { slots }) {
-      return () => slots.default?.();
-    },
-  }),
-  NMessageProvider: defineComponent({
-    name: 'NMessageProvider',
-    setup(_, { slots }) {
-      return () => h('div', { class: 'n-message-provider-stub' }, slots.default?.());
-    },
-  }),
-}));
-
 const buildSuperdocStore = () => {
   const documents = ref([
     {

--- a/packages/superdoc/src/SuperDoc.vue
+++ b/packages/superdoc/src/SuperDoc.vue
@@ -15,7 +15,6 @@ import {
   watch,
   defineAsyncComponent,
 } from 'vue';
-import { NConfigProvider, NMessageProvider } from 'naive-ui';
 import { storeToRefs } from 'pinia';
 
 import CommentsLayer from './components/CommentsLayer/CommentsLayer.vue';
@@ -211,7 +210,7 @@ const handleDocumentMouseDown = (e) => {
 
 const handleHighlightClick = () => (toolsMenuPosition.top = null);
 const cancelPendingComment = (e) => {
-  if (e.target.classList.contains('n-dropdown-option-body__label')) return;
+  if (e.target.classList.contains('comments-dropdown__option-label')) return;
   commentsStore.removePendingComment(proxy.$superdoc);
 };
 
@@ -1021,150 +1020,146 @@ const getPDFViewer = () => {
 </script>
 
 <template>
-  <n-config-provider abstract preflight-style-disabled>
-    <div
-      class="superdoc"
-      :class="{
-        'superdoc--with-sidebar': showCommentsSidebar,
-        'superdoc--web-layout': proxy.$superdoc.config.viewOptions?.layout === 'web',
-        'high-contrast': isHighContrastMode,
-      }"
-      :style="superdocStyleVars"
-    >
-      <div class="superdoc__layers layers" ref="layers" role="group">
-        <!-- Floating tools menu (shows up when user has text selection)-->
-        <div v-if="showToolsFloatingMenu" class="superdoc__tools tools" :style="toolsMenuPosition">
-          <div class="tools-item" data-id="is-tool" @mousedown.stop.prevent="handleToolClick('comments')">
-            <div class="superdoc__tools-icon" v-html="superdocIcons.comment"></div>
-          </div>
-          <!-- AI tool button -->
-          <div
-            v-if="proxy.$superdoc.config.modules.ai"
-            class="tools-item"
-            data-id="is-tool"
-            @mousedown.stop.prevent="handleToolClick('ai')"
-          >
-            <div class="superdoc__tools-icon ai-tool"></div>
-          </div>
+  <div
+    class="superdoc"
+    :class="{
+      'superdoc--with-sidebar': showCommentsSidebar,
+      'superdoc--web-layout': proxy.$superdoc.config.viewOptions?.layout === 'web',
+      'high-contrast': isHighContrastMode,
+    }"
+    :style="superdocStyleVars"
+  >
+    <div class="superdoc__layers layers" ref="layers" role="group">
+      <!-- Floating tools menu (shows up when user has text selection)-->
+      <div v-if="showToolsFloatingMenu" class="superdoc__tools tools" :style="toolsMenuPosition">
+        <div class="tools-item" data-id="is-tool" @mousedown.stop.prevent="handleToolClick('comments')">
+          <div class="superdoc__tools-icon" v-html="superdocIcons.comment"></div>
         </div>
-
-        <div class="superdoc__document document">
-          <div
-            v-if="isCommentsEnabled"
-            class="superdoc__selection-layer selection-layer"
-            @mousedown="handleSelectionStart"
-            @mouseup="handleDragEnd"
-            ref="selectionLayer"
-          >
-            <div
-              :style="getSelectionPosition"
-              class="superdoc__temp-selection temp-selection sd-highlight sd-initial-highlight"
-              v-if="selectionPosition && shouldShowSelection"
-            ></div>
-          </div>
-
-          <!-- Fields layer -->
-          <HrbrFieldsLayer
-            v-if="'hrbr-fields' in modules && layers"
-            :fields="modules['hrbr-fields']"
-            class="superdoc__comments-layer comments-layer"
-            style="z-index: 2"
-            ref="hrbrFieldsLayer"
-          />
-
-          <!-- On-document comments layer -->
-          <CommentsLayer
-            v-if="layers"
-            class="superdoc__comments-layer comments-layer"
-            style="z-index: 3"
-            ref="commentsLayer"
-            :parent="layers"
-            :user="user"
-            @highlight-click="handleHighlightClick"
-          />
-
-          <!-- AI Layer for temporary highlights -->
-          <AiLayer
-            v-if="showAiLayer"
-            class="ai-layer"
-            style="z-index: 4"
-            ref="aiLayer"
-            :editor="proxy.$superdoc.activeEditor"
-          />
-
-          <!-- Whiteboard Layer -->
-          <WhiteboardLayer
-            v-if="layers && whiteboardModuleConfig"
-            style="z-index: 3"
-            :whiteboard="whiteboard"
-            :pages="whiteboardPages"
-            :page-sizes="whiteboardPageSizes"
-            :page-offsets="whiteboardPageOffsets"
-            :enabled="whiteboardEnabled"
-            :opacity="whiteboardOpacity"
-          />
-
-          <div class="superdoc__sub-document sub-document" v-for="doc in documents" :key="doc.id">
-            <!-- PDF renderer -->
-            <PdfViewer
-              v-if="doc.type === PDF"
-              :file="doc.data"
-              :file-id="doc.id"
-              :config="pdfConfig"
-              @selection-raw="handlePdfSelectionRaw"
-              @bypass-selection="handlePdfClick"
-              @page-rendered="handleWhiteboardPageReady"
-              @document-ready="({ documentId, viewerContainer }) => handleDocumentReady(documentId, viewerContainer)"
-              ref="pdfViewerRef"
-            />
-
-            <n-message-provider>
-              <SuperEditor
-                v-if="doc.type === DOCX"
-                :file-source="doc.data"
-                :state="doc.state"
-                :document-id="doc.id"
-                :options="{ ...editorOptions(doc), rulers: doc.rulers }"
-                @editor-ready="onEditorReady"
-                @pageMarginsChange="handleSuperEditorPageMarginsChange(doc, $event)"
-              />
-            </n-message-provider>
-
-            <!-- omitting field props -->
-            <HtmlViewer
-              v-if="doc.type === HTML"
-              @ready="(id) => handleDocumentReady(id, null)"
-              @selection-change="handleSelectionChange"
-              :file-source="doc.data"
-              :document-id="doc.id"
-            />
-          </div>
+        <!-- AI tool button -->
+        <div
+          v-if="proxy.$superdoc.config.modules.ai"
+          class="tools-item"
+          data-id="is-tool"
+          @mousedown.stop.prevent="handleToolClick('ai')"
+        >
+          <div class="superdoc__tools-icon ai-tool"></div>
         </div>
       </div>
 
-      <div class="superdoc__right-sidebar right-sidebar" v-if="showCommentsSidebar">
-        <div class="floating-comments">
-          <FloatingComments
-            v-if="hasInitializedLocations && (getFloatingComments.length > 0 || pendingComment)"
-            v-for="doc in documentsWithConverations"
-            :parent="layers"
-            :current-document="doc"
-          />
+      <div class="superdoc__document document">
+        <div
+          v-if="isCommentsEnabled"
+          class="superdoc__selection-layer selection-layer"
+          @mousedown="handleSelectionStart"
+          @mouseup="handleDragEnd"
+          ref="selectionLayer"
+        >
+          <div
+            :style="getSelectionPosition"
+            class="superdoc__temp-selection temp-selection sd-highlight sd-initial-highlight"
+            v-if="selectionPosition && shouldShowSelection"
+          ></div>
         </div>
-      </div>
 
-      <!-- AI Writer at cursor position -->
-      <div class="ai-writer-container" v-if="showAiWriter" :style="aiWriterPosition">
-        <AIWriter
-          :selected-text="selectedText"
-          :handle-close="handleAiWriterClose"
+        <!-- Fields layer -->
+        <HrbrFieldsLayer
+          v-if="'hrbr-fields' in modules && layers"
+          :fields="modules['hrbr-fields']"
+          class="superdoc__comments-layer comments-layer"
+          style="z-index: 2"
+          ref="hrbrFieldsLayer"
+        />
+
+        <!-- On-document comments layer -->
+        <CommentsLayer
+          v-if="layers"
+          class="superdoc__comments-layer comments-layer"
+          style="z-index: 3"
+          ref="commentsLayer"
+          :parent="layers"
+          :user="user"
+          @highlight-click="handleHighlightClick"
+        />
+
+        <!-- AI Layer for temporary highlights -->
+        <AiLayer
+          v-if="showAiLayer"
+          class="ai-layer"
+          style="z-index: 4"
+          ref="aiLayer"
           :editor="proxy.$superdoc.activeEditor"
-          :api-key="proxy.$superdoc.toolbar?.config?.aiApiKey"
-          :endpoint="proxy.$superdoc.config?.modules?.ai?.endpoint"
+        />
+
+        <!-- Whiteboard Layer -->
+        <WhiteboardLayer
+          v-if="layers && whiteboardModuleConfig"
+          style="z-index: 3"
+          :whiteboard="whiteboard"
+          :pages="whiteboardPages"
+          :page-sizes="whiteboardPageSizes"
+          :page-offsets="whiteboardPageOffsets"
+          :enabled="whiteboardEnabled"
+          :opacity="whiteboardOpacity"
+        />
+
+        <div class="superdoc__sub-document sub-document" v-for="doc in documents" :key="doc.id">
+          <!-- PDF renderer -->
+          <PdfViewer
+            v-if="doc.type === PDF"
+            :file="doc.data"
+            :file-id="doc.id"
+            :config="pdfConfig"
+            @selection-raw="handlePdfSelectionRaw"
+            @bypass-selection="handlePdfClick"
+            @page-rendered="handleWhiteboardPageReady"
+            @document-ready="({ documentId, viewerContainer }) => handleDocumentReady(documentId, viewerContainer)"
+            ref="pdfViewerRef"
+          />
+
+          <SuperEditor
+            v-if="doc.type === DOCX"
+            :file-source="doc.data"
+            :state="doc.state"
+            :document-id="doc.id"
+            :options="{ ...editorOptions(doc), rulers: doc.rulers }"
+            @editor-ready="onEditorReady"
+            @pageMarginsChange="handleSuperEditorPageMarginsChange(doc, $event)"
+          />
+
+          <!-- omitting field props -->
+          <HtmlViewer
+            v-if="doc.type === HTML"
+            @ready="(id) => handleDocumentReady(id, null)"
+            @selection-change="handleSelectionChange"
+            :file-source="doc.data"
+            :document-id="doc.id"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div class="superdoc__right-sidebar right-sidebar" v-if="showCommentsSidebar">
+      <div class="floating-comments">
+        <FloatingComments
+          v-if="hasInitializedLocations && (getFloatingComments.length > 0 || pendingComment)"
+          v-for="doc in documentsWithConverations"
+          :parent="layers"
+          :current-document="doc"
         />
       </div>
     </div>
-  </n-config-provider>
+
+    <!-- AI Writer at cursor position -->
+    <div class="ai-writer-container" v-if="showAiWriter" :style="aiWriterPosition">
+      <AIWriter
+        :selected-text="selectedText"
+        :handle-close="handleAiWriterClose"
+        :editor="proxy.$superdoc.activeEditor"
+        :api-key="proxy.$superdoc.toolbar?.config?.aiApiKey"
+        :endpoint="proxy.$superdoc.config?.modules?.ai?.endpoint"
+      />
+    </div>
+  </div>
 </template>
 
 <style scoped>

--- a/packages/superdoc/src/components/CommentsLayer/CommentDialog.test.js
+++ b/packages/superdoc/src/components/CommentsLayer/CommentDialog.test.js
@@ -93,12 +93,6 @@ vi.mock('@superdoc/components/CommentsLayer/CommentHeader.vue', () => ({ default
 vi.mock('@superdoc/components/CommentsLayer/CommentInput.vue', () => ({ default: CommentInputStub }));
 vi.mock('@superdoc/components/general/Avatar.vue', () => ({ default: AvatarStub }));
 
-vi.mock('naive-ui', () => ({
-  NDropdown: simpleStub('NDropdown'),
-  NTooltip: simpleStub('NTooltip'),
-  NSelect: simpleStub('NSelect'),
-}));
-
 vi.mock('@superdoc/core/collaboration/permissions.js', () => ({
   PERMISSIONS: { MANAGE_COMMENTS: 'manage' },
   isAllowed: () => true,

--- a/packages/superdoc/src/components/CommentsLayer/CommentDialog.vue
+++ b/packages/superdoc/src/components/CommentsLayer/CommentDialog.vue
@@ -301,7 +301,7 @@ const handleClickOutside = (e) => {
   const targetElement = e.target instanceof Element ? e.target : e.target?.parentElement;
   const clickedIgnoredTarget = targetElement?.closest?.(
     [
-      '.n-dropdown-option-body__label',
+      '.comments-dropdown__option-label',
       '.superdoc-comment-highlight',
       '.sd-editor-comment-highlight',
       '.sd-editor-tracked-change-highlight',
@@ -994,9 +994,6 @@ watch(editingCommentId, (commentId) => {
   margin-left: 5px;
 }
 
-.internal-dropdown {
-  display: inline-block;
-}
 .comment-editing {
   padding-bottom: 10px;
 }

--- a/packages/superdoc/src/components/CommentsLayer/CommentHeader.vue
+++ b/packages/superdoc/src/components/CommentsLayer/CommentHeader.vue
@@ -1,12 +1,12 @@
 <script setup>
 import { formatDate } from './helpers';
 import { superdocIcons } from '@superdoc/icons.js';
-import { NDropdown } from 'naive-ui';
 import { computed, getCurrentInstance } from 'vue';
 import { isAllowed, PERMISSIONS } from '@superdoc/core/collaboration/permissions.js';
 import { useCommentsStore } from '@superdoc/stores/comments-store';
 import Avatar from '@superdoc/components/general/Avatar.vue';
 import { useUiFontFamily } from '@superdoc/composables/useUiFontFamily.js';
+import CommentsDropdown from './CommentsDropdown.vue';
 
 const emit = defineEmits(['resolve', 'reject', 'overflow-select']);
 const commentsStore = useCommentsStore();
@@ -178,17 +178,16 @@ const getCurrentUser = computed(() => {
         @click.stop.prevent="handleReject"
       ></div>
 
-      <n-dropdown
+      <CommentsDropdown
         v-if="allowOverflow"
-        trigger="click"
         :options="getOverflowOptions"
         @select="handleSelect"
         :content-style="{ fontFamily: uiFontFamily }"
       >
-        <div class="overflow-menu__icon" @click.stop.prevent>
+        <div class="overflow-menu__icon">
           <div class="overflow-icon" v-html="superdocIcons.overflow"></div>
         </div>
-      </n-dropdown>
+      </CommentsDropdown>
     </div>
   </div>
 </template>

--- a/packages/superdoc/src/components/CommentsLayer/CommentInput.vue
+++ b/packages/superdoc/src/components/CommentsLayer/CommentInput.vue
@@ -70,7 +70,4 @@ defineExpose({ focus });
   max-width: 100%;
   transition: all 250ms ease;
 }
-.internal-dropdown {
-  display: inline-block;
-}
 </style>

--- a/packages/superdoc/src/components/CommentsLayer/CommentsDropdown.vue
+++ b/packages/superdoc/src/components/CommentsLayer/CommentsDropdown.vue
@@ -1,0 +1,222 @@
+<script setup>
+import { computed, defineComponent, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+
+const props = defineProps({
+  options: {
+    type: Array,
+    default: () => [],
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  contentStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const emit = defineEmits(['select']);
+
+const isOpen = ref(false);
+const triggerRef = ref(null);
+const menuRef = ref(null);
+const menuPosition = ref({ top: '0px', left: '0px' });
+
+const menuStyle = computed(() => ({
+  ...props.contentStyle,
+  position: 'fixed',
+  top: menuPosition.value.top,
+  left: menuPosition.value.left,
+  zIndex: 1200,
+}));
+
+const setOpen = (value) => {
+  if (props.disabled && value) return;
+  isOpen.value = value;
+};
+
+const toggle = () => {
+  if (props.disabled) return;
+  setOpen(!isOpen.value);
+};
+
+const close = () => {
+  if (!isOpen.value) return;
+  setOpen(false);
+};
+
+const updateMenuPosition = () => {
+  if (!triggerRef.value) return;
+  const rect = triggerRef.value.getBoundingClientRect();
+  const menuWidth = menuRef.value?.offsetWidth ?? 0;
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+  const gutter = 8;
+
+  let left = rect.left;
+  const maxLeft = Math.max(gutter, viewportWidth - menuWidth - gutter);
+  left = Math.min(Math.max(gutter, left), maxLeft);
+
+  menuPosition.value = {
+    top: `${rect.bottom + 4}px`,
+    left: `${left}px`,
+  };
+};
+
+const handleTriggerClick = (event) => {
+  event.stopPropagation();
+  toggle();
+};
+
+const onOptionClick = (option) => {
+  if (option?.disabled) return;
+  emit('select', option?.key, option);
+  close();
+};
+
+const hasIcon = (option) => Boolean(option?.iconString) || Boolean(option?.icon);
+
+const renderIcon = (option) => {
+  if (option?.iconString) return option.iconString;
+  if (typeof option?.icon === 'function') return option.icon(option);
+  return option?.icon || null;
+};
+
+const OptionIcon = defineComponent({
+  name: 'CommentsDropdownOptionIcon',
+  props: {
+    option: {
+      type: Object,
+      required: true,
+    },
+  },
+  setup(componentProps) {
+    return () => renderIcon(componentProps.option);
+  },
+});
+
+const handlePointerDown = (event) => {
+  if (!isOpen.value) return;
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const insideTrigger = triggerRef.value?.contains(target);
+  const insideMenu = menuRef.value?.contains(target);
+  if (insideTrigger || insideMenu) return;
+  close();
+};
+
+const handleEscape = (event) => {
+  if (event.key !== 'Escape') return;
+  close();
+};
+
+watch(isOpen, async (open) => {
+  if (!open) return;
+  await nextTick();
+  updateMenuPosition();
+});
+
+watch(isOpen, (open) => {
+  if (open) {
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    document.addEventListener('keydown', handleEscape, true);
+    window.addEventListener('resize', updateMenuPosition);
+    window.addEventListener('scroll', updateMenuPosition, true);
+  } else {
+    document.removeEventListener('pointerdown', handlePointerDown, true);
+    document.removeEventListener('keydown', handleEscape, true);
+    window.removeEventListener('resize', updateMenuPosition);
+    window.removeEventListener('scroll', updateMenuPosition, true);
+  }
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', handlePointerDown, true);
+  document.removeEventListener('keydown', handleEscape, true);
+  window.removeEventListener('resize', updateMenuPosition);
+  window.removeEventListener('scroll', updateMenuPosition, true);
+});
+</script>
+
+<template>
+  <div class="comments-dropdown">
+    <div ref="triggerRef" class="comments-dropdown__trigger" @click="handleTriggerClick">
+      <slot />
+    </div>
+
+    <Teleport to="body">
+      <div v-if="isOpen" ref="menuRef" class="comments-dropdown__menu" :style="menuStyle">
+        <div
+          v-for="option in options"
+          :key="option.key"
+          class="comments-dropdown__option"
+          :class="{ disabled: option.disabled }"
+          @click="onOptionClick(option)"
+        >
+          <span v-if="hasIcon(option)" class="comments-dropdown__option-icon">
+            <span v-if="option.iconString" v-html="option.iconString"></span>
+            <OptionIcon v-else :option="option" />
+          </span>
+          <span class="comments-dropdown__option-label">{{ option.label }}</span>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<style scoped>
+.comments-dropdown {
+  display: inline-flex;
+}
+
+.comments-dropdown__trigger {
+  display: inline-flex;
+}
+
+.comments-dropdown__menu {
+  min-width: 120px;
+  border-radius: 8px;
+  border: 1px solid var(--sd-border-default, #dbdbdb);
+  background: #fff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  padding: 4px;
+  box-sizing: border-box;
+}
+
+.comments-dropdown__option {
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.comments-dropdown__option:hover {
+  background-color: #f3f3f5;
+}
+
+.comments-dropdown__option.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.comments-dropdown__option-icon {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+}
+
+.comments-dropdown__option-icon :deep(svg) {
+  width: 100%;
+  height: 100%;
+  display: block;
+  fill: currentColor;
+}
+</style>

--- a/packages/superdoc/src/components/CommentsLayer/InternalDropdown.vue
+++ b/packages/superdoc/src/components/CommentsLayer/InternalDropdown.vue
@@ -1,8 +1,8 @@
 <script setup>
-import { computed, ref, h, onMounted, watch, getCurrentInstance } from 'vue';
-import { NDropdown } from 'naive-ui';
+import { computed, ref, onMounted, watch } from 'vue';
 import { superdocIcons } from '@superdoc/icons.js';
 import { useUiFontFamily } from '@superdoc/composables/useUiFontFamily.js';
+import CommentsDropdown from './CommentsDropdown.vue';
 
 const emit = defineEmits(['select']);
 const props = defineProps({
@@ -18,24 +18,16 @@ const props = defineProps({
 
 const { uiFontFamily } = useUiFontFamily();
 
-const renderIcon = (icon) => {
-  return () => {
-    return h('div', { innerHTML: icon, class: 'internal-dropdown__item-icon' });
-  };
-};
-
 const options = [
   {
     label: 'Internal',
     key: 'internal',
-    icon: renderIcon(superdocIcons.internal),
     iconString: superdocIcons.internal,
     backgroundColor: '#CDE6E6',
   },
   {
     label: 'External',
     key: 'external',
-    icon: renderIcon(superdocIcons.external),
     iconString: superdocIcons.external,
     backgroundColor: '#F5CFDA',
   },
@@ -85,8 +77,7 @@ onMounted(() => {
 
 <template>
   <div class="internal-dropdown" :style="getStyle">
-    <n-dropdown
-      trigger="click"
+    <CommentsDropdown
       :options="options"
       @select="handleSelect($event)"
       :disabled="isDisabled"
@@ -97,7 +88,7 @@ onMounted(() => {
         <div class="option-state">{{ getState }}</div>
         <div class="dropdown-caret" v-html="superdocIcons.caretDown"></div>
       </div>
-    </n-dropdown>
+    </CommentsDropdown>
   </div>
 </template>
 
@@ -148,30 +139,12 @@ onMounted(() => {
 
 .internal-dropdown {
   transition: all 250ms ease;
-  display: inline-block;
+  display: inline-flex;
   cursor: pointer;
   border-radius: 50px;
   padding: 2px 8px;
 }
 .internal-dropdown:hover {
   background-color: #f3f3f5;
-}
-</style>
-
-<style>
-.internal-dropdown__item-icon {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  flex-shrink: 0;
-  width: 16px;
-  height: 16px;
-}
-
-.internal-dropdown__item-icon svg {
-  width: 100%;
-  height: 100%;
-  display: block;
-  fill: currentColor;
 }
 </style>

--- a/packages/superdoc/src/components/HrbrFieldsLayer/CheckboxField.vue
+++ b/packages/superdoc/src/components/HrbrFieldsLayer/CheckboxField.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { computed } from 'vue';
-import { NCheckbox } from 'naive-ui';
 
 const props = defineProps({
   field: {
@@ -43,7 +42,8 @@ const getPreviewStyle = computed(() => {
 
 <template>
   <div class="checkbox-container">
-    <n-checkbox v-if="props.isEditing" :checked="getValue" :disabled="!props.isEditing"></n-checkbox>
+    <!-- TODO: check when migrating CLM -->
+    <div v-if="props.isEditing" class="checkbox-editing-placeholder"></div>
     <div v-else class="checkbox-preview" :style="getPreviewStyle">{{ getValue ? 'x' : '' }}</div>
   </div>
 </template>
@@ -63,6 +63,11 @@ const getPreviewStyle = computed(() => {
   justify-content: center;
   align-items: center;
   line-height: 1.2;
+  width: 100%;
+  height: 100%;
+}
+
+.checkbox-editing-placeholder {
   width: 100%;
   height: 100%;
 }

--- a/packages/superdoc/src/composables/useUiFontFamily.js
+++ b/packages/superdoc/src/composables/useUiFontFamily.js
@@ -37,7 +37,7 @@ export const DEFAULT_UI_FONT_FAMILY = 'Arial, Helvetica, sans-serif';
  *
  * @example
  * // In a template
- * <n-dropdown :content-style="{ fontFamily: uiFontFamily }" />
+ * <CommentsDropdown :content-style="{ fontFamily: uiFontFamily }" />
  */
 export function useUiFontFamily() {
   const instance = getCurrentInstance();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,9 +132,9 @@ catalogs:
     lib0:
       specifier: ^0.2.114
       version: 0.2.117
-    naive-ui:
-      specifier: ^2.43.1
-      version: 2.43.2
+    nodemon:
+      specifier: ^3.1.10
+      version: 3.1.14
     pdfjs-dist:
       specifier: ^5.4.296
       version: 5.4.624
@@ -192,6 +192,9 @@ catalogs:
     prosemirror-transform:
       specifier: ^1.9.0
       version: 1.11.0
+    prosemirror-view:
+      specifier: ^1.33.8
+      version: 1.41.6
     react:
       specifier: 19.2.4
       version: 19.2.4
@@ -273,6 +276,9 @@ catalogs:
     xml-js:
       specifier: 1.6.11
       version: 1.6.11
+    y-prosemirror:
+      specifier: ^1.3.7
+      version: 1.3.7
     y-protocols:
       specifier: ^1.0.6
       version: 1.0.7
@@ -480,7 +486,7 @@ importers:
         version: 14.0.3
       mintlify:
         specifier: ^4.2.331
-        version: 4.2.331(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/node@22.19.2)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(typescript@5.9.3)
+        version: 4.2.331(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/node@25.3.5)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(typescript@5.9.3)
       remark-mdx:
         specifier: ^3.1.1
         version: 3.1.1
@@ -1057,9 +1063,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.23
-      naive-ui:
-        specifier: ^2.38.2
-        version: 2.43.2(vue@3.5.25(typescript@5.9.3))
       prosemirror-commands:
         specifier: 'catalog:'
         version: 1.7.1
@@ -1131,7 +1134,7 @@ importers:
         version: 1.6.11
       y-prosemirror:
         specifier: 'catalog:'
-        version: 1.3.7(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.19))(yjs@13.6.19)
+        version: 1.3.7(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.19))(yjs@13.6.19)
       yjs:
         specifier: 'catalog:'
         version: 13.6.19
@@ -1229,9 +1232,6 @@ importers:
       konva:
         specifier: 'catalog:'
         version: 10.2.0
-      naive-ui:
-        specifier: 'catalog:'
-        version: 2.43.2(vue@3.5.25(typescript@5.9.3))
       pinia:
         specifier: 'catalog:'
         version: 2.3.1(typescript@5.9.3)(vue@3.5.25(typescript@5.9.3))
@@ -1246,7 +1246,7 @@ importers:
         version: 3.5.25(typescript@5.9.3)
       y-prosemirror:
         specifier: 'catalog:'
-        version: 1.3.7(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.19))(yjs@13.6.19)
+        version: 1.3.7(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.19))(yjs@13.6.19)
       y-websocket:
         specifier: 'catalog:'
         version: 3.0.0(yjs@13.6.19)
@@ -9615,9 +9615,6 @@ packages:
   prosemirror-transform@1.11.0:
     resolution: {integrity: sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==}
 
-  prosemirror-view@1.41.5:
-    resolution: {integrity: sha512-UDQbIPnDrjE8tqUBbPmCOZgtd75htE6W3r0JCmY9bL6W1iemDM37MZEKC49d+tdQ0v/CKx4gjxLoLsfkD2NiZA==}
-
   prosemirror-view@1.41.6:
     resolution: {integrity: sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==}
 
@@ -13180,128 +13177,128 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@22.19.2)':
+  '@inquirer/checkbox@4.3.2(@types/node@25.3.5)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
+      '@inquirer/core': 10.3.2(@types/node@25.3.5)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.2
+      '@types/node': 25.3.5
 
-  '@inquirer/confirm@5.1.21(@types/node@22.19.2)':
+  '@inquirer/confirm@5.1.21(@types/node@25.3.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
+      '@inquirer/core': 10.3.2(@types/node@25.3.5)
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
     optionalDependencies:
-      '@types/node': 22.19.2
+      '@types/node': 25.3.5
 
-  '@inquirer/core@10.3.2(@types/node@22.19.2)':
+  '@inquirer/core@10.3.2(@types/node@25.3.5)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.2
+      '@types/node': 25.3.5
 
-  '@inquirer/editor@4.2.23(@types/node@22.19.2)':
+  '@inquirer/editor@4.2.23(@types/node@25.3.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/external-editor': 1.0.3(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
+      '@inquirer/core': 10.3.2(@types/node@25.3.5)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.3.5)
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
     optionalDependencies:
-      '@types/node': 22.19.2
+      '@types/node': 25.3.5
 
-  '@inquirer/expand@4.0.23(@types/node@22.19.2)':
+  '@inquirer/expand@4.0.23(@types/node@25.3.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
+      '@inquirer/core': 10.3.2(@types/node@25.3.5)
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.2
+      '@types/node': 25.3.5
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.19.2)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.3.5)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.19.2
+      '@types/node': 25.3.5
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@22.19.2)':
+  '@inquirer/input@4.3.1(@types/node@25.3.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
+      '@inquirer/core': 10.3.2(@types/node@25.3.5)
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
     optionalDependencies:
-      '@types/node': 22.19.2
+      '@types/node': 25.3.5
 
-  '@inquirer/number@3.0.23(@types/node@22.19.2)':
+  '@inquirer/number@3.0.23(@types/node@25.3.5)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
+      '@inquirer/core': 10.3.2(@types/node@25.3.5)
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
     optionalDependencies:
-      '@types/node': 22.19.2
+      '@types/node': 25.3.5
 
-  '@inquirer/password@4.0.23(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-    optionalDependencies:
-      '@types/node': 22.19.2
-
-  '@inquirer/prompts@7.9.0(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@22.19.2)
-      '@inquirer/confirm': 5.1.21(@types/node@22.19.2)
-      '@inquirer/editor': 4.2.23(@types/node@22.19.2)
-      '@inquirer/expand': 4.0.23(@types/node@22.19.2)
-      '@inquirer/input': 4.3.1(@types/node@22.19.2)
-      '@inquirer/number': 3.0.23(@types/node@22.19.2)
-      '@inquirer/password': 4.0.23(@types/node@22.19.2)
-      '@inquirer/rawlist': 4.1.11(@types/node@22.19.2)
-      '@inquirer/search': 3.2.2(@types/node@22.19.2)
-      '@inquirer/select': 4.4.2(@types/node@22.19.2)
-    optionalDependencies:
-      '@types/node': 22.19.2
-
-  '@inquirer/rawlist@4.1.11(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.2
-
-  '@inquirer/search@3.2.2(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.2
-
-  '@inquirer/select@4.4.2(@types/node@22.19.2)':
+  '@inquirer/password@4.0.23(@types/node@25.3.5)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
+      '@inquirer/core': 10.3.2(@types/node@25.3.5)
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
+    optionalDependencies:
+      '@types/node': 25.3.5
+
+  '@inquirer/prompts@7.9.0(@types/node@25.3.5)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@25.3.5)
+      '@inquirer/confirm': 5.1.21(@types/node@25.3.5)
+      '@inquirer/editor': 4.2.23(@types/node@25.3.5)
+      '@inquirer/expand': 4.0.23(@types/node@25.3.5)
+      '@inquirer/input': 4.3.1(@types/node@25.3.5)
+      '@inquirer/number': 3.0.23(@types/node@25.3.5)
+      '@inquirer/password': 4.0.23(@types/node@25.3.5)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.3.5)
+      '@inquirer/search': 3.2.2(@types/node@25.3.5)
+      '@inquirer/select': 4.4.2(@types/node@25.3.5)
+    optionalDependencies:
+      '@types/node': 25.3.5
+
+  '@inquirer/rawlist@4.1.11(@types/node@25.3.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.3.5)
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.2
+      '@types/node': 25.3.5
 
-  '@inquirer/type@3.0.10(@types/node@22.19.2)':
+  '@inquirer/search@3.2.2(@types/node@25.3.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.3.5)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.2
+      '@types/node': 25.3.5
+
+  '@inquirer/select@4.4.2(@types/node@25.3.5)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@25.3.5)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.3.5
+
+  '@inquirer/type@3.0.10(@types/node@25.3.5)':
+    optionalDependencies:
+      '@types/node': 25.3.5
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -13456,9 +13453,9 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mintlify/cli@4.0.935(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/node@22.19.2)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(typescript@5.9.3)':
+  '@mintlify/cli@4.0.935(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/node@25.3.5)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(typescript@5.9.3)':
     dependencies:
-      '@inquirer/prompts': 7.9.0(@types/node@22.19.2)
+      '@inquirer/prompts': 7.9.0(@types/node@25.3.5)
       '@mintlify/common': 1.0.713(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@mintlify/link-rot': 3.0.872(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@mintlify/models': 0.0.268
@@ -13472,7 +13469,7 @@ snapshots:
       front-matter: 4.0.2
       fs-extra: 11.2.0
       ink: 6.3.0(@types/react@19.2.14)(react@19.2.3)
-      inquirer: 12.3.0(@types/node@22.19.2)
+      inquirer: 12.3.0(@types/node@25.3.5)
       js-yaml: 4.1.0
       mdast-util-mdx-jsx: 3.2.0
       react: 19.2.3
@@ -14078,7 +14075,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.2
+      semver: 7.7.4
       tar-fs: 3.1.1
       unbzip2-stream: 1.4.3
       yargs: 17.7.2
@@ -15080,7 +15077,7 @@ snapshots:
 
   '@stoplight/json-ref-readers@1.2.2':
     dependencies:
-      node-fetch: 2.6.7
+      node-fetch: 2.7.0
       tslib: 1.14.1
     transitivePeerDependencies:
       - encoding
@@ -17010,7 +17007,7 @@ snapshots:
       conventional-commits-filter: 5.0.0
       handlebars: 4.7.8
       meow: 13.2.0
-      semver: 7.7.3
+      semver: 7.7.4
 
   conventional-commits-filter@5.0.0: {}
 
@@ -18538,7 +18535,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -19192,12 +19189,12 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  inquirer@12.3.0(@types/node@22.19.2):
+  inquirer@12.3.0(@types/node@25.3.5):
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/prompts': 7.9.0(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-      '@types/node': 22.19.2
+      '@inquirer/core': 10.3.2(@types/node@25.3.5)
+      '@inquirer/prompts': 7.9.0(@types/node@25.3.5)
+      '@inquirer/type': 3.0.10(@types/node@25.3.5)
+      '@types/node': 25.3.5
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
@@ -19646,7 +19643,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.3
+      semver: 7.7.4
 
   jsprim@2.0.2:
     dependencies:
@@ -20931,9 +20928,9 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
-  mintlify@4.2.331(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/node@22.19.2)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(typescript@5.9.3):
+  mintlify@4.2.331(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/node@25.3.5)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(typescript@5.9.3):
     dependencies:
-      '@mintlify/cli': 4.0.935(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/node@22.19.2)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(typescript@5.9.3)
+      '@mintlify/cli': 4.0.935(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(react@19.2.3))(@types/node@25.3.5)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.3))(typescript@5.9.3)
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/node'
@@ -21160,7 +21157,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.3
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -21830,12 +21827,6 @@ snapshots:
   prosemirror-transform@1.11.0:
     dependencies:
       prosemirror-model: 1.25.4
-
-  prosemirror-view@1.41.5:
-    dependencies:
-      prosemirror-model: 1.25.4
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
 
   prosemirror-view@1.41.6:
     dependencies:
@@ -22930,7 +22921,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.1.2
-      semver: 7.7.2
+      semver: 7.7.4
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -24655,15 +24646,6 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
-
-  y-prosemirror@1.3.7(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.19))(yjs@13.6.19):
-    dependencies:
-      lib0: 0.2.117
-      prosemirror-model: 1.25.4
-      prosemirror-state: 1.4.4
-      prosemirror-view: 1.41.5
-      y-protocols: 1.0.7(yjs@13.6.19)
-      yjs: 13.6.19
 
   y-prosemirror@1.3.7(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.19))(yjs@13.6.19):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,6 @@ catalog:
   lefthook: ^1.11.13
   lib0: ^0.2.114
   marked: ^16.2.0
-  naive-ui: ^2.43.1
   nodemon: ^3.1.10
   patch-package: ^8.0.1
   pdfjs-dist: ^5.4.296

--- a/tests/behavior/tests/comments/edit-comment-text.spec.ts
+++ b/tests/behavior/tests/comments/edit-comment-text.spec.ts
@@ -21,7 +21,7 @@ test('editing a comment updates its text', async ({ superdoc }) => {
   await dialog.locator('.overflow-icon').click();
   await superdoc.waitForStable();
 
-  const editOption = superdoc.page.locator('.n-dropdown-option-body__label', { hasText: 'Edit' });
+  const editOption = superdoc.page.locator('.comments-dropdown__option-label', { hasText: 'Edit' });
   await expect(editOption.first()).toBeVisible({ timeout: 5_000 });
   await editOption.first().click();
   await superdoc.waitForStable();

--- a/tests/behavior/tests/toolbar/dropdown-behavior.spec.ts
+++ b/tests/behavior/tests/toolbar/dropdown-behavior.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, type SuperDocFixture } from '../../fixtures/superdoc.js';
+
+test.use({ config: { toolbar: 'full', showSelection: true } });
+
+async function openFontSizeDropdown(superdoc: SuperDocFixture): Promise<void> {
+  await superdoc.page.locator('[data-item="btn-fontSize"]').click();
+  await superdoc.waitForStable();
+}
+
+async function expectFontSizeDropdownOpen(superdoc: SuperDocFixture): Promise<void> {
+  await expect(superdoc.page.locator('[data-item="btn-fontSize-option"]').first()).toBeVisible();
+}
+
+async function expectFontSizeDropdownClosed(superdoc: SuperDocFixture): Promise<void> {
+  await expect(superdoc.page.locator('[data-item="btn-fontSize-option"]:visible')).toHaveCount(0);
+}
+
+async function openDocumentModeDropdown(superdoc: SuperDocFixture): Promise<void> {
+  await superdoc.page.locator('[data-item="btn-documentMode"]').click();
+  await superdoc.waitForStable();
+}
+
+async function expectDocumentModeDropdownOpen(superdoc: SuperDocFixture): Promise<void> {
+  await expect(superdoc.page.locator('[data-item="btn-documentMode-option"]').first()).toBeVisible();
+}
+
+async function expectDocumentModeDropdownClosed(superdoc: SuperDocFixture): Promise<void> {
+  await expect(superdoc.page.locator('[data-item="btn-documentMode-option"]:visible')).toHaveCount(0);
+}
+
+test('cross-group switch closes previous dropdown (font size -> document mode)', async ({ superdoc }) => {
+  await openFontSizeDropdown(superdoc);
+  await expectFontSizeDropdownOpen(superdoc);
+
+  await openDocumentModeDropdown(superdoc);
+  await expectDocumentModeDropdownOpen(superdoc);
+  await expectFontSizeDropdownClosed(superdoc);
+});
+
+test('same trigger click toggles dropdown open/close', async ({ superdoc }) => {
+  await openFontSizeDropdown(superdoc);
+  await expectFontSizeDropdownOpen(superdoc);
+
+  await superdoc.page.locator('[data-item="btn-fontSize"]').click();
+  await superdoc.waitForStable();
+  await expectFontSizeDropdownClosed(superdoc);
+});
+
+test('outside click closes open dropdown', async ({ superdoc }) => {
+  await superdoc.type('Outside click test');
+  await superdoc.waitForStable();
+
+  await openFontSizeDropdown(superdoc);
+  await expectFontSizeDropdownOpen(superdoc);
+
+  await superdoc.page
+    .locator('.presentation-editor__viewport')
+    .first()
+    .click({ position: { x: 10, y: 10 } });
+  await superdoc.waitForStable();
+  await expectFontSizeDropdownClosed(superdoc);
+});
+
+test('regular button click closes currently open dropdown', async ({ superdoc }) => {
+  await openDocumentModeDropdown(superdoc);
+  await expectDocumentModeDropdownOpen(superdoc);
+
+  await superdoc.page.locator('[data-item="btn-bold"]').click();
+  await superdoc.waitForStable();
+
+  await expectDocumentModeDropdownClosed(superdoc);
+});
+
+test('escape closes currently open dropdown', async ({ superdoc }) => {
+  await openFontSizeDropdown(superdoc);
+  await expectFontSizeDropdownOpen(superdoc);
+
+  await superdoc.page.keyboard.press('Escape');
+  await superdoc.waitForStable();
+
+  await expectFontSizeDropdownClosed(superdoc);
+});


### PR DESCRIPTION
Linear: SD-1190

- Removed naive ui from the codebase.
- Created necessary components for replacing naive ui components.
- The toolbar and comment dropdowns separated for easier migration, as they have different contracts.
- The required contract for toolbar dropdown (naive ui contract) has been preserved to avoid major refactoring.
- Similar styles and animations (as in naive ui) for toolbar dropdowns and tooltips have been preserved.