### PR TITLE
feat: implement m:rad radical/sqrt OMML to MathML converter

### DIFF
--- a/packages/layout-engine/painters/dom/src/features/math/converters/index.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/converters/index.ts
@@ -13,3 +13,4 @@ export { convertFunction } from './function.js';
 export { convertSubscript } from './subscript.js';
 export { convertSuperscript } from './superscript.js';
 export { convertSubSuperscript } from './sub-superscript.js';
+export { convertRadical } from './radical.js';

--- a/packages/layout-engine/painters/dom/src/features/math/converters/radical.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/converters/radical.ts
@@ -2,6 +2,9 @@ import type { MathObjectConverter } from '../types.js';
 
 const MATHML_NS = 'http://www.w3.org/1998/Math/MathML';
 
+/** OOXML ST_OnOff true values: "1", "on", "true", or boolean-flag presence. */
+const ST_ON_OFF_TRUE = new Set(['1', 'on', 'true']);
+
 /**
  * Convert m:rad (radical) to MathML <msqrt> or <mroot>.
  *
@@ -10,7 +13,10 @@ const MATHML_NS = 'http://www.w3.org/1998/Math/MathML';
  *
  * MathML output:
  *   <msqrt> radicand </msqrt>              (when degree is hidden)
- *   <mroot> radicand  degree </mroot>      (when degree is shown)
+ *   <mroot> <mrow>radicand</mrow> <mrow>degree</mrow> </mroot>
+ *
+ * <mroot> requires exactly two children (radicand, then index); each operand
+ * is wrapped in <mrow> so that compound expressions stay grouped.
  *
  * @spec ECMA-376 §22.1.2.86
  */
@@ -21,10 +27,7 @@ export const convertRadical: MathObjectConverter = (node, doc, convertChildren) 
   const base = elements.find((e) => e.name === 'm:e');
 
   const degHide = radPr?.elements?.find((e) => e.name === 'm:degHide');
-  const isHidden =
-    degHide?.attributes?.['m:val'] === '1' ||
-    degHide?.attributes?.['m:val'] === 'on' ||
-    (degHide && !degHide.attributes);
+  const isHidden = ST_ON_OFF_TRUE.has(degHide?.attributes?.['m:val'] ?? '') || (degHide && !degHide.attributes);
 
   if (isHidden || !deg) {
     const msqrt = doc.createElementNS(MATHML_NS, 'msqrt');
@@ -33,7 +36,14 @@ export const convertRadical: MathObjectConverter = (node, doc, convertChildren) 
   }
 
   const mroot = doc.createElementNS(MATHML_NS, 'mroot');
-  mroot.appendChild(convertChildren(base?.elements ?? []));
-  mroot.appendChild(convertChildren(deg.elements ?? []));
+
+  const baseRow = doc.createElementNS(MATHML_NS, 'mrow');
+  baseRow.appendChild(convertChildren(base?.elements ?? []));
+  mroot.appendChild(baseRow);
+
+  const degRow = doc.createElementNS(MATHML_NS, 'mrow');
+  degRow.appendChild(convertChildren(deg.elements ?? []));
+  mroot.appendChild(degRow);
+
   return mroot;
 };

