### PR TITLE
fix(ci): trigger docs CI on superdoc and super-editor changes

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - 'apps/docs/**'
+      - 'packages/superdoc/**'
+      - 'packages/super-editor/**'
       - 'packages/document-api/src/contract/**'
       - 'packages/document-api/scripts/**'
       - 'scripts/generate-all.mjs'


### PR DESCRIPTION
The doctest suite imports from packages/superdoc/dist/ and tests real API calls against the editor. Without these triggers, renaming or removing an editor method wouldn't run the docs example tests until someone separately touches apps/docs/.