### PR TITLE
fix(image): sync headless image media to Y.Doc for collab persistence (SD-2150)

### DIFF
--- a/packages/super-editor/src/extensions/image/imageHelpers/imageRegistrationPlugin.js
+++ b/packages/super-editor/src/extensions/image/imageHelpers/imageRegistrationPlugin.js
@@ -216,6 +216,14 @@ export const handleNodePath = (foundImages, editor, state) => {
     const mediaPath = buildMediaPath(uniqueFileName);
     mediaStore[mediaPath] = src;
 
+    // Sync image data to Y.Doc media map so other collab clients can access it.
+    // We write directly to the Y.Doc map instead of using editor.commands because
+    // this runs inside appendTransaction where commands don't dispatch properly.
+    if (editor.options.ydoc) {
+      const mediaMap = editor.options.ydoc.getMap('media');
+      mediaMap.set(mediaPath, src);
+    }
+
     const path = mediaPath.startsWith('word/') ? mediaPath.slice(5) : mediaPath;
     const rId = addImageRelationship({ editor, path });
     const inferredSize = hasFinitePositiveSize(node.attrs?.size) ? null : parseSizeFromImageUrl(src);

--- a/packages/super-editor/src/extensions/image/imageHelpers/imageRegistrationPlugin.test.js
+++ b/packages/super-editor/src/extensions/image/imageHelpers/imageRegistrationPlugin.test.js
@@ -161,6 +161,41 @@ describe('handleNodePath', () => {
     expect(state.tr.setNodeMarkup).toHaveBeenCalledWith(0, undefined, expect.objectContaining({ size: existingSize }));
   });
 
+  it('syncs image data to Y.Doc media map when in collaboration mode', () => {
+    const base64 = `data:image/png;base64,${Buffer.from('test-image').toString('base64')}`;
+    const foundImages = [{ node: { attrs: { src: base64 } }, pos: 0 }];
+
+    const state = createStateStub();
+    const mediaMapSet = vi.fn();
+    const editor = {
+      ...createEditorStub(),
+      options: {
+        mode: 'docx',
+        ydoc: { getMap: vi.fn(() => ({ set: mediaMapSet })) },
+      },
+    };
+
+    handleNodePath(foundImages, editor, state);
+
+    expect(editor.options.ydoc.getMap).toHaveBeenCalledWith('media');
+    expect(mediaMapSet).toHaveBeenCalledTimes(1);
+    expect(mediaMapSet).toHaveBeenCalledWith(expect.stringMatching(/^word\/media\//), base64);
+  });
+
+  it('does not write to Y.Doc media map when not in collaboration mode', () => {
+    const base64 = `data:image/png;base64,${Buffer.from('test-image').toString('base64')}`;
+    const foundImages = [{ node: { attrs: { src: base64 } }, pos: 0 }];
+
+    const state = createStateStub();
+    const editor = createEditorStub(); // no ydoc
+
+    handleNodePath(foundImages, editor, state);
+
+    // Should not throw — just silently skip collab sync
+    const mediaEntries = Object.entries(editor.storage.image.media);
+    expect(mediaEntries).toHaveLength(1);
+  });
+
   it('infers size from compact WxH path segment', () => {
     const sourceUrl = 'https://example.com/images/800x600';
     const foundImages = [{ node: { attrs: { src: sourceUrl } }, pos: 0 }];


### PR DESCRIPTION
handleNodePath (headless/CLI image registration) stored media only in the local editor.storage.image.media object but never wrote to the Y.Doc media map. When a second collab session connected, image nodes synced via XmlFragment but the media binary data was missing.

Write directly to ydoc.getMap('media') instead of using editor.commands.addImageToCollaboration, which doesn't dispatch properly inside ProseMirror's appendTransaction callback.
