### PR TITLE
feat(template-builder): reactive mode changes and refresh method (SD-2406)

### DIFF
--- a/apps/docs/solutions/template-builder/api-reference.mdx
+++ b/apps/docs/solutions/template-builder/api-reference.mdx
@@ -357,6 +357,14 @@ const fields = builderRef.current?.getFields();
 // Returns: TemplateField[]
 ```
 
+### refresh()
+
+Re-discover fields from the editor and trigger `onFieldsChange`. Use this when field data arrives asynchronously or after external changes to the document:
+
+```typescript
+builderRef.current?.refresh();
+```
+
 ### exportTemplate()
 
 Export the template as a .docx file:

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -416,6 +416,12 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
             discoverFields(editor);
           }
 
+          // Apply any mode change that arrived during init
+          if (pendingModeRef.current) {
+            (instance as any)?.setDocumentMode(pendingModeRef.current);
+            pendingModeRef.current = null;
+          }
+
           onReady?.();
         };
 
@@ -463,10 +469,15 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
 
     // Apply document mode changes without recreating the editor
     const prevModeRef = useRef(document?.mode);
+    const pendingModeRef = useRef<string | null>(null);
     useEffect(() => {
       const mode = document?.mode || 'editing';
-      if (prevModeRef.current !== mode && superdocRef.current) {
-        (superdocRef.current as any).setDocumentMode(mode);
+      if (prevModeRef.current !== mode) {
+        if (superdocRef.current) {
+          (superdocRef.current as any).setDocumentMode(mode);
+        } else {
+          pendingModeRef.current = mode;
+        }
       }
       prevModeRef.current = mode;
     }, [document?.mode]);

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -451,7 +451,6 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
       };
     }, [
       document?.source,
-      document?.mode,
       trigger,
       discoverFields,
       onReady,
@@ -461,6 +460,16 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
       stableTelemetry,
       licenseKey,
     ]);
+
+    // Apply document mode changes without recreating the editor
+    const prevModeRef = useRef(document?.mode);
+    useEffect(() => {
+      const mode = document?.mode || 'editing';
+      if (prevModeRef.current !== mode && superdocRef.current) {
+        (superdocRef.current as any).setDocumentMode(mode);
+      }
+      prevModeRef.current = mode;
+    }, [document?.mode]);
 
     const handleMenuSelect = useCallback(
       async (field: Types.FieldDefinition) => {
@@ -611,6 +620,11 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
       nextField,
       previousField,
       getFields: () => templateFields,
+      refresh: () => {
+        if (superdocRef.current?.activeEditor) {
+          discoverFields(superdocRef.current.activeEditor);
+        }
+      },
       exportTemplate,
       getSuperDoc: () => superdocRef.current,
     }));

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -9,6 +9,10 @@ export { FieldMenu, FieldList };
 
 type Editor = NonNullable<SuperDoc['activeEditor']>;
 
+const applyDocumentMode = (instance: SuperDoc, mode: string) => {
+  (instance as any).setDocumentMode(mode);
+};
+
 const getTemplateFieldsFromEditor = (editor: Editor): Types.TemplateField[] => {
   const structuredContentHelpers = (editor.helpers as any)?.structuredContentCommands;
 
@@ -417,8 +421,8 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
           }
 
           // Apply any mode change that arrived during init
-          if (pendingModeRef.current) {
-            (instance as any)?.setDocumentMode(pendingModeRef.current);
+          if (pendingModeRef.current && instance) {
+            applyDocumentMode(instance, pendingModeRef.current);
             pendingModeRef.current = null;
           }
 
@@ -454,6 +458,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
         }
 
         superdocRef.current = null;
+        pendingModeRef.current = null;
       };
     }, [
       document?.source,
@@ -468,18 +473,15 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
     ]);
 
     // Apply document mode changes without recreating the editor
-    const prevModeRef = useRef(document?.mode);
     const pendingModeRef = useRef<string | null>(null);
     useEffect(() => {
       const mode = document?.mode || 'editing';
-      if (prevModeRef.current !== mode) {
-        if (superdocRef.current) {
-          (superdocRef.current as any).setDocumentMode(mode);
-        } else {
-          pendingModeRef.current = mode;
-        }
+      if (superdocRef.current) {
+        applyDocumentMode(superdocRef.current, mode);
+        pendingModeRef.current = null;
+      } else {
+        pendingModeRef.current = mode;
       }
-      prevModeRef.current = mode;
     }, [document?.mode]);
 
     const handleMenuSelect = useCallback(

--- a/packages/template-builder/src/types.ts
+++ b/packages/template-builder/src/types.ts
@@ -156,6 +156,8 @@ export interface SuperDocTemplateBuilderHandle {
   nextField: () => void;
   previousField: () => void;
   getFields: () => TemplateField[];
+  /** Re-discover fields from the editor and notify via onFieldsChange */
+  refresh: () => void;
   exportTemplate: (config?: ExportConfig) => Promise<void | Blob>;
   /**
    * Returns the SuperDoc instance.


### PR DESCRIPTION
Mode changes (edit → view) no longer destroy and recreate the editor. A new `refresh()` method lets consumers re-discover fields after async data delivery.

- Removes `document.mode` from the init effect dependency array — mode changes now call `setDocumentMode()` imperatively instead of rebuilding the editor
- Follows the same pattern as the React wrapper (`SuperDocEditor.tsx:101-114`)
- Adds `refresh()` to the imperative handle — triggers field re-discovery and `onFieldsChange`
- No scroll jump, no content flash, no lost state

```tsx
// Switch mode without recreating
<SuperDocTemplateBuilder document={{ source: file, mode: isEditing ? 'editing' : 'viewing' }} />

// Force field re-discovery after async data arrives
builderRef.current?.refresh();
```

Closes SD-2406, unblocks IT-758