### PR TITLE
fix(sdk): include tools/*.md in Python wheel package data

### DIFF
--- a/packages/sdk/langs/python/pyproject.toml
+++ b/packages/sdk/langs/python/pyproject.toml
@@ -29,5 +29,6 @@ packages = [
 [tool.setuptools.package-data]
 superdoc = [
   "skills/*.md",
+  "tools/*.md",
   "tools/*.json",
 ]


### PR DESCRIPTION
Closes [SD-2424] 
https://linear.app/superdocworkspace/issue/SD-2424/bug-python-sdk-120-wheel-omits-system-promptmd-and-breaks-get-system

## Summary

- Python SDK 1.2.0 wheel omits `system-prompt.md`, causing `get_system_prompt()` to throw `TOOLS_ASSET_NOT_FOUND` at runtime
- Root cause: `pyproject.toml` package-data only included `tools/*.json`, not `tools/*.md`
- Fix: add `"tools/*.md"` to the `[tool.setuptools.package-data]` glob list

## Root cause

In `packages/sdk/langs/python/pyproject.toml`, the package-data section was:

```toml
[tool.setuptools.package-data]
superdoc = [
  "skills/*.md",
  "tools/*.json",
]
```

The `skills/*.md` glob correctly includes markdown files from the skills directory (e.g., `editing-docx.md`), but `tools/*.json` only matches JSON tool catalogs. `tools/system-prompt.md` was silently excluded from the built wheel.

At runtime, `tools_api.py:201` calls `importlib.resources.files('superdoc').joinpath('tools', 'system-prompt.md')` which raises `FileNotFoundError` because the file was never packaged.

## How to reproduce locally

```bash
cd packages/sdk/langs/python

# 1. Build the wheel
rm -rf dist build superdoc_sdk.egg-info
python3 -m build --wheel

# 2. Check if system-prompt.md is in the wheel (it won't be on main)
unzip -l dist/superdoc_sdk-1.2.0-py3-none-any.whl | grep system-prompt

# 3. Install in an isolated venv
python3 -m venv /tmp/superdoc-test-venv
source /tmp/superdoc-test-venv/bin/activate       # bash/zsh
# source /tmp/superdoc-test-venv/bin/activate.fish  # fish shell
pip install dist/superdoc_sdk-1.2.0-py3-none-any.whl --no-deps --force-reinstall

# 4. Test from OUTSIDE the source tree (critical — running from the source
#    directory masks the bug because Python adds cwd to sys.path and finds
#    the local superdoc/ package which has the file)
cd /tmp
python3 -c "from superdoc.tools_api import get_system_prompt; print(get_system_prompt()[:80])"
```

**Before fix:** step 2 returns nothing, step 4 throws `SuperDocError: System prompt not found.`
**After fix:** step 2 shows `superdoc/tools/system-prompt.md`, step 4 prints the prompt.

## Test plan

- [ ] Build the wheel: `cd packages/sdk/langs/python && python3 -m build --wheel`
- [ ] Verify `system-prompt.md` is in the wheel: `unzip -l dist/*.whl | grep system-prompt`
- [ ] Install in isolated venv and call `get_system_prompt()` from outside the source tree
- [ ] Verify existing JSON tool assets are still included: `unzip -l dist/*.whl | grep tools/`