### PR TITLE
fix: handle null declaration in DocxExporter to prevent export crash

### DIFF
--- a/packages/super-editor/src/core/super-converter/exporter.js
+++ b/packages/super-editor/src/core/super-converter/exporter.js
@@ -577,7 +577,11 @@ export class DocxExporter {
 
   #generate_xml_as_list(data, debug = false) {
     const json = JSON.parse(JSON.stringify(data));
-    const declaration = this.converter.declaration.attributes;
+    const declaration = this.converter.declaration?.attributes ?? {
+      version: '1.0',
+      encoding: 'UTF-8',
+      standalone: 'yes',
+    };
     const xmlTag = `<?xml${Object.entries(declaration)
       .map(([key, value]) => ` ${key}="${value}"`)
       .join('')}?>`;

--- a/packages/super-editor/src/tests/export/docxExporter.test.js
+++ b/packages/super-editor/src/tests/export/docxExporter.test.js
@@ -41,6 +41,48 @@ describe('DocxExporter', () => {
     expect(xml).toContain('Format=&lt;&lt;NUM&gt;&gt;_&lt;&lt;VER&gt;&gt;');
   });
 
+  describe('null declaration handling', () => {
+    it('uses default XML declaration when converter.declaration is null', () => {
+      const exporter = new DocxExporter({ declaration: null });
+
+      const data = {
+        name: 'w:document',
+        attributes: {},
+        elements: [
+          {
+            name: 'w:t',
+            elements: [{ type: 'text', text: 'Hello' }],
+          },
+        ],
+      };
+
+      const xml = exporter.schemaToXml(data);
+
+      expect(xml).toContain('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>');
+      expect(xml).toContain('<w:t>Hello</w:t>');
+    });
+
+    it('uses default XML declaration when converter.declaration is undefined', () => {
+      const exporter = new DocxExporter({});
+
+      const data = {
+        name: 'w:document',
+        attributes: {},
+        elements: [
+          {
+            name: 'w:t',
+            elements: [{ type: 'text', text: 'Hello' }],
+          },
+        ],
+      };
+
+      const xml = exporter.schemaToXml(data);
+
+      expect(xml).toContain('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>');
+      expect(xml).toContain('<w:t>Hello</w:t>');
+    });
+  });
+
   it('encodes all ampersands in text nodes including entity-like sequences', () => {
     const exporter = new DocxExporter(createConverterStub());
 


### PR DESCRIPTION
## Summary

- Fixes `TypeError: Cannot read properties of null (reading 'attributes')` crash when exporting a SuperDoc to DOCX
- The crash occurs in `DocxExporter.#generate_xml_as_list` when `converter.declaration` is null — which happens for documents created/edited via Yjs collaboration that were never initialized from raw XML
- Adds optional chaining and a standard XML declaration fallback (`version="1.0" encoding="UTF-8" standalone="yes"`)

## Root Cause

`exporter.js` line 580 accessed `this.converter.declaration.attributes` without a null check. `SuperConverter.declaration` is initialized as `null` in the constructor and only populated in `parseFromXml()`, which isn't called for Yjs-only documents.

## Test plan

- [x] Added unit tests for null and undefined declaration cases
- [ ] Verify exporting the specific failing superdoc to DOCX produces a valid file that opens in Word
- [ ] Confirm the fallback encoding (UTF-8 uppercase) is compatible with downstream consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)