### PR TITLE
chore(template-builder, esign): bump superdoc peer dep to ^1.23.0

### DIFF
--- a/packages/esign/package.json
+++ b/packages/esign/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "superdoc": "^1.19.0"
+    "superdoc": "^1.23.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "catalog:",

--- a/packages/template-builder/package.json
+++ b/packages/template-builder/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "superdoc": "^1.19.0"
+    "superdoc": "^1.23.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "catalog:",


### PR DESCRIPTION
Bumps superdoc peer dependency from `^1.19.0` to `^1.23.0` in both `@superdoc-dev/template-builder` and `@superdoc-dev/esign`.

Picks up fixes shipped since v1.19.0 that are relevant:
- SD-2323: image resize handles hidden in view mode
- SD-1361: layout engine no longer hides block SDTs
- SD-1850: ProseMirror CSS scoped to prevent host-app bleed

Both packages tested locally — template-builder (46/46 tests), esign (49/49 tests).