### PR TITLE
fix(layout-engine): fix overlapping text in justified paragraphs with first-line/hanging indent (SD-2415)

### DIFF
--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -29,6 +29,8 @@ export {
 export {
   shouldApplyJustify,
   calculateJustifySpacing,
+  getFirstLineIndentOffset,
+  adjustAvailableWidthForTextIndent,
   SPACE_CHARS,
   type ShouldApplyJustifyParams,
   type CalculateJustifySpacingParams,

--- a/packages/layout-engine/contracts/src/justify-utils.test.ts
+++ b/packages/layout-engine/contracts/src/justify-utils.test.ts
@@ -3,6 +3,8 @@ import {
   SPACE_CHARS,
   shouldApplyJustify,
   calculateJustifySpacing,
+  getFirstLineIndentOffset,
+  adjustAvailableWidthForTextIndent,
   type ShouldApplyJustifyParams,
   type CalculateJustifySpacingParams,
 } from './justify-utils.js';
@@ -305,5 +307,58 @@ describe('calculateJustifySpacing', () => {
       shouldJustify: false,
     };
     expect(calculateJustifySpacing(params)).toBe(0);
+  });
+});
+
+describe('getFirstLineIndentOffset', () => {
+  it('returns firstLine minus hanging', () => {
+    expect(getFirstLineIndentOffset({ firstLine: 72, hanging: 0 }, false)).toBe(72);
+  });
+
+  it('returns negative offset for hanging indent', () => {
+    expect(getFirstLineIndentOffset({ firstLine: 0, hanging: 160 }, false)).toBe(-160);
+  });
+
+  it('returns combined offset when both set', () => {
+    expect(getFirstLineIndentOffset({ firstLine: 36, hanging: 72 }, false)).toBe(-36);
+  });
+
+  it('returns 0 when suppressFirstLineIndent is true', () => {
+    expect(getFirstLineIndentOffset({ firstLine: 72, hanging: 0 }, true)).toBe(0);
+  });
+
+  it('returns 0 for undefined indent', () => {
+    expect(getFirstLineIndentOffset(undefined, false)).toBe(0);
+  });
+
+  it('returns 0 for empty indent object', () => {
+    expect(getFirstLineIndentOffset({}, false)).toBe(0);
+  });
+});
+
+describe('adjustAvailableWidthForTextIndent', () => {
+  it('widens for negative offset (hanging indent) regardless of maxWidth', () => {
+    // offset=-160 means hanging indent: availableWidth should increase
+    expect(adjustAvailableWidthForTextIndent(308, -160, 468)).toBe(468);
+  });
+
+  it('narrows for positive offset when maxWidth is null (fallback path)', () => {
+    expect(adjustAvailableWidthForTextIndent(432, 72, null)).toBe(360);
+  });
+
+  it('narrows for positive offset when maxWidth is undefined (fallback path)', () => {
+    expect(adjustAvailableWidthForTextIndent(432, 72, undefined)).toBe(360);
+  });
+
+  it('does not adjust for positive offset when maxWidth is set (measurer already accounted)', () => {
+    expect(adjustAvailableWidthForTextIndent(360, 72, 360)).toBe(360);
+  });
+
+  it('returns original width when offset is 0', () => {
+    expect(adjustAvailableWidthForTextIndent(468, 0, null)).toBe(468);
+  });
+
+  it('clamps to 0 when adjustment would go negative', () => {
+    expect(adjustAvailableWidthForTextIndent(50, 100, null)).toBe(0);
   });
 });

