### PR TITLE
feat(math): implement m:sSup superscript converter (SD-2372)

### DIFF
--- a/packages/layout-engine/painters/dom/src/features/math/converters/fraction.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/converters/fraction.ts
@@ -19,8 +19,14 @@ export const convertFraction: MathObjectConverter = (node, doc, convertChildren)
   const den = elements.find((e) => e.name === 'm:den');
 
   const frac = doc.createElementNS(MATHML_NS, 'mfrac');
-  frac.appendChild(convertChildren(num?.elements ?? []));
-  frac.appendChild(convertChildren(den?.elements ?? []));
+
+  const numRow = doc.createElementNS(MATHML_NS, 'mrow');
+  numRow.appendChild(convertChildren(num?.elements ?? []));
+  frac.appendChild(numRow);
+
+  const denRow = doc.createElementNS(MATHML_NS, 'mrow');
+  denRow.appendChild(convertChildren(den?.elements ?? []));
+  frac.appendChild(denRow);
 
   return frac;
 };

--- a/packages/layout-engine/painters/dom/src/features/math/converters/index.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/converters/index.ts
@@ -9,3 +9,4 @@
 export { convertMathRun } from './math-run.js';
 export { convertFraction } from './fraction.js';
 export { convertBar } from './bar.js';
+export { convertSuperscript } from './superscript.js';

--- a/packages/layout-engine/painters/dom/src/features/math/converters/superscript.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/converters/superscript.ts
@@ -19,8 +19,14 @@ export const convertSuperscript: MathObjectConverter = (node, doc, convertChildr
   const sup = elements.find((e) => e.name === 'm:sup');
 
   const msup = doc.createElementNS(MATHML_NS, 'msup');
-  msup.appendChild(convertChildren(base?.elements ?? []));
-  msup.appendChild(convertChildren(sup?.elements ?? []));
+
+  const baseRow = doc.createElementNS(MATHML_NS, 'mrow');
+  baseRow.appendChild(convertChildren(base?.elements ?? []));
+  msup.appendChild(baseRow);
+
+  const supRow = doc.createElementNS(MATHML_NS, 'mrow');
+  supRow.appendChild(convertChildren(sup?.elements ?? []));
+  msup.appendChild(supRow);
 
   return msup;
 };

--- a/packages/layout-engine/painters/dom/src/features/math/converters/superscript.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/converters/superscript.ts
@@ -1,0 +1,26 @@
+import type { MathObjectConverter } from '../types.js';
+
+const MATHML_NS = 'http://www.w3.org/1998/Math/MathML';
+
+/**
+ * Convert m:sSup (superscript) to MathML <msup>.
+ *
+ * OMML structure:
+ *   m:sSup → m:sSupPr (optional), m:e (base), m:sup (superscript)
+ *
+ * MathML output:
+ *   <msup> <mrow>base</mrow> <mrow>sup</mrow> </msup>
+ *
+ * @spec ECMA-376 §22.1.2.105
+ */
+export const convertSuperscript: MathObjectConverter = (node, doc, convertChildren) => {
+  const elements = node.elements ?? [];
+  const base = elements.find((e) => e.name === 'm:e');
+  const sup = elements.find((e) => e.name === 'm:sup');
+
+  const msup = doc.createElementNS(MATHML_NS, 'msup');
+  msup.appendChild(convertChildren(base?.elements ?? []));
+  msup.appendChild(convertChildren(sup?.elements ?? []));
+
+  return msup;
+};

--- a/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
@@ -284,3 +284,84 @@ describe('m:bar converter', () => {
     expect(mo?.textContent).toBe('\u203E');
   });
 });
+
+describe('m:sSup converter', () => {
+  it('converts m:sSup to <msup> with base and superscript', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:sSup',
+          elements: [
+            {
+              name: 'm:e',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'x' }] }] }],
+            },
+            {
+              name: 'm:sup',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '2' }] }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const msup = result!.querySelector('msup');
+    expect(msup).not.toBeNull();
+    expect(msup!.children.length).toBe(2);
+    expect(msup!.children[0]!.textContent).toBe('x');
+    expect(msup!.children[1]!.textContent).toBe('2');
+  });
+
+  it('ignores m:sSupPr properties element', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:sSup',
+          elements: [
+            { name: 'm:sSupPr', elements: [{ name: 'm:ctrlPr' }] },
+            {
+              name: 'm:e',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'a' }] }] }],
+            },
+            {
+              name: 'm:sup',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'b' }] }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const msup = result!.querySelector('msup');
+    expect(msup).not.toBeNull();
+    expect(msup!.children.length).toBe(2);
+    expect(msup!.children[0]!.textContent).toBe('a');
+    expect(msup!.children[1]!.textContent).toBe('b');
+  });
+
+  it('handles missing m:sup gracefully', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:sSup',
+          elements: [
+            {
+              name: 'm:e',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'x' }] }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const msup = result!.querySelector('msup');
+    expect(msup).not.toBeNull();
+    expect(msup!.children[0]!.textContent).toBe('x');
+  });
+});

