### PR TITLE
fix(docs): log warning when local dev server is unreachable (SD-2144)

### DIFF
--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -217,7 +217,6 @@ export default defineConfig(({ mode, command }) => {
     },
     server: {
       port: 9094,
-      strictPort: true,
       host: '0.0.0.0',
       fs: {
         allow: [


### PR DESCRIPTION
The docs SuperDocEditor widget silently fell back to unpkg when the local Vite dev server was unavailable. Add console.info/warn messages so developers know which bundle is loaded. Also set strictPort on the Vite dev server so it fails instead of silently binding to another port.