### PR TITLE
fix(super-editor): handle splitBefore/splitAfter in whole-textblock rewrite (SD-2362)

### DIFF
--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/executor.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/executor.test.ts
@@ -1023,6 +1023,284 @@ describe('executeCompiledPlan: text.rewrite style behavior', () => {
     expect(tr.doc.child(0).textContent).toBe('Alpha\n\nBeta');
   });
 
+  it('handles splitBefore with single core block on whole-textblock rewrite', () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: 'block+' },
+        paragraph: { group: 'block', content: 'text*' },
+        text: { group: 'inline' },
+      },
+    });
+
+    const doc = schema.nodes.doc.create({}, [
+      schema.nodes.paragraph.create({}, schema.text('before')),
+      schema.nodes.paragraph.create({}, schema.text('hello world')),
+      schema.nodes.paragraph.create({}, schema.text('after')),
+    ]);
+
+    let absFrom = -1;
+    doc.descendants((node, pos) => {
+      if (node.isText && node.text === 'hello world') {
+        absFrom = pos;
+        return false;
+      }
+      return undefined;
+    });
+
+    const state = EditorState.create({ schema, doc });
+    const tr = state.tr;
+    const editor = { state } as unknown as Editor;
+
+    mockedDeps.resolveInlineStyle.mockReturnValue([]);
+
+    const target = makeTarget({
+      absFrom,
+      absTo: absFrom + 'hello world'.length,
+      from: 0,
+      to: 'hello world'.length,
+      text: 'hello world',
+      capturedStyle: { runs: [], isUniform: true },
+    }) as any;
+    const step: TextRewriteStep = {
+      id: 'step-split-before',
+      op: 'text.rewrite',
+      where: { by: 'select', select: { type: 'text', pattern: 'hello world' }, require: 'exactlyOne' },
+      args: { replacement: { text: '\nAlpha' } },
+    };
+
+    const outcome = executeTextRewrite(editor, tr, target, step, { map: (pos: number) => pos } as any);
+
+    expect(outcome).toEqual({ changed: true });
+    expect(tr.doc.childCount).toBe(4);
+    expect(tr.doc.child(0).textContent).toBe('before');
+    expect(tr.doc.child(1).textContent).toBe('');
+    expect(tr.doc.child(2).textContent).toBe('Alpha');
+    expect(tr.doc.child(3).textContent).toBe('after');
+  });
+
+  it('handles splitAfter with single core block on whole-textblock rewrite', () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: 'block+' },
+        paragraph: { group: 'block', content: 'text*' },
+        text: { group: 'inline' },
+      },
+    });
+
+    const doc = schema.nodes.doc.create({}, [
+      schema.nodes.paragraph.create({}, schema.text('before')),
+      schema.nodes.paragraph.create({}, schema.text('hello world')),
+      schema.nodes.paragraph.create({}, schema.text('after')),
+    ]);
+
+    let absFrom = -1;
+    doc.descendants((node, pos) => {
+      if (node.isText && node.text === 'hello world') {
+        absFrom = pos;
+        return false;
+      }
+      return undefined;
+    });
+
+    const state = EditorState.create({ schema, doc });
+    const tr = state.tr;
+    const editor = { state } as unknown as Editor;
+
+    mockedDeps.resolveInlineStyle.mockReturnValue([]);
+
+    const target = makeTarget({
+      absFrom,
+      absTo: absFrom + 'hello world'.length,
+      from: 0,
+      to: 'hello world'.length,
+      text: 'hello world',
+      capturedStyle: { runs: [], isUniform: true },
+    }) as any;
+    const step: TextRewriteStep = {
+      id: 'step-split-after',
+      op: 'text.rewrite',
+      where: { by: 'select', select: { type: 'text', pattern: 'hello world' }, require: 'exactlyOne' },
+      args: { replacement: { text: 'Alpha\n' } },
+    };
+
+    const outcome = executeTextRewrite(editor, tr, target, step, { map: (pos: number) => pos } as any);
+
+    expect(outcome).toEqual({ changed: true });
+    expect(tr.doc.childCount).toBe(4);
+    expect(tr.doc.child(0).textContent).toBe('before');
+    expect(tr.doc.child(1).textContent).toBe('Alpha');
+    expect(tr.doc.child(2).textContent).toBe('');
+    expect(tr.doc.child(3).textContent).toBe('after');
+  });
+
+  it('handles both splitBefore and splitAfter with single core block on whole-textblock rewrite', () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: 'block+' },
+        paragraph: { group: 'block', content: 'text*' },
+        text: { group: 'inline' },
+      },
+    });
+
+    const doc = schema.nodes.doc.create({}, [
+      schema.nodes.paragraph.create({}, schema.text('before')),
+      schema.nodes.paragraph.create({}, schema.text('hello world')),
+      schema.nodes.paragraph.create({}, schema.text('after')),
+    ]);
+
+    let absFrom = -1;
+    doc.descendants((node, pos) => {
+      if (node.isText && node.text === 'hello world') {
+        absFrom = pos;
+        return false;
+      }
+      return undefined;
+    });
+
+    const state = EditorState.create({ schema, doc });
+    const tr = state.tr;
+    const editor = { state } as unknown as Editor;
+
+    mockedDeps.resolveInlineStyle.mockReturnValue([]);
+
+    const target = makeTarget({
+      absFrom,
+      absTo: absFrom + 'hello world'.length,
+      from: 0,
+      to: 'hello world'.length,
+      text: 'hello world',
+      capturedStyle: { runs: [], isUniform: true },
+    }) as any;
+    const step: TextRewriteStep = {
+      id: 'step-split-both',
+      op: 'text.rewrite',
+      where: { by: 'select', select: { type: 'text', pattern: 'hello world' }, require: 'exactlyOne' },
+      args: { replacement: { text: '\nAlpha\n' } },
+    };
+
+    const outcome = executeTextRewrite(editor, tr, target, step, { map: (pos: number) => pos } as any);
+
+    expect(outcome).toEqual({ changed: true });
+    expect(tr.doc.childCount).toBe(5);
+    expect(tr.doc.child(0).textContent).toBe('before');
+    expect(tr.doc.child(1).textContent).toBe('');
+    expect(tr.doc.child(2).textContent).toBe('Alpha');
+    expect(tr.doc.child(3).textContent).toBe('');
+    expect(tr.doc.child(4).textContent).toBe('after');
+  });
+
+  it('handles splitBefore with multi-block replacement on whole-textblock rewrite', () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: 'block+' },
+        paragraph: { group: 'block', content: 'text*' },
+        text: { group: 'inline' },
+      },
+    });
+
+    const doc = schema.nodes.doc.create({}, [
+      schema.nodes.paragraph.create({}, schema.text('before')),
+      schema.nodes.paragraph.create({}, schema.text('hello world')),
+      schema.nodes.paragraph.create({}, schema.text('after')),
+    ]);
+
+    let absFrom = -1;
+    doc.descendants((node, pos) => {
+      if (node.isText && node.text === 'hello world') {
+        absFrom = pos;
+        return false;
+      }
+      return undefined;
+    });
+
+    const state = EditorState.create({ schema, doc });
+    const tr = state.tr;
+    const editor = { state } as unknown as Editor;
+
+    mockedDeps.resolveInlineStyle.mockReturnValue([]);
+
+    const target = makeTarget({
+      absFrom,
+      absTo: absFrom + 'hello world'.length,
+      from: 0,
+      to: 'hello world'.length,
+      text: 'hello world',
+      capturedStyle: { runs: [], isUniform: true },
+    }) as any;
+    const step: TextRewriteStep = {
+      id: 'step-split-before-multi',
+      op: 'text.rewrite',
+      where: { by: 'select', select: { type: 'text', pattern: 'hello world' }, require: 'exactlyOne' },
+      args: { replacement: { text: '\nAlpha\n\nBeta' } },
+    };
+
+    const outcome = executeTextRewrite(editor, tr, target, step, { map: (pos: number) => pos } as any);
+
+    expect(outcome).toEqual({ changed: true });
+    expect(tr.doc.childCount).toBe(5);
+    expect(tr.doc.child(0).textContent).toBe('before');
+    expect(tr.doc.child(1).textContent).toBe('');
+    expect(tr.doc.child(2).textContent).toBe('Alpha');
+    expect(tr.doc.child(3).textContent).toBe('Beta');
+    expect(tr.doc.child(4).textContent).toBe('after');
+  });
+
+  it('handles splitAfter with multi-block replacement on whole-textblock rewrite', () => {
+    const schema = new Schema({
+      nodes: {
+        doc: { content: 'block+' },
+        paragraph: { group: 'block', content: 'text*' },
+        text: { group: 'inline' },
+      },
+    });
+
+    const doc = schema.nodes.doc.create({}, [
+      schema.nodes.paragraph.create({}, schema.text('before')),
+      schema.nodes.paragraph.create({}, schema.text('hello world')),
+      schema.nodes.paragraph.create({}, schema.text('after')),
+    ]);
+
+    let absFrom = -1;
+    doc.descendants((node, pos) => {
+      if (node.isText && node.text === 'hello world') {
+        absFrom = pos;
+        return false;
+      }
+      return undefined;
+    });
+
+    const state = EditorState.create({ schema, doc });
+    const tr = state.tr;
+    const editor = { state } as unknown as Editor;
+
+    mockedDeps.resolveInlineStyle.mockReturnValue([]);
+
+    const target = makeTarget({
+      absFrom,
+      absTo: absFrom + 'hello world'.length,
+      from: 0,
+      to: 'hello world'.length,
+      text: 'hello world',
+      capturedStyle: { runs: [], isUniform: true },
+    }) as any;
+    const step: TextRewriteStep = {
+      id: 'step-split-after-multi',
+      op: 'text.rewrite',
+      where: { by: 'select', select: { type: 'text', pattern: 'hello world' }, require: 'exactlyOne' },
+      args: { replacement: { text: 'Alpha\n\nBeta\n' } },
+    };
+
+    const outcome = executeTextRewrite(editor, tr, target, step, { map: (pos: number) => pos } as any);
+
+    expect(outcome).toEqual({ changed: true });
+    expect(tr.doc.childCount).toBe(5);
+    expect(tr.doc.child(0).textContent).toBe('before');
+    expect(tr.doc.child(1).textContent).toBe('Alpha');
+    expect(tr.doc.child(2).textContent).toBe('Beta');
+    expect(tr.doc.child(3).textContent).toBe('');
+    expect(tr.doc.child(4).textContent).toBe('after');
+  });
+
   it('keeps partial-range rewrites inline in a real transaction when replacement text stays within one block', () => {
     const schema = new Schema({
       nodes: {

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/executor.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/executor.ts
@@ -1270,12 +1270,18 @@ function resolveStructuralRangeRewrite(
     return null;
   }
 
-  const replacementBlocks = payload.blocks;
+  const effectiveBlocks = [...payload.blocks];
+  if (payload.splitBefore) {
+    effectiveBlocks.unshift('');
+  }
+  if (payload.splitAfter) {
+    effectiveBlocks.push('');
+  }
 
   if (replacesEntireTextblock) {
-    if (replacementBlocks.length <= 1) {
+    if (effectiveBlocks.length <= 1) {
       debugTextRewrite('structural rewrite skipped: whole-textblock rewrite resolved to one block', {
-        replacementBlocks,
+        replacementBlocks: effectiveBlocks,
         stepId: step.id,
       });
       return null;
@@ -1291,14 +1297,14 @@ function resolveStructuralRangeRewrite(
       inlineRange,
       replaceFrom,
       replaceTo,
-      replacementBlockCount: replacementBlocks.length,
+      replacementBlockCount: effectiveBlocks.length,
       openStart: 0,
       openEnd: 0,
       stepId: step.id,
     });
 
     return {
-      replacementBlocks,
+      replacementBlocks: effectiveBlocks,
       paragraphAttrs: stripIdentityAttrs($from.node(textblockDepth).attrs as Record<string, unknown>),
       replaceFrom,
       replaceTo,
@@ -1311,13 +1317,6 @@ function resolveStructuralRangeRewrite(
 
   const leadingWrappers = resolveInlineWrapperChainAt(doc, absFrom, textblockDepth);
   const trailingWrappers = resolveInlineWrapperChainAt(doc, absTo, textblockDepth);
-  const effectiveBlocks = [...replacementBlocks];
-  if (payload.splitBefore) {
-    effectiveBlocks.unshift('');
-  }
-  if (payload.splitAfter) {
-    effectiveBlocks.push('');
-  }
   const openStart = 1 + leadingWrappers.length;
   const openEnd = 1 + trailingWrappers.length;
   debugTextRewrite('structural rewrite enabled', {

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/tracked-rewrite.integration.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/tracked-rewrite.integration.test.ts
@@ -220,4 +220,94 @@ describe('doc.replace multi-paragraph integration', () => {
 
     expect(insertedTexts).toEqual(expect.arrayContaining(['Alpha', 'Beta']));
   });
+
+  it('creates an empty paragraph before the replacement when text has a leading newline (direct)', () => {
+    editor = makeEditor();
+    const receipt = editor.doc.replace(
+      {
+        ref: getFirstMatchRef(editor, 'hello world'),
+        text: '\nAlpha',
+      },
+      { changeMode: 'direct' },
+    );
+
+    expect(receipt.success).toBe(true);
+    expect(paragraphTexts(editor)).toEqual(['', 'Alpha']);
+  });
+
+  it('creates an empty paragraph after the replacement when text has a trailing newline (direct)', () => {
+    editor = makeEditor();
+    const receipt = editor.doc.replace(
+      {
+        ref: getFirstMatchRef(editor, 'hello world'),
+        text: 'Alpha\n',
+      },
+      { changeMode: 'direct' },
+    );
+
+    expect(receipt.success).toBe(true);
+    expect(paragraphTexts(editor)).toEqual(['Alpha', '']);
+  });
+
+  it('preserves paragraph structure with leading newline in tracked mode', () => {
+    editor = makeEditor();
+    const receipt = editor.doc.replace(
+      {
+        ref: getFirstMatchRef(editor, 'hello world'),
+        text: '\nAlpha',
+      },
+      { changeMode: 'tracked' },
+    );
+
+    expect(receipt.success).toBe(true);
+
+    const texts = paragraphTexts(editor);
+    expect(texts.length).toBeGreaterThanOrEqual(2);
+
+    const insertedTexts: string[] = [];
+    const deletedTexts: string[] = [];
+    editor.state.doc.descendants((node: any) => {
+      if (!node.isText || !node.text) return;
+      if (node.marks.some((mark: any) => mark.type.name === TrackInsertMarkName)) {
+        insertedTexts.push(node.text);
+      }
+      if (node.marks.some((mark: any) => mark.type.name === TrackDeleteMarkName)) {
+        deletedTexts.push(node.text);
+      }
+    });
+
+    expect(insertedTexts).toEqual(expect.arrayContaining(['Alpha']));
+    expect(deletedTexts.join('')).toContain('hello world');
+  });
+
+  it('preserves paragraph structure with trailing newline in tracked mode', () => {
+    editor = makeEditor();
+    const receipt = editor.doc.replace(
+      {
+        ref: getFirstMatchRef(editor, 'hello world'),
+        text: 'Alpha\n',
+      },
+      { changeMode: 'tracked' },
+    );
+
+    expect(receipt.success).toBe(true);
+
+    const texts = paragraphTexts(editor);
+    expect(texts.length).toBeGreaterThanOrEqual(2);
+
+    const insertedTexts: string[] = [];
+    const deletedTexts: string[] = [];
+    editor.state.doc.descendants((node: any) => {
+      if (!node.isText || !node.text) return;
+      if (node.marks.some((mark: any) => mark.type.name === TrackInsertMarkName)) {
+        insertedTexts.push(node.text);
+      }
+      if (node.marks.some((mark: any) => mark.type.name === TrackDeleteMarkName)) {
+        deletedTexts.push(node.text);
+      }
+    });
+
+    expect(insertedTexts).toEqual(expect.arrayContaining(['Alpha']));
+    expect(deletedTexts.join('')).toContain('hello world');
+  });
 });


### PR DESCRIPTION
Follow-up to #2733. Fixes a remaining edge case in the structural text.rewrite path where leading/trailing newlines on whole-paragraph replacements fell back to inline insertion.

- The `replacesEntireTextblock` branch in `resolveStructuralRangeRewrite` used `payload.blocks` directly without applying `splitBefore`/`splitAfter` signals
- Inputs like `"\nAlpha"` (one core block + `splitBefore: true`) hit the `length <= 1` guard and fell to inline, inserting a literal `\n` character instead of creating a paragraph split
- This produced non-compliant OOXML on export (literal `\n` in `<w:t>` instead of separate `<w:p>` elements)

Fix moves the `effectiveBlocks` computation above both branches so the whole-textblock path uses the same split-signal logic the partial-range path already had.

- 5 unit tests for split-signal edge cases (splitBefore, splitAfter, both, + multi-block combos)
- 4 integration tests for leading/trailing newlines in direct and tracked modes through the full editor API

SD-2362