### PR TITLE
test: verify community label fix

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -125,3 +125,4 @@ jobs:
               issue_number: prNumber,
               labels: [label.name],
             });
+


### PR DESCRIPTION
Test PR to verify the community label is NOT applied to team members. Delete after verification.