### PR TITLE
feat(template-builder): wire lockMode through field insertion paths

### DIFF
--- a/apps/docs/solutions/template-builder/api-reference.mdx
+++ b/apps/docs/solutions/template-builder/api-reference.mdx
@@ -75,6 +75,10 @@ None - the component works with zero configuration.
   - `object` — full toolbar configuration (see ToolbarConfig)
 </ParamField>
 
+<ParamField path="defaultLockMode" type="'unlocked' | 'sdtLocked' | 'contentLocked' | 'sdtContentLocked'">
+  Lock mode for all inserted fields. Per-field `lockMode` overrides this. See [lock modes](/extensions/structured-content#lock-modes).
+</ParamField>
+
 <ParamField path="cspNonce" type="string">
   Content Security Policy nonce for dynamically injected styles
 </ParamField>
@@ -174,6 +178,7 @@ interface FieldDefinition {
   mode?: "inline" | "block";       // Insertion mode (default: "inline")
   group?: string;                  // Group ID for linked fields
   fieldType?: string;              // Field type, e.g. "owner" or "signer" (default: "owner")
+  lockMode?: LockMode;             // Lock mode for this field (overrides defaultLockMode)
 }
 ```
 
@@ -190,6 +195,7 @@ interface TemplateField {
   mode?: "inline" | "block"; // Rendering mode
   group?: string;            // Group ID for linked fields
   fieldType?: string;        // Field type, e.g. "owner" or "signer"
+  lockMode?: LockMode;       // Current lock mode of this field
 }
 ```
 
@@ -426,6 +432,7 @@ import type {
   SuperDocTemplateBuilderHandle,
   FieldDefinition,
   TemplateField,
+  LockMode,
   TriggerEvent,
   ExportEvent,
   ExportConfig,

--- a/apps/docs/solutions/template-builder/configuration.mdx
+++ b/apps/docs/solutions/template-builder/configuration.mdx
@@ -112,11 +112,11 @@ When enabled, the field menu shows a "Create New Field" option with inputs for n
 
 ### Field locking
 
-Make fields read-only so users can't edit or delete them:
+Make fields read-only so end users can't edit their content:
 
 ```tsx
 <SuperDocTemplateBuilder
-  defaultLockMode="sdtContentLocked"
+  defaultLockMode="contentLocked"
   fields={{
     available: [
       { id: "1", label: "Customer Name" },
@@ -126,16 +126,9 @@ Make fields read-only so users can't edit or delete them:
 />
 ```
 
-Per-field `lockMode` overrides `defaultLockMode`. Four modes:
+Per-field `lockMode` overrides `defaultLockMode`. The default field creation form includes a "Locked" checkbox that sets `contentLocked`.
 
-| Mode | Container | Content |
-| ---- | --------- | ------- |
-| `unlocked` | Deletable | Editable |
-| `sdtLocked` | Protected | Editable |
-| `contentLocked` | Deletable | Read-only |
-| `sdtContentLocked` | Protected | Read-only |
-
-Most apps want `sdtContentLocked`. See [lock modes](/extensions/structured-content#lock-modes) for details.
+Template authors can always delete and manage fields regardless of lock mode — locking only affects end users interacting with the document. For advanced use cases, see [lock modes](/extensions/structured-content#lock-modes).
 
 ### Linked fields
 

--- a/apps/docs/solutions/template-builder/configuration.mdx
+++ b/apps/docs/solutions/template-builder/configuration.mdx
@@ -110,6 +110,33 @@ Allow users to create new fields while building templates:
 
 When enabled, the field menu shows a "Create New Field" option with inputs for name, mode (inline/block), and field type (owner/signer).
 
+### Field locking
+
+Make fields read-only so users can't edit or delete them:
+
+```tsx
+<SuperDocTemplateBuilder
+  defaultLockMode="sdtContentLocked"
+  fields={{
+    available: [
+      { id: "1", label: "Customer Name" },
+      { id: "2", label: "Notes", lockMode: "unlocked" }, // this one stays editable
+    ],
+  }}
+/>
+```
+
+Per-field `lockMode` overrides `defaultLockMode`. Four modes:
+
+| Mode | Container | Content |
+| ---- | --------- | ------- |
+| `unlocked` | Deletable | Editable |
+| `sdtLocked` | Protected | Editable |
+| `contentLocked` | Deletable | Read-only |
+| `sdtContentLocked` | Protected | Read-only |
+
+Most apps want `sdtContentLocked`. See [lock modes](/extensions/structured-content#lock-modes) for details.
+
 ### Linked fields
 
 When a user selects an existing field from the "Existing Fields" section in the menu, a linked copy is inserted. Both instances share a group ID and stay in sync.

--- a/packages/template-builder/src/defaults/FieldList.tsx
+++ b/packages/template-builder/src/defaults/FieldList.tsx
@@ -124,6 +124,21 @@ const FieldItem: FC<{
               {field.fieldType}
             </span>
           )}
+          {field.lockMode && field.lockMode !== 'unlocked' && (
+            <span
+              style={{
+                fontSize: '9px',
+                padding: '2px 5px',
+                borderRadius: '3px',
+                background: '#fef2f2',
+                color: '#991b1b',
+                fontWeight: '500',
+              }}
+              title={field.lockMode}
+            >
+              🔒
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/packages/template-builder/src/defaults/FieldMenu.tsx
+++ b/packages/template-builder/src/defaults/FieldMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { FieldDefinition, FieldMenuProps, LockMode } from '../types';
+import type { FieldDefinition, FieldMenuProps } from '../types';
 import { getFieldTypeStyle } from '../utils';
 import { InfoTooltip } from './InfoTooltip';
 
@@ -20,7 +20,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
   const [newFieldName, setNewFieldName] = useState('');
   const [fieldMode, setFieldMode] = useState<'inline' | 'block'>('inline');
   const [fieldType, setFieldType] = useState<string>('owner');
-  const [fieldLockMode, setFieldLockMode] = useState<LockMode | ''>('');
+  const [fieldLocked, setFieldLocked] = useState(false);
   const [existingExpanded, setExistingExpanded] = useState(true);
   const [availableExpanded, setAvailableExpanded] = useState(true);
 
@@ -30,7 +30,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
       setNewFieldName('');
       setFieldMode('inline');
       setFieldType('owner');
-      setFieldLockMode('');
+      setFieldLocked(false);
     }
   }, [isVisible]);
 
@@ -71,7 +71,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
       label: trimmedName,
       mode: fieldMode,
       fieldType: fieldType,
-      ...(fieldLockMode && { lockMode: fieldLockMode as LockMode }),
+      ...(fieldLocked && { lockMode: 'contentLocked' as const }),
     };
 
     try {
@@ -86,7 +86,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
       setNewFieldName('');
       setFieldMode('inline');
       setFieldType('owner');
-      setFieldLockMode('');
+      setFieldLocked(false);
     }
   };
 
@@ -135,7 +135,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
                 setIsCreating(false);
                 setNewFieldName('');
                 setFieldMode('inline');
-                setFieldLockMode('');
+                setFieldLocked(false);
               }
             }}
             autoFocus