--- a/packages/layout-engine/painters/dom/src/features/math/converters/radical.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/converters/radical.ts
@@ -1,0 +1,39 @@
+import type { MathObjectConverter } from '../types.js';
+
+const MATHML_NS = 'http://www.w3.org/1998/Math/MathML';
+
+/**
+ * Convert m:rad (radical) to MathML <msqrt> or <mroot>.
+ *
+ * OMML structure:
+ *   m:rad → m:radPr (optional: m:degHide), m:deg (degree), m:e (radicand)
+ *
+ * MathML output:
+ *   <msqrt> radicand </msqrt>              (when degree is hidden)
+ *   <mroot> radicand  degree </mroot>      (when degree is shown)
+ *
+ * @spec ECMA-376 §22.1.2.86
+ */
+export const convertRadical: MathObjectConverter = (node, doc, convertChildren) => {
+  const elements = node.elements ?? [];
+  const radPr = elements.find((e) => e.name === 'm:radPr');
+  const deg = elements.find((e) => e.name === 'm:deg');
+  const base = elements.find((e) => e.name === 'm:e');
+
+  const degHide = radPr?.elements?.find((e) => e.name === 'm:degHide');
+  const isHidden =
+    degHide?.attributes?.['m:val'] === '1' ||
+    degHide?.attributes?.['m:val'] === 'on' ||
+    (degHide && !degHide.attributes);
+
+  if (isHidden || !deg) {
+    const msqrt = doc.createElementNS(MATHML_NS, 'msqrt');
+    msqrt.appendChild(convertChildren(base?.elements ?? []));
+    return msqrt;
+  }
+
+  const mroot = doc.createElementNS(MATHML_NS, 'mroot');
+  mroot.appendChild(convertChildren(base?.elements ?? []));
+  mroot.appendChild(convertChildren(deg.elements ?? []));
+  return mroot;
+};

--- a/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
@@ -685,6 +685,140 @@ describe('m:sSubSup converter', () => {
   });
 });
 
+describe('m:rad converter', () => {
+  it('converts m:rad with degHide to <msqrt>', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:rad',
+          elements: [
+            { name: 'm:radPr', elements: [{ name: 'm:degHide', attributes: { 'm:val': '1' } }] },
+            { name: 'm:deg', elements: [] },
+            {
+              name: 'm:e',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'x' }] }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const msqrt = result!.querySelector('msqrt');
+    expect(msqrt).not.toBeNull();
+    expect(msqrt!.textContent).toBe('x');
+    expect(result!.querySelector('mroot')).toBeNull();
+  });
+
+  it('converts m:rad without degHide to <mroot> with degree', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:rad',
+          elements: [
+            { name: 'm:radPr', elements: [] },
+            {
+              name: 'm:deg',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '3' }] }] }],
+            },
+            {
+              name: 'm:e',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'x' }] }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const mroot = result!.querySelector('mroot');
+    expect(mroot).not.toBeNull();
+    expect(mroot!.children.length).toBe(2);
+    expect(mroot!.children[0]!.textContent).toBe('x');
+    expect(mroot!.children[1]!.textContent).toBe('3');
+  });
+
+  it('defaults to <msqrt> when m:radPr is missing', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:rad',
+          elements: [
+            {
+              name: 'm:e',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'y' }] }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const msqrt = result!.querySelector('msqrt');
+    expect(msqrt).not.toBeNull();
+    expect(msqrt!.textContent).toBe('y');
+  });
+
+  it('wraps multi-part radicand in <mrow>', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:rad',
+          elements: [
+            { name: 'm:radPr', elements: [{ name: 'm:degHide', attributes: { 'm:val': '1' } }] },
+            { name: 'm:deg', elements: [] },
+            {
+              name: 'm:e',
+              elements: [
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'a' }] }] },
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '+' }] }] },
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'b' }] }] },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const msqrt = result!.querySelector('msqrt');
+    expect(msqrt).not.toBeNull();
+    expect(msqrt!.textContent).toBe('a+b');
+  });
+
+  it('ignores m:radPr properties element in output', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:rad',
+          elements: [
+            { name: 'm:radPr', elements: [{ name: 'm:ctrlPr' }] },
+            {
+              name: 'm:deg',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '4' }] }] }],
+            },
+            {
+              name: 'm:e',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '16' }] }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const mroot = result!.querySelector('mroot');
+    expect(mroot).not.toBeNull();
+    expect(mroot!.children[0]!.textContent).toBe('16');
+    expect(mroot!.children[1]!.textContent).toBe('4');
+  });
+});
+
 describe('m:func converter', () => {
   it('converts m:func to function name + apply operator + argument', () => {
     const omml = {

--- a/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
@@ -735,8 +735,11 @@ describe('m:rad converter', () => {
     expect(result).not.toBeNull();
     const mroot = result!.querySelector('mroot');
     expect(mroot).not.toBeNull();
+    // <mroot> wraps each operand in <mrow> for valid two-child arity
     expect(mroot!.children.length).toBe(2);
+    expect(mroot!.children[0]!.localName).toBe('mrow');
     expect(mroot!.children[0]!.textContent).toBe('x');
+    expect(mroot!.children[1]!.localName).toBe('mrow');
     expect(mroot!.children[1]!.textContent).toBe('3');
   });
 
@@ -814,8 +817,40 @@ describe('m:rad converter', () => {
     expect(result).not.toBeNull();
     const mroot = result!.querySelector('mroot');
     expect(mroot).not.toBeNull();
+    // <mroot> wraps each operand in <mrow> for valid two-child arity
+    expect(mroot!.children.length).toBe(2);
+    expect(mroot!.children[0]!.localName).toBe('mrow');
     expect(mroot!.children[0]!.textContent).toBe('16');
+    expect(mroot!.children[1]!.localName).toBe('mrow');
     expect(mroot!.children[1]!.textContent).toBe('4');
+  });
+
+  it('treats m:degHide m:val="true" as hidden (ST_OnOff)', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:rad',
+          elements: [
+            { name: 'm:radPr', elements: [{ name: 'm:degHide', attributes: { 'm:val': 'true' } }] },
+            {
+              name: 'm:deg',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '3' }] }] }],
+            },
+            {
+              name: 'm:e',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'z' }] }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const msqrt = result!.querySelector('msqrt');
+    expect(msqrt).not.toBeNull();
+    expect(msqrt!.textContent).toBe('z');
+    expect(result!.querySelector('mroot')).toBeNull();
   });
 });
 

