### PR TITLE
fix(presentation-editor): arrow key scroll-into-view with unconstrained containers (SD-1950)

### DIFF
--- a/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
@@ -3075,8 +3075,10 @@ export class PresentationEditor extends EventEmitter {
    * to expand to fit all content instead of scrolling.
    *
    * After layout, we can check scrollHeight vs clientHeight. If the detected
-   * container isn't actually scrollable, we walk further up to find one that is,
-   * or fall back to window.
+   * container isn't actually scrollable AND it grew beyond the viewport (ruling
+   * out properly constrained containers that simply don't have enough content
+   * yet), we walk further up to find one that actually scrolls, or fall back
+   * to window.
    */
   #revalidateScrollContainer(): void {
     if (this.#scrollContainerValidated) return;
@@ -3085,7 +3087,14 @@ export class PresentationEditor extends EventEmitter {
     if (!(this.#scrollContainer instanceof Element)) return;
     if (this.#scrollContainer.scrollHeight > this.#scrollContainer.clientHeight + 1) return;
 
+    // A properly constrained container (e.g. height:600px; overflow:auto) may
+    // not be overflowing yet if the document is short. Its clientHeight stays
+    // within viewport bounds. Only switch when the container grew beyond the
+    // viewport — a clear sign its height is unconstrained.
     const win = this.#scrollContainer.ownerDocument?.defaultView;
+    const viewportHeight = win?.innerHeight ?? 0;
+    if (this.#scrollContainer.clientHeight <= viewportHeight) return;
+
     let el: Element | null = this.#scrollContainer.parentElement;
     let next: Element | Window | null = win ?? null;
 
@@ -3107,9 +3116,7 @@ export class PresentationEditor extends EventEmitter {
     if (next instanceof Element) {
       next.addEventListener('scroll', this.#scrollHandler!, { passive: true });
     }
-    if (this.#domPainter && next instanceof HTMLElement) {
-      this.#domPainter.setScrollContainer(next);
-    }
+    this.#domPainter?.setScrollContainer?.(next instanceof HTMLElement ? next : null);
   }
 
   /**


### PR DESCRIPTION
## Demo


https://github.com/user-attachments/assets/e2e870cd-2b3a-49d1-b7ad-344add582ba5



## Summary

Fixes [SD-1950](https://linear.app/superdocworkspace/issue/SD-1950): Arrow key up/down navigation was not auto-scrolling to keep the cursor visible when the consumer's container had `overflow: auto` but no height constraint.

## Root Cause

`#findScrollableAncestor()` detects the scroll container at setup time by walking the DOM and returning the first ancestor with `overflow-y: auto|scroll`. However, it cannot verify that the element **actually constrains content height** — content isn't laid out yet at that point.

When a consumer sets `overflow: auto` on the SuperDoc container without constraining its height (no `height`, `max-height`, or bounded flex parent), the container expands to fit all content instead of scrolling. This makes `scrollHeight === clientHeight`, meaning the element is never actually scrollable.

This caused **three cascading failures**:

| Problem | Impact |
|---|---|
| **Caret scroll-into-view** | `getBoundingClientRect()` on the ~15,000px container always contained the caret, so the scroll-down/scroll-up conditions in `#scrollScreenRectIntoView` never triggered |
| **Virtualization** | `domPainter.setScrollContainer()` received the wrong element, computing page visibility against the full expanded container instead of the actual viewport |
| **Scroll offsets** | All scroll-relative logic referenced a container that never actually scrolled |

### Reproduction

Observed in SuperDoc Labs Version Tester (v1.18.2) where `#superdoc` has `overflow: auto; flex: 1` but no height constraint in the ancestor chain. The DOM hierarchy showed:

```
#superdoc (overflow: auto, scrollHeight: 15138, clientHeight: 15138) ← detected as scroll container, but NOT actually scrollable
  ...
<html> (scrollHeight: 15326, clientHeight: 992) ← where scrolling actually happens
```

## Fix

Added `#revalidateScrollContainer()` — called **once** after the first layout completes. At that point content is laid out and we can reliably check `scrollHeight > clientHeight`.

If the initially detected scroll container isn't actually scrollable:
1. Walks further up the DOM to find an ancestor that truly constrains content
2. Falls back to `window` if none found
3. Updates scroll event listener and `domPainter.setScrollContainer()` reference

### Why this approach

- **Fixes the root cause** — corrects scroll container detection, not individual symptoms. All three problems (caret scroll, virtualization, scroll offsets) are fixed by correcting the single source of truth (`this.#scrollContainer`)
- **Non-breaking** — if the consumer properly constrains height, the revalidation is a no-op (early return on line 2: `scrollHeight > clientHeight + 1`)
- **Consumers don't need to change anything** — SuperDoc adapts to whatever container layout it's given
- **Minimal surface area** — one new method, one new boolean flag, one call site. No modifications to existing methods or APIs
- **Runs once** — guarded by `#scrollContainerValidated` flag, no per-keystroke overhead

### Changes

- **`#scrollContainerValidated`** field (line 318) — ensures revalidation runs only once
- **`#revalidateScrollContainer()`** method (lines 3068–3116) — post-layout scroll container validation
- **Call site** in `#rerender()` (line 3852) — invoked after first layout completes, before permission overlay update

## Test plan

- [x] Existing `scrollCaretIntoView.test.ts` tests pass (9/9)
- [x] Lint and format hooks pass
- [ ] Manual test: Load editor in Version Tester (v1.18.2), place cursor, press ArrowDown repeatedly — caret should remain visible with auto-scroll
- [ ] Manual test: ArrowUp near top boundary should auto-scroll upward
- [ ] Manual test: Arrow navigation inside tables should auto-scroll
- [ ] Manual test: Verify virtualization works (pages outside viewport should unmount in large documents)
- [ ] Manual test: Consumer with properly constrained container (`height: 100vh; overflow: auto`) still works as before
