### PR TITLE
docs: add Document Comparison guide and Diffing extension reference (SD-2240)

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -111,7 +111,7 @@
               },
               {
                 "group": "SDKs",
-                "pages": ["document-engine/sdks", "document-engine/sdk-diffing"]
+                "pages": ["document-engine/sdks", "guides/document-comparison/server-side"]
               },
               "document-engine/cli",
               {
@@ -160,6 +160,7 @@
                   "extensions/content-block",
                   "extensions/custom-selection",
                   "extensions/document",
+                  "extensions/diffing",
                   "extensions/document-index",
                   "extensions/dropcursor",
                   "extensions/font-family",
@@ -238,6 +239,14 @@
             "pages": [
               "guides/general/storage",
               "guides/general/stable-navigation",
+              {
+                "group": "Document Comparison",
+                "pages": [
+                  "guides/document-comparison/overview",
+                  "guides/document-comparison/client-side",
+                  "guides/document-comparison/server-side"
+                ]
+              },
               {
                 "group": "Collaboration",
                 "pages": [
@@ -405,6 +414,10 @@
     {
       "source": "/getting-started/ai-ready",
       "destination": "/getting-started/ai-agents"
+    },
+    {
+      "source": "/document-engine/sdk-diffing",
+      "destination": "/guides/document-comparison/server-side"
     },
     {
       "source": "/api-reference/documents/sign",

--- a/apps/docs/extensions/diffing.mdx
+++ b/apps/docs/extensions/diffing.mdx
@@ -1,0 +1,144 @@
+---
+title: Diffing extension
+sidebarTitle: Diffing
+description: Compare two ProseMirror documents and replay differences as tracked changes
+keywords: "diffing, document comparison, compareDocuments, replayDifferences, diff, redline"
+---
+
+Compare two documents and replay the differences as tracked changes. The `Diffing` extension is included in the starter extensions by default.
+
+For usage guides, see [Document comparison](/guides/document-comparison/overview).
+
+## Commands
+
+### compareDocuments
+
+Compares the current document against an updated document and returns the differences. Does not modify the document.
+
+<CodeGroup>
+
+```javascript Usage
+const diff = editor.commands.compareDocuments(
+  updatedDocument,       // ProseMirror Node
+  updatedComments,       // CommentInput[] (optional)
+  updatedStyles,         // StylesDocumentProperties (optional)
+  updatedNumbering,      // NumberingProperties (optional)
+);
+```
+
+```javascript Full Example
+import { SuperDoc } from 'superdoc';
+import { Editor, getStarterExtensions } from 'superdoc/super-editor';
+import 'superdoc/style.css';
+
+const superdoc = new SuperDoc({
+  selector: '#editor',
+  document: baseFile,
+  user: { name: 'Reviewer', email: 'reviewer@example.com' },
+  onReady: async (superdoc) => {
+    const editor = superdoc.activeEditor;
+
+    const [docx, media, mediaFiles, fonts] = await Editor.loadXmlData(targetFile);
+    const headless = new Editor({
+      isHeadless: true,
+      skipViewCreation: true,
+      extensions: getStarterExtensions(),
+      content: docx,
+      mode: 'docx',
+      media,
+      mediaFiles,
+      fonts,
+    });
+
+    const diff = editor.commands.compareDocuments(
+      headless.state.doc,
+      headless.converter?.comments ?? [],
+      headless.converter?.translatedLinkedStyles ?? null,
+      headless.converter?.translatedNumbering ?? null,
+    );
+
+    editor.commands.replayDifferences(diff, { applyTrackedChanges: true });
+    headless.destroy();
+  },
+});
+```
+
+</CodeGroup>
+
+**Parameters:**
+
+<ParamField path="updatedDocument" type="Node" required>
+  The ProseMirror document to compare against. Typically from a headless `Editor` instance.
+</ParamField>
+
+<ParamField path="updatedComments" type="CommentInput[]">
+  Comments from the updated document. Defaults to the current document's comments if omitted.
+</ParamField>
+
+<ParamField path="updatedStyles" type="StylesDocumentProperties | null">
+  OOXML styles from the updated document. Defaults to current styles if omitted.
+</ParamField>
+
+<ParamField path="updatedNumbering" type="NumberingProperties | null">
+  OOXML numbering from the updated document. Defaults to current numbering if omitted.
+</ParamField>
+
+**Returns:** A `DiffResult` object containing the computed differences.
+
+### replayDifferences
+
+Applies a `DiffResult` onto the current document. By default, changes are wrapped in tracked-change marks.
+
+<CodeGroup>
+
+```javascript Usage
+editor.commands.replayDifferences(diff, { applyTrackedChanges: true });
+```
+
+```javascript Full Example
+import { SuperDoc } from 'superdoc';
+import 'superdoc/style.css';
+
+const superdoc = new SuperDoc({
+  selector: '#editor',
+  document: baseFile,
+  user: { name: 'Reviewer', email: 'reviewer@example.com' },
+  onReady: (superdoc) => {
+    const editor = superdoc.activeEditor;
+
+    // diff obtained from compareDocuments
+    editor.commands.replayDifferences(diff, { applyTrackedChanges: true });
+  },
+});
+```
+
+</CodeGroup>
+
+**Parameters:**
+
+<ParamField path="diff" type="DiffResult" required>
+  The diff result from `compareDocuments`.
+</ParamField>
+
+<ParamField path="options.applyTrackedChanges" type="boolean" default="true">
+  When `true`, changes are tagged as tracked changes with author attribution. When `false`, changes are applied silently. Requires a `user` on the editor instance.
+</ParamField>
+
+## DiffResult
+
+The object returned by `compareDocuments`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `docDiffs` | `NodeDiff[]` | Block and inline structural differences |
+| `commentDiffs` | `CommentDiff[]` | Added, deleted, and modified comments |
+| `stylesDiff` | `StylesDiff \| null` | OOXML style changes |
+| `numberingDiff` | `NumberingDiff \| null` | OOXML numbering changes |
+
+Each `NodeDiff` has an `action` of `'added'`, `'deleted'`, or `'modified'`, with serialized node data and position anchors.
+
+## Source code
+
+import { SourceCodeLink } from '/snippets/components/source-code-link.jsx'
+
+<SourceCodeLink path="packages/super-editor/src/extensions/diffing/diffing.js" />

--- a/apps/docs/extensions/overview.mdx
+++ b/apps/docs/extensions/overview.mdx
@@ -53,6 +53,7 @@ Basic document capabilities:
 ### Advanced features
 Complex functionality:
 - **[Track Changes](/extensions/track-changes)** - Revision tracking
+- **[Diffing](/extensions/diffing)** - Document comparison
 - **[Comments](/extensions/comments)** - Discussions
 - **[Field Annotation](/extensions/field-annotation)** - Form fields
 - **[Document Section](/extensions/document-section)** - Locked sections

--- a/apps/docs/extensions/track-changes.mdx
+++ b/apps/docs/extensions/track-changes.mdx
@@ -285,13 +285,22 @@ const superdoc = new SuperDoc({
 
 ## Full example
 
-<Card
-  title="Track Changes Example"
-  icon="github"
-  href="https://github.com/superdoc-dev/superdoc/tree/main/examples/features/track-changes"
->
-  Runnable example with mode switching, accept/reject, and comments sidebar
-</Card>
+<CardGroup cols={2}>
+  <Card
+    title="Track Changes example"
+    icon="github"
+    href="https://github.com/superdoc-dev/superdoc/tree/main/examples/features/track-changes"
+  >
+    Runnable example with mode switching, accept/reject, and comments sidebar
+  </Card>
+  <Card
+    title="Compare documents"
+    icon="files"
+    href="/guides/document-comparison/overview"
+  >
+    Diff two DOCX files and surface differences as tracked changes
+  </Card>
+</CardGroup>
 
 ## Source code
 

--- a/apps/docs/guides/document-comparison/client-side.mdx
+++ b/apps/docs/guides/document-comparison/client-side.mdx
@@ -1,0 +1,148 @@
+---
+title: Client-side comparison
+sidebarTitle: Client-side
+description: Compare two DOCX documents in the browser and render differences as tracked changes
+keywords: "document comparison, client-side diff, browser diff, compare documents, redline, tracked changes"
+---
+
+Compare two DOCX documents in the browser using the `Diffing` extension commands. The differences are replayed onto the visible editor as tracked changes.
+
+## Quick start
+
+The core flow is three steps: parse the second document with a headless editor, compare, and replay.
+
+<CodeGroup>
+
+```javascript Usage
+// 1. Parse the second document headlessly
+const [docx, media, mediaFiles, fonts] = await Editor.loadXmlData(targetFile);
+
+const headless = new Editor({
+  isHeadless: true,
+  skipViewCreation: true,
+  extensions: getStarterExtensions(),
+  content: docx,
+  mode: 'docx',
+  media,
+  mediaFiles,
+  fonts,
+});
+
+// 2. Compare the visible editor against the headless document
+const diff = editor.commands.compareDocuments(
+  headless.state.doc,
+  headless.converter?.comments ?? [],
+  headless.converter?.translatedLinkedStyles ?? null,
+  headless.converter?.translatedNumbering ?? null,
+);
+
+// 3. Replay the differences as tracked changes
+editor.commands.replayDifferences(diff, { applyTrackedChanges: true });
+
+headless.destroy();
+```
+
+```javascript Full Example
+import { SuperDoc } from 'superdoc';
+import { Editor, getStarterExtensions } from 'superdoc/super-editor';
+import 'superdoc/style.css';
+
+const superdoc = new SuperDoc({
+  selector: '#editor',
+  document: baseFile,
+  user: { name: 'Reviewer', email: 'reviewer@example.com' },
+  onReady: async (superdoc) => {
+    const editor = superdoc.activeEditor;
+
+    // Parse the target document headlessly
+    const [docx, media, mediaFiles, fonts] = await Editor.loadXmlData(targetFile);
+
+    const headless = new Editor({
+      isHeadless: true,
+      skipViewCreation: true,
+      extensions: getStarterExtensions(),
+      content: docx,
+      mode: 'docx',
+      media,
+      mediaFiles,
+      fonts,
+    });
+
+    // Compare and replay
+    const diff = editor.commands.compareDocuments(
+      headless.state.doc,
+      headless.converter?.comments ?? [],
+      headless.converter?.translatedLinkedStyles ?? null,
+      headless.converter?.translatedNumbering ?? null,
+    );
+
+    editor.commands.replayDifferences(diff, { applyTrackedChanges: true });
+
+    headless.destroy();
+  },
+});
+```
+
+</CodeGroup>
+
+After replay, the editor shows insertions, deletions, and formatting changes as tracked changes. Users can review them with the standard [accept/reject workflow](/extensions/track-changes).
+
+## Headless editor pattern
+
+The second document needs to be parsed into a ProseMirror document tree before comparison. Create a headless `Editor` instance — no DOM, no view — just the parsed document state.
+
+```javascript
+const headless = new Editor({
+  isHeadless: true,
+  skipViewCreation: true,
+  extensions: getStarterExtensions(),
+  content: docx,
+  mode: 'docx',
+  media,
+  mediaFiles,
+  fonts,
+});
+```
+
+Extract what you need from `headless.state.doc`, `headless.converter.comments`, `headless.converter.translatedLinkedStyles`, and `headless.converter.translatedNumbering`. Then call `headless.destroy()`.
+
+## Bidirectional comparison
+
+To show changes on both sides (like the [diffing example](https://github.com/superdoc-dev/superdoc/tree/main/examples/features/diffing)), run the comparison in both directions:
+
+```javascript
+// Left editor shows what Right changed
+const leftDiff = leftEditor.commands.compareDocuments(
+  rightHeadless.state.doc,
+  rightHeadless.converter?.comments ?? [],
+  rightHeadless.converter?.translatedLinkedStyles ?? null,
+  rightHeadless.converter?.translatedNumbering ?? null,
+);
+leftEditor.commands.replayDifferences(leftDiff, { applyTrackedChanges: true });
+
+// Right editor shows what Left changed
+const rightDiff = rightEditor.commands.compareDocuments(
+  leftHeadless.state.doc,
+  leftHeadless.converter?.comments ?? [],
+  leftHeadless.converter?.translatedLinkedStyles ?? null,
+  leftHeadless.converter?.translatedNumbering ?? null,
+);
+rightEditor.commands.replayDifferences(rightDiff, { applyTrackedChanges: true });
+```
+
+## Tracked changes vs silent apply
+
+By default, `replayDifferences` wraps every change in tracked-change marks. Set `applyTrackedChanges: false` to apply changes silently — useful when you want to merge documents without review.
+
+```javascript
+// Apply silently (no tracked changes)
+editor.commands.replayDifferences(diff, { applyTrackedChanges: false });
+```
+
+<Note>
+Tracked changes require a `user` on the SuperDoc or Editor instance. Without one, changes are applied silently regardless of the option.
+</Note>
+
+## API reference
+
+See the [Diffing extension](/extensions/diffing) page for the full command signatures and `DiffResult` type.

--- a/apps/docs/guides/document-comparison/overview.mdx
+++ b/apps/docs/guides/document-comparison/overview.mdx
@@ -1,0 +1,59 @@
+---
+title: Compare documents
+sidebarTitle: Overview
+description: Compare two DOCX documents and surface every difference as tracked changes
+keywords: "document comparison, diff, diffing, redline, compare documents, tracked changes, version comparison, document review"
+---
+
+Load two DOCX documents, compare them, and see every difference as tracked changes — insertions, deletions, and formatting changes. Accept or reject each change individually, then export back to `.docx`.
+
+## How it works
+
+SuperDoc compares two documents at the paragraph level, detects what changed, and replays those changes onto the base document as tracked changes. The result looks exactly like a Word redline.
+
+1. **Compare** — Diff the document trees, comments, styles, and numbering
+2. **Replay** — Apply the differences as tracked changes with author attribution
+3. **Review** — Accept or reject each change using the standard [Track Changes](/extensions/track-changes) workflow
+
+## Two paths
+
+<CardGroup cols={2}>
+  <Card title="Client-side" icon="browser" href="/guides/document-comparison/client-side">
+    Compare documents in the browser using editor commands. Best for interactive review UIs where users pick two files and see the redline immediately.
+  </Card>
+  <Card title="Server-side" icon="server" href="/guides/document-comparison/server-side">
+    Compare documents headlessly with the Node.js or Python SDK. Best for automation — CI pipelines, webhook handlers, or batch processing.
+  </Card>
+</CardGroup>
+
+## What gets compared
+
+| Content | v1 support |
+|---------|-----------|
+| Body text and formatting | Yes |
+| Comments | Yes |
+| Styles | Yes |
+| Numbering / lists | Yes |
+| Headers and footers | Not yet |
+
+## Output
+
+The comparison produces a document based on the **base** document with all differences from the **target** surfaced as tracked changes. Comments, styles, and numbering changes are applied directly.
+
+Export the result as a `.docx` file and it opens in Microsoft Word with the tracked changes intact.
+
+## Example
+
+<Card
+  title="Diffing example"
+  icon="github"
+  href="https://github.com/superdoc-dev/superdoc/tree/main/examples/features/diffing"
+>
+  Side-by-side comparison demo with bidirectional tracked changes
+</Card>
+
+## Related
+
+- [Track Changes](/extensions/track-changes) — Accept/reject workflow for reviewed changes
+- [Diffing extension](/extensions/diffing) — API reference for `compareDocuments` and `replayDifferences`
+- [diff.capture](/document-api/reference/diff/capture), [diff.compare](/document-api/reference/diff/compare), [diff.apply](/document-api/reference/diff/apply) — Document API operations

--- a/apps/docs/guides/document-comparison/server-side.mdx
+++ b/apps/docs/guides/document-comparison/server-side.mdx
@@ -1,34 +1,23 @@
 ---
-title: SDK Diffing
-sidebarTitle: Diffing
-description: Generate tracked-change redlines from two documents with the Node.js and Python SDKs
-keywords: "sdk diffing, tracked changes, redline, compare documents, node sdk, python sdk"
+title: Server-side comparison
+sidebarTitle: Server-side
+description: Compare two DOCX documents headlessly with the Node.js and Python SDKs
+keywords: "sdk diffing, server-side diff, headless comparison, tracked changes, redline, compare documents, node sdk, python sdk"
 ---
 
-SuperDoc SDKs expose snapshot-based diffing through `doc.diff.capture`, `doc.diff.compare`, and `doc.diff.apply`.
+Compare two DOCX documents headlessly using the Node.js or Python SDK. The output is a new `.docx` file with all differences rendered as tracked changes.
 
-This page covers the main file-to-file workflow:
+## Workflow
 
-- You already have a base document, `Doc1`
-- A new document, `Doc2`, arrives later
-- You want to produce `Doc3`, which starts from `Doc1` and contains all `Doc2` changes as tracked changes
-
-## Recommended workflow
-
-Use two sessions:
-
-1. Open `Doc1` as the base session
-2. Open `Doc2` as a temporary target session
-3. Capture a diff snapshot from the target session
-4. Compare the base session against that snapshot
-5. Apply the diff back onto the base session with `changeMode: 'tracked'`
-6. Save the base session to a new output path as `Doc3`
+1. Open the base document (`Doc1`) and the target document (`Doc2`) in separate sessions
+2. Capture a diff snapshot from the target session
+3. Compare the base session against that snapshot
+4. Apply the diff onto the base session as tracked changes
+5. Save the result as a new file (`Doc3`)
 
 <Info>
 Tracked diff apply requires a user identity. Set `user` on the SDK client so tracked changes are attributed correctly.
 </Info>
-
-If your app already has `Doc1` open, keep using that session as the base session and only open the uploaded document as the temporary target session.
 
 ## Node.js
 
@@ -151,7 +140,7 @@ If the base document changes after `diff.compare` and before `diff.apply`, re-ru
 
 ## See also
 
-- [SDKs Overview](/document-engine/sdks)
-- [diff.capture reference](/document-api/reference/diff/capture)
-- [diff.compare reference](/document-api/reference/diff/compare)
-- [diff.apply reference](/document-api/reference/diff/apply)
+- [Document comparison overview](/guides/document-comparison/overview)
+- [Client-side comparison](/guides/document-comparison/client-side) — Compare documents in the browser
+- [SDKs overview](/document-engine/sdks)
+- [diff.capture](/document-api/reference/diff/capture), [diff.compare](/document-api/reference/diff/compare), [diff.apply](/document-api/reference/diff/apply) — API reference

--- a/apps/docs/modules/overview.mdx
+++ b/apps/docs/modules/overview.mdx
@@ -56,6 +56,9 @@ These features are configured at the top level rather than through `modules`, bu
   <Card title="Track Changes" icon="git-compare" href="/extensions/track-changes">
     Accept/reject workflow with `documentMode: 'suggesting'`
   </Card>
+  <Card title="Document Comparison" icon="files" href="/guides/document-comparison/overview">
+    Compare two DOCX files and surface differences as tracked changes
+  </Card>
   <Card title="AI Agents" icon="sparkles" href="/getting-started/ai-agents">
     Headless mode for server-side document processing and LLM workflows
   </Card>


### PR DESCRIPTION
Consolidate diffing documentation into a dedicated guide section with client-side and server-side paths. Add Diffing extension API reference page. Relocate sdk-diffing.mdx content with redirect. Cross-link from Track Changes, Modules overview, and Extensions overview.