### PR TITLE
feat(superdoc): center comment and document anchor on sidebar click

### DIFF
--- a/packages/superdoc/src/components/CommentsLayer/CommentDialog.vue
+++ b/packages/superdoc/src/components/CommentsLayer/CommentDialog.vue
@@ -278,7 +278,8 @@ const hasTextContent = computed(() => {
 
 const setFocus = () => {
   const editor = proxy.$superdoc.activeEditor;
-  const targetClientY = Math.round(window.innerHeight * 0.38);
+  const COMMENT_FOCUS_VIEWPORT_RATIO = 0.38;
+  const targetClientY = Math.round(window.innerHeight * COMMENT_FOCUS_VIEWPORT_RATIO);
   const willChangeActiveThread = !props.comment.resolvedTime && activeComment.value !== props.comment.commentId;
   if (willChangeActiveThread) {
     requestInstantSidebarAlignment(targetClientY);


### PR DESCRIPTION


https://github.com/user-attachments/assets/d629a7aa-58b2-4915-83bf-e77c7f665df5



## Summary

fixes SD-2248 
https://linear.app/superdocworkspace/issue/SD-2248/bug-in-tester-tools-googleapis-and-labs-commenttc-bubbles-and-doc-do


- When clicking a comment card in the sidebar, both the document anchor and the sidebar comment now smoothly scroll to the vertical center of the viewport instead of staying at the comment's current screen position
- Document scroll uses `behavior: 'smooth'` instead of instant jump
- Sidebar alignment uses CSS transitions (non-instant path) for smooth motion
- Applies consistently to all sidebar-originated activations: direct click, comments list, thread expansion

## How it works

The entire alignment pipeline is parameterized by a single `targetClientY` value. This PR changes it from `commentDialog.getBoundingClientRect().top` (the card's current position) to `window.innerHeight * 0.38` (optical center of the viewport).

The 0.38 ratio places content slightly above true center to leave room for comment card content below. This is a tunable constant (`VIEWPORT_CENTER_RATIO`).

## What does NOT change

- "From document" clicks (clicking tracked change text) still align the sidebar to the anchor position without centering scroll
- PDF comment centering (already uses `scrollIntoView({ block: 'center' })`)
- All existing alignment infrastructure (FloatingComments watchers, collision avoidance, PresentationEditor scroll)

## Test plan

- [ ] Click a tracked change comment near the top/bottom of the sidebar. Both document text and comment card should smoothly scroll to viewport center at the same Y level
- [ ] Click a regular (non-tracked-change) comment. Same centering behavior
- [ ] Click a comment whose anchor is on the first/last page. Scroll should clamp gracefully
- [ ] Click tracked change text in the document body. Sidebar should align to anchor Y without centering scroll (unchanged)
- [ ] Click "N more replies" on a thread. Thread should expand and center
- [ ] Click several different comments rapidly. No stale positioning artifacts