### PR TITLE
feat(layout): implement AutoFit table layout algorithm (SD-2174)

### DIFF
--- a/packages/layout-engine/measuring/dom/src/index.test.ts
+++ b/packages/layout-engine/measuring/dom/src/index.test.ts
@@ -5474,5 +5474,52 @@ describe('measureBlock', () => {
       // The wider content column should get a proportionally larger share
       expect(tableMeasure.columnWidths[1]).toBeGreaterThan(tableMeasure.columnWidths[0]);
     });
+
+    it('skips AutoFit when grid widths are reasonable (not placeholder values)', async () => {
+      // Grid total = 400px, maxWidth = 600px → 66% of page width.
+      // This is well above the 10% placeholder threshold, so AutoFit should NOT run.
+      // Columns should keep their original grid widths even if content is wider.
+      const block: FlowBlock = {
+        kind: 'table',
+        id: 'autofit-skip-reasonable',
+        rows: [
+          {
+            id: 'row-0',
+            cells: [
+              {
+                id: 'cell-0-0',
+                blocks: [
+                  {
+                    kind: 'paragraph',
+                    id: 'para-0',
+                    runs: [{ text: 'VeryWideContentThatExceedsColumnWidth', fontFamily: 'Arial', fontSize: 12 }],
+                  },
+                ],
+              },
+              {
+                id: 'cell-0-1',
+                blocks: [
+                  {
+                    kind: 'paragraph',
+                    id: 'para-1',
+                    runs: [{ text: 'Short', fontFamily: 'Arial', fontSize: 12 }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        columnWidths: [200, 200], // Reasonable grid widths (400/600 = 66%)
+      };
+
+      const measure = await measureBlock(block, { maxWidth: 600 });
+
+      expect(measure.kind).toBe('table');
+      const tableMeasure = measure as TableMeasure;
+
+      // Grid widths should be preserved — AutoFit should not have run
+      expect(tableMeasure.columnWidths[0]).toBe(200);
+      expect(tableMeasure.columnWidths[1]).toBe(200);
+    });
   });
 });

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -2611,9 +2611,29 @@ async function measureTableBlock(block: TableBlock, constraints: MeasureConstrai
   //   2. Use max content widths as target column widths
   //   3. If total exceeds available width, proportionally scale down
   //   4. Table can grow up to page width to accommodate content
+  //
+  // IMPORTANT — INTENTIONALLY LIMITED SCOPE (SD-2174):
+  // We only apply AutoFit when the grid column widths are clearly placeholder values
+  // (total grid width < 10% of available page width). Some DOCX generators (e.g. non-Word
+  // tools) emit dummy w:gridCol values like w=100 for every column, paired with a tiny
+  // w:tblW percentage, producing columns of ~7px that render as vertical slivers.
+  //
+  // A full AutoFit implementation would run on ALL non-fixed tables, but doing so today
+  // changes the layout of ~30 documents in our test corpus because the rest of the table
+  // pipeline (grid priority, percentage width scaling, cell measurement) was built without
+  // AutoFit in mind. Broadening this to all tables requires:
+  //   - VRT baselines for every affected document
+  //   - Verifying each change improves Word parity (not just "different")
+  //   - Possibly adjusting the column width priority logic in pm-adapter
+  //
+  // Until then, we only rescue tables that are clearly broken. If you're here because a
+  // table renders too narrow, consider lowering the threshold or removing this gate — but
+  // run pnpm test:layout first to understand the blast radius.
   const isFixedLayout = block.attrs?.tableLayout === 'fixed';
+  const totalGridWidth = columnWidths.reduce((a, b) => a + b, 0);
+  const gridLooksLikePlaceholder = totalGridWidth < maxWidth * 0.1;
 
-  if (!isFixedLayout) {
+  if (!isFixedLayout && gridLooksLikePlaceholder) {
     const gridColCount = columnWidths.length;
     const maxContentWidths = new Array(gridColCount).fill(0);
 


### PR DESCRIPTION
Some DOCX files (often from non-Word tools) use tiny placeholder column widths, making tables render as unreadable vertical slivers. This PR detects those broken grids and resizes columns to fit their content — matching how Word handles it.

- Added content-based column sizing in the table measurement step
- Columns expand to fit their widest content, up to page width
- If everything is too wide, columns shrink proportionally to fit
- Works with text, images, lists, and nested tables

Applying this to all tables changes ~30 documents in our test corpus. We have not verified those changes against Word yet, so this only kicks in when columns are clearly broken (total grid width < 10% of page width). The code comments explain how to broaden it later.

## Tests

<img width="815" height="187" alt="image" src="https://github.com/user-attachments/assets/3bed4e1c-e0c8-4da7-8d0b-a26cfbded629" />
<img width="827" height="357" alt="image" src="https://github.com/user-attachments/assets/354b54b8-1869-4044-9679-55b16e4de927" />
