### PR TITLE
feat(navigation): universal scrollToElement API (SD-2519)

### DIFF
--- a/apps/docs/core/superdoc/methods.mdx
+++ b/apps/docs/core/superdoc/methods.mdx
@@ -765,6 +765,69 @@ const superdoc = new SuperDoc({
 
 </CodeGroup>
 
+### `scrollToElement`
+
+Scroll to any document element by its ID. Pass a paragraph `nodeId`, comment `entityId`, or tracked change `entityId` — the method figures out what kind of element it is and scrolls there.
+
+<ParamField path="elementId" type="string" required>
+  The element's stable ID. Get this from `query.match` results (`address.nodeId`), `comments.list` (`entityId`), or `trackChanges.list` (`entityId`).
+</ParamField>
+
+**Returns:** `Promise<boolean>` — `true` if the element was found and scrolled to, `false` otherwise. Never throws.
+
+<CodeGroup>
+
+```javascript Usage
+// Get a paragraph's nodeId from the Document API
+const result = editor.doc.query.match({
+  select: { type: 'text', pattern: 'Introduction', mode: 'contains' },
+  require: 'first',
+});
+const nodeId = result.items[0].address.nodeId;
+
+// Scroll to it — one call, any element type
+await superdoc.scrollToElement(nodeId);
+```
+
+```javascript Full Example
+import { SuperDoc } from 'superdoc';
+import 'superdoc/style.css';
+
+const superdoc = new SuperDoc({
+  selector: '#editor',
+  document: yourFile,
+  modules: { comments: {} },
+  onReady: async (superdoc) => {
+    const editor = superdoc.editor;
+
+    // Navigate to a paragraph
+    const match = editor.doc.query.match({
+      select: { type: 'text', pattern: 'Summary', mode: 'contains' },
+      require: 'first',
+    });
+    await superdoc.scrollToElement(match.items[0].address.nodeId);
+
+    // Navigate to a comment
+    const comments = editor.doc.comments.list();
+    if (comments.items.length > 0) {
+      await superdoc.scrollToElement(comments.items[0].entityId);
+    }
+
+    // Navigate to a tracked change
+    const changes = editor.doc.trackChanges.list();
+    if (changes.items.length > 0) {
+      await superdoc.scrollToElement(changes.items[0].entityId);
+    }
+  },
+});
+```
+
+</CodeGroup>
+
+<Info>
+For DOCX-imported documents, paragraph `nodeId` values come from the OOXML `paraId` attribute and are stable across sessions. See [cross-session block addressing](/document-api/common-workflows#cross-session-block-addressing) for the full pattern.
+</Info>
+
 ## User management
 
 ### `addSharedUser`

--- a/apps/docs/document-api/common-workflows.mdx
+++ b/apps/docs/document-api/common-workflows.mdx
@@ -279,6 +279,27 @@ for (const { address } of saved) {
 editor2.destroy();
 ```
 
+### Navigate to saved addresses in the browser
+
+When the saved addresses are used in a browser-based viewer (RAG citations, search results, cross-references), pass the `nodeId` directly to `scrollToElement`:
+
+```ts
+// In the browser — user clicks a citation
+const savedNodeId = citation.nodeId; // from your database / vector store
+const found = await superdoc.scrollToElement(savedNodeId);
+
+if (!found) {
+  console.warn('Element no longer exists in the document');
+}
+```
+
+`scrollToElement` also works with comment and tracked change IDs:
+
+```ts
+await superdoc.scrollToElement(commentEntityId);
+await superdoc.scrollToElement(trackedChangeEntityId);
+```
+
 <Info>
 `nodeId` stability depends on the ID source. For DOCX-imported content, `nodeId` comes from `paraId` when available and is best-effort stable across loads. Runtime-created content is still not guaranteed stable across loads; many nodes use session-scoped editor identity, while some structures such as tables or table cells may expose deterministic fallback IDs instead of raw `sdBlockId`.
 </Info>

--- a/apps/docs/guides/general/stable-navigation.mdx
+++ b/apps/docs/guides/general/stable-navigation.mdx
@@ -1,13 +1,45 @@
 ---
 title: Stable navigation after edits
 sidebarTitle: Stable navigation
-description: Find nodes once and navigate to them reliably after document edits.
+description: Navigate to document elements reliably — during edits and across sessions.
 ---
 
-When users edit a document, stored positions can drift.
-Use `PositionTracker` so navigation targets stay stable.
+SuperDoc has two navigation approaches depending on your use case:
 
-## Hyperlinks example
+| Approach | Use case | Stability |
+|----------|----------|-----------|
+| `scrollToElement(id)` | Navigate to any element by its ID | Cross-session (for DOCX-imported content) |
+| `PositionTracker` | Track nodes that move during edits | Within a single session |
+
+## Navigate by element ID
+
+`scrollToElement` takes any element ID — paragraph, comment, or tracked change — and scrolls to it. The ID comes from the Document API.
+
+```javascript
+// Get an element's ID
+const match = editor.doc.query.match({
+  select: { type: 'text', pattern: 'Introduction', mode: 'contains' },
+  require: 'first',
+});
+const nodeId = match.items[0].address.nodeId;
+
+// Navigate to it — works for paragraphs, comments, tracked changes
+await superdoc.scrollToElement(nodeId);
+```
+
+This is the approach to use for:
+- **RAG citations** — store `nodeId` alongside embeddings, navigate on click
+- **Cross-references** — link to specific paragraphs from external UI
+- **Search results** — scroll to the matching paragraph
+- **Cross-session addressing** — IDs from DOCX-imported content survive reloads
+
+For the full cross-session pattern, see [cross-session block addressing](/document-api/common-workflows#cross-session-block-addressing).
+
+## Track nodes during edits
+
+When users edit a document, stored positions can drift. Use `PositionTracker` so navigation targets stay stable within the current session.
+
+### Hyperlinks example
 
 ```javascript
 // 1) Find hyperlink nodes
@@ -30,7 +62,7 @@ function goToLink(link) {
 
 ## Best practices
 
-- Track results right after `find()`.
-- Store `trackerId` in UI state, not raw positions.
-- Re-run `find()` and rebuild tracked IDs when refreshing your list.
-- Handle missing targets gracefully (`goToTracked` can return `false` if content was removed).
+- Use `scrollToElement` when you have an element ID from the Document API.
+- Use `PositionTracker` when you need to follow nodes that move during edits.
+- For cross-session use, store `nodeId` values (not `sdBlockId` — those regenerate on each open).
+- Handle missing targets gracefully — both APIs return `false` if the element no longer exists.

--- a/packages/document-api/src/types/address.ts
+++ b/packages/document-api/src/types/address.ts
@@ -128,3 +128,32 @@ export type TrackedChangeAddress = {
 };
 
 export type EntityAddress = CommentAddress | TrackedChangeAddress;
+
+// ---------------------------------------------------------------------------
+// Navigation addressing
+// ---------------------------------------------------------------------------
+
+/**
+ * Address for navigating to a block-level element by its node ID.
+ *
+ * The `nodeId` maps to `paraId` (from OOXML) when available, with fallback
+ * to `sdBlockId` (session-scoped). Use the value returned by Document API
+ * queries (e.g. `query.match`, `find`, `getNode`) as the `nodeId`.
+ *
+ * When `nodeType` is omitted, the lookup searches across all block types.
+ */
+export type BlockNavigationAddress = {
+  kind: 'block';
+  nodeId: string;
+  nodeType?: SelectionEdgeNodeType;
+};
+
+/**
+ * Union of all address types accepted by `navigateTo()`.
+ *
+ * Supports navigation to:
+ * - Blocks by `nodeId` (paragraphs, headings, tables, images, SDTs)
+ * - Comments by `entityId`
+ * - Tracked changes by `entityId`
+ */
+export type NavigableAddress = BlockNavigationAddress | CommentAddress | TrackedChangeAddress;

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -130,7 +130,10 @@ import {
   ensureEditorFieldAnnotationInteractionStyles,
 } from './dom/EditorStyleInjector.js';
 
-import type { ResolveRangeOutput, DocumentApi } from '@superdoc/document-api';
+import type { ResolveRangeOutput, DocumentApi, NavigableAddress, BlockNavigationAddress } from '@superdoc/document-api';
+import { getBlockIndex } from '../../document-api-adapters/helpers/index-cache.js';
+import { findBlockByNodeIdOnly, findBlockById } from '../../document-api-adapters/helpers/node-address-resolver.js';
+import { resolveTrackedChange } from '../../document-api-adapters/helpers/tracked-change-resolver.js';
 import type { SelectionHandle } from '../selection-state.js';
 
 const DOCUMENT_RELS_PART_ID = 'word/_rels/document.xml.rels';
@@ -5842,6 +5845,133 @@ export class PresentationEditor extends EventEmitter {
    * This allows sufficient time for virtualized pages to render before giving up.
    */
   private static readonly ANCHOR_NAV_TIMEOUT_MS = 2000;
+
+  /**
+   * Navigate to any addressable element in the document.
+   *
+   * Accepts blocks (by nodeId), comments (by entityId), and tracked changes
+   * (by entityId). Returns true if navigation succeeded, false otherwise.
+   *
+   * @param target - The element address to navigate to.
+   * @returns Promise resolving to true if navigation succeeded.
+   */
+  async navigateTo(target: NavigableAddress): Promise<boolean> {
+    if (!target) return false;
+
+    try {
+      if (target.kind === 'block') {
+        return await this.#navigateToBlock(target);
+      }
+
+      if (target.kind === 'entity') {
+        if (target.entityType === 'comment') {
+          return this.#navigateToComment(target.entityId);
+        }
+        if (target.entityType === 'trackedChange') {
+          return await this.#navigateToTrackedChange(target.entityId);
+        }
+      }
+
+      return false;
+    } catch (error) {
+      console.error('[PresentationEditor] navigateTo failed:', error);
+      this.emit('error', { error, context: 'navigateTo' });
+      return false;
+    }
+  }
+
+  async #navigateToBlock(target: BlockNavigationAddress): Promise<boolean> {
+    const editor = this.#editor;
+    if (!editor) return false;
+
+    const index = getBlockIndex(editor);
+
+    let candidate;
+    try {
+      if (target.nodeType) {
+        candidate = findBlockById(index, { kind: 'block', nodeType: target.nodeType, nodeId: target.nodeId });
+      } else {
+        candidate = findBlockByNodeIdOnly(index, target.nodeId);
+      }
+    } catch {
+      return false;
+    }
+
+    if (!candidate) return false;
+
+    // Resolve the first text-content position inside the block. The layout
+    // engine maps fragments to text content ranges — block wrappers and
+    // zero-width annotation nodes (bookmarkStart, commentRangeStart) don't
+    // generate layout fragments. We walk the block's children to find the
+    // first inline node with text content (typically a `run` node).
+    const blockNode = editor.state.doc.nodeAt(candidate.pos);
+    let contentPos = candidate.pos + 1;
+    if (blockNode) {
+      blockNode.forEach((child, offset) => {
+        if (contentPos !== candidate.pos + 1) return;
+        if (child.textContent.length > 0) {
+          // Position inside the child: block pos + 1 (block open) + offset + 1 (child open, if not text)
+          contentPos = candidate.pos + 1 + offset + (child.isText ? 0 : 1);
+        }
+      });
+    }
+
+    const scrolled = await this.scrollToPositionAsync(contentPos, {
+      behavior: 'auto',
+      block: 'center',
+    });
+    if (!scrolled) return false;
+
+    editor.commands?.setTextSelection?.({ from: contentPos, to: contentPos });
+    editor.view?.focus?.();
+    return true;
+  }
+
+  #navigateToComment(entityId: string): boolean {
+    const editor = this.#editor;
+    if (!editor) return false;
+
+    const setCursorById = editor.commands?.setCursorById;
+    if (typeof setCursorById === 'function') {
+      return setCursorById(entityId, {
+        preferredActiveThreadId: entityId,
+        activeCommentId: entityId,
+      });
+    }
+
+    return false;
+  }
+
+  async #navigateToTrackedChange(entityId: string): Promise<boolean> {
+    const editor = this.#editor;
+    if (!editor) return false;
+
+    // Try direct cursor placement first.
+    const setCursorById = editor.commands?.setCursorById;
+    if (typeof setCursorById === 'function' && setCursorById(entityId, { preferredActiveThreadId: entityId })) {
+      return true;
+    }
+
+    // Fall back to resolving the tracked change position and scrolling.
+    const resolved = resolveTrackedChange(editor, entityId);
+    if (!resolved) return false;
+
+    // Try with the raw ID (tracked changes may use a different internal ID).
+    if (typeof setCursorById === 'function' && resolved.rawId !== entityId) {
+      if (setCursorById(resolved.rawId, { preferredActiveThreadId: resolved.rawId })) {
+        return true;
+      }
+    }
+
+    // Last resort: scroll to position directly.
+    await this.scrollToPositionAsync(resolved.from, {
+      behavior: 'auto',
+      block: 'center',
+    });
+    editor.commands?.setTextSelection?.({ from: resolved.from, to: resolved.from });
+    editor.view?.focus?.();
+    return true;
+  }
 
   /**
    * Navigate to a bookmark/anchor in the current document (e.g., TOC links).

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -5890,7 +5890,7 @@ export class PresentationEditor extends EventEmitter {
 
       if (target.kind === 'entity') {
         if (target.entityType === 'comment') {
-          return this.#navigateToComment(target.entityId);
+          return await this.#navigateToComment(target.entityId);
         }
         if (target.entityType === 'trackedChange') {
           return await this.#navigateToTrackedChange(target.entityId);
@@ -5958,28 +5958,32 @@ export class PresentationEditor extends EventEmitter {
     return true;
   }
 
-  #navigateToComment(entityId: string): boolean {
+  async #navigateToComment(entityId: string): Promise<boolean> {
     const editor = this.#editor;
     if (!editor) return false;
 
     const setCursorById = editor.commands?.setCursorById;
-    if (typeof setCursorById === 'function') {
-      return setCursorById(entityId, {
-        preferredActiveThreadId: entityId,
-        activeCommentId: entityId,
-      });
+    if (typeof setCursorById !== 'function') return false;
+
+    if (!setCursorById(entityId, { preferredActiveThreadId: entityId, activeCommentId: entityId })) {
+      return false;
     }
 
-    return false;
+    // Scroll the viewport — setCursorById places the cursor but doesn't
+    // scroll in presentation mode where DomPainter renders the output.
+    await this.scrollToPositionAsync(editor.state.selection.from, { behavior: 'auto', block: 'center' });
+    return true;
   }
 
   async #navigateToTrackedChange(entityId: string): Promise<boolean> {
     const editor = this.#editor;
     if (!editor) return false;
 
-    // Try direct cursor placement first.
     const setCursorById = editor.commands?.setCursorById;
+
+    // Try direct cursor placement, then scroll to the new selection.
     if (typeof setCursorById === 'function' && setCursorById(entityId, { preferredActiveThreadId: entityId })) {
+      await this.scrollToPositionAsync(editor.state.selection.from, { behavior: 'auto', block: 'center' });
       return true;
     }
 
@@ -5990,6 +5994,7 @@ export class PresentationEditor extends EventEmitter {
     // Try with the raw ID (tracked changes may use a different internal ID).
     if (typeof setCursorById === 'function' && resolved.rawId !== entityId) {
       if (setCursorById(resolved.rawId, { preferredActiveThreadId: resolved.rawId })) {
+        await this.scrollToPositionAsync(editor.state.selection.from, { behavior: 'auto', block: 'center' });
         return true;
       }
     }

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -5847,6 +5847,59 @@ export class PresentationEditor extends EventEmitter {
   private static readonly ANCHOR_NAV_TIMEOUT_MS = 2000;
 
   /**
+   * Scroll to any document element by its ID.
+   *
+   * Accepts any element ID — paragraph nodeId, comment entityId, or tracked
+   * change entityId. Resolves the element type automatically:
+   * 1. Tries block index lookup (paragraphs, headings, tables)
+   * 2. Falls back to comment/tracked-change mark lookup
+   *
+   * @param elementId - The element's stable ID (nodeId, commentId, or trackedChangeId).
+   * @returns Promise resolving to true if the element was found and scrolled to.
+   */
+  async scrollToElement(elementId: string): Promise<boolean> {
+    if (!elementId || !this.#editor) return false;
+
+    try {
+      // Try block navigation first (O(1) index lookup).
+      const index = getBlockIndex(this.#editor);
+      try {
+        const candidate = findBlockByNodeIdOnly(index, elementId);
+        if (candidate) {
+          return await this.#scrollToBlockCandidate(this.#editor, candidate);
+        }
+      } catch {
+        // Not a block — fall through to mark lookup.
+      }
+
+      // Try comment/tracked-change marks (walks the document).
+      const setCursorById = this.#editor.commands?.setCursorById;
+      if (typeof setCursorById === 'function' && setCursorById(elementId, { preferredActiveThreadId: elementId })) {
+        return true;
+      }
+
+      // Try tracked change resolution (canonical ID → raw ID fallback).
+      const resolved = resolveTrackedChange(this.#editor, elementId);
+      if (resolved) {
+        if (typeof setCursorById === 'function' && resolved.rawId !== elementId) {
+          if (setCursorById(resolved.rawId, { preferredActiveThreadId: resolved.rawId })) {
+            return true;
+          }
+        }
+        await this.scrollToPositionAsync(resolved.from, { behavior: 'auto', block: 'center' });
+        this.#editor.commands?.setTextSelection?.({ from: resolved.from, to: resolved.from });
+        this.#editor.view?.focus?.();
+        return true;
+      }
+
+      return false;
+    } catch (error) {
+      console.error('[PresentationEditor] scrollToElement failed:', error);
+      return false;
+    }
+  }
+
+  /**
    * Navigate to any addressable element in the document.
    *
    * Accepts blocks (by nodeId), comments (by entityId), and tracked changes
@@ -5898,19 +5951,25 @@ export class PresentationEditor extends EventEmitter {
     }
 
     if (!candidate) return false;
+    return this.#scrollToBlockCandidate(editor, candidate);
+  }
 
-    // Resolve the first text-content position inside the block. The layout
-    // engine maps fragments to text content ranges — block wrappers and
-    // zero-width annotation nodes (bookmarkStart, commentRangeStart) don't
-    // generate layout fragments. We walk the block's children to find the
-    // first inline node with text content (typically a `run` node).
+  /**
+   * Scroll to a resolved block candidate and place the cursor inside it.
+   *
+   * Resolves the first text-content position inside the block — the layout
+   * engine maps fragments to text content ranges, so block wrappers and
+   * zero-width annotation nodes (bookmarkStart, commentRangeStart) don't
+   * generate layout fragments. We walk the block's children to find the
+   * first inline node with text content (typically a `run` node).
+   */
+  async #scrollToBlockCandidate(editor: Editor, candidate: { pos: number }): Promise<boolean> {
     const blockNode = editor.state.doc.nodeAt(candidate.pos);
     let contentPos = candidate.pos + 1;
     if (blockNode) {
       blockNode.forEach((child, offset) => {
         if (contentPos !== candidate.pos + 1) return;
         if (child.textContent.length > 0) {
-          // Position inside the child: block pos + 1 (block open) + offset + 1 (child open, if not text)
           contentPos = candidate.pos + 1 + offset + (child.isText ? 0 : 1);
         }
       });

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -5852,60 +5852,32 @@ export class PresentationEditor extends EventEmitter {
    * Accepts any element ID — paragraph nodeId, comment entityId, or tracked
    * change entityId. Resolves the element type automatically:
    * 1. Tries block index lookup (paragraphs, headings, tables)
-   * 2. Falls back to comment/tracked-change mark lookup
+   * 2. Tries comment navigation (activates comment thread)
+   * 3. Tries tracked change navigation (with raw ID fallback)
    *
    * @param elementId - The element's stable ID (nodeId, commentId, or trackedChangeId).
    * @returns Promise resolving to true if the element was found and scrolled to.
    */
   async scrollToElement(elementId: string): Promise<boolean> {
-    if (!elementId || !this.#editor) return false;
+    if (!elementId) return false;
 
-    try {
-      // Try block navigation first (O(1) index lookup).
-      const index = getBlockIndex(this.#editor);
-      try {
-        const candidate = findBlockByNodeIdOnly(index, elementId);
-        if (candidate) {
-          return await this.#scrollToBlockCandidate(this.#editor, candidate);
-        }
-      } catch {
-        // Not a block — fall through to mark lookup.
-      }
+    // Try block first — O(1) index lookup, most common for RAG citations.
+    if (await this.navigateTo({ kind: 'block', nodeId: elementId })) return true;
 
-      // Try comment/tracked-change marks (walks the document).
-      const setCursorById = this.#editor.commands?.setCursorById;
-      if (typeof setCursorById === 'function' && setCursorById(elementId, { preferredActiveThreadId: elementId })) {
-        return true;
-      }
+    // Try comment — setCursorById handles both comment and TC marks,
+    // but we try comment first to get full thread activation.
+    if (await this.navigateTo({ kind: 'entity', entityType: 'comment', entityId: elementId })) return true;
 
-      // Try tracked change resolution (canonical ID → raw ID fallback).
-      const resolved = resolveTrackedChange(this.#editor, elementId);
-      if (resolved) {
-        if (typeof setCursorById === 'function' && resolved.rawId !== elementId) {
-          if (setCursorById(resolved.rawId, { preferredActiveThreadId: resolved.rawId })) {
-            return true;
-          }
-        }
-        await this.scrollToPositionAsync(resolved.from, { behavior: 'auto', block: 'center' });
-        this.#editor.commands?.setTextSelection?.({ from: resolved.from, to: resolved.from });
-        this.#editor.view?.focus?.();
-        return true;
-      }
+    // Try tracked change — has its own fallback chain (canonical → raw ID → scroll).
+    if (await this.navigateTo({ kind: 'entity', entityType: 'trackedChange', entityId: elementId })) return true;
 
-      return false;
-    } catch (error) {
-      console.error('[PresentationEditor] scrollToElement failed:', error);
-      return false;
-    }
+    return false;
   }
 
   /**
-   * Navigate to any addressable element in the document.
+   * Navigate to a typed document element address.
    *
-   * Accepts blocks (by nodeId), comments (by entityId), and tracked changes
-   * (by entityId). Returns true if navigation succeeded, false otherwise.
-   *
-   * @param target - The element address to navigate to.
+   * @param target - Typed address: block (nodeId), comment (entityId), or tracked change (entityId).
    * @returns Promise resolving to true if navigation succeeded.
    */
   async navigateTo(target: NavigableAddress): Promise<boolean> {
@@ -6023,10 +5995,12 @@ export class PresentationEditor extends EventEmitter {
     }
 
     // Last resort: scroll to position directly.
-    await this.scrollToPositionAsync(resolved.from, {
+    const scrolled = await this.scrollToPositionAsync(resolved.from, {
       behavior: 'auto',
       block: 'center',
     });
+    if (!scrolled) return false;
+
     editor.commands?.setTextSelection?.({ from: resolved.from, to: resolved.from });
     editor.view?.focus?.();
     return true;

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -1239,23 +1239,6 @@ export class SuperDoc extends EventEmitter {
   }
 
   /**
-   * Navigate to any addressable element in the document by its ID.
-   *
-   * Accepts blocks (by nodeId), comments (by entityId), and tracked changes
-   * (by entityId). Returns true if navigation succeeded, false otherwise.
-   *
-   * @param {NavigableAddress} address - The element address to navigate to.
-   * @returns {Promise<boolean>} Whether navigation succeeded.
-   */
-  async navigateTo(address) {
-    const storeDocs = this.superdocStore?.documents;
-    if (!storeDocs?.length) return false;
-    const presentationEditor = storeDocs[0].getPresentationEditor?.();
-    if (!presentationEditor?.navigateTo) return false;
-    return presentationEditor.navigateTo(address);
-  }
-
-  /**
    * Toggle the custom context menu globally.
    * Updates both flow editors and PresentationEditor instances so downstream listeners can short-circuit early.
    * @param {boolean} disabled

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -1214,6 +1214,23 @@ export class SuperDoc extends EventEmitter {
   }
 
   /**
+   * Navigate to any addressable element in the document by its ID.
+   *
+   * Accepts blocks (by nodeId), comments (by entityId), and tracked changes
+   * (by entityId). Returns true if navigation succeeded, false otherwise.
+   *
+   * @param {NavigableAddress} address - The element address to navigate to.
+   * @returns {Promise<boolean>} Whether navigation succeeded.
+   */
+  async navigateTo(address) {
+    const storeDocs = this.superdocStore?.documents;
+    if (!storeDocs?.length) return false;
+    const presentationEditor = storeDocs[0].getPresentationEditor?.();
+    if (!presentationEditor?.navigateTo) return false;
+    return presentationEditor.navigateTo(address);
+  }
+
+  /**
    * Toggle the custom context menu globally.
    * Updates both flow editors and PresentationEditor instances so downstream listeners can short-circuit early.
    * @param {boolean} disabled

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -1214,6 +1214,31 @@ export class SuperDoc extends EventEmitter {
   }
 
   /**
+   * Scroll to any document element by its ID.
+   *
+   * Pass any element ID — paragraph nodeId, comment entityId, or tracked
+   * change entityId. The method resolves the element type automatically
+   * and scrolls to it.
+   *
+   * @param {string} elementId - The element's stable ID.
+   * @returns {Promise<boolean>} Whether the element was found and scrolled to.
+   *
+   * @example
+   * // Navigate to a paragraph by its nodeId
+   * await superdoc.scrollToElement('5AF80E61');
+   *
+   * // Navigate to a comment by its entityId
+   * await superdoc.scrollToElement('imported-25def254');
+   */
+  async scrollToElement(elementId) {
+    const storeDocs = this.superdocStore?.documents;
+    if (!storeDocs?.length) return false;
+    const presentationEditor = storeDocs[0].getPresentationEditor?.();
+    if (!presentationEditor?.scrollToElement) return false;
+    return presentationEditor.scrollToElement(elementId);
+  }
+
+  /**
    * Navigate to any addressable element in the document by its ID.
    *
    * Accepts blocks (by nodeId), comments (by entityId), and tracked changes

--- a/packages/superdoc/src/core/types/index.js
+++ b/packages/superdoc/src/core/types/index.js
@@ -43,35 +43,6 @@
 /** @typedef {import('../SuperDoc.js').SuperDoc} SuperDoc */
 
 /**
- * Address for navigating to a block-level element by its node ID.
- * @typedef {Object} BlockNavigationAddress
- * @property {'block'} kind
- * @property {string} nodeId
- * @property {'paragraph' | 'heading' | 'table' | 'tableOfContents' | 'sdt' | 'image'} [nodeType]
- */
-
-/**
- * Address for navigating to a comment by its entity ID.
- * @typedef {Object} CommentNavigationAddress
- * @property {'entity'} kind
- * @property {'comment'} entityType
- * @property {string} entityId
- */
-
-/**
- * Address for navigating to a tracked change by its entity ID.
- * @typedef {Object} TrackedChangeNavigationAddress
- * @property {'entity'} kind
- * @property {'trackedChange'} entityType
- * @property {string} entityId
- */
-
-/**
- * Union of all address types accepted by `navigateTo()`.
- * @typedef {BlockNavigationAddress | CommentNavigationAddress | TrackedChangeNavigationAddress} NavigableAddress
- */
-
-/**
  * @typedef {Object} UpgradeToCollaborationOptions Options for `upgradeToCollaboration()`
  * @property {import('yjs').Doc} ydoc The target Yjs document to seed and connect to
  * @property {CollaborationProvider} provider The collaboration provider to use

--- a/packages/superdoc/src/core/types/index.js
+++ b/packages/superdoc/src/core/types/index.js
@@ -43,6 +43,35 @@
 /** @typedef {import('../SuperDoc.js').SuperDoc} SuperDoc */
 
 /**
+ * Address for navigating to a block-level element by its node ID.
+ * @typedef {Object} BlockNavigationAddress
+ * @property {'block'} kind
+ * @property {string} nodeId
+ * @property {'paragraph' | 'heading' | 'table' | 'tableOfContents' | 'sdt' | 'image'} [nodeType]
+ */
+
+/**
+ * Address for navigating to a comment by its entity ID.
+ * @typedef {Object} CommentNavigationAddress
+ * @property {'entity'} kind
+ * @property {'comment'} entityType
+ * @property {string} entityId
+ */
+
+/**
+ * Address for navigating to a tracked change by its entity ID.
+ * @typedef {Object} TrackedChangeNavigationAddress
+ * @property {'entity'} kind
+ * @property {'trackedChange'} entityType
+ * @property {string} entityId
+ */
+
+/**
+ * Union of all address types accepted by `navigateTo()`.
+ * @typedef {BlockNavigationAddress | CommentNavigationAddress | TrackedChangeNavigationAddress} NavigableAddress
+ */
+
+/**
  * @typedef {Object} UpgradeToCollaborationOptions Options for `upgradeToCollaboration()`
  * @property {import('yjs').Doc} ydoc The target Yjs document to seed and connect to
  * @property {CollaborationProvider} provider The collaboration provider to use

--- a/tests/behavior/tests/navigation/scroll-to-element.spec.ts
+++ b/tests/behavior/tests/navigation/scroll-to-element.spec.ts
@@ -1,0 +1,109 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test, expect } from '../../fixtures/superdoc.js';
+import { assertDocumentApiReady } from '../../helpers/document-api.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = path.resolve(
+  __dirname,
+  '../../../../packages/super-editor/src/editors/v1/tests/data/advanced-text.docx',
+);
+
+test.skip(!fs.existsSync(DOC_PATH), 'Test document not available');
+test.use({ config: { comments: 'on', trackChanges: true } });
+
+test.describe('scrollToElement', () => {
+  test('@behavior navigates to a paragraph by nodeId', async ({ superdoc }) => {
+    await superdoc.loadDocument(DOC_PATH);
+    await superdoc.waitForStable(2000);
+    await assertDocumentApiReady(superdoc.page);
+
+    const result = await superdoc.page.evaluate(() => {
+      const qm = (window as any).editor?.doc?.query?.match;
+      const match = qm({ select: { type: 'text', pattern: 'Fortune favors', mode: 'contains' }, require: 'first' });
+      const nodeId = match?.items?.[0]?.address?.nodeId;
+      if (!nodeId) return { error: 'nodeId not found' };
+      return { nodeId };
+    });
+
+    expect(result).toHaveProperty('nodeId');
+    const nodeId = (result as { nodeId: string }).nodeId;
+
+    const navResult = await superdoc.page.evaluate((id) => (window as any).superdoc.scrollToElement(id), nodeId);
+    expect(navResult).toBe(true);
+  });
+
+  test('@behavior navigates to a comment by entityId', async ({ superdoc }) => {
+    await superdoc.loadDocument(DOC_PATH);
+    await superdoc.waitForStable(2000);
+    await assertDocumentApiReady(superdoc.page);
+
+    const commentId = await superdoc.page.evaluate(() => {
+      const comments = (window as any).editor?.doc?.comments?.list?.();
+      return comments?.items?.[0]?.address?.entityId ?? comments?.items?.[0]?.id ?? null;
+    });
+
+    if (!commentId) {
+      test.skip();
+      return;
+    }
+
+    const navResult = await superdoc.page.evaluate((id) => (window as any).superdoc.scrollToElement(id), commentId);
+    expect(navResult).toBe(true);
+  });
+
+  test('@behavior navigates to a tracked change by entityId', async ({ superdoc }) => {
+    await superdoc.loadDocument(DOC_PATH);
+    await superdoc.waitForStable(2000);
+    await assertDocumentApiReady(superdoc.page);
+
+    const tcId = await superdoc.page.evaluate(() => {
+      const tcs = (window as any).editor?.doc?.trackChanges?.list?.();
+      return tcs?.items?.[0]?.address?.entityId ?? tcs?.items?.[0]?.id ?? null;
+    });
+
+    if (!tcId) {
+      test.skip();
+      return;
+    }
+
+    const navResult = await superdoc.page.evaluate((id) => (window as any).superdoc.scrollToElement(id), tcId);
+    expect(navResult).toBe(true);
+  });
+
+  test('@behavior returns false for non-existent element ID', async ({ superdoc }) => {
+    await superdoc.loadDocument(DOC_PATH);
+    await superdoc.waitForStable(2000);
+    await assertDocumentApiReady(superdoc.page);
+
+    const navResult = await superdoc.page.evaluate(() => (window as any).superdoc.scrollToElement('DOES_NOT_EXIST'));
+    expect(navResult).toBe(false);
+  });
+
+  test('@behavior navigates to multiple blocks sequentially', async ({ superdoc }) => {
+    await superdoc.loadDocument(DOC_PATH);
+    await superdoc.waitForStable(2000);
+    await assertDocumentApiReady(superdoc.page);
+
+    const results = await superdoc.page.evaluate(async () => {
+      const qm = (window as any).editor?.doc?.query?.match;
+      const targets = ['Fortune favors', 'Dropcaps', 'SuperDoc Advanced'];
+      const navResults: Array<{ text: string; success: boolean }> = [];
+
+      for (const text of targets) {
+        const match = qm({ select: { type: 'text', pattern: text, mode: 'contains' }, require: 'first' });
+        const nodeId = match?.items?.[0]?.address?.nodeId;
+        const success = nodeId ? await (window as any).superdoc.scrollToElement(nodeId) : false;
+        navResults.push({ text, success });
+        await new Promise((r) => setTimeout(r, 300));
+      }
+
+      return navResults;
+    });
+
+    for (const r of results) {
+      expect(r.success, `Navigation to "${r.text}" should succeed`).toBe(true);
+    }
+  });
+});

--- a/tests/consumer-typecheck/src/customer-scenario.ts
+++ b/tests/consumer-typecheck/src/customer-scenario.ts
@@ -409,6 +409,13 @@ function testPresentationEditorMethods(pe: PresentationEditor) {
   pe.scrollToPosition(100);
   pe.scrollThreadAnchorToClientY('thread-1', 300);
 
+  // Element navigation
+  pe.scrollToElement('paraId-ABC123');
+  pe.navigateTo({ kind: 'block', nodeId: 'paraId-ABC123' });
+  pe.navigateTo({ kind: 'block', nodeId: 'paraId-ABC123', nodeType: 'paragraph' });
+  pe.navigateTo({ kind: 'entity', entityType: 'comment', entityId: 'comment-1' });
+  pe.navigateTo({ kind: 'entity', entityType: 'trackedChange', entityId: 'tc-1' });
+
   // Dispatch
   pe.dispatch(pe.state.tr);
   pe.dispatchInActiveEditor((ed) => {


### PR DESCRIPTION
Add `scrollToElement(id)` to SuperDoc — navigate to any document element by passing a single ID string. Works for paragraphs, headings, comments, and tracked changes without the consumer needing to know the element type.

- `scrollToElement(id)` on SuperDoc: one method, one string — resolves element type automatically via block index lookup → comment/TC mark fallback
- `navigateTo(address)` on PresentationEditor: typed internal dispatcher for block, comment, and tracked change addresses
- `BlockNavigationAddress` and `NavigableAddress` types in `@superdoc/document-api`
- Block position resolution handles zero-width annotation nodes (bookmarkStart, commentRangeStart) by finding first text-content child
- Tracked change fallback checks `scrollToPositionAsync` return value instead of returning true unconditionally
- Verified with Word-native documents (real paraIds): 12/12 block navigations, cross-page scroll, comment/TC activation

```js
await superdoc.scrollToElement('5AF80E61');        // paragraph
await superdoc.scrollToElement('imported-25def254'); // comment
await superdoc.scrollToElement('197927c2...');       // tracked change
await superdoc.scrollToElement('nonexistent');       // → false
```

SD-2519