### PR TITLE
fix(comments): export commentsExtended.xml for resolved comments (SD-2306)

### DIFF
--- a/packages/super-editor/src/core/super-converter/v2/exporter/commentsExporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/exporter/commentsExporter.js
@@ -190,6 +190,7 @@ export const updateCommentsExtendedXml = (comments = [], commentsExtendedXml, th
   const exportStrategy = typeof threadingProfile === 'string' ? threadingProfile : 'word';
   const profile = typeof threadingProfile === 'string' ? null : threadingProfile;
   const hasThreadedComments = comments.some((comment) => comment.threadingParentCommentId || comment.parentCommentId);
+  const hasResolvedComments = comments.some((comment) => comment.resolvedTime || comment.isDone);
 
   // Always generate commentsExtended.xml when exporting comments (unless Google Docs style)
   // This ensures that comments without threading relationships are explicitly marked as
@@ -204,7 +205,9 @@ export const updateCommentsExtendedXml = (comments = [], commentsExtendedXml, th
   // If any threaded comments exist, always include commentsExtended.xml so Word can retain threads.
   const shouldIncludeForThreads = hasThreadedComments;
 
-  if (!shouldGenerateCommentsExtended && !shouldIncludeForThreads) {
+  // Word reads w15:done from commentsExtended.xml to determine resolved status.
+  // Without this file, resolved comments appear unresolved when opened in Word.
+  if (!shouldGenerateCommentsExtended && !shouldIncludeForThreads && !hasResolvedComments) {
     return null;
   }
 

--- a/packages/super-editor/src/core/super-converter/v2/exporter/commentsExporter.test.js
+++ b/packages/super-editor/src/core/super-converter/v2/exporter/commentsExporter.test.js
@@ -513,6 +513,70 @@ describe('updateCommentsExtendedXml', () => {
 
     expect(childEntry.attributes['w15:paraIdParent']).toBe('PARENT-PARA');
   });
+
+  it('SD-2306: generates commentsExtended.xml for resolved comments with range-based threading', () => {
+    const comments = [
+      {
+        commentId: 'resolved-comment',
+        commentParaId: 'RESOLVED-PARA',
+        resolvedTime: 1711234567890,
+      },
+    ];
+
+    const commentsExtendedXml = {
+      elements: [{ elements: [] }],
+    };
+
+    const profile = {
+      defaultStyle: 'range-based',
+      mixed: false,
+      fileSet: {
+        hasCommentsExtended: false,
+        hasCommentsExtensible: false,
+        hasCommentsIds: false,
+      },
+    };
+
+    const result = updateCommentsExtendedXml(comments, commentsExtendedXml, profile);
+
+    // Must not return null — Word needs this file to read w15:done
+    expect(result).not.toBeNull();
+    const entries = result.elements[0].elements;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].attributes['w15:done']).toBe('1');
+  });
+
+  it('SD-2306: generates commentsExtended.xml for isDone comments with range-based threading', () => {
+    const comments = [
+      {
+        commentId: 'done-comment',
+        commentParaId: 'DONE-PARA',
+        isDone: true,
+        resolvedTime: null,
+      },
+    ];
+
+    const commentsExtendedXml = {
+      elements: [{ elements: [] }],
+    };
+
+    const profile = {
+      defaultStyle: 'range-based',
+      mixed: false,
+      fileSet: {
+        hasCommentsExtended: false,
+        hasCommentsExtensible: false,
+        hasCommentsIds: false,
+      },
+    };
+
+    const result = updateCommentsExtendedXml(comments, commentsExtendedXml, profile);
+
+    expect(result).not.toBeNull();
+    const entries = result.elements[0].elements;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].attributes['w15:done']).toBe('1');
+  });
 });
 
 // =============================================================================

--- a/tests/behavior/tests/comments/sd-2306-resolved-comment-export.spec.ts
+++ b/tests/behavior/tests/comments/sd-2306-resolved-comment-export.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '../../fixtures/superdoc.js';
+import { assertDocumentApiReady, addCommentByText, resolveComment, listComments } from '../../helpers/document-api.js';
+import JSZip from 'jszip';
+
+test.use({ config: { toolbar: 'full', comments: 'on' } });
+
+test('SD-2306 resolved comment is marked as done in exported DOCX', async ({ superdoc }) => {
+  await assertDocumentApiReady(superdoc.page);
+
+  // 1. Type a line of text
+  await superdoc.type('This text has a resolved comment');
+  await superdoc.waitForStable();
+
+  // 2. Add a comment to "resolved comment"
+  const commentId = await addCommentByText(superdoc.page, {
+    pattern: 'resolved comment',
+    text: 'This is a test comment',
+  });
+  await superdoc.waitForStable();
+
+  // 3. Resolve the comment
+  await resolveComment(superdoc.page, { commentId });
+  await superdoc.waitForStable();
+
+  // Verify the comment is resolved before exporting
+  const comments = await listComments(superdoc.page, { includeResolved: true });
+  expect(comments.matches.some((entry: any) => entry.status === 'resolved')).toBe(true);
+
+  // 4. Export to DOCX
+  const bytes: number[] = await superdoc.page.evaluate(async () => {
+    const blob: Blob = await (window as any).editor.exportDocx();
+    const buffer = await blob.arrayBuffer();
+    return Array.from(new Uint8Array(buffer));
+  });
+
+  // 5. Parse the exported zip and verify the resolved status
+  const zip = await JSZip.loadAsync(Buffer.from(bytes));
+
+  // commentsExtended.xml must exist — Word reads w15:done from this file
+  // to determine whether a comment is resolved
+  const commentsExtendedFile = zip.file('word/commentsExtended.xml');
+  expect(commentsExtendedFile).not.toBeNull();
+
+  const commentsExtendedXml = await commentsExtendedFile!.async('string');
+  expect(commentsExtendedXml).toContain('w15:done="1"');
+});


### PR DESCRIPTION
- Exported DOCX files were missing `commentsExtended.xml` when comments were resolved but used range-based threading (no `commentsExtended.xml` in the original file). Word reads `w15:done` from this file to determine resolved status, so without it resolved comments appeared unresolved when opened in Word.
- The fix adds a `hasResolvedComments` check so `updateCommentsExtendedXml` no longer returns `null` when resolved or done comments are present.