### PR TITLE
fix(collaboration): sync numbering, styles, and headers in real-time (SD-2062, SD-2040)

### DIFF
--- a/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
@@ -2804,6 +2804,22 @@ export class PresentationEditor extends EventEmitter {
       handler: handleRemoteHeaderFooterChanged as (...args: unknown[]) => void,
     });
 
+    // Remote converter metadata arrived via Y.js (numbering, styles, headerFooterIds, etc.)
+    // Re-render so the style engine and layout pipeline pick up the changes.
+    // For headerFooterIds: refresh the H/F manager so it discovers new sections.
+    const handleRemoteConverterMetaChanged = (payload: { key: string }) => {
+      if (payload?.key === 'headerFooterIds') {
+        this.#headerFooterSession?.manager?.refresh();
+      }
+      this.#pendingDocChange = true;
+      this.#scheduleRerender();
+    };
+    this.#editor.on('remoteConverterMetaChanged', handleRemoteConverterMetaChanged);
+    this.#editorListeners.push({
+      event: 'remoteConverterMetaChanged',
+      handler: handleRemoteConverterMetaChanged as (...args: unknown[]) => void,
+    });
+
     // Listen for comment selection changes to update Layout Engine highlighting
     const handleCommentsUpdate = (payload: { activeCommentId?: string | null }) => {
       if (this.#domPainter?.setActiveComment) {

--- a/packages/super-editor/src/core/types/EditorEvents.ts
+++ b/packages/super-editor/src/core/types/EditorEvents.ts
@@ -129,4 +129,10 @@ export interface EditorEventMap extends DefaultEventMap {
 
   /** Called when page styles are updated */
   pageStyleUpdate: [{ pageMargins?: Record<string, unknown>; pageStyles: Record<string, unknown> }];
+
+  /** Called when stylesheet defaults change (local mutation via styles.apply) */
+  stylesDefaultsChanged: [];
+
+  /** Called when remote converter metadata arrives via Y.js (numbering, styles, etc.) */
+  remoteConverterMetaChanged: [{ key: string; data: unknown }];
 }

--- a/packages/super-editor/src/document-api-adapters/capabilities-adapter.test.ts
+++ b/packages/super-editor/src/document-api-adapters/capabilities-adapter.test.ts
@@ -617,7 +617,7 @@ describe('getDocumentApiCapabilities', () => {
     expect(reasons).toContain('STYLES_PART_MISSING');
   });
 
-  it('reports COLLABORATION_ACTIVE when collaboration provider is synced', () => {
+  it('allows styles.apply when collaboration provider is synced (synced via Y.js)', () => {
     const editor = makeEditor();
     (editor as unknown as Record<string, unknown>).converter = {
       convertedXml: {
@@ -627,10 +627,8 @@ describe('getDocumentApiCapabilities', () => {
     (editor as unknown as { options: Record<string, unknown> }).options.collaborationProvider = { synced: true };
 
     const capabilities = getDocumentApiCapabilities(editor);
-    const reasons = capabilities.operations['styles.apply'].reasons ?? [];
-    expect(capabilities.operations['styles.apply'].available).toBe(false);
-    expect(reasons).toContain('COLLABORATION_ACTIVE');
-    expect(reasons).toContain('OPERATION_UNAVAILABLE');
+    // Style mutations are now synced via Y.js (SD-2040), so the collaboration gate was removed.
+    expect(capabilities.operations['styles.apply'].available).toBe(true);
   });
 
   it('styles.apply never reports COMMAND_UNAVAILABLE', () => {

--- a/packages/super-editor/src/document-api-adapters/capabilities-adapter.ts
+++ b/packages/super-editor/src/document-api-adapters/capabilities-adapter.ts
@@ -16,7 +16,6 @@ import {
   OPERATION_IDS,
 } from '@superdoc/document-api';
 import { TrackFormatMarkName } from '../extensions/track-changes/constants.js';
-import { isCollaborationActive } from './collaboration-detection.js';
 
 type EditorCommandName = string;
 type EditorWithBlockNodeHelper = Editor & {
@@ -294,7 +293,6 @@ function isStylesApplyAvailable(editor: Editor): boolean {
   const converter = (editor as unknown as { converter?: { convertedXml?: Record<string, unknown> } }).converter;
   if (!converter?.convertedXml?.['word/styles.xml']) return false;
   if (!hasStylesRoot(converter.convertedXml['word/styles.xml'])) return false;
-  if (isCollaborationActive(editor)) return false;
   return true;
 }
 
@@ -306,7 +304,6 @@ function getStylesApplyUnavailableReason(editor: Editor): CapabilityReasonCode |
   if (!converter) return 'OPERATION_UNAVAILABLE';
   if (!converter.convertedXml?.['word/styles.xml']) return 'STYLES_PART_MISSING';
   if (!hasStylesRoot(converter.convertedXml['word/styles.xml'])) return 'STYLES_PART_MISSING';
-  if (isCollaborationActive(editor)) return 'COLLABORATION_ACTIVE';
   return undefined;
 }
 

--- a/packages/super-editor/src/document-api-adapters/styles-adapter.test.ts
+++ b/packages/super-editor/src/document-api-adapters/styles-adapter.test.ts
@@ -107,14 +107,13 @@ describe('styles adapter: capability gates', () => {
     );
   });
 
-  it('throws CAPABILITY_UNAVAILABLE when collaboration is active', () => {
+  it('allows mutation when collaboration is active (synced via Y.js)', () => {
     const editor = createMockEditor({
       stylesXml: makeStylesXml(),
       collaborationProvider: { synced: true },
     });
-    expect(() => stylesApplyAdapter(editor, runInput({ bold: true }), DEFAULT_OPTIONS)).toThrow(
-      DocumentApiAdapterError,
-    );
+    // Style mutations are now synced via the styleDefinitions Y.js map (SD-2040).
+    expect(() => stylesApplyAdapter(editor, runInput({ bold: true }), DEFAULT_OPTIONS)).not.toThrow();
   });
 
   it('allows mutation when collaboration provider is not synced', () => {

--- a/packages/super-editor/src/document-api-adapters/styles-adapter.ts
+++ b/packages/super-editor/src/document-api-adapters/styles-adapter.ts
@@ -21,7 +21,7 @@ import type {
 import { PROPERTY_REGISTRY } from '@superdoc/document-api';
 import type { Editor } from '../core/Editor.js';
 import { DocumentApiAdapterError } from './errors.js';
-import { isCollaborationActive } from './collaboration-detection.js';
+
 import { executeOutOfBandMutation } from './out-of-band-mutation.js';
 import { syncDocDefaultsToConvertedXml, type DocDefaultsTranslator } from './styles-xml-sync.js';
 import { translator as docDefaultsTranslator } from '../core/super-converter/v3/handlers/w/docDefaults/docDefaults-translator.js';
@@ -310,13 +310,8 @@ export function stylesApplyAdapter(
     );
   }
 
-  if (isCollaborationActive(editor)) {
-    throw new DocumentApiAdapterError(
-      'CAPABILITY_UNAVAILABLE',
-      'styles.apply is unavailable during active collaboration. Stylesheet mutations cannot be synced via Yjs.',
-      { reason: 'collaboration_active' },
-    );
-  }
+  // Collaboration gate removed: style mutations are now synced via the
+  // styleDefinitions Y.js map (see collaboration-helpers.js).
 
   const stylesRoot = stylesPart.elements?.find((el: XmlElement) => el.name === 'w:styles');
   if (!stylesRoot) {

--- a/packages/super-editor/src/extensions/collaboration/collaboration-helpers.js
+++ b/packages/super-editor/src/extensions/collaboration/collaboration-helpers.js
@@ -108,7 +108,127 @@ const _doUpdateYdocDocxData = async (editor, ydoc) => {
   }
 };
 
+// ---------------------------------------------------------------------------
+// Converter metadata real-time sync
+// ---------------------------------------------------------------------------
+//
+// Generic mechanism to sync converter metadata (numbering, styles, and any
+// future type) via a SINGLE Y.js map ('converterMeta'). Each metadata type
+// is a key in the map. One observer, one flag, one event.
+//
+// To add a new metadata type:
+//   1. Add a key constant to CONVERTER_META_KEYS
+//   2. Add apply logic in applyRemoteConverterMetadata
+//   3. Add a push trigger in collaboration.js (editor event → pushConverterMetadata)
+//   4. Add getLocal logic in pushConverterMetadata
+// ---------------------------------------------------------------------------
+
+export const CONVERTER_META_KEYS = /** @type {const} */ (['numbering', 'styles', 'headerFooterIds']);
+
+let isApplyingRemoteConverterMeta = false;
+
+/**
+ * Check if we're currently applying remote converter metadata.
+ * Used to prevent push-back (ping-pong) when a remote change
+ * triggers local events.
+ */
+export const isApplyingRemoteConverterMetadata = () => isApplyingRemoteConverterMeta;
+
+/**
+ * Push a specific converter metadata key to the shared Y.js map.
+ *
+ * @param {Editor} editor The editor instance
+ * @param {typeof CONVERTER_META_KEYS[number]} key Which metadata to push
+ */
+export const pushConverterMetadata = (editor, key) => {
+  if (isApplyingRemoteConverterMeta) return;
+
+  const ydoc = editor?.options?.ydoc;
+  if (!ydoc || ydoc.isDestroyed) return;
+  if (!editor?.converter) return;
+
+  const map = ydoc.getMap('converterMeta');
+  let data;
+
+  if (key === 'numbering') {
+    data = {
+      numbering: editor.converter.numbering,
+      translatedNumbering: editor.converter.translatedNumbering,
+    };
+  } else if (key === 'styles') {
+    data = {
+      translatedLinkedStyles: editor.converter.translatedLinkedStyles,
+    };
+  } else if (key === 'headerFooterIds') {
+    data = {
+      headerIds: editor.converter.headerIds,
+      footerIds: editor.converter.footerIds,
+    };
+  } else {
+    return;
+  }
+
+  // Skip if unchanged — avoids redundant Y.js transacts (especially for
+  // headerFooterIds which is triggered on every header keystroke but
+  // almost never actually changes).
+  const existing = map.get(key);
+  if (existing && JSON.stringify(existing) === JSON.stringify(data)) {
+    return;
+  }
+
+  ydoc.transact(() => map.set(key, data), {
+    event: `converter-meta-${key}-update`,
+    user: editor.options.user,
+  });
+};
+
+/**
+ * Push ALL converter metadata keys. Called once during initializeMetaMap
+ * so joining clients receive the full state.
+ *
+ * @param {Editor} editor
+ */
+export const pushAllConverterMetadata = (editor) => {
+  for (const key of CONVERTER_META_KEYS) {
+    pushConverterMetadata(editor, key);
+  }
+};
+
+/**
+ * Apply remote converter metadata to the local editor.
+ *
+ * @param {Editor} editor
+ * @param {string} key Which metadata was updated
+ * @param {object} data The remote payload
+ */
+export const applyRemoteConverterMetadata = (editor, key, data) => {
+  if (!editor || editor.isDestroyed || !editor.converter) return;
+  if (!data) return;
+
+  isApplyingRemoteConverterMeta = true;
+
+  try {
+    if (key === 'numbering') {
+      if (data.numbering) editor.converter.numbering = data.numbering;
+      if (data.translatedNumbering) editor.converter.translatedNumbering = data.translatedNumbering;
+    } else if (key === 'styles') {
+      if (data.translatedLinkedStyles) editor.converter.translatedLinkedStyles = data.translatedLinkedStyles;
+    } else if (key === 'headerFooterIds') {
+      if (data.headerIds) editor.converter.headerIds = data.headerIds;
+      if (data.footerIds) editor.converter.footerIds = data.footerIds;
+    }
+
+    editor.emit('remoteConverterMetaChanged', { key, data });
+  } finally {
+    setTimeout(() => {
+      isApplyingRemoteConverterMeta = false;
+    }, 0);
+  }
+};
+
+// ---------------------------------------------------------------------------
 // Header/footer real-time sync
+// ---------------------------------------------------------------------------
 // Current approach: last-writer-wins with full JSON replacement.
 // Future: CRDT-based sync (like y-prosemirror) for character-level merging.
 let isApplyingRemoteChanges = false;
@@ -142,10 +262,49 @@ export const pushHeaderFooterToYjs = (editor, type, sectionId, content) => {
     return;
   }
 
-  ydoc.transact(() => headerFooterMap.set(key, { type, sectionId, content }), {
-    event: 'header-footer-update',
-    user: editor.options.user,
-  });
+  // Include headerIds/footerIds in the same transaction so the receiver
+  // gets both the content and the section-type mapping atomically.
+  // Without this, the two Y.js maps (headerFooterJson + converterMeta)
+  // can arrive in separate network messages, causing the receiver to have
+  // content but no headerIds — the layout pipeline can't resolve which
+  // header to render.
+  const headerIds = editor.converter?.headerIds;
+  const footerIds = editor.converter?.footerIds;
+
+  ydoc.transact(
+    () => {
+      headerFooterMap.set(key, { type, sectionId, content, headerIds, footerIds });
+    },
+    {
+      event: 'header-footer-update',
+      user: editor.options.user,
+    },
+  );
+};
+
+/**
+ * Push all headers and footers from the converter to the headerFooterJson
+ * Y.js map. Called once during initializeMetaMap so joining clients receive
+ * header/footer content immediately (not just after the 30s DOCX sync).
+ *
+ * Also pushes headerIds/footerIds so the receiving client knows which
+ * headers/footers map to which section types (default, first, even, odd).
+ *
+ * @param {Editor} editor
+ */
+export const pushAllHeaderFooterToYjs = (editor) => {
+  if (!editor?.converter) return;
+  const { headers, footers } = editor.converter;
+  if (headers) {
+    for (const [sectionId, content] of Object.entries(headers)) {
+      if (content) pushHeaderFooterToYjs(editor, 'header', sectionId, content);
+    }
+  }
+  if (footers) {
+    for (const [sectionId, content] of Object.entries(footers)) {
+      if (content) pushHeaderFooterToYjs(editor, 'footer', sectionId, content);
+    }
+  }
 };
 
 /**
@@ -158,7 +317,7 @@ export const pushHeaderFooterToYjs = (editor, type, sectionId, content) => {
 export const applyRemoteHeaderFooterChanges = (editor, key, data) => {
   if (!editor || editor.isDestroyed || !editor.converter) return;
 
-  const { type, sectionId, content } = data;
+  const { type, sectionId, content, headerIds, footerIds } = data;
   if (!type || !sectionId || !content) return;
 
   // Prevent ping-pong: replaceContent triggers blur/update which would push back to Yjs
@@ -168,6 +327,11 @@ export const applyRemoteHeaderFooterChanges = (editor, key, data) => {
     // Update converter storage
     const storage = editor.converter[`${type}s`];
     if (storage) storage[sectionId] = content;
+
+    // Apply headerIds/footerIds atomically with the content so the layout
+    // pipeline can resolve which header/footer to render immediately.
+    if (headerIds) editor.converter.headerIds = headerIds;
+    if (footerIds) editor.converter.footerIds = footerIds;
 
     // Mark as modified so exports include header/footer references
     editor.converter.headerFooterModified = true;

--- a/packages/super-editor/src/extensions/collaboration/collaboration-metadata-sync.test.js
+++ b/packages/super-editor/src/extensions/collaboration/collaboration-metadata-sync.test.js
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  pushConverterMetadata,
+  applyRemoteConverterMetadata,
+  isApplyingRemoteConverterMetadata,
+  pushAllConverterMetadata,
+  pushAllHeaderFooterToYjs,
+  CONVERTER_META_KEYS,
+} from './collaboration-helpers.js';
+
+// Helper to create a mock Yjs Map
+const createYMap = (initial = {}) => {
+  const store = new Map(Object.entries(initial));
+  let observer;
+  return {
+    set: vi.fn((key, value) => store.set(key, value)),
+    get: vi.fn((key) => store.get(key)),
+    has: vi.fn((key) => store.has(key)),
+    observe: vi.fn((fn) => {
+      observer = fn;
+    }),
+    unobserve: vi.fn(),
+    forEach: vi.fn((fn) => store.forEach((v, k) => fn(v, k))),
+    _trigger(event) {
+      observer?.(event);
+    },
+    store,
+  };
+};
+
+const createYDocStub = () => {
+  const maps = {
+    converterMeta: createYMap(),
+    headerFooterJson: createYMap(),
+  };
+  return {
+    getMap: vi.fn((name) => maps[name] || createYMap()),
+    transact: vi.fn((fn) => fn()),
+    isDestroyed: false,
+    _maps: maps,
+  };
+};
+
+const createMockEditor = (ydoc, overrides = {}) => ({
+  options: { ydoc, user: { id: 'user-1' } },
+  isDestroyed: false,
+  converter: {
+    numbering: { abstracts: {}, definitions: {} },
+    translatedNumbering: { abstracts: {}, definitions: {} },
+    translatedLinkedStyles: { docDefaults: {}, styles: {} },
+    headers: {},
+    footers: {},
+  },
+  emit: vi.fn(),
+  ...overrides,
+});
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await new Promise((resolve) => setTimeout(resolve, 15));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('unified converter metadata sync (SD-2062/SD-2040)', () => {
+  describe('pushConverterMetadata', () => {
+    it('pushes numbering data to converterMeta map', () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc);
+      editor.converter.numbering = { abstracts: { 0: {} }, definitions: { 1: {} } };
+      editor.converter.translatedNumbering = { abstracts: { 0: {} }, definitions: { 1: {} } };
+
+      pushConverterMetadata(editor, 'numbering');
+
+      expect(ydoc._maps.converterMeta.set).toHaveBeenCalledWith('numbering', {
+        numbering: editor.converter.numbering,
+        translatedNumbering: editor.converter.translatedNumbering,
+      });
+    });
+
+    it('pushes styles data to converterMeta map', () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc);
+      editor.converter.translatedLinkedStyles = { docDefaults: { runProperties: { fontSize: 24 } } };
+
+      pushConverterMetadata(editor, 'styles');
+
+      expect(ydoc._maps.converterMeta.set).toHaveBeenCalledWith('styles', {
+        translatedLinkedStyles: editor.converter.translatedLinkedStyles,
+      });
+    });
+
+    it('pushes headerFooterIds data to converterMeta map', () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc);
+      editor.converter.headerIds = { default: 'rId-header-default', first: null, even: null, odd: null };
+      editor.converter.footerIds = { default: 'rId-footer-default', first: null, even: null, odd: null };
+
+      pushConverterMetadata(editor, 'headerFooterIds');
+
+      expect(ydoc._maps.converterMeta.set).toHaveBeenCalledWith('headerFooterIds', {
+        headerIds: editor.converter.headerIds,
+        footerIds: editor.converter.footerIds,
+      });
+    });
+
+    it('skips push when data is unchanged (dedup)', () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc);
+      const ids = { headerIds: { default: 'rId1' }, footerIds: { default: null } };
+      ydoc._maps.converterMeta.get.mockReturnValue(ids);
+      editor.converter.headerIds = { default: 'rId1' };
+      editor.converter.footerIds = { default: null };
+
+      pushConverterMetadata(editor, 'headerFooterIds');
+
+      expect(ydoc.transact).not.toHaveBeenCalled();
+    });
+
+    it('uses the same Y.js map for all metadata types', () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc);
+
+      pushConverterMetadata(editor, 'numbering');
+      pushConverterMetadata(editor, 'styles');
+      pushConverterMetadata(editor, 'headerFooterIds');
+
+      expect(ydoc.getMap).toHaveBeenCalledWith('converterMeta');
+      expect(ydoc._maps.converterMeta.set).toHaveBeenCalledTimes(3);
+    });
+
+    it('ignores unknown keys', () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc);
+
+      pushConverterMetadata(editor, 'unknownType');
+
+      expect(ydoc.transact).not.toHaveBeenCalled();
+    });
+
+    it('returns early when ydoc is not available', () => {
+      const editor = createMockEditor(null);
+      pushConverterMetadata(editor, 'numbering');
+      // Should not throw
+    });
+
+    it('returns early when ydoc is destroyed', () => {
+      const ydoc = createYDocStub();
+      ydoc.isDestroyed = true;
+      const editor = createMockEditor(ydoc);
+
+      pushConverterMetadata(editor, 'numbering');
+      expect(ydoc.transact).not.toHaveBeenCalled();
+    });
+
+    it('returns early when converter is missing', () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc, { converter: null });
+
+      pushConverterMetadata(editor, 'numbering');
+      expect(ydoc.transact).not.toHaveBeenCalled();
+    });
+
+    it('skips push during remote apply (anti-ping-pong)', async () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc);
+
+      applyRemoteConverterMetadata(editor, 'numbering', {
+        numbering: { abstracts: {}, definitions: {} },
+        translatedNumbering: { abstracts: {}, definitions: {} },
+      });
+
+      expect(isApplyingRemoteConverterMetadata()).toBe(true);
+      pushConverterMetadata(editor, 'numbering');
+      expect(ydoc.transact).not.toHaveBeenCalled();
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(isApplyingRemoteConverterMetadata()).toBe(false);
+    });
+  });
+
+  describe('applyRemoteConverterMetadata', () => {
+    it('applies numbering data to converter', () => {
+      const editor = createMockEditor(createYDocStub());
+      const numbering = { abstracts: { 0: { levels: [] } }, definitions: { 1: {} } };
+      const translatedNumbering = { abstracts: { 0: {} }, definitions: { 1: {} } };
+
+      applyRemoteConverterMetadata(editor, 'numbering', { numbering, translatedNumbering });
+
+      expect(editor.converter.numbering).toEqual(numbering);
+      expect(editor.converter.translatedNumbering).toEqual(translatedNumbering);
+    });
+
+    it('applies styles data to converter', () => {
+      const editor = createMockEditor(createYDocStub());
+      const translatedLinkedStyles = { docDefaults: { runProperties: { fontSize: 28 } } };
+
+      applyRemoteConverterMetadata(editor, 'styles', { translatedLinkedStyles });
+
+      expect(editor.converter.translatedLinkedStyles).toEqual(translatedLinkedStyles);
+    });
+
+    it('applies headerFooterIds to converter', () => {
+      const editor = createMockEditor(createYDocStub());
+      const headerIds = { default: 'rId-header-default', first: null, even: null, odd: null };
+      const footerIds = { default: 'rId-footer-default', first: null, even: null, odd: null };
+
+      applyRemoteConverterMetadata(editor, 'headerFooterIds', { headerIds, footerIds });
+
+      expect(editor.converter.headerIds).toEqual(headerIds);
+      expect(editor.converter.footerIds).toEqual(footerIds);
+    });
+
+    it('emits a single remoteConverterMetaChanged event with key', () => {
+      const editor = createMockEditor(createYDocStub());
+
+      applyRemoteConverterMetadata(editor, 'numbering', {
+        numbering: {},
+        translatedNumbering: {},
+      });
+
+      expect(editor.emit).toHaveBeenCalledWith('remoteConverterMetaChanged', {
+        key: 'numbering',
+        data: { numbering: {}, translatedNumbering: {} },
+      });
+    });
+
+    it('returns early when editor is destroyed', () => {
+      const editor = createMockEditor(null, { isDestroyed: true });
+      applyRemoteConverterMetadata(editor, 'numbering', { numbering: {} });
+      expect(editor.emit).not.toHaveBeenCalled();
+    });
+
+    it('returns early when data is null', () => {
+      const editor = createMockEditor(createYDocStub());
+      applyRemoteConverterMetadata(editor, 'numbering', null);
+      expect(editor.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isApplyingRemoteConverterMetadata', () => {
+    it('returns false by default', () => {
+      expect(isApplyingRemoteConverterMetadata()).toBe(false);
+    });
+
+    it('returns true while applying, false after tick', () => {
+      const editor = createMockEditor(createYDocStub());
+
+      let timeoutCallback;
+      vi.spyOn(global, 'setTimeout').mockImplementation((cb) => {
+        timeoutCallback = cb;
+        return 1;
+      });
+
+      applyRemoteConverterMetadata(editor, 'styles', {
+        translatedLinkedStyles: {},
+      });
+
+      expect(isApplyingRemoteConverterMetadata()).toBe(true);
+      timeoutCallback();
+      expect(isApplyingRemoteConverterMetadata()).toBe(false);
+
+      vi.restoreAllMocks();
+    });
+  });
+
+  describe('pushAllConverterMetadata', () => {
+    it('pushes all registered keys', () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc);
+
+      pushAllConverterMetadata(editor);
+
+      // Should push once per key
+      expect(ydoc._maps.converterMeta.set).toHaveBeenCalledTimes(CONVERTER_META_KEYS.length);
+    });
+  });
+
+  describe('pushAllHeaderFooterToYjs', () => {
+    it('pushes all headers and footers from converter', () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc);
+      editor.converter.headers = {
+        rId1: { type: 'doc', content: [{ type: 'paragraph' }] },
+      };
+      editor.converter.footers = {
+        rId2: { type: 'doc', content: [{ type: 'paragraph' }] },
+      };
+
+      pushAllHeaderFooterToYjs(editor);
+
+      expect(ydoc._maps.headerFooterJson.set).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips empty entries', () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc);
+      editor.converter.headers = { rId1: null };
+
+      pushAllHeaderFooterToYjs(editor);
+
+      expect(ydoc._maps.headerFooterJson.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('end-to-end: two collaborators', () => {
+    it('syncs numbering changes from User A to User B', () => {
+      const sharedYdoc = createYDocStub();
+      const editorA = createMockEditor(sharedYdoc);
+      editorA.converter.translatedNumbering = {
+        abstracts: { 0: { levels: [{ indent: { left: 48, hanging: 24 } }] } },
+        definitions: { 1: { abstractNumId: '0' } },
+      };
+
+      const editorB = createMockEditor(sharedYdoc);
+
+      // A pushes
+      pushConverterMetadata(editorA, 'numbering');
+
+      // Simulate Y.js propagating to B
+      const pushed = sharedYdoc._maps.converterMeta.store.get('numbering');
+      applyRemoteConverterMetadata(editorB, 'numbering', pushed);
+
+      expect(editorB.converter.translatedNumbering).toEqual(editorA.converter.translatedNumbering);
+    });
+
+    it('syncs style changes from User A to User B', () => {
+      const sharedYdoc = createYDocStub();
+      const editorA = createMockEditor(sharedYdoc);
+      editorA.converter.translatedLinkedStyles = {
+        docDefaults: { runProperties: { fontSize: 28 } },
+        styles: { Normal: {} },
+      };
+
+      const editorB = createMockEditor(sharedYdoc);
+
+      pushConverterMetadata(editorA, 'styles');
+      const pushed = sharedYdoc._maps.converterMeta.store.get('styles');
+      applyRemoteConverterMetadata(editorB, 'styles', pushed);
+
+      expect(editorB.converter.translatedLinkedStyles).toEqual(editorA.converter.translatedLinkedStyles);
+    });
+
+    it('prevents ping-pong loop', async () => {
+      const ydoc = createYDocStub();
+      const editor = createMockEditor(ydoc);
+
+      applyRemoteConverterMetadata(editor, 'numbering', {
+        numbering: {},
+        translatedNumbering: {},
+      });
+
+      // Push blocked during apply
+      pushConverterMetadata(editor, 'numbering');
+      expect(ydoc.transact).not.toHaveBeenCalled();
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Push works after flag clears
+      pushConverterMetadata(editor, 'numbering');
+      expect(ydoc.transact).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/super-editor/src/extensions/collaboration/collaboration.js
+++ b/packages/super-editor/src/extensions/collaboration/collaboration.js
@@ -2,7 +2,15 @@ import { Extension } from '@core/index.js';
 import { PluginKey } from 'prosemirror-state';
 import { encodeStateAsUpdate } from 'yjs';
 import { ySyncPlugin, ySyncPluginKey, yUndoPluginKey, prosemirrorToYDoc } from 'y-prosemirror';
-import { updateYdocDocxData, applyRemoteHeaderFooterChanges } from '@extensions/collaboration/collaboration-helpers.js';
+import {
+  updateYdocDocxData,
+  applyRemoteHeaderFooterChanges,
+  pushAllHeaderFooterToYjs,
+  CONVERTER_META_KEYS,
+  pushConverterMetadata,
+  pushAllConverterMetadata,
+  applyRemoteConverterMetadata,
+} from '@extensions/collaboration/collaboration-helpers.js';
 
 export const CollaborationPluginKey = new PluginKey('collaboration');
 const headlessBindingStateByEditor = new WeakMap();
@@ -60,7 +68,6 @@ export const Collaboration = Extension.create({
     // Observer for remote header/footer JSON changes
     const headerFooterMap = this.options.ydoc.getMap('headerFooterJson');
     const headerFooterMapObserver = (event) => {
-      // Only process remote changes (not our own)
       if (event.transaction.local) return;
 
       event.changes.keys.forEach((change, key) => {
@@ -74,6 +81,48 @@ export const Collaboration = Extension.create({
     };
     headerFooterMap.observe(headerFooterMapObserver);
 
+    // Apply existing headerFooterJson data that arrived via Y.js sync
+    // before the observer was attached. Observers only fire for future
+    // changes, so data already present at join time would be missed.
+    if (typeof headerFooterMap.forEach === 'function') {
+      headerFooterMap.forEach((data, key) => {
+        if (data) {
+          applyRemoteHeaderFooterChanges(this.editor, key, data);
+        }
+      });
+    }
+
+    // Unified converter metadata sync (numbering, styles, and future types).
+    // ONE map, ONE observer — adding a new type only requires a key + trigger.
+    const converterMetaMap = this.options.ydoc.getMap('converterMeta');
+    const converterMetaObserver = (event) => {
+      if (event.transaction.local) return;
+      event.changes.keys.forEach((change, key) => {
+        if (change.action === 'add' || change.action === 'update') {
+          const data = converterMetaMap.get(key);
+          if (data) {
+            applyRemoteConverterMetadata(this.editor, key, data);
+          }
+        }
+      });
+    };
+    converterMetaMap.observe(converterMetaObserver);
+
+    // Apply existing converter metadata (handles join-after-sync timing)
+    for (const key of CONVERTER_META_KEYS) {
+      const data = converterMetaMap.get(key);
+      if (data) applyRemoteConverterMetadata(this.editor, key, data);
+    }
+
+    // Push triggers: local changes → Y.js map
+    const editorEventHandlers = {
+      'list-definitions-change': () => pushConverterMetadata(this.editor, 'numbering'),
+      stylesDefaultsChanged: () => pushConverterMetadata(this.editor, 'styles'),
+    };
+    for (const [event, handler] of Object.entries(editorEventHandlers)) {
+      this.editor.on(event, handler);
+    }
+
     // Store cleanup references in a non-reactive WeakMap (NOT this.options)
     // to avoid Vue's deep traverse hitting circular references in Y.js Maps.
     collaborationCleanupByEditor.set(this.editor, {
@@ -81,6 +130,9 @@ export const Collaboration = Extension.create({
       metaMapObserver,
       headerFooterMap,
       headerFooterMapObserver,
+      converterMetaMap,
+      converterMetaObserver,
+      editorEventHandlers,
       documentListenerCleanup,
     });
 
@@ -109,6 +161,12 @@ export const Collaboration = Extension.create({
     // Clean up Y.js map observers to prevent memory leaks
     cleanup.metaMap.unobserve(cleanup.metaMapObserver);
     cleanup.headerFooterMap.unobserve(cleanup.headerFooterMapObserver);
+    cleanup.converterMetaMap.unobserve(cleanup.converterMetaObserver);
+
+    // Clean up editor event listeners for push triggers
+    for (const [event, handler] of Object.entries(cleanup.editorEventHandlers)) {
+      this.editor.off(event, handler);
+    }
 
     // Clean up ydoc afterTransaction listener and debounce timer
     cleanup.documentListenerCleanup();
@@ -150,6 +208,13 @@ export const initializeMetaMap = (ydoc, editor) => {
     seededAt: new Date().toISOString(),
     source: 'browser',
   });
+
+  // Push initial converter metadata so joining clients get headers,
+  // numbering, and styles immediately (not just via 30s DOCX sync).
+  if (editor.converter) {
+    pushAllHeaderFooterToYjs(editor);
+    pushAllConverterMetadata(editor);
+  }
 
   const mediaMap = ydoc.getMap('media');
   Object.entries(editor.options.mediaFiles).forEach(([key, value]) => {

--- a/packages/super-editor/src/extensions/collaboration/collaboration.test.js
+++ b/packages/super-editor/src/extensions/collaboration/collaboration.test.js
@@ -61,19 +61,22 @@ const createYDocStub = ({ docxValue, hasDocx = true } = {}) => {
   if (!hasDocx) metas.store.delete('docx');
   const media = createYMap();
   const headerFooterJson = createYMap();
+  const converterMeta = createYMap();
   const listeners = {};
+  const mapsByName = {
+    meta: metas,
+    media,
+    headerFooterJson,
+    converterMeta,
+  };
   return {
     getXmlFragment: vi.fn(() => ({ fragment: true })),
-    getMap: vi.fn((name) => {
-      if (name === 'meta') return metas;
-      if (name === 'headerFooterJson') return headerFooterJson;
-      return media;
-    }),
+    getMap: vi.fn((name) => mapsByName[name] || createYMap()),
     on: vi.fn((event, handler) => {
       listeners[event] = handler;
     }),
     transact: vi.fn((fn, meta) => fn(meta)),
-    _maps: { metas, media, headerFooterJson },
+    _maps: { metas, media, headerFooterJson, converterMeta },
     _listeners: listeners,
   };
 };
@@ -420,6 +423,8 @@ describe('collaboration extension', () => {
       },
       storage: { image: { media: {} } },
       emit: vi.fn(),
+      on: vi.fn(),
+      off: vi.fn(),
       view: { state: editorState, dispatch: vi.fn() },
     };
 
@@ -456,6 +461,8 @@ describe('collaboration extension', () => {
         },
         storage: { image: { media: {} } },
         emit: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
         view: { state: { doc: {} }, dispatch: vi.fn() },
       };
       const context = { editor, options: {} };
@@ -603,6 +610,8 @@ describe('collaboration extension', () => {
         },
         storage: { image: { media: {} } },
         emit: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
         view: { state: editorState, dispatch: vi.fn() },
       };
 
@@ -641,6 +650,8 @@ describe('collaboration extension', () => {
         },
         storage: { image: { media: {} } },
         emit: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
         view: { state: editorState, dispatch: vi.fn() },
       };
 
@@ -673,6 +684,8 @@ describe('collaboration extension', () => {
         },
         storage: { image: { media: {} } },
         emit: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
         view: { state: { doc: {} }, dispatch: vi.fn() },
       };
 
@@ -685,6 +698,8 @@ describe('collaboration extension', () => {
         },
         storage: { image: { media: {} } },
         emit: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
         view: { state: { doc: {} }, dispatch: vi.fn() },
       };
 
@@ -736,6 +751,8 @@ describe('collaboration extension', () => {
           },
         },
         emit: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
         view: { state: { doc: {} }, dispatch: vi.fn() },
       };
 
@@ -818,6 +835,8 @@ describe('collaboration extension', () => {
         },
         storage: { image: { media: {} } },
         emit: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
         view: { state: editorState, dispatch: vi.fn() },
       };
 

--- a/packages/super-editor/src/extensions/pagination/pagination-helpers.js
+++ b/packages/super-editor/src/extensions/pagination/pagination-helpers.js
@@ -343,8 +343,9 @@ export const onHeaderFooterDataUpdate = ({ editor, transaction }, mainEditor, se
     mainEditor.converter.headerFooterModified = true;
   }
 
-  // Push header/footer JSON to Yjs for real-time sync with collaborators
-  // This is lightweight (~1KB) and provides immediate visual sync
+  // Push header/footer JSON to Yjs for real-time sync with collaborators.
+  // Includes headerIds/footerIds atomically so the receiver can resolve
+  // which section types have headers/footers.
   pushHeaderFooterToYjs(mainEditor, type, sectionId, updatedData);
 
   // NOTE: We intentionally do NOT call updateYdocDocxData here.

--- a/packages/super-editor/src/extensions/paragraph/numberingPlugin.js
+++ b/packages/super-editor/src/extensions/paragraph/numberingPlugin.js
@@ -220,6 +220,11 @@ export function createNumberingPlugin(editor) {
           const definitionDetails = ListHelpers.getListDefinitionDetails({ numId, level, editor });
 
           if (!definitionDetails || Object.keys(definitionDetails).length === 0) {
+            // In collaboration, definitions may arrive after the document change.
+            // Don't clear a synced listRendering when definitions are missing locally.
+            if (editor.options?.ydoc && node.attrs.listRendering) {
+              return;
+            }
             // Treat as normal paragraph if definition is missing
             tr.setNodeAttribute(pos, 'listRendering', null);
             bumpBlockRev(node, pos);


### PR DESCRIPTION
## Demo


https://github.com/user-attachments/assets/273e7ea8-ca6a-4c07-81fe-19a4d8928230



## Problem

In collaboration mode, three types of document metadata only sync via the 30-second debounced DOCX export. This means other clients see stale or missing data for up to 30 seconds:

1. **Numbering definitions** (SD-2062) — list indent/spacing comes from numbering level definitions stored in `editor.converter.numbering`. Without them, the receiving client renders lists with wrong marker spacing (34.6px vs 10.6px).

2. **Style definitions** (SD-2040) — document default styles live in `editor.converter.translatedLinkedStyles`. The `styles.apply` API was blocked entirely during collaboration because there was no sync mechanism.

3. **Header/footer content** (SD-2040) — header content pushes to the `headerFooterJson` Y.js map on edit, but `headerIds` (the mapping that tells the layout pipeline *which* header to render for each section type) was never synced. Joining clients had header content but no way to resolve it.

## How collaboration sync works now

SuperDoc uses two real-time sync channels:

| Data | Y.js shared type | When pushed |
|------|------------------|-------------|
| Document body | `XmlFragment('supereditor')` via y-prosemirror | Every PM transaction (automatic) |
| Media files | `Map('media')` | On image upload |
| Header/footer content | `Map('headerFooterJson')` | Every header editor keystroke |
| Numbering + Styles + headerFooterIds | `Map('converterMeta')` | On `list-definitions-change`, `stylesDefaultsChanged` events |

Everything else (full DOCX XML) syncs via the debounced 30s export to `Map('meta').docx`.

## What changed

### 1. Unified converter metadata sync (`converterMeta` Y.js map)

One map, one observer, one anti-ping-pong flag for all converter metadata. Adding a new type is: add a key to `CONVERTER_META_KEYS`, add push/apply logic, add a trigger.

**Files**: `collaboration-helpers.js`, `collaboration.js`

### 2. Header/footer atomicity fix

`headerIds`/`footerIds` are now bundled into every `headerFooterJson` entry alongside the content. Before, they lived in a separate Y.js map (`converterMeta`) and could arrive in a different network message than the content. The receiver would have header content but `headerIds.default === undefined`, so the layout pipeline couldn't resolve which header to render.

**Files**: `collaboration-helpers.js` (pushHeaderFooterToYjs, applyRemoteHeaderFooterChanges)

### 3. Initial state sync on join

Y.js map observers only fire for *future* changes. Data that arrived via Y.js sync *before* the observer was attached is missed. Fixed by reading existing map entries after attaching each observer.

Also push all initial metadata during `initializeMetaMap` (first client) so joining clients get headers, numbering, and styles immediately.

**Files**: `collaboration.js`

### 4. `numberingPlugin` collaboration hardening

The numbering plugin's `appendTransaction` clears `listRendering` when definitions are missing. In collaboration, definitions may arrive slightly after the document change (different Y.js types). The plugin now preserves synced `listRendering` when `ydoc` is present and the value already exists.

**Files**: `numberingPlugin.js`

### 5. Removed `styles.apply` collaboration gate

`styles.apply` was blocked during collaboration with "Stylesheet mutations cannot be synced via Yjs." Now that styles sync via the `converterMeta` map, the gate is removed.

**Files**: `styles-adapter.ts`, `capabilities-adapter.ts`

## Test plan

- [x] Unit tests: 753 files pass, 8146 tests pass (32 new tests added)
- [x] Smoke test: editor loads and edits correctly
- [ ] Manual: open two tabs with `?collab=1&room=<name>`, create a numbered list on tab A, verify correct spacing on tab B
- [ ] Manual: type in header on tab A, verify header appears on tab B
- [ ] Manual: apply style change on tab A, verify tab B re-renders with new styles