### PR TITLE
fix(super-editor): prevent cursor jump when changing font from toolbar

### DIFF
--- a/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/core/presentation-editor/PresentationEditor.ts
@@ -753,6 +753,7 @@ export class PresentationEditor extends EventEmitter {
 
       const beforeX = win.scrollX;
       const beforeY = win.scrollY;
+      const alreadyFocused = view.hasFocus();
       let focused = false;
 
       // Strategy 1: Try focus with preventScroll option (modern browsers)
@@ -789,6 +790,16 @@ export class PresentationEditor extends EventEmitter {
             strategy: 'original',
           });
         }
+      }
+
+      // When the editor was not focused before, the browser places the DOM selection
+      // at an arbitrary position inside the off-screen contenteditable. ProseMirror's
+      // DOMObserver would read this stale position via a selectionchange event and
+      // overwrite PM state, causing the cursor to jump. Suppress selection updates
+      // for the next 50ms so PM re-applies its own selection to the DOM instead.
+      if (!alreadyFocused) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (view as any).domObserver.suppressSelectionUpdates();
       }
 
       // Restore scroll position if any focus attempt changed it

--- a/packages/super-editor/src/core/presentation-editor/tests/PresentationEditor.draggableFocus.test.ts
+++ b/packages/super-editor/src/core/presentation-editor/tests/PresentationEditor.draggableFocus.test.ts
@@ -118,6 +118,12 @@ vi.mock('../../Editor.js', () => {
           focus: function () {
             // Plain function that can be wrapped
           },
+          hasFocus: function () {
+            return domElement === domElement.ownerDocument.activeElement;
+          },
+          domObserver: {
+            suppressSelectionUpdates: vi.fn(),
+          },
           dispatch: vi.fn(),
         },
         options: {

--- a/packages/super-editor/src/core/presentation-editor/tests/PresentationEditor.focusWrapping.test.ts
+++ b/packages/super-editor/src/core/presentation-editor/tests/PresentationEditor.focusWrapping.test.ts
@@ -133,6 +133,12 @@ vi.mock('../../Editor.js', () => {
           focus: function () {
             // Plain function that can be wrapped
           },
+          hasFocus: function () {
+            return domElement === domElement.ownerDocument.activeElement;
+          },
+          domObserver: {
+            suppressSelectionUpdates: vi.fn(),
+          },
           dispatch: vi.fn(),
         },
         options: {


### PR DESCRIPTION
Fixes SD-2263

https://linear.app/superdocworkspace/issue/SD-2263/bug-cursor-jumps-to-top-of-document-after-rejecting-change

## Summary

- Fixes cursor jumping to the top of the document when changing font family/size from the toolbar dropdown
- Root cause: the hidden ProseMirror editor's wrapped `focus()` method didn't call `selectionToDOM()` after focusing, so the browser placed the DOM selection at an arbitrary position. ProseMirror's `DOMObserver` then read this stale position via a `selectionchange` event and overwrote the PM selection state.
- Fix: call `view.domObserver.suppressSelectionUpdates()` after focusing when the editor was previously unfocused, so PM re-applies its own selection to the DOM instead of reading the browser's incorrect position.

## Root Cause Analysis

ProseMirror's original `focus()` does:
1. `domObserver.stop()` — pause DOM observation
2. `focusPreventScroll(dom)` — focus the contenteditable
3. `selectionToDOM(view)` — sync the DOM selection to match PM state
4. `domObserver.start()` — resume observation

The `PresentationEditor` wraps `view.focus()` to prevent scroll when focusing the hidden off-screen editor (`left: -9999px`). The wrapped version only did step 2, skipping steps 1, 3, and 4. When the toolbar dropdown steals focus and the editor is re-focused, the browser places the DOM selection at offset 0 of the nearest text node (PM position 2). The `DOMObserver`'s `selectionchange` handler then reads this and dispatches a transaction that moves the cursor.

## Test plan

- [x] All 840 super-editor test files pass (9146 tests, 0 failures)
- [x] Verified fix in browser: cursor stays at position 539 after changing font (was jumping to 2)
- [x] Verified with text selection: selection range preserved after font change
- [x] Verified with multiple consecutive font changes: cursor stable across all changes
- [ ] Manual test: open a document, place cursor mid-document, change font from dropdown — cursor should not move
- [ ] Manual test: select text mid-document, change font — selection should be preserved