### PR TITLE
feat(template-builder): add fieldColors prop for field type styling (SD-883)

### DIFF
--- a/apps/docs/solutions/template-builder/api-reference.mdx
+++ b/apps/docs/solutions/template-builder/api-reference.mdx
@@ -79,6 +79,10 @@ None - the component works with zero configuration.
   Lock mode for all inserted fields. Per-field `lockMode` overrides this. See [lock modes](/extensions/structured-content#lock-modes).
 </ParamField>
 
+<ParamField path="fieldColors" type="Record<string, string>">
+  Colors for field types in the document and sidebar. Keys are `fieldType` values, values are CSS colors (e.g. `{ owner: '#629be7', signer: '#d97706' }`). Generates scoped CSS automatically — no stylesheet import needed.
+</ParamField>
+
 <ParamField path="cspNonce" type="string">
   Content Security Policy nonce for dynamically injected styles
 </ParamField>
@@ -393,13 +397,25 @@ Returns `SuperDoc | null`.
 
 ## Field type styling
 
-Import the optional CSS to color-code fields by type in the editor:
+Use the `fieldColors` prop to color-code fields by type:
+
+```tsx
+<SuperDocTemplateBuilder
+  fieldColors={{
+    owner: "#629be7",
+    signer: "#d97706",
+    date: "#059669",
+  }}
+/>
+```
+
+This generates scoped CSS automatically. Each color controls the field border and label in the document. Sidebar badges match.
+
+For manual control, you can still import the standalone stylesheet and use CSS variables:
 
 ```jsx
 import "@superdoc-dev/template-builder/field-types.css";
 ```
-
-Override colors with CSS variables:
 
 ```css
 :root {

--- a/apps/docs/solutions/template-builder/configuration.mdx
+++ b/apps/docs/solutions/template-builder/configuration.mdx
@@ -65,24 +65,30 @@ Tag fields with a `fieldType` to distinguish roles:
 />
 ```
 
-Import the optional CSS to color-code fields in the editor:
+Color-code fields in the document and sidebar with `fieldColors`:
 
-```jsx
-import "@superdoc-dev/template-builder/field-types.css";
+```tsx
+<SuperDocTemplateBuilder
+  fields={{
+    available: [
+      { id: "1", label: "Company Name", fieldType: "owner" },
+      { id: "2", label: "Signer Name", fieldType: "signer" },
+      { id: "3", label: "Effective Date", fieldType: "date" },
+    ],
+  }}
+  fieldColors={{
+    owner: "#629be7",
+    signer: "#d97706",
+    date: "#059669",
+  }}
+/>
 ```
 
-Customize colors with CSS variables:
+Each color controls the field's border and label in the document. The sidebar badges match automatically. Custom field types beyond `owner` and `signer` work the same way — just add them to `fieldColors`.
 
-```css
-:root {
-  --superdoc-field-owner-color: #629be7;
-  --superdoc-field-signer-color: #d97706;
-}
-```
-
-<Important>
-  Without `field-types.css`, structured content fields use the default Word-like appearance: borders are transparent and only visible on selection. Importing this stylesheet makes field borders always visible and color-coded by field type, which helps template authors quickly identify fields in the document.
-</Important>
+<Tip>
+  You can also import `@superdoc-dev/template-builder/field-types.css` directly and use CSS variables instead. The `fieldColors` prop is the recommended approach — no extra imports needed.
+</Tip>
 
 The `fieldType` value flows through all callbacks (`onFieldInsert`, `onFieldsChange`, `onExport`, etc.) and is stored in the SDT tag metadata.
 

--- a/packages/template-builder/demo/src/App.css
+++ b/packages/template-builder/demo/src/App.css
@@ -255,12 +255,6 @@ header {
   background: #000000;
 }
 
-/* Field type color overrides — just set the CSS variables */
-:root {
-  --superdoc-field-owner-color: #1bb754;
-  --superdoc-field-signer-color: #d81313;
-}
-
 /* Responsive */
 @media (max-width: 768px) {
   .header-content {

--- a/packages/template-builder/demo/src/App.tsx
+++ b/packages/template-builder/demo/src/App.tsx
@@ -8,7 +8,6 @@ import type {
   ExportEvent,
 } from '@superdoc-dev/template-builder';
 import 'superdoc/style.css';
-import '@superdoc-dev/template-builder/field-types.css';
 import './App.css';
 
 const availableFields: FieldDefinition[] = [
@@ -253,6 +252,10 @@ export function App() {
           fields={fieldsConfig}
           list={listConfig}
           toolbar={true}
+          fieldColors={{
+            owner: '#629be7',
+            signer: '#d97706',
+          }}
           telemetry={{
             enabled: true,
             metadata: {

--- a/packages/template-builder/src/defaults/FieldList.tsx
+++ b/packages/template-builder/src/defaults/FieldList.tsx
@@ -13,7 +13,8 @@ const FieldItem: FC<{
   onDelete: (id: string | number) => void;
   isSelected: boolean;
   isGrouped?: boolean;
-}> = ({ field, onSelect, onDelete, isSelected, isGrouped = false }) => {
+  fieldColors?: Record<string, string>;
+}> = ({ field, onSelect, onDelete, isSelected, isGrouped = false, fieldColors }) => {
   return (
     <div
       onClick={() => onSelect(field)}
@@ -117,7 +118,7 @@ const FieldItem: FC<{
                 fontSize: '9px',
                 padding: '2px 5px',
                 borderRadius: '3px',
-                ...getFieldTypeStyle(field.fieldType),
+                ...getFieldTypeStyle(field.fieldType, fieldColors),
                 fontWeight: '500',
               }}
             >
@@ -145,7 +146,7 @@ const FieldItem: FC<{
   );
 };
 
-export const FieldList: FC<FieldListProps> = ({ fields, onSelect, onDelete, selectedFieldId }) => {
+export const FieldList: FC<FieldListProps> = ({ fields, onSelect, onDelete, selectedFieldId, fieldColors }) => {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
   const { groupedFields, ungroupedFields } = useMemo(() => {
@@ -211,6 +212,7 @@ export const FieldList: FC<FieldListProps> = ({ fields, onSelect, onDelete, sele
               onSelect={onSelect}
               onDelete={onDelete}
               isSelected={selectedFieldId === field.id}
+              fieldColors={fieldColors}
             />
           ))}
 
@@ -273,6 +275,7 @@ export const FieldList: FC<FieldListProps> = ({ fields, onSelect, onDelete, sele
                         onDelete={onDelete}
                         isSelected={selectedFieldId === field.id}
                         isGrouped
+                        fieldColors={fieldColors}
                       />
                     ))}
                   </div>

--- a/packages/template-builder/src/defaults/FieldMenu.tsx
+++ b/packages/template-builder/src/defaults/FieldMenu.tsx
@@ -15,6 +15,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
   onCreateField,
   existingFields = [],
   onSelectExisting,
+  fieldColors,
 }) => {
   const [isCreating, setIsCreating] = useState(false);
   const [newFieldName, setNewFieldName] = useState('');
@@ -389,7 +390,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
                               padding: '2px 6px',
                               borderRadius: '3px',
                               textTransform: 'capitalize',
-                              ...getFieldTypeStyle(entry.fieldType),
+                              ...getFieldTypeStyle(entry.fieldType, fieldColors),
                               fontWeight: 500,
                             }}
                           >
@@ -501,7 +502,7 @@ export const FieldMenu: React.FC<FieldMenuProps> = ({
                           padding: '2px 6px',
                           borderRadius: '3px',
                           textTransform: 'capitalize',
-                          ...getFieldTypeStyle(field.fieldType),
+                          ...getFieldTypeStyle(field.fieldType, fieldColors),
                           fontWeight: 500,
                         }}
                       >

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -2,7 +2,13 @@ import { useRef, useState, useEffect, useCallback, useMemo, forwardRef, useImper
 import type { SuperDoc } from 'superdoc'; // requires superdoc >=1.24.2 for correct types
 import type * as Types from './types';
 import { FieldMenu, FieldList } from './defaults';
-import { areTemplateFieldsEqual, resolveToolbar, clampToViewport, getPresentationEditor } from './utils';
+import {
+  areTemplateFieldsEqual,
+  resolveToolbar,
+  clampToViewport,
+  getPresentationEditor,
+  generateFieldColorCSS,
+} from './utils';
 
 export * from './types';
 export { FieldMenu, FieldList };
@@ -53,6 +59,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
       list = {},
       toolbar,
       defaultLockMode,
+      fieldColors,
       cspNonce,
       telemetry,
       licenseKey,
@@ -100,6 +107,27 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
       }),
       [telemetry?.enabled, JSON.stringify(telemetry?.metadata)],
     );
+
+    const stableFieldColors = useMemo(() => JSON.stringify(fieldColors), [fieldColors]);
+
+    // Inject scoped field-color CSS when fieldColors is provided
+    useEffect(() => {
+      if (!stableFieldColors || stableFieldColors === 'undefined') return;
+      const colors = JSON.parse(stableFieldColors) as Record<string, string>;
+      const scope = `.superdoc-template-builder`;
+      const css = generateFieldColorCSS(colors, scope);
+      if (!css) return;
+
+      const style = window.document.createElement('style');
+      style.setAttribute('data-superdoc-field-colors', '');
+      if (cspNonce) style.nonce = cspNonce;
+      style.textContent = css;
+      window.document.head.appendChild(style);
+
+      return () => {
+        style.remove();
+      };
+    }, [stableFieldColors, cspNonce]);
 
     const computeFilteredFields = useCallback(
       (query: string) => {
@@ -629,6 +657,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
                 onDelete={deleteField}
                 onUpdate={(field) => updateField(field.id, field)}
                 selectedFieldId={selectedFieldId || undefined}
+                fieldColors={fieldColors}
               />
             </div>
           )}
@@ -674,6 +703,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
           onCreateField={onFieldCreate}
           existingFields={templateFields}
           onSelectExisting={handleSelectExisting}
+          fieldColors={fieldColors}
         />
       </div>
     );

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -685,6 +685,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
                 onDelete={deleteField}
                 onUpdate={(field) => updateField(field.id, field)}
                 selectedFieldId={selectedFieldId || undefined}
+                fieldColors={fieldColors}
               />
             </div>
           )}

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -108,26 +108,25 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
       [telemetry?.enabled, JSON.stringify(telemetry?.metadata)],
     );
 
-    const stableFieldColors = useMemo(() => JSON.stringify(fieldColors), [fieldColors]);
+    const fieldColorCSS = useMemo(() => {
+      if (!fieldColors) return '';
+      return generateFieldColorCSS(fieldColors, '.superdoc-template-builder');
+    }, [fieldColors]);
 
     // Inject scoped field-color CSS when fieldColors is provided
     useEffect(() => {
-      if (!stableFieldColors || stableFieldColors === 'undefined') return;
-      const colors = JSON.parse(stableFieldColors) as Record<string, string>;
-      const scope = `.superdoc-template-builder`;
-      const css = generateFieldColorCSS(colors, scope);
-      if (!css) return;
+      if (!fieldColorCSS) return;
 
       const style = window.document.createElement('style');
       style.setAttribute('data-superdoc-field-colors', '');
       if (cspNonce) style.nonce = cspNonce;
-      style.textContent = css;
+      style.textContent = fieldColorCSS;
       window.document.head.appendChild(style);
 
       return () => {
         style.remove();
       };
-    }, [stableFieldColors, cspNonce]);
+    }, [fieldColorCSS, cspNonce]);
 
     const computeFilteredFields = useCallback(
       (query: string) => {

--- a/packages/template-builder/src/tests/utils.test.ts
+++ b/packages/template-builder/src/tests/utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { areTemplateFieldsEqual, resolveToolbar, clampToViewport } from '../utils';
+import {
+  areTemplateFieldsEqual,
+  resolveToolbar,
+  clampToViewport,
+  getFieldTypeStyle,
+  generateFieldColorCSS,
+} from '../utils';
 import type { TemplateField } from '../types';
 
 describe('areTemplateFieldsEqual', () => {
@@ -154,5 +160,78 @@ describe('clampToViewport', () => {
     // maxTop = 768 - 300 - 10 = 458
     expect(result.left).toBe(764);
     expect(result.top).toBe(458);
+  });
+});
+
+describe('getFieldTypeStyle', () => {
+  it('returns hardcoded signer style without fieldColors', () => {
+    const style = getFieldTypeStyle('signer');
+    expect(style).toEqual({ background: '#fef3c7', color: '#b45309' });
+  });
+
+  it('returns default style for unknown type without fieldColors', () => {
+    const style = getFieldTypeStyle('unknown');
+    expect(style).toEqual({ background: '#f3f4f6', color: '#6b7280' });
+  });
+
+  it('returns custom color with color-mix background when fieldColors provided', () => {
+    const style = getFieldTypeStyle('date', { date: '#059669' });
+    expect(style.color).toBe('#059669');
+    expect(style.background).toContain('color-mix');
+    expect(style.background).toContain('#059669');
+  });
+
+  it('falls back to default for types not in fieldColors', () => {
+    const style = getFieldTypeStyle('unknown', { owner: '#629be7' });
+    expect(style).toEqual({ background: '#f3f4f6', color: '#6b7280' });
+  });
+
+  it('works with non-hex colors', () => {
+    const style = getFieldTypeStyle('custom', { custom: 'rgb(100, 200, 50)' });
+    expect(style.color).toBe('rgb(100, 200, 50)');
+    expect(style.background).toContain('color-mix');
+  });
+});
+
+describe('generateFieldColorCSS', () => {
+  it('returns empty string for empty object', () => {
+    expect(generateFieldColorCSS({}, '.scope')).toBe('');
+  });
+
+  it('generates per-type rules with data-sdt-tag selectors', () => {
+    const css = generateFieldColorCSS({ signer: '#d97706' }, '.scope');
+    expect(css).toContain('[data-sdt-tag*=\'"fieldType":"signer"\']');
+    expect(css).toContain('#d97706');
+  });
+
+  it('generates default rule when owner is defined', () => {
+    const css = generateFieldColorCSS({ owner: '#629be7', signer: '#d97706' }, '.scope');
+    // Default rule (no tag selector) + per-type rules
+    expect(css).toContain('.scope .superdoc-structured-content-inline,');
+    expect(css).toContain('#629be7');
+    expect(css).toContain('#d97706');
+  });
+
+  it('does not generate default rule when no owner key', () => {
+    const css = generateFieldColorCSS({ signer: '#d97706' }, '.scope');
+    // Should only have tag-selector rules, not a blanket default
+    const lines = css.split('\n').filter((l) => l.includes('border-color'));
+    lines.forEach((line) => {
+      // Every border-color rule should be within a tag selector context
+      expect(css).toContain('data-sdt-tag');
+    });
+  });
+
+  it('uses correct label selectors for inline and block', () => {
+    const css = generateFieldColorCSS({ owner: '#629be7' }, '.scope');
+    expect(css).toContain('.superdoc-structured-content-inline__label');
+    expect(css).toContain('.superdoc-structured-content__label');
+    // Should NOT contain the wrong block label class
+    expect(css).not.toContain('.superdoc-structured-content-block__label');
+  });
+
+  it('uses color-mix for label backgrounds', () => {
+    const css = generateFieldColorCSS({ owner: '#629be7' }, '.scope');
+    expect(css).toContain('color-mix(in srgb, #629be7 87%, transparent)');
   });
 });

--- a/packages/template-builder/src/types.ts
+++ b/packages/template-builder/src/types.ts
@@ -50,6 +50,7 @@ export interface FieldMenuProps {
   onCreateField?: (field: FieldDefinition) => void | Promise<FieldDefinition | void>;
   existingFields?: TemplateField[];
   onSelectExisting?: (field: TemplateField) => void;
+  fieldColors?: Record<string, string>;
 }
 
 export interface FieldListProps {
@@ -58,6 +59,7 @@ export interface FieldListProps {
   onDelete: (fieldId: string | number) => void;
   onUpdate?: (field: TemplateField) => void;
   selectedFieldId?: string | number;
+  fieldColors?: Record<string, string>;
 }
 
 export interface DocumentConfig {
@@ -120,6 +122,9 @@ export interface SuperDocTemplateBuilderProps {
 
   /** Lock mode applied to all inserted fields unless overridden per-field */
   defaultLockMode?: LockMode;
+
+  /** Colors for field types in the document and sidebar. Keys are fieldType values, values are CSS colors. */
+  fieldColors?: Record<string, string>;
 
   /** Content Security Policy nonce for dynamically injected styles */
   cspNonce?: string;

--- a/packages/template-builder/src/utils.ts
+++ b/packages/template-builder/src/utils.ts
@@ -68,59 +68,55 @@ const FIELD_TYPE_STYLES: Record<string, { background: string; color: string }> =
 const DEFAULT_FIELD_TYPE_STYLE = { background: '#f3f4f6', color: '#6b7280' };
 
 /**
- * Derive a light background + dark text from a single hex/css color.
+ * Derive a light background + dark text from a single color.
  * Falls back to the hardcoded map when no fieldColors are provided.
  */
 export const getFieldTypeStyle = (fieldType: string, fieldColors?: Record<string, string>) => {
   if (fieldColors?.[fieldType]) {
-    return { background: fieldColors[fieldType] + '1a', color: fieldColors[fieldType] };
+    const color = fieldColors[fieldType];
+    return { background: `color-mix(in srgb, ${color} 10%, transparent)`, color };
   }
   return FIELD_TYPE_STYLES[fieldType] ?? DEFAULT_FIELD_TYPE_STYLE;
 };
 
 const SDT_INLINE = '.superdoc-structured-content-inline';
 const SDT_BLOCK = '.superdoc-structured-content-block';
+const INLINE_LABEL = '.superdoc-structured-content-inline__label';
+const BLOCK_LABEL = '.superdoc-structured-content__label';
+
+function buildColorRules(scope: string, selector: string, color: string): string {
+  return `
+${scope} ${SDT_INLINE}${selector},
+${scope} ${SDT_BLOCK}${selector} {
+  border-color: ${color};
+}
+${scope} ${SDT_INLINE}${selector}:hover,
+${scope} ${SDT_BLOCK}${selector}:hover {
+  border-color: ${color};
+}
+${scope} ${SDT_INLINE}${selector} ${INLINE_LABEL},
+${scope} ${SDT_BLOCK}${selector} ${BLOCK_LABEL} {
+  border-color: ${color};
+  background-color: color-mix(in srgb, ${color} 87%, transparent);
+}`;
+}
 
 /** Generate scoped CSS rules for field type colors. */
 export function generateFieldColorCSS(fieldColors: Record<string, string>, scopeSelector: string): string {
-  const rules: string[] = [];
   const entries = Object.entries(fieldColors);
   if (entries.length === 0) return '';
 
-  // Default color (owner or first entry)
-  const defaultColor = fieldColors.owner ?? entries[0][1];
-  rules.push(`
-${scopeSelector} ${SDT_INLINE},
-${scopeSelector} ${SDT_BLOCK} {
-  border-color: ${defaultColor};
-}
-${scopeSelector} ${SDT_INLINE}:hover,
-${scopeSelector} ${SDT_BLOCK}:hover {
-  border-color: ${defaultColor};
-}
-${scopeSelector} ${SDT_INLINE} ${SDT_INLINE}__label,
-${scopeSelector} ${SDT_BLOCK} ${SDT_BLOCK}__label {
-  border-color: ${defaultColor};
-  background-color: color-mix(in srgb, ${defaultColor} 87%, transparent);
-}`);
+  const rules: string[] = [];
+
+  // Default color applied to all fields (only if owner is defined)
+  if (fieldColors.owner) {
+    rules.push(buildColorRules(scopeSelector, '', fieldColors.owner));
+  }
 
   // Per-type overrides
   for (const [type, color] of entries) {
     const tagSel = `[data-sdt-tag*='"fieldType":"${type}"']`;
-    rules.push(`
-${scopeSelector} ${SDT_INLINE}${tagSel},
-${scopeSelector} ${SDT_BLOCK}${tagSel} {
-  border-color: ${color};
-}
-${scopeSelector} ${SDT_INLINE}${tagSel}:hover,
-${scopeSelector} ${SDT_BLOCK}${tagSel}:hover {
-  border-color: ${color};
-}
-${scopeSelector} ${SDT_INLINE}${tagSel} ${SDT_INLINE}__label,
-${scopeSelector} ${SDT_BLOCK}${tagSel} ${SDT_BLOCK}__label {
-  border-color: ${color};
-  background-color: color-mix(in srgb, ${color} 87%, transparent);
-}`);
+    rules.push(buildColorRules(scopeSelector, tagSel, color));
   }
 
   return rules.join('\n');

--- a/packages/template-builder/src/utils.ts
+++ b/packages/template-builder/src/utils.ts
@@ -67,7 +67,64 @@ const FIELD_TYPE_STYLES: Record<string, { background: string; color: string }> =
 
 const DEFAULT_FIELD_TYPE_STYLE = { background: '#f3f4f6', color: '#6b7280' };
 
-export const getFieldTypeStyle = (fieldType: string) => FIELD_TYPE_STYLES[fieldType] ?? DEFAULT_FIELD_TYPE_STYLE;
+/**
+ * Derive a light background + dark text from a single hex/css color.
+ * Falls back to the hardcoded map when no fieldColors are provided.
+ */
+export const getFieldTypeStyle = (fieldType: string, fieldColors?: Record<string, string>) => {
+  if (fieldColors?.[fieldType]) {
+    return { background: fieldColors[fieldType] + '1a', color: fieldColors[fieldType] };
+  }
+  return FIELD_TYPE_STYLES[fieldType] ?? DEFAULT_FIELD_TYPE_STYLE;
+};
+
+const SDT_INLINE = '.superdoc-structured-content-inline';
+const SDT_BLOCK = '.superdoc-structured-content-block';
+
+/** Generate scoped CSS rules for field type colors. */
+export function generateFieldColorCSS(fieldColors: Record<string, string>, scopeSelector: string): string {
+  const rules: string[] = [];
+  const entries = Object.entries(fieldColors);
+  if (entries.length === 0) return '';
+
+  // Default color (owner or first entry)
+  const defaultColor = fieldColors.owner ?? entries[0][1];
+  rules.push(`
+${scopeSelector} ${SDT_INLINE},
+${scopeSelector} ${SDT_BLOCK} {
+  border-color: ${defaultColor};
+}
+${scopeSelector} ${SDT_INLINE}:hover,
+${scopeSelector} ${SDT_BLOCK}:hover {
+  border-color: ${defaultColor};
+}
+${scopeSelector} ${SDT_INLINE} ${SDT_INLINE}__label,
+${scopeSelector} ${SDT_BLOCK} ${SDT_BLOCK}__label {
+  border-color: ${defaultColor};
+  background-color: color-mix(in srgb, ${defaultColor} 87%, transparent);
+}`);
+
+  // Per-type overrides
+  for (const [type, color] of entries) {
+    const tagSel = `[data-sdt-tag*='"fieldType":"${type}"']`;
+    rules.push(`
+${scopeSelector} ${SDT_INLINE}${tagSel},
+${scopeSelector} ${SDT_BLOCK}${tagSel} {
+  border-color: ${color};
+}
+${scopeSelector} ${SDT_INLINE}${tagSel}:hover,
+${scopeSelector} ${SDT_BLOCK}${tagSel}:hover {
+  border-color: ${color};
+}
+${scopeSelector} ${SDT_INLINE}${tagSel} ${SDT_INLINE}__label,
+${scopeSelector} ${SDT_BLOCK}${tagSel} ${SDT_BLOCK}__label {
+  border-color: ${color};
+  background-color: color-mix(in srgb, ${color} 87%, transparent);
+}`);
+  }
+
+  return rules.join('\n');
+}
 
 export const MENU_VIEWPORT_PADDING = 10;
 export const MENU_APPROX_WIDTH = 250;


### PR DESCRIPTION
Adds a `fieldColors` prop so consumers can color-code fields by type in the document and sidebar without importing CSS or writing style overrides.

- `fieldColors` accepts `Record<string, string>` — keys are `fieldType` values, values are CSS colors
- Generates scoped CSS and injects into `<head>` (respects `cspNonce`)
- Sidebar and menu badges match document field colors automatically
- Custom field types beyond `owner`/`signer` work out of the box
- `field-types.css` still available as standalone import for consumers not using TB
- Demo updated to use `fieldColors` instead of manual CSS variable overrides

```tsx
<SuperDocTemplateBuilder
  fieldColors={{
    owner: '#629be7',
    signer: '#d97706',
    date: '#059669',
  }}
/>
```

Closes SD-883, unblocks IT-755