### PR TITLE
fix(types): chain commands return ChainableCommandObject, not boolean (SD-2334)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/types/ChainedCommands.ts
+++ b/packages/super-editor/src/editors/v1/core/types/ChainedCommands.ts
@@ -48,36 +48,12 @@ type KnownCommandRecord = {
 };
 
 /**
- * Transforms a command interface so every method returns ChainableCommandObject
- * instead of boolean, preserving parameter types.
+ * Union of all command interfaces via explicit imports.
+ * Module augmentation doesn't survive the npm boundary, so this is the
+ * single source of truth for the built-in command surface. Used by
+ * EditorCommands, ChainableCommandObject, and CanObject.
  */
-type Chainified<T> = {
-  [K in keyof T]: T[K] extends (...args: infer A) => unknown ? (...args: A) => ChainableCommandObject : T[K];
-};
-
-/**
- * All chain-typed commands composed from explicit imports.
- * Mirrors EditorCommands but with each method returning ChainableCommandObject.
- *
- * Module augmentation (CoreCommandMap/ExtensionCommandMap) doesn't survive
- * the npm boundary, so we use direct imports — same pattern as EditorCommands.
- */
-type AllChainedCommands = Chainified<CoreCommandSignatures> &
-  Chainified<CommentCommands> &
-  Chainified<FormattingCommandAugmentations> &
-  Chainified<HistoryLinkTableCommandAugmentations> &
-  Chainified<SpecializedCommandAugmentations> &
-  Chainified<ParagraphCommands> &
-  Chainified<BlockNodeCommands> &
-  Chainified<ImageCommands> &
-  Chainified<MiscellaneousCommands> &
-  Chainified<TrackChangesCommands>;
-
-/**
- * All can-check commands composed from explicit imports.
- * Mirrors EditorCommands with original return types for availability checks.
- */
-type AllCanCommands = CoreCommandSignatures &
+type AllCommandSignatures = CoreCommandSignatures &
   CommentCommands &
   FormattingCommandAugmentations &
   HistoryLinkTableCommandAugmentations &
@@ -89,6 +65,29 @@ type AllCanCommands = CoreCommandSignatures &
   TrackChangesCommands;
 
 /**
+ * Transforms a command interface so every method returns ChainableCommandObject
+ * instead of boolean, preserving parameter types.
+ */
+type Chainified<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => unknown ? (...args: A) => ChainableCommandObject : T[K];
+};
+
+/**
+ * Commands from module augmentation, transformed for chaining.
+ * Empty for npm consumers (augmentation doesn't survive the boundary),
+ * but consumers who augment ExtensionCommandMap get their custom commands
+ * on chain() for free.
+ */
+type AugmentedChainedCommands = {
+  [K in keyof RegisteredCommands]: (...args: CommandArgs<K>) => ChainableCommandObject;
+};
+
+/** Same as AugmentedChainedCommands but with original return types for can(). */
+type AugmentedCanCommands = {
+  [K in keyof RegisteredCommands]: (...args: CommandArgs<K>) => CommandResult<K>;
+};
+
+/**
  * A chainable version of an editor command keyed by command name.
  */
 export type ChainedCommand<K extends string = string> = (...args: CommandArgs<K>) => ChainableCommandObject;
@@ -96,10 +95,14 @@ export type ChainedCommand<K extends string = string> = (...args: CommandArgs<K>
 /**
  * Chainable command object returned by `createChain`.
  * Only `run()` returns boolean — all other methods return ChainableCommandObject.
+ *
+ * Includes AugmentedChainedCommands so consumers who extend ExtensionCommandMap
+ * via module augmentation get their custom commands on chain() automatically.
  */
 export type ChainableCommandObject = {
   run: () => boolean;
-} & AllChainedCommands;
+} & Chainified<AllCommandSignatures> &
+  AugmentedChainedCommands;
 
 /**
  * A command that can be checked for availability.
@@ -113,10 +116,14 @@ export type CanCommands = Record<string, CanCommand>;
 
 /**
  * Object returned by `createCan`: typed boolean commands + a `chain()` helper.
+ *
+ * Includes AugmentedCanCommands so consumers who extend ExtensionCommandMap
+ * via module augmentation get their custom commands on can() automatically.
  */