--- a/packages/layout-engine/contracts/src/justify-utils.ts
+++ b/packages/layout-engine/contracts/src/justify-utils.ts
@@ -102,6 +102,41 @@ export type CalculateJustifySpacingParams = {
  * @param params - Parameters for spacing calculation
  * @returns Extra spacing per space in pixels (can be negative)
  */
+/**
+ * Computes the first-line indent offset from paragraph indent attributes.
+ *
+ * Returns 0 when first-line indent is suppressed.
+ * The result is positive for firstLine indent, negative for hanging indent.
+ */
+export function getFirstLineIndentOffset(
+  indent: { firstLine?: number; hanging?: number } | undefined,
+  suppressFirstLineIndent: boolean,
+): number {
+  if (suppressFirstLineIndent) return 0;
+  return (indent?.firstLine ?? 0) - (indent?.hanging ?? 0);
+}
+
+/**
+ * Adjusts availableWidth for first-line text indent.
+ *
+ * Negative textIndent (hanging indent): the measurer sets line.maxWidth to the
+ * correct wider value, but Math.min with fallbackAvailableWidth clamps it back down.
+ * Always adjust to restore actual available space.
+ *
+ * Positive textIndent (firstLine indent): the measurer already bakes it into
+ * line.maxWidth, so only adjust on the fallback path (maxWidth not set).
+ */
+export function adjustAvailableWidthForTextIndent(
+  availableWidth: number,
+  textIndentOffset: number,
+  lineMaxWidth: number | null | undefined,
+): number {
+  if (textIndentOffset !== 0 && (textIndentOffset < 0 || lineMaxWidth == null)) {
+    return Math.max(0, availableWidth - textIndentOffset);
+  }
+  return availableWidth;
+}
+
 export function calculateJustifySpacing(params: CalculateJustifySpacingParams): number {
   const { lineWidth, availableWidth, spaceCount, shouldJustify } = params;
 

--- a/packages/layout-engine/layout-bridge/src/index.ts
+++ b/packages/layout-engine/layout-bridge/src/index.ts
@@ -1352,13 +1352,14 @@ const mapPmToX = (
   let paraIndentRight = 0;
   let effectiveLeft = 0;
   let isListParagraph = false;
+  let wl: ReturnType<typeof getWordLayoutConfig> | undefined;
   if (block.kind === 'paragraph') {
     const indentLeft = typeof block.attrs?.indent?.left === 'number' ? block.attrs.indent.left : 0;
     const indentRight = typeof block.attrs?.indent?.right === 'number' ? block.attrs.indent.right : 0;
     paraIndentLeft = Number.isFinite(indentLeft) ? indentLeft : 0;
     paraIndentRight = Number.isFinite(indentRight) ? indentRight : 0;
     effectiveLeft = paraIndentLeft;
-    const wl = getWordLayoutConfig(block);
+    wl = getWordLayoutConfig(block);
     isListParagraph = Boolean(block.attrs?.numberingProperties) || Boolean(wl?.marker);
     if (isListParagraph) {
       const explicitTextStart =

--- a/packages/layout-engine/layout-bridge/src/index.ts
+++ b/packages/layout-engine/layout-bridge/src/index.ts
@@ -585,8 +585,25 @@ export function selectionToRects(
           const isJustified = blockAlignment === 'justify';
           const alignmentOverride = isListItemFlag && !isJustified ? 'left' : undefined;
           const isFirstLine = index === fragment.fromLine && !fragment.continuesFromPrev;
-          const startX = mapPmToX(block, line, charOffsetFrom, fragment.width, alignmentOverride, isFirstLine);
-          const endX = mapPmToX(block, line, charOffsetTo, fragment.width, alignmentOverride, isFirstLine);
+          const fragmentMarkerTextWidth = fragment.markerTextWidth ?? measure.marker?.markerTextWidth ?? undefined;
+          const startX = mapPmToX(
+            block,
+            line,
+            charOffsetFrom,
+            fragment.width,
+            alignmentOverride,
+            isFirstLine,
+            fragmentMarkerTextWidth,
+          );
+          const endX = mapPmToX(
+            block,
+            line,
+            charOffsetTo,
+            fragment.width,
+            alignmentOverride,
+            isFirstLine,
+            fragmentMarkerTextWidth,
+          );
 
           // Calculate text indent using shared utility
           const indent = extractParagraphIndent(block.attrs?.indent);
@@ -595,7 +612,7 @@ export function selectionToRects(
             isFirstLine,
             isListItem: isListItemFlag,
             markerWidth,
-            markerTextWidth: fragment.markerTextWidth ?? measure.marker?.markerTextWidth ?? undefined,
+            markerTextWidth: fragmentMarkerTextWidth,
             paraIndentLeft: indent.left,
             firstLineIndent: indent.firstLine,
             hangingIndent: indent.hanging,
@@ -888,6 +905,7 @@ export function selectionToRects(
                 const charOffsetTo = pmPosToCharOffset(info.block, line, sliceTo);
                 const availableWidth = Math.max(1, cellMeasure.width - padding.left - padding.right);
                 const isFirstLine = index === 0;
+                const cellMarkerTextWidth = info.measure?.marker?.markerTextWidth ?? undefined;
                 const startX = mapPmToX(
                   info.block,
                   line,
@@ -895,15 +913,24 @@ export function selectionToRects(
                   availableWidth,
                   alignmentOverride,
                   isFirstLine,
+                  cellMarkerTextWidth,
                 );
-                const endX = mapPmToX(info.block, line, charOffsetTo, availableWidth, alignmentOverride, isFirstLine);
+                const endX = mapPmToX(
+                  info.block,
+                  line,
+                  charOffsetTo,
+                  availableWidth,
+                  alignmentOverride,
+                  isFirstLine,
+                  cellMarkerTextWidth,
+                );
 
                 // Calculate text indent using shared utility
                 const textIndentAdjust = calculateTextStartIndent({
                   isFirstLine,
                   isListItem: cellIsListItem,
                   markerWidth: paragraphMarkerWidth,
-                  markerTextWidth: info.measure?.marker?.markerTextWidth ?? undefined,
+                  markerTextWidth: cellMarkerTextWidth,
                   paraIndentLeft: cellIndent.left,
                   firstLineIndent: cellIndent.firstLine,
                   hangingIndent: cellIndent.hanging,
@@ -1344,6 +1371,15 @@ const mapPmToX = (
   fragmentWidth: number,
   alignmentOverride?: string,
   isFirstLine?: boolean,
+  /**
+   * Measured marker text width for the hit fragment (or cell measure).
+   * Mirrors the painter's `fragment.markerTextWidth` check at
+   * `renderer.ts:3210-3211` — a list paragraph whose marker metadata exists
+   * but renders to zero width (empty/vanished marker, continuation fragment)
+   * must still receive the first-line width adjustment, so we gate on
+   * measured width, not on raw `marker.markerText` attribute.
+   */
+  markerTextWidth?: number,
 ): number => {
   if (fragmentWidth <= 0 || line.width <= 0) return 0;
 
@@ -1387,8 +1423,10 @@ const mapPmToX = (
   }
 
   // Adjust availableWidth for first-line text indent to match the painter's justify spacing.
-  // Skip for list-marker first lines — the renderer doesn't adjust those (only when marker has actual text).
-  const hasRenderedMarkerText = isListParagraph && Boolean(wl?.marker?.markerText);
+  // Skip for list-marker first lines — the renderer only skips when the marker is actually
+  // rendered with non-zero measured text width, so gate on `markerTextWidth`, not on the
+  // raw `marker.markerText` attribute (which can be truthy for markers that measure to zero).
+  const hasRenderedMarkerText = isListParagraph && (markerTextWidth ?? 0) > 0;
   if (isFirstLine && block.kind === 'paragraph' && !hasRenderedMarkerText) {
     const suppressFLI = (block.attrs as Record<string, unknown>)?.suppressFirstLineIndent === true;
     const firstLineOffset = getFirstLineIndentOffset(block.attrs?.indent, suppressFLI);

--- a/packages/layout-engine/layout-bridge/src/index.ts
+++ b/packages/layout-engine/layout-bridge/src/index.ts
@@ -1386,8 +1386,9 @@ const mapPmToX = (
   }
 
   // Adjust availableWidth for first-line text indent to match the painter's justify spacing.
-  // Skip for list-marker first lines — the renderer doesn't adjust those.
-  if (isFirstLine && block.kind === 'paragraph' && !isListParagraph) {
+  // Skip for list-marker first lines — the renderer doesn't adjust those (only when marker has actual text).
+  const hasRenderedMarkerText = isListParagraph && Boolean(wl?.marker?.markerText);
+  if (isFirstLine && block.kind === 'paragraph' && !hasRenderedMarkerText) {
     const suppressFLI = (block.attrs as Record<string, unknown>)?.suppressFirstLineIndent === true;
     const firstLineOffset = getFirstLineIndentOffset(block.attrs?.indent, suppressFLI);
     availableWidth = adjustAvailableWidthForTextIndent(availableWidth, firstLineOffset, line.maxWidth);

--- a/packages/layout-engine/layout-bridge/src/index.ts
+++ b/packages/layout-engine/layout-bridge/src/index.ts
@@ -882,7 +882,7 @@ export function selectionToRects(
                 const charOffsetFrom = pmPosToCharOffset(info.block, line, sliceFrom);
                 const charOffsetTo = pmPosToCharOffset(info.block, line, sliceTo);
                 const availableWidth = Math.max(1, cellMeasure.width - padding.left - padding.right);
-                const isFirstLine = index === info.startLine;
+                const isFirstLine = index === 0;
                 const startX = mapPmToX(
                   info.block,
                   line,

--- a/packages/layout-engine/layout-bridge/src/index.ts
+++ b/packages/layout-engine/layout-bridge/src/index.ts
@@ -579,13 +579,13 @@ export function selectionToRects(
           const blockAlignment = block.attrs?.alignment;
           const isJustified = blockAlignment === 'justify';
           const alignmentOverride = isListItemFlag && !isJustified ? 'left' : undefined;
-          const startX = mapPmToX(block, line, charOffsetFrom, fragment.width, alignmentOverride);
-          const endX = mapPmToX(block, line, charOffsetTo, fragment.width, alignmentOverride);
+          const isFirstLine = index === fragment.fromLine && !fragment.continuesFromPrev;
+          const startX = mapPmToX(block, line, charOffsetFrom, fragment.width, alignmentOverride, isFirstLine);
+          const endX = mapPmToX(block, line, charOffsetTo, fragment.width, alignmentOverride, isFirstLine);
 
           // Calculate text indent using shared utility
           const indent = extractParagraphIndent(block.attrs?.indent);
           const wordLayout = getWordLayoutConfig(block);
-          const isFirstLine = index === fragment.fromLine;
           const indentAdjust = calculateTextStartIndent({
             isFirstLine,
             isListItem: isListItemFlag,
@@ -882,11 +882,18 @@ export function selectionToRects(
                 const charOffsetFrom = pmPosToCharOffset(info.block, line, sliceFrom);
                 const charOffsetTo = pmPosToCharOffset(info.block, line, sliceTo);
                 const availableWidth = Math.max(1, cellMeasure.width - padding.left - padding.right);
-                const startX = mapPmToX(info.block, line, charOffsetFrom, availableWidth, alignmentOverride);
-                const endX = mapPmToX(info.block, line, charOffsetTo, availableWidth, alignmentOverride);
+                const isFirstLine = index === info.startLine;
+                const startX = mapPmToX(
+                  info.block,
+                  line,
+                  charOffsetFrom,
+                  availableWidth,
+                  alignmentOverride,
+                  isFirstLine,
+                );
+                const endX = mapPmToX(info.block, line, charOffsetTo, availableWidth, alignmentOverride, isFirstLine);
 
                 // Calculate text indent using shared utility
-                const isFirstLine = index === info.startLine;
                 const textIndentAdjust = calculateTextStartIndent({
                   isFirstLine,
                   isListItem: cellIsListItem,
@@ -1331,6 +1338,7 @@ const mapPmToX = (
   offset: number,
   fragmentWidth: number,
   alignmentOverride?: string,
+  isFirstLine?: boolean,
 ): number => {
   if (fragmentWidth <= 0 || line.width <= 0) return 0;
 
@@ -1338,6 +1346,7 @@ const mapPmToX = (
   let paraIndentLeft = 0;
   let paraIndentRight = 0;
   let effectiveLeft = 0;
+  let isListParagraph = false;
   if (block.kind === 'paragraph') {
     const indentLeft = typeof block.attrs?.indent?.left === 'number' ? block.attrs.indent.left : 0;
     const indentRight = typeof block.attrs?.indent?.right === 'number' ? block.attrs.indent.right : 0;
@@ -1345,7 +1354,7 @@ const mapPmToX = (
     paraIndentRight = Number.isFinite(indentRight) ? indentRight : 0;
     effectiveLeft = paraIndentLeft;
     const wl = getWordLayoutConfig(block);
-    const isListParagraph = Boolean(block.attrs?.numberingProperties) || Boolean(wl?.marker);
+    isListParagraph = Boolean(block.attrs?.numberingProperties) || Boolean(wl?.marker);
     if (isListParagraph) {
       const explicitTextStart =
         typeof wl?.marker?.textStartX === 'number' && Number.isFinite(wl.marker.textStartX)
@@ -1360,7 +1369,7 @@ const mapPmToX = (
   }
 
   const totalIndent = effectiveLeft + paraIndentRight;
-  const availableWidth = Math.max(0, fragmentWidth - totalIndent);
+  let availableWidth = Math.max(0, fragmentWidth - totalIndent);
 
   // Validation: Warn when indents exceed fragment width (potential layout issue)
   if (totalIndent > fragmentWidth) {
@@ -1369,6 +1378,18 @@ const mapPmToX = (
         `for block ${block.id}. This may indicate a layout miscalculation. ` +
         `Available width clamped to 0.`,
     );
+  }
+
+  // Adjust availableWidth for first-line text indent to match the painter's justify spacing.
+  // Skip for list-marker first lines — the renderer doesn't adjust those.
+  if (isFirstLine && block.kind === 'paragraph' && !isListParagraph) {
+    const suppressFLI = (block.attrs as Record<string, unknown>)?.suppressFirstLineIndent === true;
+    const firstLineOffset = suppressFLI
+      ? 0
+      : (block.attrs?.indent?.firstLine ?? 0) - (block.attrs?.indent?.hanging ?? 0);
+    if (firstLineOffset !== 0 && (firstLineOffset < 0 || line.maxWidth == null)) {
+      availableWidth = Math.max(0, availableWidth - firstLineOffset);
+    }
   }
 
   // Use shared text measurement utility for pixel-perfect accuracy

--- a/packages/layout-engine/layout-bridge/src/index.ts
+++ b/packages/layout-engine/layout-bridge/src/index.ts
@@ -13,7 +13,12 @@ import type {
   ParagraphBlock,
   ParagraphMeasure,
 } from '@superdoc/contracts';
-import { computeLinePmRange as computeLinePmRangeUnified, effectiveTableCellSpacing } from '@superdoc/contracts';
+import {
+  adjustAvailableWidthForTextIndent,
+  computeLinePmRange as computeLinePmRangeUnified,
+  effectiveTableCellSpacing,
+  getFirstLineIndentOffset,
+} from '@superdoc/contracts';
 import { describeCellRenderBlocks, computeCellSliceContentHeight, getEmbeddedRowLines } from '@superdoc/layout-engine';
 import { measureCharacterX } from './text-measurement.js';
 import { clickToPositionDom, findPageElement } from './dom-mapping.js';
@@ -1384,12 +1389,8 @@ const mapPmToX = (
   // Skip for list-marker first lines — the renderer doesn't adjust those.
   if (isFirstLine && block.kind === 'paragraph' && !isListParagraph) {
     const suppressFLI = (block.attrs as Record<string, unknown>)?.suppressFirstLineIndent === true;
-    const firstLineOffset = suppressFLI
-      ? 0
-      : (block.attrs?.indent?.firstLine ?? 0) - (block.attrs?.indent?.hanging ?? 0);
-    if (firstLineOffset !== 0 && (firstLineOffset < 0 || line.maxWidth == null)) {
-      availableWidth = Math.max(0, availableWidth - firstLineOffset);
-    }
+    const firstLineOffset = getFirstLineIndentOffset(block.attrs?.indent, suppressFLI);
+    availableWidth = adjustAvailableWidthForTextIndent(availableWidth, firstLineOffset, line.maxWidth);
   }
 
   // Use shared text measurement utility for pixel-perfect accuracy

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -860,7 +860,10 @@ export function clickToPositionGeometry(
 
       // Adjust availableWidth for first-line text indent to match the painter's justify spacing.
       // Skip for list-marker first lines — the renderer doesn't adjust those.
-      if (lineIndex === 0 && !isListItem) {
+      // When a row is split across pages, partialRow.fromLineByCell tells us the real
+      // starting line for this cell slice — only apply when it's truly line 0.
+      const cellLineStart = tableHit.fragment.partialRow?.fromLineByCell?.[tableHit.cellColIndex] ?? 0;
+      if (lineIndex === 0 && cellLineStart === 0 && !isListItem) {
         const suppressFLI = (cellBlock.attrs as Record<string, unknown>)?.suppressFirstLineIndent === true;
         const firstLineOffset = getFirstLineIndentOffset(cellBlock.attrs?.indent, suppressFLI);
         availableWidth = adjustAvailableWidthForTextIndent(availableWidth, firstLineOffset, line.maxWidth);

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -781,11 +781,12 @@ export function clickToPositionGeometry(
 
       const markerWidth = fragment.markerWidth ?? measure.marker?.markerWidth ?? 0;
       const isListItem = markerWidth > 0;
+      const hasRenderedMarkerText = isListItem && Boolean(fragment.markerTextWidth);
 
       // Adjust availableWidth for first-line text indent to match the painter's justify spacing.
-      // Skip for list-marker first lines — the renderer doesn't adjust those (the marker occupies the hanging region).
+      // Skip for list-marker first lines — the renderer doesn't adjust those (only when marker has actual text).
       const isFirstLineOfParagraph = lineIndex === 0 && !fragment.continuesFromPrev;
-      if (isFirstLineOfParagraph && !isListItem) {
+      if (isFirstLineOfParagraph && !hasRenderedMarkerText) {
         const suppressFLI = (block.attrs as Record<string, unknown>)?.suppressFirstLineIndent === true;
         const firstLineOffset = getFirstLineIndentOffset(block.attrs?.indent, suppressFLI);
         availableWidth = adjustAvailableWidthForTextIndent(availableWidth, firstLineOffset, line.maxWidth);

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -75,6 +75,14 @@ export type TableHitResult = {
   localX: number;
   /** Y coordinate relative to the cell content area */
   localY: number;
+  /**
+   * Cumulative line count of preceding paragraph blocks in this cell.
+   * Used by callers to compute the hit paragraph's local first-line flag
+   * when the row continues from a prior page: `isFirstLineOfParagraph` is
+   * `lineIndex === 0 && max(0, cellLineStart - blockStartGlobal) === 0`,
+   * matching `renderTableCell.ts`'s `localStartLine` computation.
+   */
+  blockStartGlobal: number;
 };
 
 type AtomicFragment = DrawingFragment | ImageFragment;
@@ -556,6 +564,12 @@ export const hitTestTableFragment = (
     );
 
     let blockStartY = 0;
+    // Cumulative line count of preceding paragraph blocks in this cell.
+    // Tracked in parallel with blockStartY so we can report it on hit return —
+    // callers use it to compute the hit paragraph's local first-line flag
+    // when a row spans multiple pages (matches renderTableCell's per-block
+    // `localStartLine = max(0, globalFromLine - blockStartGlobal)`).
+    let blockStartGlobalLines = 0;
     const getBlockHeight = (m: Measure | undefined): number => {
       if (!m) return 0;
       if ('totalHeight' in m && typeof (m as { totalHeight?: number }).totalHeight === 'number') {
@@ -600,10 +614,12 @@ export const hitTestTableFragment = (
           cellMeasure: paragraphMeasure,
           localX: Math.max(0, cellLocalX),
           localY: Math.max(0, localYWithinBlock),
+          blockStartGlobal: blockStartGlobalLines,
         };
       }
 
       blockStartY = blockEndY;
+      blockStartGlobalLines += paragraphMeasure.lines.length;
     }
   }
 
@@ -862,9 +878,13 @@ export function clickToPositionGeometry(
       // Adjust availableWidth for first-line text indent to match the painter's justify spacing.
       // Skip for list-marker first lines — the renderer doesn't adjust those.
       // When a row is split across pages, partialRow.fromLineByCell tells us the real
-      // starting line for this cell slice — only apply when it's truly line 0.
+      // starting line for the cell slice, but the painter decides per-paragraph (see
+      // renderTableCell's `localStartLine = max(0, globalFromLine - blockStartGlobal)`).
+      // Subtract the hit paragraph's cumulative block offset so multi-block cells
+      // spanning pages stay aligned with the painter (SD-2415).
       const cellLineStart = tableHit.fragment.partialRow?.fromLineByCell?.[tableHit.cellColIndex] ?? 0;
-      if (lineIndex === 0 && cellLineStart === 0 && !isListItem) {
+      const localStartLine = Math.max(0, cellLineStart - tableHit.blockStartGlobal);
+      if (lineIndex === 0 && localStartLine === 0 && !isListItem) {
         const suppressFLI = (cellBlock.attrs as Record<string, unknown>)?.suppressFirstLineIndent === true;
         const firstLineOffset = getFirstLineIndentOffset(cellBlock.attrs?.indent, suppressFLI);
         availableWidth = adjustAvailableWidthForTextIndent(availableWidth, firstLineOffset, line.maxWidth);

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -769,7 +769,7 @@ export function clickToPositionGeometry(
       const paraIndentRight = Number.isFinite(indentRight) ? indentRight : 0;
 
       const totalIndent = paraIndentLeft + paraIndentRight;
-      const availableWidth = Math.max(0, fragment.width - totalIndent);
+      let availableWidth = Math.max(0, fragment.width - totalIndent);
 
       if (totalIndent > fragment.width) {
         console.warn(
@@ -781,6 +781,19 @@ export function clickToPositionGeometry(
 
       const markerWidth = fragment.markerWidth ?? measure.marker?.markerWidth ?? 0;
       const isListItem = markerWidth > 0;
+
+      // Adjust availableWidth for first-line text indent to match the painter's justify spacing.
+      // Skip for list-marker first lines — the renderer doesn't adjust those (the marker occupies the hanging region).
+      const isFirstLineOfParagraph = lineIndex === 0 && !fragment.continuesFromPrev;
+      if (isFirstLineOfParagraph && !isListItem) {
+        const suppressFLI = (block.attrs as Record<string, unknown>)?.suppressFirstLineIndent === true;
+        const firstLineOffset = suppressFLI
+          ? 0
+          : (block.attrs?.indent?.firstLine ?? 0) - (block.attrs?.indent?.hanging ?? 0);
+        if (firstLineOffset !== 0 && (firstLineOffset < 0 || line.maxWidth == null)) {
+          availableWidth = Math.max(0, availableWidth - firstLineOffset);
+        }
+      }
       const paraAlignment = block.attrs?.alignment;
       const isJustified = paraAlignment === 'justify';
       const alignmentOverride = isListItem && !isJustified ? 'left' : undefined;
@@ -836,7 +849,7 @@ export function clickToPositionGeometry(
       const paraIndentRight = Number.isFinite(indentRight) ? indentRight : 0;
 
       const totalIndent = paraIndentLeft + paraIndentRight;
-      const availableWidth = Math.max(0, tableHit.fragment.width - totalIndent);
+      let availableWidth = Math.max(0, tableHit.fragment.width - totalIndent);
 
       if (totalIndent > tableHit.fragment.width) {
         console.warn(
@@ -848,6 +861,18 @@ export function clickToPositionGeometry(
 
       const cellMarkerWidth = cellMeasure.marker?.markerWidth ?? 0;
       const isListItem = cellMarkerWidth > 0;
+
+      // Adjust availableWidth for first-line text indent to match the painter's justify spacing.
+      // Skip for list-marker first lines — the renderer doesn't adjust those.
+      if (lineIndex === 0 && !isListItem) {
+        const suppressFLI = (cellBlock.attrs as Record<string, unknown>)?.suppressFirstLineIndent === true;
+        const firstLineOffset = suppressFLI
+          ? 0
+          : (cellBlock.attrs?.indent?.firstLine ?? 0) - (cellBlock.attrs?.indent?.hanging ?? 0);
+        if (firstLineOffset !== 0 && (firstLineOffset < 0 || line.maxWidth == null)) {
+          availableWidth = Math.max(0, availableWidth - firstLineOffset);
+        }
+      }
       const cellAlignment = cellBlock.attrs?.alignment;
       const isJustified = cellAlignment === 'justify';
       const alignmentOverride = isListItem && !isJustified ? 'left' : undefined;

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -23,7 +23,7 @@ import type {
   ParagraphBlock,
   ParagraphMeasure,
 } from '@superdoc/contracts';
-import { computeLinePmRange } from '@superdoc/contracts';
+import { adjustAvailableWidthForTextIndent, computeLinePmRange, getFirstLineIndentOffset } from '@superdoc/contracts';
 import { charOffsetToPm, findCharacterAtX } from './text-measurement.js';
 import type { PageGeometryHelper } from './page-geometry-helper.js';
 
@@ -787,12 +787,8 @@ export function clickToPositionGeometry(
       const isFirstLineOfParagraph = lineIndex === 0 && !fragment.continuesFromPrev;
       if (isFirstLineOfParagraph && !isListItem) {
         const suppressFLI = (block.attrs as Record<string, unknown>)?.suppressFirstLineIndent === true;
-        const firstLineOffset = suppressFLI
-          ? 0
-          : (block.attrs?.indent?.firstLine ?? 0) - (block.attrs?.indent?.hanging ?? 0);
-        if (firstLineOffset !== 0 && (firstLineOffset < 0 || line.maxWidth == null)) {
-          availableWidth = Math.max(0, availableWidth - firstLineOffset);
-        }
+        const firstLineOffset = getFirstLineIndentOffset(block.attrs?.indent, suppressFLI);
+        availableWidth = adjustAvailableWidthForTextIndent(availableWidth, firstLineOffset, line.maxWidth);
       }
       const paraAlignment = block.attrs?.alignment;
       const isJustified = paraAlignment === 'justify';
@@ -866,12 +862,8 @@ export function clickToPositionGeometry(
       // Skip for list-marker first lines — the renderer doesn't adjust those.
       if (lineIndex === 0 && !isListItem) {
         const suppressFLI = (cellBlock.attrs as Record<string, unknown>)?.suppressFirstLineIndent === true;
-        const firstLineOffset = suppressFLI
-          ? 0
-          : (cellBlock.attrs?.indent?.firstLine ?? 0) - (cellBlock.attrs?.indent?.hanging ?? 0);
-        if (firstLineOffset !== 0 && (firstLineOffset < 0 || line.maxWidth == null)) {
-          availableWidth = Math.max(0, availableWidth - firstLineOffset);
-        }
+        const firstLineOffset = getFirstLineIndentOffset(cellBlock.attrs?.indent, suppressFLI);
+        availableWidth = adjustAvailableWidthForTextIndent(availableWidth, firstLineOffset, line.maxWidth);
       }
       const cellAlignment = cellBlock.attrs?.alignment;
       const isJustified = cellAlignment === 'justify';

--- a/packages/layout-engine/layout-bridge/src/remeasure.ts
+++ b/packages/layout-engine/layout-bridge/src/remeasure.ts
@@ -29,6 +29,8 @@ type ParagraphBlockAttrs = {
   decimalSeparator?: string;
   wordLayout?: WordParagraphLayoutOutput;
   numberingProperties?: unknown;
+  /** Word quirk: justified paragraphs ignore first-line indent. Set by pm-adapter. */
+  suppressFirstLineIndent?: boolean;
 };
 
 let canvas: HTMLCanvasElement | null = null;
@@ -1081,7 +1083,12 @@ export function remeasureParagraph(
   const indentRight = Math.max(0, rawIndentRight);
   const indentFirstLine = Math.max(0, indent?.firstLine ?? 0);
   const indentHanging = Math.max(0, indent?.hanging ?? 0);
-  const baseFirstLineOffset = firstLineIndent || indentFirstLine - indentHanging;
+  // Match measuring/dom/src/index.ts: `suppressFirstLineIndent` is a Word quirk where
+  // justified paragraphs ignore their first-line indent. Without honoring it here, the
+  // initial measure and remeasure (triggered by live editing, resize, etc.) produce
+  // different first-line offsets and the first line jumps on redraw.
+  const suppressFirstLine = attrs?.suppressFirstLineIndent === true;
+  const baseFirstLineOffset = suppressFirstLine ? 0 : firstLineIndent || indentFirstLine - indentHanging;
   // When wordLayout is present, the hanging region is occupied by the list marker/tab,
   // so keep the same available width as body lines. For normal paragraphs we must honor
   // negative offsets (hanging indent) so the first line can extend into the hanging region.

--- a/packages/layout-engine/layout-bridge/src/remeasure.ts
+++ b/packages/layout-engine/layout-bridge/src/remeasure.ts
@@ -1082,11 +1082,19 @@ export function remeasureParagraph(
   const indentFirstLine = Math.max(0, indent?.firstLine ?? 0);
   const indentHanging = Math.max(0, indent?.hanging ?? 0);
   const baseFirstLineOffset = firstLineIndent || indentFirstLine - indentHanging;
-  const rawFirstLineOffset = baseFirstLineOffset;
+  // When wordLayout is present, the hanging region is occupied by the list marker/tab,
+  // so keep the same available width as body lines. For normal paragraphs we must honor
+  // negative offsets (hanging indent) so the first line can extend into the hanging region.
   const clampedFirstLineOffset = Math.max(0, baseFirstLineOffset);
-  const hasNegativeIndent = rawIndentLeft < 0 || rawIndentRight < 0;
-  const allowNegativeFirstLineOffset = !wordLayout?.marker && !hasNegativeIndent && baseFirstLineOffset < 0;
-  const effectiveFirstLineOffset = allowNegativeFirstLineOffset ? baseFirstLineOffset : clampedFirstLineOffset;
+  // Avoid widening the first line when a negative LEFT indent already expands the content area.
+  // Negative right indent doesn't cause this problem — it only extends rightward.
+  const hasNegativeLeftIndent = rawIndentLeft < 0;
+  const allowNegativeFirstLineOffset = !wordLayout?.marker && !hasNegativeLeftIndent && baseFirstLineOffset < 0;
+  const effectiveFirstLineOffset = wordLayout?.marker
+    ? 0
+    : allowNegativeFirstLineOffset
+      ? baseFirstLineOffset
+      : clampedFirstLineOffset;
   const contentWidth = Math.max(1, maxWidth - indentLeft - indentRight);
   // Shared helper is the canonical source for list text-start geometry.
   // Keep an explicit top-level fallback for producers that only provide textStartPx.
@@ -1127,7 +1135,7 @@ export function remeasureParagraph(
     const isFirstLine = lines.length === 0;
     // For first line, reduce available width by textStart/first-line offset (e.g., for in-flow list markers)
     const effectiveMaxWidth = Math.max(1, isFirstLine ? firstLineWidth : contentWidth);
-    const effectiveIndent = isFirstLine ? indentLeft + rawFirstLineOffset : indentLeft;
+    const effectiveIndent = isFirstLine ? indentLeft + baseFirstLineOffset : indentLeft;
     const startRun = currentRun;
     const startChar = currentChar;
     let width = 0;
@@ -1322,7 +1330,7 @@ export function remeasureParagraph(
     (run) => run?.kind === 'text' && typeof (run as TextRun).text === 'string' && (run as TextRun).text.includes('\t'),
   );
   if (hasTabRun || hasTextTab) {
-    applyTabLayoutToLines(lines, runs, tabStops, decimalSeparator, indentLeft, rawFirstLineOffset);
+    applyTabLayoutToLines(lines, runs, tabStops, decimalSeparator, indentLeft, baseFirstLineOffset);
   }
 
   const totalHeight = lines.reduce((s, l) => s + l.lineHeight, 0);

--- a/packages/layout-engine/layout-bridge/test/remeasure.test.ts
+++ b/packages/layout-engine/layout-bridge/test/remeasure.test.ts
@@ -611,6 +611,63 @@ describe('remeasureParagraph', () => {
       expect(measure.lines[1].maxWidth).toBe(maxWidth);
     });
 
+    // SD-2415: the guard was relaxed from `hasNegativeIndent` to `hasNegativeLeftIndent`.
+    // These tests pin the new behavior so a revert is caught.
+    it('widens first line with hanging when only right indent is negative', () => {
+      const maxWidth = 200;
+      const block = createBlock([textRun('A'.repeat(40))], {
+        indent: { left: 0, right: -30, hanging: 20 },
+      });
+      const measure = remeasureParagraph(block, maxWidth);
+
+      expect(measure.lines.length).toBeGreaterThan(1);
+      // First line widens by hanging amount; body lines use plain content width.
+      expect(measure.lines[0].maxWidth).toBe(maxWidth + 20);
+      expect(measure.lines[1].maxWidth).toBe(maxWidth);
+    });
+
+    it('does NOT widen first line when left indent is negative (SD-1401 regression guard)', () => {
+      const maxWidth = 200;
+      const block = createBlock([textRun('A'.repeat(40))], {
+        indent: { left: -20, right: 0, hanging: 20 },
+      });
+      const measure = remeasureParagraph(block, maxWidth);
+
+      expect(measure.lines.length).toBeGreaterThan(1);
+      expect(measure.lines[0].maxWidth).toBe(maxWidth);
+      expect(measure.lines[1].maxWidth).toBe(maxWidth);
+    });
+
+    // SD-2415: remeasure must match the initial measurer on `suppressFirstLineIndent`.
+    // Without this, remeasure (triggered by typing, resize, style change) produces a
+    // different first-line offset than the initial measure and text jumps on redraw.
+    it('honors suppressFirstLineIndent by not widening the first line', () => {
+      const maxWidth = 200;
+      const block = createBlock([textRun('A'.repeat(40))], {
+        indent: { left: 0, right: 0, hanging: 20 },
+        suppressFirstLineIndent: true,
+      });
+      const measure = remeasureParagraph(block, maxWidth);
+
+      expect(measure.lines.length).toBeGreaterThan(1);
+      // With suppressFirstLineIndent=true, firstLineOffset is forced to 0,
+      // so the first line uses the same width as body lines.
+      expect(measure.lines[0].maxWidth).toBe(maxWidth);
+      expect(measure.lines[1].maxWidth).toBe(maxWidth);
+    });
+
+    it('widens first line when suppressFirstLineIndent is false (default)', () => {
+      const maxWidth = 200;
+      const block = createBlock([textRun('A'.repeat(40))], {
+        indent: { left: 0, right: 0, hanging: 20 },
+      });
+      const measure = remeasureParagraph(block, maxWidth);
+
+      expect(measure.lines.length).toBeGreaterThan(1);
+      expect(measure.lines[0].maxWidth).toBe(maxWidth + 20);
+      expect(measure.lines[1].maxWidth).toBe(maxWidth);
+    });
+
     it('respects firstLineIndent parameter for list markers', () => {
       // firstLineIndent parameter (different from attrs.indent.firstLine) is for in-flow list markers
       const block = createBlock([textRun('A'.repeat(15))]); // 15 chars = 150px

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
@@ -1307,6 +1307,152 @@ describe('resolveLayout', () => {
       expect(content.lines[0].availableWidth).toBe(468);
     });
 
+    it('does not adjust availableWidth for list paragraphs with hanging indent', () => {
+      const layout: Layout = {
+        pageSize: { w: 612, h: 792 },
+        pages: [
+          {
+            number: 1,
+            fragments: [
+              {
+                kind: 'para',
+                blockId: 'p1',
+                fromLine: 0,
+                toLine: 2,
+                x: 72,
+                y: 100,
+                width: 468,
+                markerWidth: 36,
+                markerTextWidth: 10,
+              },
+            ],
+          },
+        ],
+      };
+      const blocks: FlowBlock[] = [
+        {
+          kind: 'paragraph',
+          id: 'p1',
+          runs: [{ kind: 'text', text: 'List item text here' }],
+          attrs: {
+            indent: { left: 36, hanging: 36 },
+            wordLayout: {
+              marker: {
+                markerText: '1.',
+                justification: 'left',
+                suffix: 'tab',
+                run: { fontFamily: 'Arial', fontSize: 12 },
+              },
+            },
+          },
+        },
+      ];
+      const measures: Measure[] = [
+        {
+          kind: 'paragraph',
+          lines: [makeLine(), makeLine({ fromChar: 10, toChar: 20 })],
+          totalHeight: 40,
+        },
+      ];
+
+      const result = resolveLayout({ layout, flowMode: 'paginated', blocks, measures });
+      const content = (result.pages[0].items[0] as any).content;
+      // List first line: textIndentPx should be 0 (list marker occupies the hanging region),
+      // so availableWidth should NOT be adjusted for hanging indent.
+      expect(content.lines[0].textIndentPx).toBe(0);
+      // base = 468 - max(0, 36) = 432 — stays at 432, no hanging indent adjustment
+      expect(content.lines[0].availableWidth).toBe(432);
+    });
+
+    it('does not adjust availableWidth on continuation fragment even with hanging indent', () => {
+      const layout: Layout = {
+        pageSize: { w: 612, h: 792 },
+        pages: [
+          {
+            number: 1,
+            fragments: [{ kind: 'para', blockId: 'p1', fromLine: 0, toLine: 1, x: 72, y: 100, width: 468 }],
+          },
+          {
+            number: 2,
+            fragments: [
+              {
+                kind: 'para',
+                blockId: 'p1',
+                fromLine: 1,
+                toLine: 2,
+                x: 72,
+                y: 72,
+                width: 468,
+                continuesFromPrev: true,
+              },
+            ],
+          },
+        ],
+      };
+      const blocks: FlowBlock[] = [
+        {
+          kind: 'paragraph',
+          id: 'p1',
+          runs: [{ kind: 'text', text: 'Hello world test line continued' }],
+          attrs: { indent: { left: 160, hanging: 160 } },
+        },
+      ];
+      const measures: Measure[] = [
+        {
+          kind: 'paragraph',
+          lines: [makeLine(), makeLine({ fromChar: 10, toChar: 20 })],
+          totalHeight: 40,
+        },
+      ];
+
+      const result = resolveLayout({ layout, flowMode: 'paginated', blocks, measures });
+      // Page 1: first line of paragraph — gets hanging indent adjustment
+      const page1Content = (result.pages[0].items[0] as any).content;
+      expect(page1Content.lines[0].textIndentPx).toBe(-160);
+      expect(page1Content.lines[0].availableWidth).toBe(468);
+
+      // Page 2: continuation fragment — first line here is NOT the paragraph's first line,
+      // so textIndentPx should be 0 and availableWidth should NOT be adjusted.
+      const page2Content = (result.pages[1].items[0] as any).content;
+      expect(page2Content.lines[0].textIndentPx).toBe(0);
+      // base = 468 - max(0, 160) = 308 — no adjustment
+      expect(page2Content.lines[0].availableWidth).toBe(308);
+    });
+
+    it('does not adjust availableWidth when suppressFirstLineIndent is true', () => {
+      const layout: Layout = {
+        pageSize: { w: 612, h: 792 },
+        pages: [
+          {
+            number: 1,
+            fragments: [{ kind: 'para', blockId: 'p1', fromLine: 0, toLine: 2, x: 72, y: 100, width: 468 }],
+          },
+        ],
+      };
+      const blocks: FlowBlock[] = [
+        {
+          kind: 'paragraph',
+          id: 'p1',
+          runs: [{ kind: 'text', text: 'Hello world test line' }],
+          attrs: { indent: { left: 160, hanging: 160 }, suppressFirstLineIndent: true } as any,
+        },
+      ];
+      const measures: Measure[] = [
+        {
+          kind: 'paragraph',
+          lines: [makeLine(), makeLine({ fromChar: 10, toChar: 20 })],
+          totalHeight: 40,
+        },
+      ];
+
+      const result = resolveLayout({ layout, flowMode: 'paginated', blocks, measures });
+      const content = (result.pages[0].items[0] as any).content;
+      // suppressFirstLineIndent zeroes the firstLineOffset, so textIndent = 0
+      // and availableWidth stays at base = 468 - max(0, 160) = 308
+      expect(content.lines[0].textIndentPx).toBe(0);
+      expect(content.lines[0].availableWidth).toBe(308);
+    });
+
     it('does not double-subtract positive firstLine indent when line.maxWidth already accounts for it', () => {
       const layout: Layout = {
         pageSize: { w: 612, h: 792 },

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
@@ -1196,5 +1196,149 @@ describe('resolveLayout', () => {
       // availableWidth = fragment.width - max(0, left) - max(0, right) = 468 - 36 - 36 = 396
       expect(line0.availableWidth).toBe(396);
     });
+
+    it('increases availableWidth on first line when hanging indent produces negative textIndent', () => {
+      const layout: Layout = {
+        pageSize: { w: 612, h: 792 },
+        pages: [
+          {
+            number: 1,
+            fragments: [{ kind: 'para', blockId: 'p1', fromLine: 0, toLine: 2, x: 72, y: 100, width: 468 }],
+          },
+        ],
+      };
+      const blocks: FlowBlock[] = [
+        {
+          kind: 'paragraph',
+          id: 'p1',
+          runs: [{ kind: 'text', text: 'Hello world test line' }],
+          attrs: { indent: { left: 160, hanging: 160 } },
+        },
+      ];
+      const measures: Measure[] = [
+        {
+          kind: 'paragraph',
+          lines: [makeLine(), makeLine({ fromChar: 10, toChar: 20 })],
+          totalHeight: 40,
+        },
+      ];
+
+      const result = resolveLayout({ layout, flowMode: 'paginated', blocks, measures });
+      const content = (result.pages[0].items[0] as any).content;
+      // First line: textIndent = -160 (firstLine(0) - hanging(160))
+      // availableWidth should account for the negative textIndent:
+      // base = 468 - max(0, 160) = 308, then adjusted by -(-160) = 308 + 160 = 468
+      expect(content.lines[0].textIndentPx).toBe(-160);
+      expect(content.lines[0].availableWidth).toBe(468);
+      // Body line: no textIndent adjustment, availableWidth stays at base
+      expect(content.lines[1].textIndentPx).toBe(0);
+      expect(content.lines[1].availableWidth).toBe(308);
+    });
+
+    it('decreases availableWidth on first line when firstLine indent produces positive textIndent', () => {
+      const layout: Layout = {
+        pageSize: { w: 612, h: 792 },
+        pages: [
+          {
+            number: 1,
+            fragments: [{ kind: 'para', blockId: 'p1', fromLine: 0, toLine: 2, x: 72, y: 100, width: 468 }],
+          },
+        ],
+      };
+      const blocks: FlowBlock[] = [
+        {
+          kind: 'paragraph',
+          id: 'p1',
+          runs: [{ kind: 'text', text: 'Hello world test line' }],
+          attrs: { indent: { left: 36, firstLine: 72 } },
+        },
+      ];
+      const measures: Measure[] = [
+        {
+          kind: 'paragraph',
+          lines: [makeLine(), makeLine({ fromChar: 10, toChar: 20 })],
+          totalHeight: 40,
+        },
+      ];
+
+      const result = resolveLayout({ layout, flowMode: 'paginated', blocks, measures });
+      const content = (result.pages[0].items[0] as any).content;
+      // First line: textIndent = 72 (firstLine(72) - hanging(0))
+      // availableWidth should be reduced: base = 468 - 36 = 432, then 432 - 72 = 360
+      expect(content.lines[0].textIndentPx).toBe(72);
+      expect(content.lines[0].availableWidth).toBe(360);
+      // Body line: no textIndent, availableWidth = 468 - 36 = 432
+      expect(content.lines[1].textIndentPx).toBe(0);
+      expect(content.lines[1].availableWidth).toBe(432);
+    });
+
+    it('adjusts availableWidth for hanging indent even when line.maxWidth is set (Math.min clamps it)', () => {
+      const layout: Layout = {
+        pageSize: { w: 612, h: 792 },
+        pages: [
+          {
+            number: 1,
+            fragments: [{ kind: 'para', blockId: 'p1', fromLine: 0, toLine: 2, x: 72, y: 100, width: 468 }],
+          },
+        ],
+      };
+      const blocks: FlowBlock[] = [
+        {
+          kind: 'paragraph',
+          id: 'p1',
+          runs: [{ kind: 'text', text: 'Hello world test line' }],
+          attrs: { indent: { left: 160, hanging: 160 } },
+        },
+      ];
+      // The measurer sets maxWidth = contentWidth - firstLineOffset = (468-160) - (-160) = 468
+      // but Math.min(468, fallback=308) clamps it to 308. The textIndent adjustment restores it.
+      const measures: Measure[] = [
+        {
+          kind: 'paragraph',
+          lines: [makeLine({ maxWidth: 468 }), makeLine({ fromChar: 10, toChar: 20 })],
+          totalHeight: 40,
+        },
+      ];
+
+      const result = resolveLayout({ layout, flowMode: 'paginated', blocks, measures });
+      const content = (result.pages[0].items[0] as any).content;
+      // First line: min(468, 308) = 308, then adjusted by -(-160) = 468
+      expect(content.lines[0].textIndentPx).toBe(-160);
+      expect(content.lines[0].availableWidth).toBe(468);
+    });
+
+    it('does not double-subtract positive firstLine indent when line.maxWidth already accounts for it', () => {
+      const layout: Layout = {
+        pageSize: { w: 612, h: 792 },
+        pages: [
+          {
+            number: 1,
+            fragments: [{ kind: 'para', blockId: 'p1', fromLine: 0, toLine: 2, x: 72, y: 100, width: 468 }],
+          },
+        ],
+      };
+      const blocks: FlowBlock[] = [
+        {
+          kind: 'paragraph',
+          id: 'p1',
+          runs: [{ kind: 'text', text: 'Hello world test line' }],
+          attrs: { indent: { left: 36, firstLine: 72 } },
+        },
+      ];
+      // The measurer sets maxWidth = contentWidth - firstLineOffset = 432 - 72 = 360
+      const measures: Measure[] = [
+        {
+          kind: 'paragraph',
+          lines: [makeLine({ maxWidth: 360 }), makeLine({ fromChar: 10, toChar: 20 })],
+          totalHeight: 40,
+        },
+      ];
+
+      const result = resolveLayout({ layout, flowMode: 'paginated', blocks, measures });
+      const content = (result.pages[0].items[0] as any).content;
+      // First line: min(360, 432) = 360 — already correct, should NOT subtract again
+      expect(content.lines[0].textIndentPx).toBe(72);
+      expect(content.lines[0].availableWidth).toBe(360);
+    });
   });
 });

--- a/packages/layout-engine/layout-resolved/src/resolveParagraph.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveParagraph.ts
@@ -9,6 +9,7 @@ import type {
   ResolvedDropCapItem,
   ResolvedListMarkerItem,
 } from '@superdoc/contracts';
+import { adjustAvailableWidthForTextIndent } from '@superdoc/contracts';
 import {
   isMinimalWordLayout,
   resolveListMarkerGeometry,
@@ -287,14 +288,7 @@ export function resolveParagraphContent(
     }
 
     // Adjust availableWidth for first-line text indent.
-    // Negative textIndentPx (hanging indent): the measurer sets line.maxWidth to the
-    // correct wider value, but Math.min with fallbackAvailableWidth clamps it back down.
-    // Always adjust to restore the actual available space.
-    // Positive textIndentPx (firstLine indent): the measurer already bakes it into
-    // line.maxWidth, so only adjust on the fallback path (maxWidth not set).
-    if (textIndentPx !== 0 && (textIndentPx < 0 || line.maxWidth == null)) {
-      availableWidth = Math.max(0, availableWidth - textIndentPx);
-    }
+    availableWidth = adjustAvailableWidthForTextIndent(availableWidth, textIndentPx, line.maxWidth);
 
     // --- indentOffset for segment positioning path (mirrors renderer lines 5635-5653) ---
     const indentLeft = paraIndent?.left ?? 0;

--- a/packages/layout-engine/layout-resolved/src/resolveParagraph.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveParagraph.ts
@@ -286,6 +286,16 @@ export function resolveParagraphContent(
       }
     }
 
+    // Adjust availableWidth for first-line text indent.
+    // Negative textIndentPx (hanging indent): the measurer sets line.maxWidth to the
+    // correct wider value, but Math.min with fallbackAvailableWidth clamps it back down.
+    // Always adjust to restore the actual available space.
+    // Positive textIndentPx (firstLine indent): the measurer already bakes it into
+    // line.maxWidth, so only adjust on the fallback path (maxWidth not set).
+    if (textIndentPx !== 0 && (textIndentPx < 0 || line.maxWidth == null)) {
+      availableWidth = Math.max(0, availableWidth - textIndentPx);
+    }
+
     // --- indentOffset for segment positioning path (mirrors renderer lines 5635-5653) ---
     const indentLeft = paraIndent?.left ?? 0;
     const firstLine = paraIndent?.firstLine ?? 0;

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -912,9 +912,10 @@ async function measureParagraphBlock(block: ParagraphBlock, maxWidth: number): P
   // so keep the same available width as body lines. For normal paragraphs we must honor
   // negative offsets (hanging indent) so the first line can extend into the hanging region.
   const clampedFirstLineOffset = Math.max(0, rawFirstLineOffset);
-  const hasNegativeIndent = indentLeft < 0 || indentRight < 0;
-  // Avoid widening the first line when negative indents already expand fragment width.
-  const allowNegativeFirstLineOffset = !isWordLayoutList && !hasNegativeIndent && rawFirstLineOffset < 0;
+  // Avoid widening the first line when a negative LEFT indent already expands the content area.
+  // Negative right indent doesn't cause this problem — it only extends rightward.
+  const hasNegativeLeftIndent = indentLeft < 0;
+  const allowNegativeFirstLineOffset = !isWordLayoutList && !hasNegativeLeftIndent && rawFirstLineOffset < 0;
   const firstLineOffset = isWordLayoutList
     ? 0
     : allowNegativeFirstLineOffset

--- a/packages/layout-engine/measuring/dom/src/negativeIndent.test.ts
+++ b/packages/layout-engine/measuring/dom/src/negativeIndent.test.ts
@@ -674,5 +674,63 @@ describe('negative indent measurement', () => {
       expect(measure.lines[0].maxWidth).toBe(contentWidth);
       expect(measure.lines[1].maxWidth).toBe(contentWidth);
     });
+
+    // SD-2415: the guard was relaxed from `hasNegativeIndent` (left<0 || right<0)
+    // to `hasNegativeLeftIndent` (left<0). The cases below pin the changed
+    // behavior so a future revert is caught by the test suite.
+    it('widens first line with hanging indent when only the RIGHT indent is negative', async () => {
+      const maxWidth = 468;
+      const negativeRight = -48;
+      const hanging = 24;
+
+      const longText =
+        'The first line of this paragraph extends into the hanging region while the right indent pushes every line further into the right margin area, so the text should wrap across multiple lines when the available width is exhausted by the natural measurement of the run contents.';
+
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'sd2415-neg-right-only-with-hanging',
+        runs: [{ text: longText, fontFamily: 'Arial', fontSize: 12 }],
+        attrs: {
+          indent: { left: 0, right: negativeRight, hanging },
+        },
+      };
+
+      const measure = expectParagraphMeasure(await measureBlock(block, maxWidth));
+      expect(measure.lines.length).toBeGreaterThan(1);
+
+      // contentWidth = maxWidth - left(0) - right(-48) = maxWidth + 48.
+      // First-line offset from hanging = -24, so first-line maxWidth = contentWidth + 24.
+      const contentWidth = maxWidth + Math.abs(negativeRight);
+      expect(measure.lines[0].maxWidth).toBe(contentWidth + hanging);
+      // Body lines use the plain content width.
+      expect(measure.lines[1].maxWidth).toBe(contentWidth);
+    });
+
+    it('does NOT widen first line when the LEFT indent is negative, even with hanging', async () => {
+      // Regression guard for SD-1401: a negative LEFT indent already widens
+      // contentWidth leftward, so adding hanging on top would double-count.
+      const maxWidth = 468;
+      const negativeLeft = -48;
+      const hanging = 24;
+
+      const longText =
+        'This paragraph has a negative left indent which already widens every line leftward into the page margin, so the first line must not be widened by the hanging amount on top of that expansion or the first line will overflow the fragment area and produce misaligned justified spacing across wrapped body text.';
+
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'sd1401-neg-left-with-hanging',
+        runs: [{ text: longText, fontFamily: 'Arial', fontSize: 12 }],
+        attrs: {
+          indent: { left: negativeLeft, right: 0, hanging },
+        },
+      };
+
+      const measure = expectParagraphMeasure(await measureBlock(block, maxWidth));
+      expect(measure.lines.length).toBeGreaterThan(1);
+
+      const contentWidth = maxWidth + Math.abs(negativeLeft);
+      expect(measure.lines[0].maxWidth).toBe(contentWidth);
+      expect(measure.lines[1].maxWidth).toBe(contentWidth);
+    });
   });
 });

--- a/packages/layout-engine/painters/dom/src/renderer-hanging-indent.test.ts
+++ b/packages/layout-engine/painters/dom/src/renderer-hanging-indent.test.ts
@@ -2333,4 +2333,165 @@ describe('DomPainter hanging indent with tabs', () => {
       expect(lineEl.style.paddingLeft).toBe('200px');
     });
   });
+
+  /**
+   * SD-2415: Justified paragraphs with hanging indent.
+   *
+   * The customer bug was visible character overlap in docs like LOI-copy.docx.
+   * Mechanism: the painter was computing first-line `availableWidth` as the body-line
+   * width (`fragment.width - paraIndentLeft`) instead of the widened first-line width
+   * (`fragment.width`, since hanging extends the first line leftward). When
+   * `lineWidth > availableWidth`, `calculateJustifySpacing` returns a negative
+   * `spacingPerSpace`, which CSS `word-spacing` applies as visible character
+   * compression — letters from adjacent words visibly touch and overlap.
+   *
+   * These tests pin the painter's first-line availableWidth to the measurer's
+   * `line.maxWidth` so `wordSpacing` never goes negative for justified hanging
+   * paragraphs whose first line fits within the widened width.
+   */
+  describe('Justified paragraphs with hanging indent (SD-2415)', () => {
+    function createJustifiedHangingMeasure(opts: {
+      naturalWidth: number;
+      maxWidth: number;
+      spaceCount: number;
+      charCount: number;
+    }): Measure {
+      return {
+        kind: 'paragraph',
+        lines: [
+          {
+            fromRun: 0,
+            fromChar: 0,
+            toRun: 0,
+            toChar: opts.charCount,
+            width: opts.naturalWidth,
+            maxWidth: opts.maxWidth,
+            ascent: 12,
+            descent: 4,
+            lineHeight: 20,
+            spaceCount: opts.spaceCount,
+          } as Line,
+        ],
+        totalHeight: 20,
+      };
+    }
+
+    function paintJustifiedHanging(opts: {
+      text: string;
+      fragmentWidth: number;
+      left: number;
+      hanging: number;
+      naturalWidth: number;
+      maxWidth: number;
+      spaceCount: number;
+    }): HTMLElement {
+      const blockId = 'sd-2415';
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: blockId,
+        runs: [{ text: opts.text, fontFamily: 'Arial', fontSize: 12, pmStart: 0, pmEnd: opts.text.length }],
+        attrs: {
+          alignment: 'both',
+          indent: { left: opts.left, hanging: opts.hanging },
+        },
+      };
+
+      const measure = createJustifiedHangingMeasure({
+        naturalWidth: opts.naturalWidth,
+        maxWidth: opts.maxWidth,
+        spaceCount: opts.spaceCount,
+        charCount: opts.text.length,
+      });
+
+      const layout: Layout = {
+        pageSize: { w: 600, h: 500 },
+        pages: [
+          {
+            number: 1,
+            fragments: [
+              {
+                kind: 'para',
+                blockId,
+                fromLine: 0,
+                toLine: 1,
+                x: 50,
+                y: 40,
+                width: opts.fragmentWidth,
+                pmStart: 0,
+                pmEnd: opts.text.length,
+                // Not the last line of the paragraph — justify should apply
+                continuesOnNext: true,
+              },
+            ],
+          },
+        ],
+      };
+
+      const painter = createDomPainter({ blocks: [block], measures: [measure], container });
+      painter.paint(layout, container);
+      const lineEl = container.querySelector('.superdoc-line') as HTMLElement;
+      expect(lineEl).toBeTruthy();
+      return lineEl;
+    }
+
+    it('does not produce negative word-spacing on the first line when text fits within column width but exceeds body-line width', () => {
+      // column = 300, left = 160, hanging = 160 → body-line content width = 140,
+      // first-line content width (widened) = 300. Natural text width = 250 (fits
+      // in 300 but would overflow 140). Pre-fix painter used 140 as availableWidth,
+      // producing spacingPerSpace = (140 - 250) / 5 = -22px per space — visible
+      // character overlap. Post-fix availableWidth is 300, spacingPerSpace = +10.
+      const lineEl = paintJustifiedHanging({
+        text: 'one two three four five six',
+        fragmentWidth: 300,
+        left: 160,
+        hanging: 160,
+        naturalWidth: 250,
+        maxWidth: 300,
+        spaceCount: 5,
+      });
+
+      const wordSpacingPx = lineEl.style.wordSpacing === '' ? 0 : parseFloat(lineEl.style.wordSpacing);
+      expect(Number.isNaN(wordSpacingPx)).toBe(false);
+      // Core assertion: never negative. Negative word-spacing = visible character overlap.
+      expect(wordSpacingPx).toBeGreaterThanOrEqual(0);
+    });
+
+    it('applies positive word-spacing to spread a short first line across the widened first-line width', () => {
+      // Natural width 200, first-line available 300 → slack 100 over 5 spaces = 20px each.
+      const lineEl = paintJustifiedHanging({
+        text: 'one two three four five six',
+        fragmentWidth: 300,
+        left: 160,
+        hanging: 160,
+        naturalWidth: 200,
+        maxWidth: 300,
+        spaceCount: 5,
+      });
+
+      const wordSpacingPx = parseFloat(lineEl.style.wordSpacing);
+      expect(wordSpacingPx).toBeGreaterThan(0);
+      // Post-fix: slack / spaceCount = (300 - 200) / 5 = 20.
+      // Pre-fix would have used body-line width 140: (140 - 200) / 5 = -12.
+      expect(wordSpacingPx).toBeCloseTo(20, 1);
+    });
+
+    it('leaves textIndent and paddingLeft intact for the hanging layout', () => {
+      const lineEl = paintJustifiedHanging({
+        text: 'one two three four five six',
+        fragmentWidth: 300,
+        left: 160,
+        hanging: 160,
+        naturalWidth: 250,
+        maxWidth: 300,
+        spaceCount: 5,
+      });
+
+      // text-indent shifts the first-line text leftward by the hanging amount
+      // so the visible extent covers the widened first-line width.
+      expect(lineEl.style.textIndent).toBe('-160px');
+      // padding-left matches the left indent; combined with text-indent it places
+      // the first-line text at the fragment's left edge.
+      expect(lineEl.style.paddingLeft).toBe('160px');
+    });
+  });
 });

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -56,6 +56,7 @@ import type {
   ResolvedDrawingItem,
 } from '@superdoc/contracts';
 import {
+  adjustAvailableWidthForTextIndent,
   calculateJustifySpacing,
   computeLinePmRange,
   getCellSpacingPx,
@@ -3206,17 +3207,14 @@ export class DomPainter {
           }
 
           // Adjust availableWidth for first-line text indent (hanging indent).
-          // Only unconditionally for negative offsets; positive offsets are already in line.maxWidth.
           const isFirstLine = index === 0 && !fragment.continuesFromPrev;
           const isListFirstLine = Boolean(hasListFirstLineMarker && fragment.markerTextWidth);
-          if (
-            isFirstLine &&
-            firstLineOffset &&
-            !isListFirstLine &&
-            !hasExplicitSegmentPositioning &&
-            (firstLineOffset < 0 || line.maxWidth == null)
-          ) {
-            availableWidthOverride = Math.max(0, availableWidthOverride - firstLineOffset);
+          if (isFirstLine && !isListFirstLine && !hasExplicitSegmentPositioning) {
+            availableWidthOverride = adjustAvailableWidthForTextIndent(
+              availableWidthOverride,
+              firstLineOffset,
+              line.maxWidth,
+            );
           }
 
           const isLastLineOfFragment = index === lines.length - 1;

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -3205,6 +3205,20 @@ export class DomPainter {
             availableWidthOverride = fragment.width - listFirstLineTextStartPx - Math.max(0, paraIndentRight);
           }
 
+          // Adjust availableWidth for first-line text indent (hanging indent).
+          // Only unconditionally for negative offsets; positive offsets are already in line.maxWidth.
+          const isFirstLine = index === 0 && !fragment.continuesFromPrev;
+          const isListFirstLine = Boolean(hasListFirstLineMarker && fragment.markerTextWidth);
+          if (
+            isFirstLine &&
+            firstLineOffset &&
+            !isListFirstLine &&
+            !hasExplicitSegmentPositioning &&
+            (firstLineOffset < 0 || line.maxWidth == null)
+          ) {
+            availableWidthOverride = Math.max(0, availableWidthOverride - firstLineOffset);
+          }
+
           const isLastLineOfFragment = index === lines.length - 1;
           const isLastLineOfParagraph = isLastLineOfFragment && !fragment.continuesOnNext;
           const shouldSkipJustifyForLastLine = isLastLineOfParagraph && !paragraphEndsWithLineBreak;
@@ -3218,9 +3232,6 @@ export class DomPainter {
             shouldSkipJustifyForLastLine,
             shouldUseResolvedListTextStart ? listFirstLineTextStartPx : undefined,
           );
-
-          const isListFirstLine = Boolean(hasListFirstLineMarker && fragment.markerTextWidth);
-          const isFirstLine = index === 0 && !fragment.continuesFromPrev;
 
           if (!isListFirstLine) {
             if (hasExplicitSegmentPositioning) {


### PR DESCRIPTION
## Summary

Justified paragraphs with first-line or hanging indents computed `availableWidth`
differently across the painter, layout resolver, hit-testing, and selection code
paths. The mismatch caused the justify spacing algorithm to distribute space
incorrectly, producing overlapping or misaligned text.

- Account for text-indent when computing `availableWidth` for justified lines in
  the layout resolver and painter — negative indent (hanging) widens the line,
  positive indent (firstLine) narrows it, with a guard to avoid double-subtraction
  when the measurer already baked the offset into `line.maxWidth`
- Align the same adjustment in hit-testing (`position-hit.ts`) and selection rect
  calculation (`mapPmToX`) so clicks and selection highlighting match the rendered text
- Relax the measurer/remeasurer guard from `hasNegativeIndent` to
  `hasNegativeLeftIndent` — negative *right* indent only extends rightward and
  does not cause the first-line widening problem that the original SD-1401 guard
  was protecting against
- Extract `getFirstLineIndentOffset()` and `adjustAvailableWidthForTextIndent()`
  into `contracts/justify-utils.ts` to deduplicate the adjustment logic that was
  repeated across 5 call sites
- Guard table cell hit-testing indent adjustment against `partialRow.fromLineByCell`
  to avoid applying first-line indent on continuation slices of split rows
- A document was added to the corpus for visual testing