### PR TITLE
fix(layout): lay out all header/footer variants in per-section path (SD-2500)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterPerRidLayout.ts
+++ b/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterPerRidLayout.ts
@@ -190,36 +190,6 @@ function collectReferencedRIdsBySection(effectiveRefsBySection: Map<number, Head
 }
 
 /**
- * Resolve the default header/footer rId for each section.
- *
- * Multi-section layout has historically measured only the default variant with
- * section-specific constraints. Preserve that behavior to avoid changing
- * established rendering for documents that use first/even/odd variants.
- */
-function resolveDefaultRIdPerSection(
-  sectionMetadata: SectionMetadata[],
-  kind: 'header' | 'footer',
-): Map<number, string> {
-  const result = new Map<number, string>();
-  let inheritedDefaultRId: string | undefined;
-
-  for (const section of sectionMetadata) {
-    const refs = getRefsForKind(section, kind);
-    const explicitDefaultRId = refs?.default;
-
-    if (explicitDefaultRId) {
-      inheritedDefaultRId = explicitDefaultRId;
-    }
-
-    if (inheritedDefaultRId) {
-      result.set(section.sectionIndex, inheritedDefaultRId);
-    }
-  }
-
-  return result;
-}
-
-/**
  * Layout header/footer blocks per rId, respecting per-section margins.
  *
  * For documents with multiple sections that have different margins, this function

--- a/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterPerRidLayout.ts
+++ b/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterPerRidLayout.ts
@@ -411,7 +411,9 @@ async function layoutWithPerSectionConstraints(
 ): Promise<void> {
   if (!blocksByRId) return;
 
-  const defaultRIdPerSection = resolveDefaultRIdPerSection(sectionMetadata, kind);
+  // Resolve effective refs for ALL variants (default, first, even, odd) per section,
+  // applying OOXML inheritance (sections inherit missing refs from previous sections).
+  const effectiveRefsBySection = buildEffectiveRefsBySection(sectionMetadata, kind);
 
   // Extract table width specs per rId (SD-1837).
   // Word allows tables in headers/footers to extend beyond content margins.
@@ -433,32 +435,43 @@ async function layoutWithPerSectionConstraints(
   >();
 
   for (const section of sectionMetadata) {
-    const rId = defaultRIdPerSection.get(section.sectionIndex);
-    if (!rId || !blocksByRId.has(rId)) continue;
+    const refs = effectiveRefsBySection.get(section.sectionIndex);
+    if (!refs) continue;
 
-    // Resolve the minimum width needed for tables in this section.
-    // For pct tables, this depends on the section's content width.
-    const contentWidth = buildSectionContentWidth(section, fallbackConstraints);
-    const tableWidthSpec = tableWidthSpecByRId.get(rId);
-    const tableMinWidth = resolveTableMinWidth(tableWidthSpec, contentWidth);
-    const sectionConstraints = buildConstraintsForSection(section, fallbackConstraints, tableMinWidth || undefined);
-    const effectiveWidth = sectionConstraints.width;
-    // Include vertical geometry in the key so sections with different page heights,
-    // vertical margins, or header distance get separate layouts (page-relative anchors
-    // and header band origin resolve differently).
-    const groupKey = `${rId}::w${effectiveWidth}::ph${sectionConstraints.pageHeight ?? ''}::mt${sectionConstraints.margins?.top ?? ''}::mb${sectionConstraints.margins?.bottom ?? ''}::mh${sectionConstraints.margins?.header ?? ''}`;
-
-    let group = groups.get(groupKey);
-    if (!group) {
-      group = {
-        sectionConstraints,
-        sectionIndices: [],
-        rId,
-        effectiveWidth,
-      };
-      groups.set(groupKey, group);
+    // Collect all unique rIds referenced by this section (default, first, even, odd)
+    const sectionRIds = new Set<string>();
+    for (const variant of HEADER_FOOTER_VARIANTS) {
+      const rId = refs[variant];
+      if (rId && blocksByRId.has(rId)) {
+        sectionRIds.add(rId);
+      }
     }
-    group.sectionIndices.push(section.sectionIndex);
+
+    for (const rId of sectionRIds) {
+      // Resolve the minimum width needed for tables in this section.
+      // For pct tables, this depends on the section's content width.
+      const contentWidth = buildSectionContentWidth(section, fallbackConstraints);
+      const tableWidthSpec = tableWidthSpecByRId.get(rId);
+      const tableMinWidth = resolveTableMinWidth(tableWidthSpec, contentWidth);
+      const sectionConstraints = buildConstraintsForSection(section, fallbackConstraints, tableMinWidth || undefined);
+      const effectiveWidth = sectionConstraints.width;
+      // Include vertical geometry in the key so sections with different page heights,
+      // vertical margins, or header distance get separate layouts (page-relative anchors
+      // and header band origin resolve differently).
+      const groupKey = `${rId}::w${effectiveWidth}::ph${sectionConstraints.pageHeight ?? ''}::mt${sectionConstraints.margins?.top ?? ''}::mb${sectionConstraints.margins?.bottom ?? ''}::mh${sectionConstraints.margins?.header ?? ''}`;
+
+      let group = groups.get(groupKey);
+      if (!group) {
+        group = {
+          sectionConstraints,
+          sectionIndices: [],
+          rId,
+          effectiveWidth,
+        };
+        groups.set(groupKey, group);
+      }
+      group.sectionIndices.push(section.sectionIndex);
+    }
   }
 
   // Measure and layout each unique (rId, effectiveWidth) group


### PR DESCRIPTION
`layoutWithPerSectionConstraints` only measured the default header variant per section, ignoring first/even/odd. When `titlePg` was enabled and the decoration provider resolved the first-page rId, it wasn't in `layoutsByRId` — so the cover page header with branding images never rendered.

- Replace `resolveDefaultRIdPerSection` with `buildEffectiveRefsBySection` to collect all variant rIds per section (with OOXML inheritance)
- Iterate and lay out each variant's rId with section-appropriate constraints
- Remove the now-unused `resolveDefaultRIdPerSection`

Fixes SD-2500. Affects Patriot, M3, and Heffernan — any doc where section 1 has `titlePg=true` with a branded first-page header.