@@ -232,25 +232,18 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
               Signer
             </label>
           </div>
-          <div style={{ marginTop: '8px' }}>
-            <select
-              value={fieldLockMode}
-              onChange={(e) => setFieldLockMode(e.target.value as LockMode | '')}
-              style={{
-                width: '100%',
-                padding: '4px 8px',
-                border: '1px solid #ddd',
-                borderRadius: '3px',
-                fontSize: '13px',
-                color: fieldLockMode ? '#111827' : '#9ca3af',
-              }}
-            >
-              <option value=''>No lock</option>
-              <option value='unlocked'>Unlocked</option>
-              <option value='sdtLocked'>Container locked</option>
-              <option value='contentLocked'>Content locked</option>
-              <option value='sdtContentLocked'>Fully locked</option>
-            </select>
+          <div
+            style={{
+              marginTop: '8px',
+              display: 'flex',
+              gap: '12px',
+              fontSize: '13px',
+            }}
+          >
+            <label style={{ display: 'flex', alignItems: 'center', gap: '4px', cursor: 'pointer' }}>
+              <input type='checkbox' checked={fieldLocked} onChange={(e) => setFieldLocked(e.target.checked)} />
+              Locked
+            </label>
           </div>
           <div
             style={{
@@ -279,7 +272,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
                 setNewFieldName('');
                 setFieldMode('inline');
                 setFieldType('owner');
-                setFieldLockMode('');
+                setFieldLocked(false);
               }}
               style={{
                 padding: '4px 12px',

--- a/packages/template-builder/src/defaults/FieldMenu.tsx
+++ b/packages/template-builder/src/defaults/FieldMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { FieldDefinition, FieldMenuProps } from '../types';
+import type { FieldDefinition, FieldMenuProps, LockMode } from '../types';
 import { getFieldTypeStyle } from '../utils';
 import { InfoTooltip } from './InfoTooltip';
 
@@ -20,6 +20,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
   const [newFieldName, setNewFieldName] = useState('');
   const [fieldMode, setFieldMode] = useState<'inline' | 'block'>('inline');
   const [fieldType, setFieldType] = useState<string>('owner');
+  const [fieldLockMode, setFieldLockMode] = useState<LockMode | ''>('');
   const [existingExpanded, setExistingExpanded] = useState(true);
   const [availableExpanded, setAvailableExpanded] = useState(true);
 
@@ -29,6 +30,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
       setNewFieldName('');
       setFieldMode('inline');
       setFieldType('owner');
+      setFieldLockMode('');
     }
   }, [isVisible]);
 
