### PR TITLE
fix(types): add exportDocx overloads and fix Toolbar compat (SD-2261)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -229,6 +229,19 @@ export interface SaveOptions {
 export type ExportOptions = SaveOptions;
 
 /**
+ * Full parameter set for `Editor.exportDocx()`.
+ * Extends SaveOptions with internal export format flags.
+ */
+export interface ExportDocxParams extends SaveOptions {
+  /** Return raw XML string instead of a binary blob */
+  exportXmlOnly?: boolean;
+  /** Return JSON string instead of a binary blob */
+  exportJsonOnly?: boolean;
+  /** Return the updated file map instead of a binary blob */
+  getUpdatedDocs?: boolean;
+}
+
+/**
  * Main editor class that manages document state, extensions, and user interactions
  */
 export class Editor extends EventEmitter<EditorEventMap> {
@@ -3061,7 +3074,17 @@ export class Editor extends EventEmitter<EditorEventMap> {
 
   /**
    * Export the editor document to DOCX.
+   *
+   * Return type depends on flags:
+   * - `exportXmlOnly: true` → `string` (raw XML)
+   * - `exportJsonOnly: true` → `string` (JSON string)
+   * - `getUpdatedDocs: true` → `Record<string, string | null>` (file map)
+   * - Default → `Blob` (browser) or `Buffer` (Node.js headless)
    */
+  async exportDocx(params: ExportDocxParams & { exportXmlOnly: true }): Promise<string>;
+  async exportDocx(params: ExportDocxParams & { exportJsonOnly: true }): Promise<string>;
+  async exportDocx(params: ExportDocxParams & { getUpdatedDocs: true }): Promise<Record<string, string | null>>;
+  async exportDocx(params?: ExportDocxParams): Promise<Blob | Buffer>;
   async exportDocx({
     isFinalDoc = false,
     commentsType = 'external',
@@ -3071,16 +3094,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
     getUpdatedDocs = false,
     fieldsHighlightColor = null,
     compression,
-  }: {
-    isFinalDoc?: boolean;
-    commentsType?: string;
-    exportJsonOnly?: boolean;
-    exportXmlOnly?: boolean;
-    comments?: Comment[];
-    getUpdatedDocs?: boolean;
-    fieldsHighlightColor?: string | null;
-    compression?: 'DEFLATE' | 'STORE';
-  } = {}): Promise<Blob | ArrayBuffer | Buffer | Record<string, string | null> | ProseMirrorJSON | string | undefined> {
+  }: ExportDocxParams = {}): Promise<Blob | Buffer | Record<string, string | null> | string | undefined> {
     try {
       // Use provided comments, or fall back to imported comments from converter
       const effectiveComments = comments ?? this.converter.comments ?? [];

--- a/packages/super-editor/src/editors/v1/core/types/EditorTypes.ts
+++ b/packages/super-editor/src/editors/v1/core/types/EditorTypes.ts
@@ -78,11 +78,13 @@ export interface PageStyles {
 }
 
 /**
- * Toolbar configuration
+ * Toolbar instance accepted by `Editor.setToolbar()`.
+ *
+ * Any object with an optional `setActiveEditor` method satisfies this interface,
+ * including `SuperToolbar` which extends EventEmitter.
  */
 export interface Toolbar {
   setActiveEditor?: (editor: Editor) => void;
-  [key: string]: unknown;
 }
 
 /**

--- a/packages/super-editor/src/index.ts
+++ b/packages/super-editor/src/index.ts
@@ -76,7 +76,13 @@ export type {
   ExportFormat,
   PageStyles,
 } from './editors/v1/core/types/EditorTypes.js';
-export type { OpenOptions, SaveOptions, ExportOptions, EditorLifecycleState } from './editors/v1/core/Editor.js';
+export type {
+  OpenOptions,
+  SaveOptions,
+  ExportOptions,
+  ExportDocxParams,
+  EditorLifecycleState,
+} from './editors/v1/core/Editor.js';
 
 // PresentationEditor public types
 export type {


### PR DESCRIPTION
Fix two customer-reported type errors when consuming the superdoc package.

- Add `exportDocx` function overloads that narrow the return type based on flags (`exportXmlOnly`, `exportJsonOnly`, `getUpdatedDocs`). Default returns `Blob | Buffer` matching actual runtime behavior (Blob in browser, Buffer in Node.js headless). Extract `ExportDocxParams` interface.
- Remove `[key: string]: unknown` index signature from `Toolbar` interface — was making `SuperToolbar` (extends EventEmitter) incompatible with `setToolbar()`.