### PR TITLE
feat(document-api): create.list compound op + find input normalization

### DIFF
--- a/packages/document-api/src/contract/operation-definitions.ts
+++ b/packages/document-api/src/contract/operation-definitions.ts
@@ -576,6 +576,22 @@ export const OPERATION_DEFINITIONS = {
     referenceDocPath: 'create/section-break.mdx',
     referenceGroup: 'create',
   },
+  'create.list': {
+    memberPath: 'create.list',
+    description:
+      'Create a new list from scratch. Creates a paragraph with optional text and converts it to a bullet or ordered list in one step.',
+    expectedResult: 'Returns a CreateListResult with the new list ID and first item address.',
+    requiresDocumentContext: true,
+    metadata: mutationOperation({
+      idempotency: 'non-idempotent',
+      supportsDryRun: true,
+      supportsTrackedMode: true,
+      possibleFailureCodes: ['INVALID_TARGET'],
+      throws: [...T_NOT_FOUND_CAPABLE, 'INVALID_TARGET', 'AMBIGUOUS_TARGET'],
+    }),
+    referenceDocPath: 'create/list.mdx',
+    referenceGroup: 'create',
+  },
 
   'sections.list': {
     memberPath: 'sections.list',

--- a/packages/document-api/src/contract/operation-registry.ts
+++ b/packages/document-api/src/contract/operation-registry.ts
@@ -19,6 +19,8 @@ import type {
   CreateParagraphResult,
   CreateHeadingInput,
   CreateHeadingResult,
+  CreateListInput,
+  CreateListResult,
 } from '../types/create.types.js';
 import type { BlocksDeleteInput, BlocksDeleteResult } from '../types/blocks.types.js';
 
@@ -598,6 +600,7 @@ export interface OperationRegistry extends FormatInlineAliasOperationRegistry {
   'create.paragraph': { input: CreateParagraphInput; options: MutationOptions; output: CreateParagraphResult };
   'create.heading': { input: CreateHeadingInput; options: MutationOptions; output: CreateHeadingResult };
   'create.sectionBreak': { input: CreateSectionBreakInput; options: MutationOptions; output: CreateSectionBreakResult };
+  'create.list': { input: CreateListInput; options: MutationOptions; output: CreateListResult };
 
   // --- lists.* ---
   'lists.list': { input: ListsListQuery | undefined; options: never; output: ListsListResult };

--- a/packages/document-api/src/create/create.ts
+++ b/packages/document-api/src/create/create.ts
@@ -7,6 +7,8 @@ import type {
   CreateHeadingInput,
   CreateHeadingResult,
   HeadingCreateLocation,
+  CreateListInput,
+  CreateListResult,
 } from '../types/create.types.js';
 import type { CreateTableInput, CreateTableResult, TableCreateLocation } from '../types/table-operations.types.js';
 import type {
@@ -22,6 +24,8 @@ import type {
   ContentControlMutationResult,
 } from '../content-controls/content-controls.types.js';
 import { DocumentApiValidationError } from '../errors.js';
+import type { ListsAdapter } from '../lists/lists.js';
+import { executeListsCreate } from '../lists/lists.js';
 
 export interface CreateApi {
   paragraph(input: CreateParagraphInput, options?: MutationOptions): CreateParagraphResult;
@@ -31,9 +35,10 @@ export interface CreateApi {
   tableOfContents(input: CreateTableOfContentsInput, options?: MutationOptions): CreateTableOfContentsResult;
   image(input: CreateImageInput, options?: MutationOptions): CreateImageResult;
   contentControl(input: CreateContentControlInput, options?: MutationOptions): ContentControlMutationResult;
+  list(input: CreateListInput, options?: MutationOptions): CreateListResult;
 }
 
-export type CreateAdapter = CreateApi;
+export type CreateAdapter = Omit<CreateApi, 'list'>;
 
 /**
  * Validates target-only create locations (paragraph, heading, section break)
@@ -248,4 +253,43 @@ export function executeCreateTableOfContents(
 
   validateTargetOnlyCreateLocation(at, 'create.tableOfContents');
   return adapter.tableOfContents(normalized, normalizeMutationOptions(options));
+}
+
+/**
+ * Compound operation: creates a paragraph and converts it to a list.
+ *
+ * This avoids the two-step dance consumers otherwise need:
+ * 1. `create.paragraph` → grab the address
+ * 2. `lists.create` with `mode: 'fromParagraphs'`
+ */
+export function executeCreateList(
+  createAdapter: CreateAdapter,
+  listsAdapter: ListsAdapter,
+  input: CreateListInput,
+  options?: MutationOptions,
+): CreateListResult {
+  const normalizedOptions = normalizeMutationOptions(options);
+
+  // Step 1: Create a paragraph
+  const paragraphResult = executeCreateParagraph(
+    createAdapter,
+    { text: input.text ?? '', at: input.at },
+    normalizedOptions,
+  );
+  if (!paragraphResult.success) {
+    return { success: false, failure: paragraphResult.failure };
+  }
+
+  // Step 2: Convert the paragraph to a list
+  const listResult = executeListsCreate(
+    listsAdapter,
+    {
+      mode: 'fromParagraphs',
+      target: paragraphResult.paragraph,
+      kind: input.kind ?? 'bullet',
+    },
+    normalizedOptions,
+  );
+
+  return listResult as CreateListResult;
 }

--- a/packages/document-api/src/find/find.ts
+++ b/packages/document-api/src/find/find.ts
@@ -92,14 +92,61 @@ export function normalizeFindQuery(selectorOrQuery: Selector | Query, options?: 
 }
 
 /**
+ * Normalizes an SDFindInput, handling:
+ * - Flat selectors (no `select` wrapper): `{ type: 'node', nodeKind: 'table' }` → `{ select: { type: 'node', nodeKind: 'table' } }`
+ * - `nodeType` alias for `nodeKind` in node selectors
+ */
+function normalizeSDFindInput(input: Record<string, unknown>): SDFindInput {
+  // If no `select` wrapper, treat the input itself as a flat selector + pagination
+  let select: Record<string, unknown>;
+  let rest: Record<string, unknown>;
+
+  if ('select' in input && input.select != null && typeof input.select === 'object') {
+    select = input.select as Record<string, unknown>;
+    rest = input;
+  } else if ('type' in input) {
+    // Flat selector — extract selector fields from the top-level input
+    const { type, nodeKind, nodeType, kind, pattern, mode, caseSensitive, ...pagination } = input as Record<
+      string,
+      unknown
+    >;
+    select = { type };
+    if (nodeKind != null) select.nodeKind = nodeKind;
+    if (nodeType != null) select.nodeKind ??= nodeType;
+    if (kind != null) select.kind = kind;
+    if (pattern != null) select.pattern = pattern;
+    if (mode != null) select.mode = mode;
+    if (caseSensitive != null) select.caseSensitive = caseSensitive;
+    rest = { ...pagination, select };
+  } else {
+    return input as SDFindInput;
+  }
+
+  // Accept `nodeType` as alias for `nodeKind` in node selectors
+  if (select.type === 'node' && select.nodeType != null && select.nodeKind == null) {
+    select.nodeKind = select.nodeType;
+    delete select.nodeType;
+  }
+
+  if (rest.select !== select) {
+    return { ...rest, select } as unknown as SDFindInput;
+  }
+  return rest as unknown as SDFindInput;
+}
+
+/**
  * Executes an SDM/1 find operation via the adapter.
  *
+ * Normalizes the input to accept:
+ * - Flat selectors without a `select` wrapper
+ * - `nodeType` as an alias for `nodeKind`
+ *
  * @param adapter - The engine-specific find adapter.
- * @param input - The SDFindInput to execute.
+ * @param input - The SDFindInput to execute (or a flat selector).
  * @returns An SDFindResult envelope.
  */
 export function executeFind(adapter: FindAdapter, input: SDFindInput): SDFindResult {
-  return adapter.find(input);
+  return adapter.find(normalizeSDFindInput(input as unknown as Record<string, unknown>));
 }
 
 /**

--- a/packages/document-api/src/index.ts
+++ b/packages/document-api/src/index.ts
@@ -181,11 +181,17 @@ import {
   executeCreateTable,
   executeCreateSectionBreak,
   executeCreateTableOfContents,
+  executeCreateList,
 } from './create/create.js';
 import type { BlocksAdapter, BlocksApi } from './blocks/blocks.js';
 import { executeBlocksDelete } from './blocks/blocks.js';
 import type { BlocksDeleteInput, BlocksDeleteResult } from './types/blocks.types.js';
-import type { CreateHeadingInput, CreateHeadingResult } from './types/create.types.js';
+import type {
+  CreateHeadingInput,
+  CreateHeadingResult,
+  CreateListInput,
+  CreateListResult,
+} from './types/create.types.js';
 import type {
   CreateTableInput,
   CreateTableResult,
@@ -1812,6 +1818,9 @@ export function createDocumentApi(adapters: DocumentApiAdapters): DocumentApi {
       },
       contentControl(input: CreateContentControlInput, options?: MutationOptions): ContentControlMutationResult {
         return executeCreateContentControl(adapters.contentControls, input, options);
+      },
+      list(input: CreateListInput, options?: MutationOptions): CreateListResult {
+        return executeCreateList(adapters.create, adapters.lists, input, options);
       },
     },
     capabilities,

--- a/packages/document-api/src/invoke/invoke.ts
+++ b/packages/document-api/src/invoke/invoke.ts
@@ -111,6 +111,7 @@ export function buildDispatchTable(api: DocumentApi): TypedDispatchTable {
     'create.paragraph': (input, options) => api.create.paragraph(input, options),
     'create.heading': (input, options) => api.create.heading(input, options),
     'create.sectionBreak': (input, options) => api.create.sectionBreak(input, options),
+    'create.list': (input, options) => api.create.list(input, options),
 
     // --- lists.* ---
     'lists.list': (input) => api.lists.list(input),

--- a/packages/document-api/src/types/create.types.ts
+++ b/packages/document-api/src/types/create.types.ts
@@ -50,3 +50,24 @@ export interface CreateHeadingFailureResult {
 }
 
 export type CreateHeadingResult = CreateHeadingSuccessResult | CreateHeadingFailureResult;
+
+export type ListCreateLocation = ParagraphCreateLocation;
+
+export interface CreateListInput {
+  text?: string;
+  kind?: 'bullet' | 'ordered';
+  at?: ListCreateLocation;
+}
+
+export interface CreateListSuccessResult {
+  success: true;
+  listId: string;
+  item: BlockNodeAddress;
+}
+
+export interface CreateListFailureResult {
+  success: false;
+  failure: ReceiptFailure;
+}
+
+export type CreateListResult = CreateListSuccessResult | CreateListFailureResult;


### PR DESCRIPTION
- **`create.list` compound operation** — creates a paragraph and converts it to a list in one step, enabling the llm-tools router to create lists in a single dispatch call instead of requiring two separate operations
- **`normalizeSDFindInput`** — defensive ergonomic layer in `executeFind` that accepts flat selectors (without `select` wrapper) and `nodeType` as an alias for `nodeKind`, preventing silent mismatches that caused find to return all nodes instead of filtering