@@ -69,6 +71,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
       label: trimmedName,
       mode: fieldMode,
       fieldType: fieldType,
+      ...(fieldLockMode && { lockMode: fieldLockMode as LockMode }),
     };
 
     try {
@@ -83,6 +86,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
       setNewFieldName('');
       setFieldMode('inline');
       setFieldType('owner');
+      setFieldLockMode('');
     }
   };
 
@@ -131,6 +135,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
                 setIsCreating(false);
                 setNewFieldName('');
                 setFieldMode('inline');
+                setFieldLockMode('');
               }
             }}
             autoFocus
@@ -227,6 +232,26 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
               Signer
             </label>
           </div>
+          <div style={{ marginTop: '8px' }}>
+            <select
+              value={fieldLockMode}
+              onChange={(e) => setFieldLockMode(e.target.value as LockMode | '')}
+              style={{
+                width: '100%',
+                padding: '4px 8px',
+                border: '1px solid #ddd',
+                borderRadius: '3px',
+                fontSize: '13px',
+                color: fieldLockMode ? '#111827' : '#9ca3af',
+              }}
+            >
+              <option value=''>No lock</option>
+              <option value='unlocked'>Unlocked</option>
+              <option value='sdtLocked'>Container locked</option>
+              <option value='contentLocked'>Content locked</option>
+              <option value='sdtContentLocked'>Fully locked</option>
+            </select>
+          </div>
           <div
             style={{
               marginTop: '8px',
@@ -254,6 +279,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
                 setNewFieldName('');
                 setFieldMode('inline');
                 setFieldType('owner');
+                setFieldLockMode('');
               }}
               style={{
                 padding: '4px 12px',

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -236,8 +236,15 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
         let documentFields = getTemplateFieldsFromEditor(editor);
         const fieldStillPresent = documentFields.some((field) => field.id === id);
 
+        // If the command failed and the field is still in the document,
+        // check if it's locked — locked fields should not be force-removed.
         if (!commandResult && fieldStillPresent) {
-          documentFields = documentFields.filter((field) => field.id !== id);
+          const lockedField = documentFields.find((field) => field.id === id);
+          const isLocked = lockedField?.lockMode === 'sdtLocked' || lockedField?.lockMode === 'sdtContentLocked';
+
+          if (!isLocked) {
+            documentFields = documentFields.filter((field) => field.id !== id);
+          }
         }
 
         if (groupId) {

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -146,7 +146,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
         const attrs: Record<string, unknown> = {
           alias: field.alias,
           tag: tagData,
-          ...(lockMode && { lockMode }),
+          ...(lockMode != null && { lockMode }),
         };
 
         const success = (
@@ -531,7 +531,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
         const attrs: Record<string, unknown> = {
           alias: field.alias,
           tag: tagWithGroup,
-          ...(lockMode && { lockMode }),
+          ...(lockMode != null && { lockMode }),
         };
 
         const success =

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -39,6 +39,7 @@ const getTemplateFieldsFromEditor = (editor: Editor): Types.TemplateField[] => {
       mode,
       group: structuredContentHelpers.getGroup?.(attrs.tag) ?? undefined,
       fieldType: parsedTag?.fieldType ?? 'owner',
+      lockMode: attrs.lockMode ?? undefined,
     } as Types.TemplateField;
   });
 };
@@ -51,6 +52,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
       menu = {},
       list = {},
       toolbar,
+      defaultLockMode,
       cspNonce,
       telemetry,
       licenseKey,
@@ -139,22 +141,18 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
               })
             : undefined;
 