-export type CanObject = AllCanCommands & {
-  chain: () => ChainableCommandObject;
-};
+export type CanObject = AllCommandSignatures &
+  AugmentedCanCommands & {
+    chain: () => ChainableCommandObject;
+  };
 
 /**
  * Core editor commands available on all instances.
@@ -131,23 +138,11 @@ export type ExtensionCommands = Pick<KnownCommandRecord, keyof ExtensionCommandM
 /**
  * All available editor commands.
  *
- * Composed from explicit imports of each command interface for reliable
- * cross-package typing (module augmentation doesn't survive the npm boundary).
- * The Record<string, AnyCommand> fallback allows dynamic/plugin commands.
+ * Composed from AllCommandSignatures (explicit imports) for reliable
+ * cross-package typing, plus CoreCommands/ExtensionCommands (module
+ * augmentation) and a Record fallback for dynamic/plugin commands.
  */
-export type EditorCommands = CoreCommands &
-  ExtensionCommands &
-  CoreCommandSignatures &
-  CommentCommands &
-  FormattingCommandAugmentations &
-  HistoryLinkTableCommandAugmentations &
-  SpecializedCommandAugmentations &
-  ParagraphCommands &
-  BlockNodeCommands &
-  ImageCommands &
-  MiscellaneousCommands &
-  TrackChangesCommands &
-  Record<string, AnyCommand>;
+export type EditorCommands = CoreCommands & ExtensionCommands & AllCommandSignatures & Record<string, AnyCommand>;
 
 /**
  * Command props made available to every command handler.

--- a/packages/super-editor/src/editors/v1/core/types/ChainedCommands.ts
+++ b/packages/super-editor/src/editors/v1/core/types/ChainedCommands.ts
@@ -48,31 +48,63 @@ type KnownCommandRecord = {
 };
 
 /**
+ * Transforms a command interface so every method returns ChainableCommandObject
+ * instead of boolean, preserving parameter types.
+ */
+type Chainified<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => unknown ? (...args: A) => ChainableCommandObject : T[K];
+};
+
+/**
+ * All chain-typed commands composed from explicit imports.
+ * Mirrors EditorCommands but with each method returning ChainableCommandObject.
+ *
+ * Module augmentation (CoreCommandMap/ExtensionCommandMap) doesn't survive
+ * the npm boundary, so we use direct imports — same pattern as EditorCommands.
+ */
+type AllChainedCommands = Chainified<CoreCommandSignatures> &
+  Chainified<CommentCommands> &
+  Chainified<FormattingCommandAugmentations> &
+  Chainified<HistoryLinkTableCommandAugmentations> &
+  Chainified<SpecializedCommandAugmentations> &
+  Chainified<ParagraphCommands> &
+  Chainified<BlockNodeCommands> &
+  Chainified<ImageCommands> &
+  Chainified<MiscellaneousCommands> &
+  Chainified<TrackChangesCommands>;
+
+/**
+ * All can-check commands composed from explicit imports.
+ * Mirrors EditorCommands with original return types for availability checks.
+ */
+type AllCanCommands = CoreCommandSignatures &
+  CommentCommands &
+  FormattingCommandAugmentations &
+  HistoryLinkTableCommandAugmentations &
+  SpecializedCommandAugmentations &
+  ParagraphCommands &
+  BlockNodeCommands &
+  ImageCommands &
+  MiscellaneousCommands &
+  TrackChangesCommands;
+
+/**
  * A chainable version of an editor command keyed by command name.
  */
 export type ChainedCommand<K extends string = string> = (...args: CommandArgs<K>) => ChainableCommandObject;
 
