### PR TITLE
Fix: Don't iterate over every attributeto find w:sectPr

### DIFF
--- a/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/docxImporter.js
@@ -761,12 +761,11 @@ const importHeadersFooters = (docx, converter, mainEditor, numbering, translated
 };
 
 const findSectPr = (obj, result = []) => {
-  for (const key in obj) {
-    if (obj[key] === 'w:sectPr') {
-      result.push(obj);
-    } else if (typeof obj[key] === 'object') {
-      findSectPr(obj[key], result);
-    }
+  if (obj && obj.name === 'w:sectPr') {
+    result.push(obj);
+  }
+  if (obj.elements) {
+    obj.elements.forEach((el) => findSectPr(el, result));
   }
   return result;
 };


### PR DESCRIPTION
@harbournick I noticed you wrote this code a while back. I am not entirely sure why it was written like that - it creates this problem and so I scaled the walking mechanism back. That should save time as well. It may though be that you are trying to catch more than what I do with this. So please have a look and fix it in another way if needed. What it was doing was comparing with all values of all text fields and all other attributes, which surely isn't what we wanted.

Second reviewer @caio-pizzol