+        const lockMode = field.lockMode ?? defaultLockMode;
+
+        const attrs: Record<string, unknown> = {
+          alias: field.alias,
+          tag: tagData,
+          ...(lockMode && { lockMode }),
+        };
+
         const success = (
           mode === 'inline'
-            ? editor.commands.insertStructuredContentInline?.({
-                attrs: {
-                  alias: field.alias,
-                  tag: tagData,
-                },
-                text: field.defaultValue || field.alias,
-              })
-            : editor.commands.insertStructuredContentBlock?.({
-                attrs: {
-                  alias: field.alias,
-                  tag: tagData,
-                },
-                text: field.defaultValue || field.alias,
-              })
+            ? editor.commands.insertStructuredContentInline?.({ attrs, text: field.defaultValue || field.alias })
+            : editor.commands.insertStructuredContentBlock?.({ attrs, text: field.defaultValue || field.alias })
         ) as boolean | undefined;
 
         if (success) {
@@ -174,7 +172,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
 
         return success ?? false;
       },
-      [onFieldInsert, onFieldsChange, templateFields],
+      [onFieldInsert, onFieldsChange, templateFields, defaultLockMode],
     );
 
     const updateField = useCallback(
@@ -485,6 +483,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
               metadata: createdField.metadata,
               defaultValue: createdField.defaultValue,
               fieldType: createdField.fieldType,
+              lockMode: createdField.lockMode,
             });
             setMenuVisible(false);
             return;
@@ -496,6 +495,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
           metadata: field.metadata,
           defaultValue: field.defaultValue,
           fieldType: field.fieldType,
+          lockMode: field.lockMode,
         });
         setMenuVisible(false);
       },
@@ -526,23 +526,18 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
         });
 
         const mode = field.mode || 'inline';
+        const lockMode = field.lockMode ?? defaultLockMode;
+
+        const attrs: Record<string, unknown> = {
+          alias: field.alias,
+          tag: tagWithGroup,
+          ...(lockMode && { lockMode }),
+        };
 
         const success =
           mode === 'inline'
-            ? editor.commands.insertStructuredContentInline?.({
-                attrs: {
-                  alias: field.alias,
-                  tag: tagWithGroup,
-                },
-                text: field.alias,
-              })
-            : editor.commands.insertStructuredContentBlock?.({
-                attrs: {
-                  alias: field.alias,
-                  tag: tagWithGroup,
-                },
-                text: field.alias,
-              });
+            ? editor.commands.insertStructuredContentInline?.({ attrs, text: field.alias })
+            : editor.commands.insertStructuredContentBlock?.({ attrs, text: field.alias });
 
         if (success) {
           if (!field.group) {
@@ -556,7 +551,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
           onFieldsChange?.(updatedFields);
         }
       },
