### PR TITLE
feat(math): implement m:limLow lower-limit converter

### DIFF
--- a/packages/layout-engine/painters/dom/src/features/math/converters/index.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/converters/index.ts
@@ -13,3 +13,4 @@ export { convertFunction } from './function.js';
 export { convertSubscript } from './subscript.js';
 export { convertSuperscript } from './superscript.js';
 export { convertSubSuperscript } from './sub-superscript.js';
+export { convertLowerLimit } from './lower-limit.js';

--- a/packages/layout-engine/painters/dom/src/features/math/converters/lower-limit.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/converters/lower-limit.ts
@@ -1,0 +1,34 @@
+import type { MathObjectConverter } from '../types.js';
+
+const MATHML_NS = 'http://www.w3.org/1998/Math/MathML';
+
+/**
+ * Convert m:limLow (lower limit) to MathML <munder>.
+ *
+ * OMML structure:
+ *   m:limLow → m:limLowPr (optional), m:e (base), m:lim (limit)
+ *
+ * MathML output:
+ *   <munder> <mrow>base</mrow> <mrow>limit</mrow> </munder>
+ *
+ * Common use: lim_{x→∞}, min, max, sup, inf
+ *
+ * @spec ECMA-376 §22.1.2.54
+ */
+export const convertLowerLimit: MathObjectConverter = (node, doc, convertChildren) => {
+  const elements = node.elements ?? [];
+  const base = elements.find((e) => e.name === 'm:e');
+  const lim = elements.find((e) => e.name === 'm:lim');
+
+  const munder = doc.createElementNS(MATHML_NS, 'munder');
+
+  const baseRow = doc.createElementNS(MATHML_NS, 'mrow');
+  baseRow.appendChild(convertChildren(base?.elements ?? []));
+  munder.appendChild(baseRow);
+
+  const limRow = doc.createElementNS(MATHML_NS, 'mrow');
+  limRow.appendChild(convertChildren(lim?.elements ?? []));
+  munder.appendChild(limRow);
+
+  return munder;
+};

--- a/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
@@ -927,3 +927,85 @@ describe('m:func converter', () => {
     expect(mis[1]!.textContent).toBe('cos');
   });
 });
+
+describe('m:limLow converter', () => {
+  it('converts lim_{x→0} to <munder>', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:limLow',
+          elements: [
+            {
+              name: 'm:e',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'lim' }] }] }],
+            },
+            {
+              name: 'm:lim',
+              elements: [
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'x' }] }] },
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '→' }] }] },
+                { name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: '0' }] }] },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const munder = result!.querySelector('munder');
+    expect(munder).not.toBeNull();
+    expect(munder!.children[0]!.textContent).toBe('lim');
+    expect(munder!.children[1]!.textContent).toBe('x→0');
+  });
+
+  it('handles missing m:lim gracefully', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:limLow',
+          elements: [
+            {
+              name: 'm:e',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'min' }] }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result).not.toBeNull();
+    const munder = result!.querySelector('munder');
+    expect(munder).not.toBeNull();
+    expect(munder!.children[0]!.textContent).toBe('min');
+  });
+
+  it('ignores m:limLowPr', () => {
+    const omml = {
+      name: 'm:oMath',
+      elements: [
+        {
+          name: 'm:limLow',
+          elements: [
+            { name: 'm:limLowPr', elements: [{ name: 'm:ctrlPr' }] },
+            {
+              name: 'm:e',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'sup' }] }] }],
+            },
+            {
+              name: 'm:lim',
+              elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'S' }] }] }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    const munder = result!.querySelector('munder');
+    expect(munder).not.toBeNull();
+    expect(munder!.children[0]!.textContent).toBe('sup');
+    expect(munder!.children[1]!.textContent).toBe('S');
+  });
+});

--- a/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.ts
@@ -18,6 +18,7 @@ import {
   convertSubscript,
   convertSuperscript,
   convertSubSuperscript,
+  convertLowerLimit,
 } from './converters/index.js';
 
 export const MATHML_NS = 'http://www.w3.org/1998/Math/MathML';
@@ -52,7 +53,7 @@ const MATH_OBJECT_REGISTRY: Record<string, MathObjectConverter | null> = {
   'm:d': null, // Delimiter (parentheses, brackets, braces)
   'm:eqArr': null, // Equation array (vertical array of equations)
   'm:groupChr': null, // Group character (overbrace, underbrace)
-  'm:limLow': null, // Lower limit (e.g., lim)
+  'm:limLow': convertLowerLimit, // Lower limit (e.g., lim)
   'm:limUpp': null, // Upper limit
   'm:m': null, // Matrix (grid of elements)
   'm:nary': null, // N-ary operator (integral, summation, product)


### PR DESCRIPTION
Closes #2599

## Summary
- Implements the \m:limLow\ OMML-to-MathML converter (lower limit, e.g. lim, min, max, inf)
- Maps \m:limLow\ to MathML \<munder>\ with base and limit as \<mrow>\ children
- Registers the converter in \MATH_OBJECT_REGISTRY\
- Adds 3 unit tests covering standard usage, missing limit, and property element skipping

## Spec reference
ECMA-376 Section 22.1.2.54

## Test plan
- [x] \itest run\ passes for omml-to-mathml.test.ts
- [x] Linter and formatter pass (lefthook pre-commit)

Made with [Cursor](https://cursor.com)