### PR TITLE
fix(selection): skip scroll-into-view during drag to stop viewport bounce (SD-2541)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -3246,7 +3246,12 @@ export class PresentationEditor extends EventEmitter {
     };
     const handleSelection = () => {
       // User-initiated selection change (keyboard, mouse) — scroll caret into view.
-      this.#shouldScrollSelectionIntoView = true;
+      // During an active drag, EditorInputManager.#tickAutoScroll owns viewport
+      // movement. Arming this flag per pointermove-driven selection update would
+      // compete with auto-scroll and cause the viewport to oscillate (SD-2541).
+      if (!this.#editorInputManager?.isDragging) {
+        this.#shouldScrollSelectionIntoView = true;
+      }
       // Use immediate rendering for selection-only changes (clicks, arrow keys).
       // Without immediate, the render is RAF-deferred — leaving a window where
       // a remote collaborator's edit can cancel the pending render via

--- a/tests/behavior/tests/selection/drag-past-viewport-no-bounce.spec.ts
+++ b/tests/behavior/tests/selection/drag-past-viewport-no-bounce.spec.ts
@@ -1,0 +1,79 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { test, expect } from '../../fixtures/superdoc.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = path.join(__dirname, 'fixtures', 'two-column-simple.docx');
+
+test.use({ config: { toolbar: 'full', showSelection: true } });
+
+/**
+ * Regression test for SD-2541 / IT-914: dragging a selection past the viewport
+ * edge must not cause the viewport to bounce upward. Before the fix, every
+ * pointermove-driven selection update re-armed scroll-into-view and scrolled
+ * the editor's scroll container back toward the selection anchor, cancelling
+ * auto-scroll progress.
+ */
+test('drag selection past viewport edge scrolls monotonically (SD-2541)', async ({ superdoc, page }) => {
+  await superdoc.loadDocument(DOC_PATH);
+  await superdoc.waitForStable();
+
+  // Locate the scroll container and the first page's first text span.
+  const startPoint = await page.evaluate(() => {
+    const page0 = document.querySelector('[data-page-index="0"]') as HTMLElement | null;
+    const span = page0?.querySelector('span') as HTMLElement | null;
+    if (!span) return null;
+    const r = span.getBoundingClientRect();
+    return { x: r.left + 20, y: r.top + r.height / 2 };
+  });
+  expect(startPoint, 'page 0 first span must exist').not.toBeNull();
+
+  const scrollContainerSelector = '.dev-app__main';
+  const holdPoint = await page.evaluate((sel) => {
+    const sc = document.querySelector(sel) as HTMLElement | null;
+    if (!sc) return null;
+    const r = sc.getBoundingClientRect();
+    // Hold a few pixels inside the bottom edge zone so auto-scroll ticks.
+    return { x: r.left + 200, y: r.bottom - 8 };
+  }, scrollContainerSelector);
+  expect(holdPoint, 'scroll container must exist').not.toBeNull();
+
+  const readScrollTop = () =>
+    page.evaluate((sel) => (document.querySelector(sel) as HTMLElement).scrollTop, scrollContainerSelector);
+
+  const scrollTopBefore = await readScrollTop();
+
+  // Start drag on page 0.
+  await page.mouse.move(startPoint!.x, startPoint!.y);
+  await page.mouse.down();
+
+  // Move toward the bottom edge in a few steps so auto-scroll engages.
+  await page.mouse.move(startPoint!.x, startPoint!.y + 120, { steps: 4 });
+  await page.mouse.move(startPoint!.x, holdPoint!.y, { steps: 6 });
+
+  // Hold at the edge and sample scrollTop repeatedly.
+  const samples: number[] = [];
+  for (let i = 0; i < 20; i++) {
+    await page.mouse.move(holdPoint!.x, holdPoint!.y);
+    await page.waitForTimeout(60);
+    samples.push(await readScrollTop());
+  }
+
+  await page.mouse.up();
+
+  const scrollTopAfter = samples[samples.length - 1];
+
+  // Must have actually scrolled down (auto-scroll is working).
+  expect(scrollTopAfter).toBeGreaterThan(scrollTopBefore + 100);
+
+  // No bounce: no sample may drop meaningfully below the previous one.
+  // Small sub-pixel noise can occur on some browsers, so allow a 1px slack.
+  for (let i = 1; i < samples.length; i++) {
+    const delta = samples[i] - samples[i - 1];
+    expect(
+      delta,
+      `scrollTop bounced backward at sample ${i}: ${samples[i - 1]} → ${samples[i]} (Δ ${delta})`,
+    ).toBeGreaterThanOrEqual(-1);
+  }
+});


### PR DESCRIPTION
During drag-select past the viewport edge, each pointermove dispatched a PM `selectionUpdate` which re-armed `#shouldScrollSelectionIntoView`. The resulting `#scrollActiveEndIntoView` call on every frame fought `EditorInputManager.#tickAutoScroll`, causing the viewport to oscillate instead of extending the selection into the next page. Fix guards the flag with `!isDragging` so auto-scroll owns viewport movement while a drag is active; scroll-into-view still runs for clicks, arrow keys, image clicks, and zoom (unchanged code paths).

- `packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts` — 3-line guard in `handleSelection`.
- `tests/behavior/tests/selection/drag-past-viewport-no-bounce.spec.ts` — drags from page 0 past the scroll container bottom edge and asserts `scrollTop` advances monotonically across 20 samples during the hold.

Verified at runtime: pre-fix trace showed 5× `scrollScreenRectIntoView UP` events with 701px backward jumps during a 1.5s edge hold; post-fix trace shows 0. Selection head reached pos 6228 post-fix vs. the pos-2533 plateau pre-fix. Existing `tests/behavior/tests/basic-commands/drag-selection-autoscroll.spec.ts` is unchanged and should become more reliable.

Linear: [SD-2541](https://linear.app/superdocworkspace/issue/SD-2541) • Reported: [GitHub #2797](https://github.com/superdoc-dev/superdoc/issues/2797)