### PR TITLE
perf(presentation-editor): progressive rendering for large doc cold load (SD-2172)

### DIFF
--- a/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
@@ -254,6 +254,20 @@ export class PresentationEditor extends EventEmitter {
   } as const;
 
   /**
+   * Progressive rendering: number of blocks to measure and paint in Phase 1 (initial cold load).
+   * Documents with more blocks than this trigger a two-phase render: Phase 1 lays out the first
+   * batch immediately so users see content quickly; Phase 2 (queued automatically via
+   * `#pendingDocChange`) completes the full layout.
+   *
+   * Note: Phase 1 emits `layoutUpdated`/`paginationUpdate` with a partial layout covering only
+   * the first batch. Layout-driven APIs (e.g. `goToAnchor`) may return incomplete results
+   * until Phase 2 completes. See SD-2173 for full-document measurement optimizations.
+   *
+   * Chosen to cover ~2–3 pages of typical document content.
+   */
+  static readonly #PROGRESSIVE_FIRST_BATCH_SIZE = 200;
+
+  /**
    * Get a PresentationEditor instance by document ID.
    */
   static getInstance(documentId: string): PresentationEditor | undefined {
@@ -296,6 +310,8 @@ export class PresentationEditor extends EventEmitter {
   #pendingDocChange = false;
   #pendingMapping: Mapping | null = null;
   #isRerendering = false;
+  /** Whether the initial progressive render (Phase 1) has been completed. */
+  #progressiveRenderDone = false;
   #selectionSync = new SelectionSyncCoordinator();
   #epochMapper = new EpochPositionMapper();
   #layoutEpoch = 0;
@@ -3504,7 +3520,7 @@ export class PresentationEditor extends EventEmitter {
       const semanticFootnoteBlocks = isSemanticFlow
         ? buildSemanticFootnoteBlocks(footnotesLayoutInput, this.#layoutOptions.semanticOptions?.footnotesMode)
         : [];
-      const blocksForLayout = semanticFootnoteBlocks.length > 0 ? [...blocks, ...semanticFootnoteBlocks] : blocks;
+      let blocksForLayout = semanticFootnoteBlocks.length > 0 ? [...blocks, ...semanticFootnoteBlocks] : blocks;
       const layoutOptions =
         !isSemanticFlow && footnotesLayoutInput
           ? { ...baseLayoutOptions, footnotes: footnotesLayoutInput }
@@ -3512,6 +3528,16 @@ export class PresentationEditor extends EventEmitter {
       const previousBlocks = this.#layoutState.blocks;
       const previousLayout = this.#layoutState.layout;
       const previousMeasures = this.#layoutState.measures;
+
+      // Progressive rendering for initial cold load of large documents (SD-2172).
+      // Phase 1: measure and paint the first batch of blocks immediately so users see
+      // content quickly. Phase 2 (full layout) is queued automatically — it benefits
+      // from Phase 1's warm measureCache, so only the remaining blocks need measurement.
+      if (!this.#progressiveRenderDone && blocksForLayout.length > PresentationEditor.#PROGRESSIVE_FIRST_BATCH_SIZE) {
+        blocksForLayout = blocksForLayout.slice(0, PresentationEditor.#PROGRESSIVE_FIRST_BATCH_SIZE);
+        this.#progressiveRenderDone = true;
+        this.#pendingDocChange = true; // queue Phase 2
+      }
 
       let layout: Layout;
       let measures: Measure[];

--- a/packages/super-editor/src/core/presentation-editor/tests/PresentationEditor.test.ts
+++ b/packages/super-editor/src/core/presentation-editor/tests/PresentationEditor.test.ts
@@ -4122,4 +4122,94 @@ describe('PresentationEditor', () => {
       });
     });
   });
+
+  describe('progressive rendering (SD-2172)', () => {
+    const BATCH_SIZE = 201; // one more than the threshold to trigger progressive mode
+
+    const makeBlocks = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({ kind: 'paragraph', id: `block-${i}`, runs: [], attrs: {} }));
+
+    const waitForRender = () => new Promise((resolve) => setTimeout(resolve, 150));
+
+    it('renders only the first batch on initial load when block count exceeds the threshold', async () => {
+      mockToFlowBlocks.mockReturnValue({ blocks: makeBlocks(BATCH_SIZE), bookmarks: new Map() });
+      mockIncrementalLayout.mockResolvedValue({ layout: { pages: [] }, measures: [] });
+
+      editor = new PresentationEditor({ element: container, documentId: 'progressive-test' });
+
+      // Wait for Phase 1 to complete
+      await waitForRender();
+
+      // Phase 1 should have called incrementalLayout with only the first 200 blocks
+      const firstCallBlocks = mockIncrementalLayout.mock.calls[0]?.[2];
+      expect(firstCallBlocks).toBeDefined();
+      expect(firstCallBlocks.length).toBe(200);
+    });
+
+    it('queues and completes Phase 2 with the full block set after Phase 1', async () => {
+      mockToFlowBlocks.mockReturnValue({ blocks: makeBlocks(BATCH_SIZE), bookmarks: new Map() });
+      mockIncrementalLayout.mockResolvedValue({ layout: { pages: [] }, measures: [] });
+
+      editor = new PresentationEditor({ element: container, documentId: 'progressive-phase2-test' });
+
+      // Wait for both phases to settle
+      await waitForRender();
+
+      // There should have been at least 2 incrementalLayout calls: Phase 1 (200 blocks) + Phase 2 (full)
+      expect(mockIncrementalLayout.mock.calls.length).toBeGreaterThanOrEqual(2);
+      const lastCallBlocks = mockIncrementalLayout.mock.calls[mockIncrementalLayout.mock.calls.length - 1]?.[2];
+      expect(lastCallBlocks).toBeDefined();
+      expect(lastCallBlocks.length).toBe(BATCH_SIZE);
+    });
+
+    it('does not trigger progressive rendering when block count is at or below the threshold', async () => {
+      // Exactly 200 blocks — should NOT split into phases
+      mockToFlowBlocks.mockReturnValue({ blocks: makeBlocks(200), bookmarks: new Map() });
+      mockIncrementalLayout.mockResolvedValue({ layout: { pages: [] }, measures: [] });
+
+      editor = new PresentationEditor({ element: container, documentId: 'progressive-no-split-test' });
+
+      await waitForRender();
+
+      // Every incrementalLayout call should have received all 200 blocks
+      for (const call of mockIncrementalLayout.mock.calls) {
+        const callBlocks = call[2];
+        if (callBlocks) {
+          expect(callBlocks.length).toBe(200);
+        }
+      }
+    });
+
+    it('does not re-trigger progressive rendering on subsequent doc updates', async () => {
+      mockToFlowBlocks.mockReturnValue({ blocks: makeBlocks(BATCH_SIZE), bookmarks: new Map() });
+      mockIncrementalLayout.mockResolvedValue({ layout: { pages: [] }, measures: [] });
+
+      editor = new PresentationEditor({ element: container, documentId: 'progressive-once-test' });
+
+      // Wait for both phases
+      await waitForRender();
+
+      const callsAfterInit = mockIncrementalLayout.mock.calls.length;
+
+      // Simulate a follow-up doc update
+      const mockEditorInstance = (Editor as unknown as MockedEditor).mock.results[
+        (Editor as unknown as MockedEditor).mock.results.length - 1
+      ].value;
+      const onCalls = mockEditorInstance.on as unknown as Mock;
+      const updateCall = onCalls.mock.calls.find((call: unknown[]) => call[0] === 'update');
+      const handleUpdate = updateCall?.[1] as (payload: { transaction: { docChanged: boolean } }) => void;
+      handleUpdate({ transaction: { docChanged: true } });
+
+      await waitForRender();
+
+      // The follow-up update should send all blocks (progressive flag is already done)
+      const callsAfterUpdate = mockIncrementalLayout.mock.calls.slice(callsAfterInit);
+      for (const call of callsAfterUpdate) {
+        const callBlocks = call[2];
+        if (callBlocks) {
+          expect(callBlocks.length).toBe(BATCH_SIZE);
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
Split initial layout into two phases for documents exceeding 200 blocks:
- Phase 1: measure and paint the first batch immediately (~72ms vs ~1.2s)
- Phase 2: full layout queued automatically via `#pendingDocChange`, benefits from Phase 1's warm `FlowBlockCache` and MeasureCache

Known limitation: Phase 1 emits `layoutUpdated/paginationUpdate` with a partial layout. Layout-driven APIs (e.g. `goToAnchor`) may return incomplete results until Phase 2 completes. See SD-2173 for further optimizations.