--- a/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
@@ -119,8 +119,45 @@ describe('convertOmmlToMathml', () => {
     expect(result!.textContent).toBe('z');
   });
 
-  it('handles unimplemented math objects by extracting child content', () => {
-    // m:f (fraction) is not yet implemented — should fall back to rendering children
+  it('wraps multi-part fraction operands in <mrow> for valid arity', () => {
+    // (a+b)/(c+d) — both numerator and denominator have multiple runs
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:f',
+          elements: [
+            {
+              name: 'm:num',
+              elements: [
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'a' }] }] },
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '+' }] }] },
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'b' }] }] },
+              ],
+            },
+            {
+              name: 'm:den',
+              elements: [
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'c' }] }] },
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '+' }] }] },
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'd' }] }] },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const mfrac = result!.querySelector('mfrac');
+    expect(mfrac).not.toBeNull();
+    // <mfrac> must have exactly 2 children (num + den), each wrapped in <mrow>
+    expect(mfrac!.children.length).toBe(2);
+    expect(mfrac!.children[0]!.textContent).toBe('a+b');
+    expect(mfrac!.children[1]!.textContent).toBe('c+d');
+  });
+
+  it('converts m:f (fraction) to <mfrac> with numerator and denominator', () => {
     const omml = {
       name: 'm:oMath',
       elements: [
@@ -341,6 +378,40 @@ describe('m:sSup converter', () => {
     expect(msup!.children.length).toBe(2);
     expect(msup!.children[0]!.textContent).toBe('a');
     expect(msup!.children[1]!.textContent).toBe('b');
+  });
+
+  it('wraps multi-part base and superscript in <mrow> for valid arity', () => {
+    // (x+1)^2 — base has 3 runs that must be grouped
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:sSup',
+          elements: [
+            {
+              name: 'm:e',
+              elements: [
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'x' }] }] },
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '+' }] }] },
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '1' }] }] },
+              ],
+            },
+            {
+              name: 'm:sup',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '2' }] }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const msup = result!.querySelector('msup');
+    expect(msup).not.toBeNull();
+    // <msup> must have exactly 2 children (base + superscript), each wrapped in <mrow>
+    expect(msup!.children.length).toBe(2);
+    expect(msup!.children[0]!.textContent).toBe('x+1');
+    expect(msup!.children[1]!.textContent).toBe('2');
   });
 
   it('handles missing m:sup gracefully', () => {

--- a/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.ts
@@ -10,7 +10,7 @@
  */
 
 import type { OmmlJsonNode, MathObjectConverter } from './types.js';
-import { convertMathRun, convertFraction, convertBar } from './converters/index.js';
+import { convertMathRun, convertFraction, convertBar, convertSuperscript } from './converters/index.js';
 
 export const MATHML_NS = 'http://www.w3.org/1998/Math/MathML';
 
@@ -32,6 +32,7 @@ const MATH_OBJECT_REGISTRY: Record<string, MathObjectConverter | null> = {
   'm:r': convertMathRun,
   'm:bar': convertBar, // Bar (overbar/underbar)
   'm:f': convertFraction, // Fraction (numerator/denominator)
+  'm:sSup': convertSuperscript, // Superscript
 
   // ── Not yet implemented (community contributions welcome) ────────────────
   'm:acc': null, // Accent (diacritical mark above base)
@@ -50,7 +51,6 @@ const MATH_OBJECT_REGISTRY: Record<string, MathObjectConverter | null> = {
   'm:sPre': null, // Pre-sub-superscript (left of base)
   'm:sSub': null, // Subscript
   'm:sSubSup': null, // Sub-superscript (both)
-  'm:sSup': null, // Superscript
 };
 
 /** OMML argument/container elements that wrap children in <mrow>. */


### PR DESCRIPTION
## Summary

- Add OMML `m:sSup` → MathML `<msup>` converter following the `fraction.ts` pattern
- Move `m:f` from the "not yet implemented" registry section to "implemented" where it belongs
- 3 tests: basic conversion (x²), properties element ignored, missing `m:sup` graceful degradation

## Test plan

- [x] `pnpm --filter @superdoc/painter-dom test` — `omml-to-mathml.test.ts` passes (17 tests)
- [x] Upload [sd-2372-superscript.docx](https://uploads.linear.app/92b189d9-e15d-4f28-8a87-d9ca147ba33f/7e26e3b3-be41-4e0c-b907-a49ce0f980c4/b2d65370-56e7-41c1-9acd-75c5ea4e3c7d) to dev app and verify superscript renders correctly

Closes #2595