### PR TITLE
fix(comments): improve multiline comment input styling

### DIFF
--- a/packages/superdoc/src/components/CommentsLayer/CommentDialog.vue
+++ b/packages/superdoc/src/components/CommentsLayer/CommentDialog.vue
@@ -864,10 +864,12 @@ watch(editingCommentId, (commentId) => {
 /* ── New comment input ── */
 .new-comment-input-wrapper {
   border: 1.5px solid var(--sd-border-default, #dbdbdb);
-  border-radius: 9999px;
+  border-radius: 12px;
   padding: 8.5px 10.5px;
   background: var(--sd-surface-card, #ffffff);
   margin-top: 4px;
+  max-height: 150px;
+  overflow-y: auto;
 }
 .new-comment-input-wrapper :deep(.comment-entry) {
   border-radius: 0;
@@ -909,9 +911,11 @@ watch(editingCommentId, (commentId) => {
 }
 .reply-input-wrapper {
   border: 1.5px solid var(--sd-border-default, #dbdbdb);
-  border-radius: 9999px;
+  border-radius: 12px;
   padding: 8.5px 10.5px;
   background: var(--sd-surface-card, #ffffff);
+  max-height: 150px;
+  overflow-y: auto;
 }
 .reply-input-wrapper :deep(.comment-entry) {
   border-radius: 0;


### PR DESCRIPTION
## Summary
- Replace pill shape (`border-radius: 9999px`) with rounded rect (`12px`) on comment and reply input wrappers to avoid the distorted capsule look on multiline text
- Add `max-height: 150px` with `overflow-y: auto` so long replies scroll instead of stretching the card unboundedly

## Test plan
- [ ] Open a comment, type multiline text in the new comment input. Verify it scrolls at ~150px and corners look clean
- [ ] Reply to an existing comment with multiline text. Same behavior
- [ ] Single-line input still looks correct with 12px rounded corners