### PR TITLE
fix(super-editor): align image resize handles with actual image position

### DIFF
--- a/packages/super-editor/src/components/SuperEditor.vue
+++ b/packages/super-editor/src/components/SuperEditor.vue
@@ -1262,6 +1262,7 @@ onBeforeUnmount(() => {
 .super-editor {
   color: initial;
   overflow: hidden;
+  position: relative;
 }
 
 .placeholder-editor {


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/a091bda5-754c-41e4-bdd7-39a8e7b3bc76


## After

https://github.com/user-attachments/assets/648c5403-db7b-4000-aa4a-e13a69a57bf3



## Summary

Fixes SD-2082: image resize handles (blue circles + border) are misaligned from the actual image position.

### Root cause

`ImageResizeOverlay` computes coordinates relative to `.super-editor` (via `closest('.super-editor')`), but `.super-editor` had no `position` CSS set. The overlay's `position: absolute` resolved to `.super-editor-container` (the nearest positioned ancestor up the tree) instead. Any offset between the two elements (ruler, padding) caused the handles to appear at wrong coordinates.

### Fix

Add `position: relative` to `.super-editor` so it becomes the positioned ancestor that matches the overlay's coordinate math. One line.

### Visual test failures

The visual test run (0 passed, 10 failed) likely reflects the handle misalignment in baseline comparisons. After this fix, handles will render at the correct position and baselines should be updated.

https://github.com/user-attachments/assets/eb1360ec-5bf6-43ce-8c00-af1a1049bd56




## Test plan

- [ ] Open a DOCX with images (e.g., `test-corpus/images/sd-1660-layered-image-issue.docx`)
- [ ] Click on an image. Verify resize handles align with the image corners.
- [ ] Test with rulers enabled and disabled
- [ ] Test at non-100% zoom (75%, 150%)
- [ ] Drag a resize handle and verify the image resizes correctly