-      [updateField, resetMenuFilter, onFieldsChange],
+      [updateField, resetMenuFilter, onFieldsChange, defaultLockMode],
     );
 
     const handleMenuClose = useCallback(() => {

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -236,15 +236,8 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
         let documentFields = getTemplateFieldsFromEditor(editor);
         const fieldStillPresent = documentFields.some((field) => field.id === id);
 
-        // If the command failed and the field is still in the document,
-        // check if it's locked — locked fields should not be force-removed.
         if (!commandResult && fieldStillPresent) {
-          const lockedField = documentFields.find((field) => field.id === id);
-          const isLocked = lockedField?.lockMode === 'sdtLocked' || lockedField?.lockMode === 'sdtContentLocked';
-
-          if (!isLocked) {
-            documentFields = documentFields.filter((field) => field.id !== id);
-          }
+          documentFields = documentFields.filter((field) => field.id !== id);
         }
 
         if (groupId) {

--- a/packages/template-builder/src/tests/utils.test.ts
+++ b/packages/template-builder/src/tests/utils.test.ts
@@ -72,6 +72,18 @@ describe('areTemplateFieldsEqual', () => {
     const b: TemplateField[] = [{ id: '1', alias: 'Name', fieldType: 'signer' }];
     expect(areTemplateFieldsEqual(a, b)).toBe(false);
   });
+
+  it('returns false when lockMode differs', () => {
+    const a: TemplateField[] = [{ id: '1', alias: 'Name', lockMode: 'unlocked' }];
+    const b: TemplateField[] = [{ id: '1', alias: 'Name', lockMode: 'sdtContentLocked' }];
+    expect(areTemplateFieldsEqual(a, b)).toBe(false);
+  });
+
+  it('returns true when lockMode is the same', () => {
+    const a: TemplateField[] = [{ id: '1', alias: 'Name', lockMode: 'contentLocked' }];
+    const b: TemplateField[] = [{ id: '1', alias: 'Name', lockMode: 'contentLocked' }];
+    expect(areTemplateFieldsEqual(a, b)).toBe(true);
+  });
 });
 
 describe('resolveToolbar', () => {

--- a/packages/template-builder/src/types.ts
+++ b/packages/template-builder/src/types.ts
@@ -1,5 +1,7 @@
 import type { SuperDoc } from 'superdoc';
 
+export type LockMode = 'unlocked' | 'sdtLocked' | 'contentLocked' | 'sdtContentLocked';
+
 /** Field definition for template builder */
 export interface FieldDefinition {
   id: string;
@@ -9,6 +11,7 @@ export interface FieldDefinition {
   mode?: 'inline' | 'block';
   group?: string;
   fieldType?: string;
+  lockMode?: LockMode;
 }
 
 /** Field instance in a template document */
@@ -20,6 +23,7 @@ export interface TemplateField {
   mode?: 'inline' | 'block';
   group?: string;
   fieldType?: string;
+  lockMode?: LockMode;
 }
 
 export interface TriggerEvent {
@@ -113,6 +117,9 @@ export interface SuperDocTemplateBuilderProps {
   menu?: MenuConfig;
   list?: ListConfig;
   toolbar?: boolean | string | ToolbarConfig;
+
+  /** Lock mode applied to all inserted fields unless overridden per-field */
+  defaultLockMode?: LockMode;
 
   /** Content Security Policy nonce for dynamically injected styles */
   cspNonce?: string;

--- a/packages/template-builder/src/utils.ts
+++ b/packages/template-builder/src/utils.ts
@@ -18,7 +18,8 @@ export const areTemplateFieldsEqual = (a: TemplateField[], b: TemplateField[]): 
       left.position !== right.position ||
       left.mode !== right.mode ||
       left.group !== right.group ||
-      left.fieldType !== right.fieldType
+      left.fieldType !== right.fieldType ||
+      left.lockMode !== right.lockMode
     ) {
       return false;
     }


### PR DESCRIPTION
SuperDoc core already enforces SDT lock modes, but Template Builder never passed lockMode to the editor commands. This adds:

- LockMode type and lockMode prop on FieldDefinition / TemplateField
- defaultLockMode prop on SuperDocTemplateBuilderProps
- lockMode threading through insertFieldInternal, handleSelectExisting, and handleMenuSelect
- lockMode read-back in getTemplateFieldsFromEditor

Closes SD-1866