### PR TITLE
fix: toolbar state after document load (SD-2145)

### DIFF
--- a/packages/super-editor/src/core/helpers/getMarksFromSelection.js
+++ b/packages/super-editor/src/core/helpers/getMarksFromSelection.js
@@ -212,9 +212,14 @@ function getParagraphRunContext($pos, editor) {
   }
 
   if (runProperties == null) {
-    const nodeAfter = $pos.nodeAfter;
-    if (nodeAfter?.type.name === 'run') {
-      runProperties = normalizeRunProperties(nodeAfter.attrs?.runProperties);
+    const nodeBefore = $pos.nodeBefore;
+    if (nodeBefore?.type.name === 'run') {
+      runProperties = normalizeRunProperties(nodeBefore.attrs?.runProperties);
+    } else {
+      const nodeAfter = $pos.nodeAfter;
+      if (nodeAfter?.type.name === 'run') {
+        runProperties = normalizeRunProperties(nodeAfter.attrs?.runProperties);
+      }
     }
   }
 

--- a/packages/super-editor/src/core/helpers/getMarksFromSelection.test.js
+++ b/packages/super-editor/src/core/helpers/getMarksFromSelection.test.js
@@ -267,6 +267,25 @@ describe('getMarksFromSelection', () => {
       expect(result.inlineMarks.some((mark) => mark.type.name === 'bold')).toBe(false);
     });
 
+    it('prefers nodeBefore run at the inter-run boundary', () => {
+      // doc(paragraph(run{bold}("AB"), run{italic}("CD")))
+      // Positions: 0=doc, 1=para, 2=run1, 3=A, 4=B, 5=boundary, 6=run2, 7=C, 8=D ...
+      // At pos 5: between the two runs at paragraph depth, nodeBefore=run1, nodeAfter=run2
+      const testDoc = runSchema.node('doc', null, [
+        runSchema.node('paragraph', null, [
+          runSchema.node('run', { runProperties: { bold: true } }, [runSchema.text('AB')]),
+          runSchema.node('run', { runProperties: { italic: true } }, [runSchema.text('CD')]),
+        ]),
+      ]);
+      const state = EditorState.create({ schema: runSchema, doc: testDoc });
+      const cursorState = state.apply(state.tr.setSelection(TextSelection.create(testDoc, 5)));
+
+      const result = getSelectionFormattingState(cursorState);
+
+      // Should inherit from the preceding run (bold), not the following run (italic)
+      expect(result.inlineRunProperties).toEqual({ bold: true });
+    });
+
     it('normalizes empty nodeAfter runProperties to null and falls back to cursor marks', () => {
       const testDoc = runSchema.node('doc', null, [
         runSchema.node('paragraph', null, [runSchema.node('run', { runProperties: {} }, [runSchema.text('Hello')])]),


### PR DESCRIPTION
- After document load, the cursor can land at the paragraph boundary (before the first `run` node) rather than inside it. The ancestor walk in `getParagraphRunContext` never finds a `run` at any depth, so `runProperties` stays null and the toolbar shows default formatting instead of the run's actual properties.
- Added a `$pos.nodeAfter` fallback: when the depth walk doesn't find a run, check whether the node immediately after the cursor is a `run` and read its properties.
- Added 4 unit tests covering the fallback: nodeAfter is a run with properties, cursor already inside a run (no fallback needed), nodeAfter is not a run, and empty runProperties normalization.