### PR TITLE
fix(test): stabilize flaky cleanUpParagraphWithAnnotations tests

### DIFF
--- a/packages/super-editor/src/extensions/field-annotation/cleanup-commands/cleanUpParagraphWithAnnotation.test.js
+++ b/packages/super-editor/src/extensions/field-annotation/cleanup-commands/cleanUpParagraphWithAnnotation.test.js
@@ -27,6 +27,10 @@ const textContent = (docNode) => docNode.textContent;
 const mockHelperPath = '../fieldAnnotationHelpers/index.js';
 
 describe('cleanUpParagraphWithAnnotations - test range error crash', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   /** Test to fix error in position out of range in original */
   it('throws RangeError "Position … out of range" on single-paragraph doc', async () => {
     const doc = schema.node('doc', null, [p.createAndFill(null, [text('A')])]);
@@ -48,15 +52,6 @@ describe('cleanUpParagraphWithAnnotations - test range error crash', () => {
     expect(run).not.toThrow(/Position\s+\d+\s+out of range/i);
   });
 });
-
-if (!Object.getOwnPropertyDescriptor(PMNode.prototype, 'children')) {
-  Object.defineProperty(PMNode.prototype, 'children', {
-    get() {
-      return { length: this.childCount };
-    },
-    configurable: true,
-  });
-}
 
 describe('cleanUpParagraphWithAnnotations – original behavior', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Fixes intermittent test failures in `cleanUpParagraphWithAnnotation.test.js` that surface when running the full super-editor test suite (688 files) under parallel load.

## The problem

These 5 tests fail sporadically when Vitest runs many test files concurrently:

```
× cleanUpParagraphWithAnnotations - test range error crash > throws RangeError...
× cleanUpParagraphWithAnnotations – original behavior > deletes a single-child paragraph...
× cleanUpParagraphWithAnnotations – original behavior > no-ops when parent has >= 2 inline children...
× cleanUpParagraphWithAnnotations – original behavior > no-ops when annotation node does not equal...
× cleanUpParagraphWithAnnotations – original behavior > handles multiple annotations by queuing...
```

They pass consistently when run in isolation (`pnpm test -- --run cleanUpParagraphWithAnnotation`), but fail under the broad filter patterns that load hundreds of files in parallel (e.g., `--run vertical-navigation` which matches 688 files).

## Root cause

Every test uses `vi.doMock()` + dynamic `await import('./index.js')` to swap mock implementations per-test. This pattern requires `vi.resetModules()` before each test to clear the module cache, ensuring the dynamic import picks up the fresh mock.

The **second** `describe` block had `beforeEach(() => { vi.resetModules() })`, but the **first** `describe` block did not. Under heavy parallel load, a Vitest worker could reuse a cached (unmocked) module from a previous test file processed in the same thread, causing assertion failures.

Additionally, a duplicate `PMNode.prototype.children` monkey-patch (lines 52-59, identical copy of lines 6-13) was present between the two describe blocks. The guard prevented runtime errors but it was dead code.

## Fix

- Add `beforeEach(() => { vi.resetModules() })` to the first `describe` block
- Remove the duplicate monkey-patch

## Test plan

- [x] All 5 `cleanUpParagraphWithAnnotation` tests pass in isolation
- [x] Pre-commit hooks pass (format, lint, generate-all)