### PR TITLE
fix(ci): run super-editor tests per-package to prevent OOM

### DIFF
--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -137,18 +137,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           VITEST_MAX_WORKERS: '1'
           VITEST_MIN_WORKERS: '1'
-        run: >-
-          pnpm exec vitest run
-          --project superdoc
-          --project @superdoc/ai
-          --project @superdoc/collaboration-yjs
-          --project @superdoc/contracts
-          --project @superdoc/layout-bridge
-          --project @superdoc/measuring-dom
-          --project @superdoc/painter-dom
-          --project @superdoc/pm-adapter
-          --project @superdoc/layout-tests
-          --project @superdoc-ext/vscode-ext
+        run: pnpm exec vitest run '--project=!*super-editor*'
 
       - name: Run bun tests
         if: matrix.name == 'other-packages'


### PR DESCRIPTION
Root cause: every vitest invocation from the root workspace loads 11 Vite project contexts (multi-GB baseline), regardless of which test files are passed. This causes OOM on GitHub Actions runners (7 GB RAM) — even with sharding, sub-sharding, and increased heap limits.

- Run super-editor tests from its package directory (single Vite context) with 12 shards (~75 files each) and `maxWorkers=1`
- Other vitest packages run separately via `--project` flags
- All shards run in parallel so wall time is unchanged
- Removes the `--exclude` workarounds for `decrypt-docx.integration` and `contract-conformance` since per-package runs have much lower baseline memory