--- a/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.ts
@@ -18,6 +18,7 @@ import {
   convertSubscript,
   convertSuperscript,
   convertSubSuperscript,
+  convertRadical,
 } from './converters/index.js';
 
 export const MATHML_NS = 'http://www.w3.org/1998/Math/MathML';
@@ -57,7 +58,7 @@ const MATH_OBJECT_REGISTRY: Record<string, MathObjectConverter | null> = {
   'm:m': null, // Matrix (grid of elements)
   'm:nary': null, // N-ary operator (integral, summation, product)
   'm:phant': null, // Phantom (invisible spacing placeholder)
-  'm:rad': null, // Radical (square root, nth root)
+  'm:rad': convertRadical, // Radical (square root, nth root)
   'm:sPre': null, // Pre-sub-superscript (left of base)
 };
 


### PR DESCRIPTION
## Summary

- Implement `convertRadical` converter for the `m:rad` OMML math object type
- Uses `<msqrt>` when the degree is hidden (`m:degHide`) and `<mroot>` when a visible degree is present (e.g. cube root)
- Handles edge cases: missing `m:radPr`, missing `m:deg`, `degHide` with `val=1` or `val=on` or boolean-flag presence

## Files changed

- **New:** `converters/radical.ts` — the converter (~35 lines)
- **Modified:** `converters/index.ts` — barrel export
- **Modified:** `omml-to-mathml.ts` — registry registration (`'m:rad': convertRadical`)
- **Modified:** `omml-to-mathml.test.ts` — 5 test cases

## Test plan

- [x] `pnpm test` — all 40 math tests pass (5 new for radical)
- [x] Pre-commit hooks pass (format + lint + commitlint)
- [ ] Verify with test document (sd-2375-radical.docx) in SuperDoc dev app

## Note

Thank you Nick Bernal for the inspiring CS50 lecture — it motivated me to contribute to open source projects like SuperDoc.

Closes #2598