-type KnownChainedCommands = {
-  [K in keyof RegisteredCommands]: (...args: CommandArgs<K>) => ChainableCommandObject;
-};
-
 /**
  * Chainable command object returned by `createChain`.
- * Has dynamic keys (one per command) and a `run()` method.
+ * Only `run()` returns boolean — all other methods return ChainableCommandObject.
  */
 export type ChainableCommandObject = {
   run: () => boolean;
-} & KnownChainedCommands &
-  Record<string, (...args: unknown[]) => ChainableCommandObject>;
+} & AllChainedCommands;
 
 /**
  * A command that can be checked for availability.
  */
 export type CanCommand<K extends string = string> = (...args: CommandArgs<K>) => CommandResult<K>;
-
-type KnownCanCommands = {
-  [K in keyof RegisteredCommands]: (...args: CommandArgs<K>) => CommandResult<K>;
-};
 
 /**
  * Map of commands that can be checked.
@@ -80,12 +112,11 @@ type KnownCanCommands = {
 export type CanCommands = Record<string, CanCommand>;
 
 /**
- * Object returned by `createCan`: dynamic boolean commands + a `chain()` helper.
+ * Object returned by `createCan`: typed boolean commands + a `chain()` helper.
  */
-export type CanObject = KnownCanCommands &
-  Record<string, CanCommand> & {
-    chain: () => ChainableCommandObject;
-  };
+export type CanObject = AllCanCommands & {
+  chain: () => ChainableCommandObject;
+};
 
 /**
  * Core editor commands available on all instances.

--- a/tests/consumer-typecheck/src/customer-scenario.ts
+++ b/tests/consumer-typecheck/src/customer-scenario.ts
@@ -270,6 +270,15 @@ function testEditorCommands(editor: Editor) {
 
   // Chain API
   editor.chain().toggleBold().toggleItalic().run();
+
+  // SD-2334: Chain intermediate methods must return ChainableCommandObject, not boolean.
+  // Reproduces IT-344 (Ontra): chain().setTextSelection(...).setMark(...).run()
+  const chainResult: ChainableCommandObject = editor.chain().setTextSelection({ from: 0, to: 5 });
+  const runResult: boolean = editor.chain().setTextSelection({ from: 0, to: 5 }).setMark('bold').run();
+
+  // SD-2334: can().chain() must return ChainableCommandObject, not boolean
+  const canChain: ChainableCommandObject = editor.can().chain();
+  const canChainRun: boolean = editor.can().chain().toggleBold().run();
 }
 
 function testPresentationEditorCommands(pe: PresentationEditor) {


### PR DESCRIPTION
PR #2565 (SD-2261) replaced the handwritten `index.d.ts` with auto-generated types from `ChainedCommands.ts`, fixing the `ChainableCommandObject | boolean` return type union that IT-344 and IT-780 reported. However, the replacement type still used `KnownChainedCommands` (empty for npm consumers — module augmentation doesn't survive the package boundary) and a `Record<string, ...>` index signature fallback, which left two problems:

1. **`noPropertyAccessFromIndexSignature` incompatibility** — consumers with this TS strict flag can't use dot access on chain methods (`chain.setTextSelection(...)` errors with "must be accessed with bracket notation")
2. **No parameter type safety** — all chain method params fall to `unknown[]` since `KnownChainedCommands` is empty

This PR applies the same fix already used for `EditorCommands`: compose `AllChainedCommands` from direct imports of each command interface, transformed via `Chainified<T>` to return `ChainableCommandObject`. Same treatment for `CanObject`.

- Chain methods now have proper parameter types matching `EditorCommands`
- No `Record<string, ...>` index signature — works with all TS strict flags
- `run()` is unambiguously `() => boolean`
- `can().chain()` returns `ChainableCommandObject`, not an overloaded intersection
- Consumer-typecheck regression tests for IT-344 and IT-780 scenarios

Resolves SD-2334, IT-344, IT-780