### PR TITLE
fix(comments): reduce sidebar jitter when clicking comments (SD-2034)

### DIFF
--- a/packages/superdoc/src/components/CommentsLayer/FloatingComments.vue
+++ b/packages/superdoc/src/components/CommentsLayer/FloatingComments.vue
@@ -330,7 +330,11 @@ watch(activeComment, () => {
 
       const rect = el.getBoundingClientRect();
       const margin = 80;
-      const isVisible = rect.top >= margin && rect.bottom <= window.innerHeight - margin;
+      const availableHeight = window.innerHeight - 2 * margin;
+      const isVisible =
+        rect.height > availableHeight
+          ? rect.top >= margin
+          : rect.top >= margin && rect.bottom <= window.innerHeight - margin;
 
       if (!isVisible) {
         el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });


### PR DESCRIPTION
## Summary

- Smooth container `min-height` changes with CSS transition to prevent scrollbar flash when clicking comments near the bottom of the sidebar
- Increase `ESTIMATED_HEIGHT` from 80 to 110 to better match actual comment card sizes, reducing visual overlap before measurement completes
- Fix scroll-to-comment timing (100ms to 400ms) so the CSS transition completes before checking visibility, and use `rect.bottom` for the lower bound check

Fixes [SD-2034](https://linear.app/superdocworkspace/issue/SD-2034/new-ui-bug-weird-jitter-when-clicking-an-existing-comment)

## Root cause

When clicking a comment near the bottom of the sidebar, `totalHeight` oscillates because:
1. Collision avoidance recalculates positions immediately
2. Height remeasurement at 50ms updates `measuredHeights`, causing `allPositions` to recompute
3. Height remeasurement at 350ms triggers another change

Each `totalHeight` change updates `min-height` on `.section-wrapper`, making the parent scroll container's scrollbar appear/disappear rapidly (the jitter).

## Test plan

- [ ] Load a document with many comments and tracked changes
- [ ] Click a comment/TC bubble near the bottom of the document
- [ ] Verify the scrollbar does not flash/jitter
- [ ] Verify the sidebar scrolls to show the clicked comment if off-screen
- [ ] Verify comment spacing looks correct (no visual overlap before heights are measured)