### PR TITLE
fix(super-editor): guard against style definition nodes without elements

### DIFF
--- a/packages/super-editor/src/core/super-converter/docx-helpers/get-default-style-definition.js
+++ b/packages/super-editor/src/core/super-converter/docx-helpers/get-default-style-definition.js
@@ -24,6 +24,8 @@ export const getDefaultStyleDefinition = (defaultStyleId, docx) => {
   const firstMatch = elementsWithId[0];
   if (!firstMatch) return result;
 
+  if (!firstMatch.elements) return result;
+
   const qFormat = elementsWithId.find((el) => {
     const qFormat = el.elements.find((innerEl) => innerEl.name === 'w:qFormat');
     return qFormat;

--- a/packages/super-editor/src/core/super-converter/docx-helpers/get-default-style-definition.test.js
+++ b/packages/super-editor/src/core/super-converter/docx-helpers/get-default-style-definition.test.js
@@ -38,6 +38,28 @@ describe('getDefaultStyleDefinition', () => {
     expect(res).toEqual({ lineSpaceBefore: null, lineSpaceAfter: null });
   });
 
+  it('returns minimal object when matching style has no elements', () => {
+    const docx = {
+      'word/styles.xml': {
+        elements: [
+          {
+            elements: [
+              {
+                name: 'w:style',
+                attributes: { 'w:styleId': 'Heading1' },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const res = getDefaultStyleDefinition('Heading1', docx);
+
+    expect(res).toEqual({ lineSpaceBefore: null, lineSpaceAfter: null });
+    expect(parseMarks).not.toHaveBeenCalled();
+  });
+
   it('parses style definition with spacing, indent, flags, and marks', () => {
     const docx = {
       'word/styles.xml': {


### PR DESCRIPTION
## Summary

Prevents getDefaultStyleDefinition() from crashing when a matching style node exists in word/styles.xml but does not contain an elements array.

## What changed

- Added an early return in packages/super-editor/src/core/super-converter/docx-helpers/get-default-style-definition.js when the matched w:style node has no elements
- Added a regression test in packages/super-editor/src/core/super-converter/docx-helpers/get-default-style-definition.test.js covering that malformed/incomplete style-
definition shape
- Verified the helper returns the minimal fallback object and does not attempt to parse marks in this case

## Why

Some DOCX inputs can include a style definition node with the expected w:styleId but without child elements. Before this change, the helper assumed firstMatch.elements always existed and could throw while traversing the style definition. This makes the converter more defensive and preserves the existing fallback behavior for incomplete style data.