### PR TITLE
feat(vscode-ext): auto-release on SuperDoc updates (SD-2342)

### DIFF
--- a/.github/workflows/release-vscode-ext.yml
+++ b/.github/workflows/release-vscode-ext.yml
@@ -7,8 +7,14 @@ on:
     branches: main
     paths:
       - 'apps/vscode-ext/**'
+      - 'packages/superdoc/**'
+      - 'packages/layout-engine/**'
+      - 'packages/super-editor/**'
+      - 'packages/ai/**'
+      - 'packages/word-layout/**'
+      - 'packages/preset-geometry/**'
       - 'pnpm-workspace.yaml'
-      - '!apps/vscode-ext/*.md'
+      - '!**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/apps/vscode-ext/.releaserc.cjs
+++ b/apps/vscode-ext/.releaserc.cjs
@@ -1,4 +1,24 @@
 /* eslint-env node */
+/*
+ * Commit filter: vscode-ext bundles superdoc, so git log must include
+ * commits touching superdoc's sub-packages. This shared helper patches
+ * git-log-parser to expand path coverage. It REPLACES
+ * semantic-release-commit-filter — do not use both (the filter restricts
+ * to CWD, which undoes the expansion).
+ *
+ * Keep in sync with .github/workflows/release-vscode-ext.yml paths: trigger.
+ */
+require('../../scripts/semantic-release/patch-commit-filter.cjs')([
+  'apps/vscode-ext',
+  'packages/superdoc',
+  'packages/super-editor',
+  'packages/layout-engine',
+  'packages/ai',
+  'packages/word-layout',
+  'packages/preset-geometry',
+  'pnpm-workspace.yaml',
+]);
+
 const branch = process.env.GITHUB_REF_NAME || process.env.CI_COMMIT_BRANCH;
 
 const branches = [
@@ -17,7 +37,6 @@ const config = {
   branches,
   tagFormat: 'vscode-v${version}',
   plugins: [
-    'semantic-release-commit-filter',
     '@semantic-release/commit-analyzer',
     notesPlugin,
     ['@semantic-release/npm', { npmPublish: false }], // Version bump only, no npm publish


### PR DESCRIPTION
Expand release workflow path triggers and use patch-commit-filter so superdoc core commits trigger VS Code extension releases.

- Add superdoc source paths to release-vscode-ext.yml triggers
- Replace semantic-release-commit-filter with patch-commit-filter.cjs (same pattern as CLI/SDK)
- @next auto-deploys to GitHub releases only (low risk)
- @latest still requires manual cherry-pick to stable (human gate)