### PR TITLE
feat(cli): support custom WebSocket query params in collaboration config (SD-2543)

### DIFF
--- a/apps/cli/src/__tests__/lib/context.test.ts
+++ b/apps/cli/src/__tests__/lib/context.test.ts
@@ -102,6 +102,68 @@ describe('normalizeContextMetadata', () => {
       expect(result.collaboration).toBeUndefined();
     });
 
+    test('preserves websocket params on rehydration', () => {
+      const metadata = makeMetadata({
+        sessionType: 'collab',
+        collaboration: {
+          providerType: 'y-websocket',
+          url: 'ws://localhost:4000',
+          documentId: 'test-doc',
+          params: { customAttributions: 'agent_id:abc', region: 'us-east-1' },
+        } as any,
+      });
+      const result = normalizeContextMetadata(metadata);
+      expect(result.sessionType).toBe('collab');
+      expect(result.collaboration).toMatchObject({
+        params: { customAttributions: 'agent_id:abc', region: 'us-east-1' },
+      });
+    });
+
+    test('preserves websocket profile when params is absent', () => {
+      const metadata = makeMetadata({
+        sessionType: 'collab',
+        collaboration: {
+          providerType: 'y-websocket',
+          url: 'ws://localhost:4000',
+          documentId: 'test-doc',
+        },
+      });
+      const result = normalizeContextMetadata(metadata);
+      expect(result.sessionType).toBe('collab');
+      expect(result.collaboration).toBeDefined();
+      expect((result.collaboration as any).params).toBeUndefined();
+    });
+
+    test('rejects websocket profile with non-object params', () => {
+      const metadata = makeMetadata({
+        sessionType: 'collab',
+        collaboration: {
+          providerType: 'y-websocket',
+          url: 'ws://localhost:4000',
+          documentId: 'test-doc',
+          params: 'not-an-object',
+        } as any,
+      });
+      const result = normalizeContextMetadata(metadata);
+      expect(result.sessionType).toBe('local');
+      expect(result.collaboration).toBeUndefined();
+    });
+
+    test('rejects websocket profile with non-string param values', () => {
+      const metadata = makeMetadata({
+        sessionType: 'collab',
+        collaboration: {
+          providerType: 'y-websocket',
+          url: 'ws://localhost:4000',
+          documentId: 'test-doc',
+          params: { count: 42 },
+        } as any,
+      });
+      const result = normalizeContextMetadata(metadata);
+      expect(result.sessionType).toBe('local');
+      expect(result.collaboration).toBeUndefined();
+    });
+
     test('preserves Liveblocks collab profile with publicApiKey', () => {
       const metadata = makeMetadata({
         sessionType: 'collab',

--- a/apps/cli/src/__tests__/lib/validate-type-spec.test.ts
+++ b/apps/cli/src/__tests__/lib/validate-type-spec.test.ts
@@ -142,3 +142,23 @@ describe('doc.find select schema — accepts canonical and shorthand forms', () 
     expect(() => validateValueAgainstTypeSpec({ type: 'text' }, schema, 'select')).toThrow(CliError);
   });
 });
+
+describe('validateValueAgainstTypeSpec – object without explicit properties', () => {
+  // type: 'object' schemas that use additionalProperties (or nothing at all)
+  // must not crash the validator when `properties` is absent.
+  const schema = {
+    type: 'object',
+    additionalProperties: { type: 'string' },
+  } as unknown as CliTypeSpec;
+
+  test('accepts any object when properties is absent', () => {
+    expect(() => validateValueAgainstTypeSpec({ foo: 'bar' }, schema, 'params')).not.toThrow();
+    expect(() => validateValueAgainstTypeSpec({}, schema, 'params')).not.toThrow();
+  });
+
+  test('still rejects non-object values', () => {
+    expect(() => validateValueAgainstTypeSpec('nope', schema, 'params')).toThrow(CliError);
+    expect(() => validateValueAgainstTypeSpec(42, schema, 'params')).toThrow(CliError);
+    expect(() => validateValueAgainstTypeSpec(null, schema, 'params')).toThrow(CliError);
+  });
+});

--- a/apps/cli/src/cli/operation-params.ts
+++ b/apps/cli/src/cli/operation-params.ts
@@ -987,6 +987,12 @@ const CLI_ONLY_METADATA: Record<CliOnlyOperationId, CliOperationMetadata> = {
                   description: 'Room/document identifier. Defaults to session ID if omitted.',
                 },
                 tokenEnv: { type: 'string', description: 'Environment variable name containing the auth token.' },
+                params: {
+                  type: 'object',
+                  description:
+                    'Custom query parameters appended to the WebSocket URL. Values must be strings. Reserved keys: token.',
+                  additionalProperties: { type: 'string' },
+                },
                 syncTimeoutMs: { type: 'number', description: 'Max time (ms) to wait for initial sync.' },
                 onMissing: {
                   type: 'string',

--- a/apps/cli/src/host/session-pool.test.ts
+++ b/apps/cli/src/host/session-pool.test.ts
@@ -119,6 +119,31 @@ describe('InMemorySessionPool', () => {
       expect(openCollabCalls.length).toBe(2);
     });
 
+    test('discards collab session when params differ', async () => {
+      const { pool, openCollabCalls } = createPool();
+
+      const profileA = { ...COLLAB_PROFILE, params: { region: 'us' } };
+      await pool.acquire('s1', { ...COLLAB_METADATA, collaboration: profileA }, TEST_IO);
+
+      const profileB = { ...COLLAB_PROFILE, params: { region: 'eu' } };
+      await pool.acquire('s1', { ...COLLAB_METADATA, collaboration: profileB }, TEST_IO);
+
+      expect(openCollabCalls.length).toBe(2);
+    });
+
+    test('reuses collab session when params match (key order independent)', async () => {
+      const { pool, openCollabCalls } = createPool();
+
+      const profileA = { ...COLLAB_PROFILE, params: { region: 'us', tier: 'pro' } };
+      const first = await pool.acquire('s1', { ...COLLAB_METADATA, collaboration: profileA }, TEST_IO);
+      first.dispose();
+
+      const profileB = { ...COLLAB_PROFILE, params: { tier: 'pro', region: 'us' } };
+      await pool.acquire('s1', { ...COLLAB_METADATA, collaboration: profileB }, TEST_IO);
+
+      expect(openCollabCalls.length).toBe(1);
+    });
+
     test('reuses collab session when fingerprint matches', async () => {
       const { pool, openCollabCalls } = createPool();
 

--- a/apps/cli/src/host/session-pool.ts
+++ b/apps/cli/src/host/session-pool.ts
@@ -74,12 +74,24 @@ export interface SessionPool {
 }
 
 // ---------------------------------------------------------------------------
-// Collab fingerprint (preserved from old pool)
+// Collab fingerprint
 // ---------------------------------------------------------------------------
 
+// Stable stringify that sorts keys at every depth so nested objects (e.g.
+// `params`) contribute to the hash. JSON.stringify's array replacer is a
+// single global allow-list applied at all depths, which silently strips
+// unlisted nested keys.
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify((value as Record<string, unknown>)[key])}`);
+  return `{${entries.join(',')}}`;
+}
+
 function profileToFingerprint(profile: CollaborationProfile): string {
-  const sortedJson = JSON.stringify(profile, Object.keys(profile).sort());
-  return createHash('sha256').update(sortedJson).digest('hex');
+  return createHash('sha256').update(stableStringify(profile)).digest('hex');
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/lib/collaboration/__tests__/parse.test.ts
+++ b/apps/cli/src/lib/collaboration/__tests__/parse.test.ts
@@ -80,10 +80,63 @@ describe('parseCollaborationInput — websocket', () => {
     );
   });
 
-  test('rejects params field', () => {
-    expect(() => parseCollaborationInput({ providerType: 'y-websocket', url: 'ws://x', params: {} })).toThrow(
-      'collaboration.params is not supported',
+  test('accepts params field with string values', () => {
+    const input = parseCollaborationInput({
+      providerType: 'y-websocket',
+      url: 'ws://x',
+      params: { customAttributions: 'agent_id:abc', region: 'us-east-1' },
+    });
+    expect(input).toMatchObject({
+      params: { customAttributions: 'agent_id:abc', region: 'us-east-1' },
+    });
+  });
+
+  test('omits params when not provided', () => {
+    const input = parseCollaborationInput({
+      providerType: 'y-websocket',
+      url: 'ws://x',
+    }) as WebSocketCollaborationInput;
+    expect(input.params).toBeUndefined();
+  });
+
+  test('rejects non-object params', () => {
+    expect(() =>
+      parseCollaborationInput({ providerType: 'y-websocket', url: 'ws://x', params: 'not-an-object' }),
+    ).toThrow('collaboration.params must be an object of string key-value pairs');
+    expect(() => parseCollaborationInput({ providerType: 'y-websocket', url: 'ws://x', params: ['a', 'b'] })).toThrow(
+      'collaboration.params must be an object of string key-value pairs',
     );
+  });
+
+  test('rejects non-string param values', () => {
+    expect(() =>
+      parseCollaborationInput({ providerType: 'y-websocket', url: 'ws://x', params: { count: 42 } }),
+    ).toThrow('collaboration.params.count must be a string');
+    expect(() =>
+      parseCollaborationInput({ providerType: 'y-websocket', url: 'ws://x', params: { flag: true } }),
+    ).toThrow('collaboration.params.flag must be a string');
+    expect(() =>
+      parseCollaborationInput({ providerType: 'y-websocket', url: 'ws://x', params: { nested: { a: 'b' } } }),
+    ).toThrow('collaboration.params.nested must be a string');
+  });
+
+  test('rejects reserved token key in params', () => {
+    expect(() =>
+      parseCollaborationInput({
+        providerType: 'y-websocket',
+        url: 'ws://x',
+        params: { token: 'secret' },
+      }),
+    ).toThrow('collaboration.params.token is reserved');
+  });
+
+  test('accepts params with hocuspocus provider', () => {
+    const input = parseCollaborationInput({
+      providerType: 'hocuspocus',
+      url: 'ws://x',
+      params: { workspaceId: 'ws_123' },
+    });
+    expect(input).toMatchObject({ providerType: 'hocuspocus', params: { workspaceId: 'ws_123' } });
   });
 
   test('rejects Liveblocks-only fields on websocket providers', () => {
@@ -236,6 +289,17 @@ describe('parseCollaborationInput — liveblocks', () => {
     ).toThrow('collaboration.headers is not supported');
   });
 
+  test('rejects params field', () => {
+    expect(() =>
+      parseCollaborationInput({
+        providerType: 'liveblocks',
+        roomId: 'room',
+        publicApiKey: 'pk_xxx',
+        params: { foo: 'bar' },
+      }),
+    ).toThrow('collaboration.params is not supported for Liveblocks');
+  });
+
   test('rejects unknown keys', () => {
     expect(() =>
       parseCollaborationInput({
@@ -272,6 +336,19 @@ describe('resolveCollaborationProfile', () => {
     expect(profile.documentId).toBe('explicit-doc');
   });
 
+  test('websocket: params pass through to profile', () => {
+    const input = parseCollaborationInput({
+      providerType: 'y-websocket',
+      url: 'ws://localhost:4000',
+      params: { customAttributions: 'agent_id:abc' },
+    });
+    const profile = resolveCollaborationProfile(input, 'session');
+    expect(profile).toMatchObject({
+      providerType: 'y-websocket',
+      params: { customAttributions: 'agent_id:abc' },
+    });
+  });
+
   test('liveblocks: roomId maps to documentId directly', () => {
     const input = parseCollaborationInput({
       providerType: 'liveblocks',
@@ -300,6 +377,16 @@ describe('toPublicCollaborationSummary', () => {
       documentId: 'doc-1',
       url: 'ws://localhost:4000',
     });
+  });
+
+  test('websocket: omits params (may contain identifying metadata)', () => {
+    const summary = toPublicCollaborationSummary({
+      providerType: 'y-websocket',
+      url: 'ws://localhost:4000',
+      documentId: 'doc-1',
+      params: { userId: 'secret-user-id' },
+    });
+    expect(summary).not.toHaveProperty('params');
   });
 
   test('liveblocks: excludes auth config', () => {

--- a/apps/cli/src/lib/collaboration/__tests__/runtime.test.ts
+++ b/apps/cli/src/lib/collaboration/__tests__/runtime.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { WebSocketCollaborationProfile } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mock y-websocket and @hocuspocus/provider before importing the module
+// ---------------------------------------------------------------------------
+
+const mockWsInstance = {
+  on: mock(() => {}),
+  off: mock(() => {}),
+  disconnect: mock(() => {}),
+  destroy: mock(() => {}),
+  synced: false,
+};
+
+const MockWebsocketProvider = mock(function (this: unknown, ..._args: unknown[]) {
+  Object.assign(this as Record<string, unknown>, mockWsInstance);
+});
+
+const mockHocuspocusInstance = {
+  on: mock(() => {}),
+  off: mock(() => {}),
+  disconnect: mock(() => {}),
+  destroy: mock(() => {}),
+  synced: false,
+};
+
+const MockHocuspocusProvider = mock(function (this: unknown, ..._args: unknown[]) {
+  Object.assign(this as Record<string, unknown>, mockHocuspocusInstance);
+});
+
+mock.module('y-websocket', () => ({
+  WebsocketProvider: MockWebsocketProvider,
+}));
+
+mock.module('@hocuspocus/provider', () => ({
+  HocuspocusProvider: MockHocuspocusProvider,
+}));
+
+const { createCollaborationRuntime } = await import('../runtime');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeWebSocketProfile(overrides: Partial<WebSocketCollaborationProfile> = {}): WebSocketCollaborationProfile {
+  return {
+    providerType: 'y-websocket',
+    url: 'ws://localhost:4000',
+    documentId: 'doc-1',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createCollaborationRuntime — y-websocket', () => {
+  beforeEach(() => {
+    MockWebsocketProvider.mockClear();
+    delete process.env.TEST_TOKEN_ENV;
+  });
+
+  afterEach(() => {
+    delete process.env.TEST_TOKEN_ENV;
+  });
+
+  test('forwards params to WebsocketProvider options', () => {
+    createCollaborationRuntime(
+      makeWebSocketProfile({ params: { customAttributions: 'agent_id:abc', region: 'us-east-1' } }),
+    );
+
+    expect(MockWebsocketProvider).toHaveBeenCalledTimes(1);
+    const args = MockWebsocketProvider.mock.calls[0];
+    const providerOptions = args[3] as { params: Record<string, string> };
+    expect(providerOptions.params).toMatchObject({
+      customAttributions: 'agent_id:abc',
+      region: 'us-east-1',
+    });
+  });
+
+  test('merges params with token when both are present', () => {
+    process.env.TEST_TOKEN_ENV = 'auth-token-123';
+    createCollaborationRuntime(
+      makeWebSocketProfile({
+        tokenEnv: 'TEST_TOKEN_ENV',
+        params: { region: 'us' },
+      }),
+    );
+
+    const args = MockWebsocketProvider.mock.calls[0];
+    const providerOptions = args[3] as { params: Record<string, string> };
+    expect(providerOptions.params).toEqual({
+      region: 'us',
+      token: 'auth-token-123',
+    });
+  });
+
+  test('token overrides a colliding params.token entry', () => {
+    // params.token is rejected at parse time, but the runtime must still
+    // defend in depth — the auth token wins regardless.
+    process.env.TEST_TOKEN_ENV = 'real-token';
+    createCollaborationRuntime(
+      makeWebSocketProfile({
+        tokenEnv: 'TEST_TOKEN_ENV',
+        params: { token: 'user-supplied' } as Record<string, string>,
+      }),
+    );
+
+    const args = MockWebsocketProvider.mock.calls[0];
+    const providerOptions = args[3] as { params: Record<string, string> };
+    expect(providerOptions.params.token).toBe('real-token');
+  });
+
+  test('passes only token when params is absent', () => {
+    process.env.TEST_TOKEN_ENV = 'auth-token';
+    createCollaborationRuntime(makeWebSocketProfile({ tokenEnv: 'TEST_TOKEN_ENV' }));
+
+    const args = MockWebsocketProvider.mock.calls[0];
+    const providerOptions = args[3] as { params: Record<string, string> };
+    expect(providerOptions.params).toEqual({ token: 'auth-token' });
+  });
+
+  test('omits options.params entirely when neither params nor token are present', () => {
+    createCollaborationRuntime(makeWebSocketProfile());
+
+    const args = MockWebsocketProvider.mock.calls[0];
+    const providerOptions = args[3] as { params?: Record<string, string> };
+    expect(providerOptions.params).toBeUndefined();
+  });
+});
+
+describe('createCollaborationRuntime — hocuspocus', () => {
+  beforeEach(() => {
+    MockHocuspocusProvider.mockClear();
+    delete process.env.TEST_TOKEN_ENV;
+  });
+
+  afterEach(() => {
+    delete process.env.TEST_TOKEN_ENV;
+  });
+
+  test('forwards params as `parameters` option (Hocuspocus native field name)', () => {
+    createCollaborationRuntime(
+      makeWebSocketProfile({
+        providerType: 'hocuspocus',
+        params: { workspaceId: 'ws_123' },
+      }),
+    );
+
+    expect(MockHocuspocusProvider).toHaveBeenCalledTimes(1);
+    const args = MockHocuspocusProvider.mock.calls[0];
+    const config = args[0] as { parameters?: Record<string, string> };
+    expect(config.parameters).toEqual({ workspaceId: 'ws_123' });
+  });
+
+  test('parameters is undefined when params is absent', () => {
+    createCollaborationRuntime(makeWebSocketProfile({ providerType: 'hocuspocus' }));
+
+    const args = MockHocuspocusProvider.mock.calls[0];
+    const config = args[0] as { parameters?: Record<string, string> };
+    expect(config.parameters).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/collaboration/parse.ts
+++ b/apps/cli/src/lib/collaboration/parse.ts
@@ -21,10 +21,14 @@ const WEBSOCKET_ALLOWED_KEYS = new Set([
   'url',
   'documentId',
   'tokenEnv',
+  'params',
   'syncTimeoutMs',
   'onMissing',
   'bootstrapSettlingMs',
 ]);
+
+// Keys the CLI sets itself on the WebSocket URL — users cannot override via `params`.
+const RESERVED_WEBSOCKET_PARAM_KEYS = new Set(['token']);
 
 const LIVEBLOCKS_ALLOWED_KEYS = new Set([
   'providerType',
@@ -62,6 +66,30 @@ function expectOptionalEnvVarName(value: unknown, path: string): string | undefi
     throw new CliError('VALIDATION_ERROR', `${path} must be a valid environment variable name.`);
   }
   return value;
+}
+
+function expectOptionalWebSocketParams(value: unknown, path: string): Record<string, string> | undefined {
+  if (value == null) return undefined;
+  if (!isRecord(value)) {
+    throw new CliError('VALIDATION_ERROR', `${path} must be an object of string key-value pairs.`);
+  }
+  const result: Record<string, string> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (key.trim().length === 0) {
+      throw new CliError('VALIDATION_ERROR', `${path} keys must be non-empty strings.`);
+    }
+    if (RESERVED_WEBSOCKET_PARAM_KEYS.has(key)) {
+      throw new CliError(
+        'VALIDATION_ERROR',
+        `${path}.${key} is reserved; the collaboration token is set automatically from tokenEnv.`,
+      );
+    }
+    if (typeof val !== 'string') {
+      throw new CliError('VALIDATION_ERROR', `${path}.${key} must be a string.`);
+    }
+    result[key] = val;
+  }
+  return result;
 }
 
 function parseOnMissing(value: unknown): OnMissing | undefined {
@@ -107,9 +135,6 @@ function parseWebSocketInput(raw: Record<string, unknown>): WebSocketCollaborati
   if ('token' in raw) {
     throw new CliError('VALIDATION_ERROR', 'collaboration.token is not supported in v1; use collaboration.tokenEnv.');
   }
-  if ('params' in raw) {
-    throw new CliError('VALIDATION_ERROR', 'collaboration.params is not supported in v1.');
-  }
 
   const providerType = normalizeProviderType(raw.providerType, 'collaboration.providerType') as WebSocketProviderType;
 
@@ -118,6 +143,7 @@ function parseWebSocketInput(raw: Record<string, unknown>): WebSocketCollaborati
     url: expectNonEmptyString(raw.url, 'collaboration.url').trim(),
     documentId: raw.documentId != null ? expectNonEmptyString(raw.documentId, 'collaboration.documentId') : undefined,
     tokenEnv: expectOptionalEnvVarName(raw.tokenEnv, 'collaboration.tokenEnv'),
+    params: expectOptionalWebSocketParams(raw.params, 'collaboration.params'),
     ...parseSharedFields(raw),
   };
 }
@@ -137,7 +163,7 @@ function parseLiveblocksInput(raw: Record<string, unknown>): LiveblocksCollabora
     throw new CliError('VALIDATION_ERROR', 'collaboration.token is not supported in v1.');
   }
   if ('params' in raw) {
-    throw new CliError('VALIDATION_ERROR', 'collaboration.params is not supported in v1.');
+    throw new CliError('VALIDATION_ERROR', 'collaboration.params is not supported for Liveblocks.');
   }
   if ('headers' in raw) {
     throw new CliError(

--- a/apps/cli/src/lib/collaboration/resolve.ts
+++ b/apps/cli/src/lib/collaboration/resolve.ts
@@ -19,6 +19,7 @@ function resolveWebSocketProfile(input: WebSocketCollaborationInput, sessionId: 
     url: input.url,
     documentId: input.documentId?.trim() || sessionId,
     tokenEnv: input.tokenEnv,
+    params: input.params,
     syncTimeoutMs: input.syncTimeoutMs,
     onMissing: input.onMissing,
     bootstrapSettlingMs: input.bootstrapSettlingMs,

--- a/apps/cli/src/lib/collaboration/runtime.ts
+++ b/apps/cli/src/lib/collaboration/runtime.ts
@@ -88,9 +88,13 @@ function createWebSocketRuntime(profile: WebSocketCollaborationProfile): Collabo
 
   let provider: SyncableProvider;
   if (profile.providerType === 'y-websocket') {
-    const providerOptions: { params?: Record<string, string> } = {};
+    const params: Record<string, string> = { ...(profile.params ?? {}) };
     if (token) {
-      providerOptions.params = { token };
+      params.token = token;
+    }
+    const providerOptions: { params?: Record<string, string> } = {};
+    if (Object.keys(params).length > 0) {
+      providerOptions.params = params;
     }
     provider = new WebsocketProvider(
       profile.url,
@@ -104,6 +108,7 @@ function createWebSocketRuntime(profile: WebSocketCollaborationProfile): Collabo
       document: ydoc,
       name: profile.documentId,
       token: token ?? '',
+      parameters: profile.params,
       preserveConnection: false,
     }) as unknown as SyncableProvider;
   }

--- a/apps/cli/src/lib/collaboration/types.ts
+++ b/apps/cli/src/lib/collaboration/types.ts
@@ -23,6 +23,7 @@ export type WebSocketCollaborationInput = SharedCollaborationFields & {
   url: string;
   documentId?: string;
   tokenEnv?: string;
+  params?: Record<string, string>;
 };
 
 export type LiveblocksCollaborationInput = SharedCollaborationFields & {
@@ -44,6 +45,7 @@ export type WebSocketCollaborationProfile = SharedCollaborationFields & {
   url: string;
   documentId: string;
   tokenEnv?: string;
+  params?: Record<string, string>;
 };
 
 export type LiveblocksCollaborationProfile = SharedCollaborationFields & {

--- a/apps/cli/src/lib/context.ts
+++ b/apps/cli/src/lib/context.ts
@@ -6,7 +6,7 @@ import { homedir, hostname } from 'node:os';
 import { join, resolve } from 'node:path';
 import { ENV_VAR_NAME_PATTERN, type CollaborationProfile } from './collaboration';
 import { CliError } from './errors';
-import { asRecord, pathExists } from './guards';
+import { asRecord, isRecord, pathExists } from './guards';
 import { validateSessionId } from './session';
 import type { CliIO, ExecutionMode, UserIdentity } from './types';
 
@@ -174,6 +174,18 @@ function normalizeSharedFields(record: Record<string, unknown>): SharedProfileFi
   };
 }
 
+function normalizeWebSocketParams(value: unknown): Record<string, string> | null | undefined {
+  if (value == null) return undefined;
+  if (!isRecord(value)) return null;
+  const result: Record<string, string> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (typeof key !== 'string' || key.length === 0) return null;
+    if (typeof val !== 'string') return null;
+    result[key] = val;
+  }
+  return result;
+}
+
 function normalizeWebSocketProfile(record: Record<string, unknown>): CollaborationProfile | undefined {
   const { providerType, url, documentId, tokenEnv } = record;
   if (typeof url !== 'string' || url.length === 0) return undefined;
@@ -183,11 +195,15 @@ function normalizeWebSocketProfile(record: Record<string, unknown>): Collaborati
   const shared = normalizeSharedFields(record);
   if (!shared) return undefined;
 
+  const params = normalizeWebSocketParams(record.params);
+  if (params === null) return undefined;
+
   return {
     providerType: providerType as 'hocuspocus' | 'y-websocket',
     url,
     documentId,
     tokenEnv: typeof tokenEnv === 'string' ? tokenEnv : undefined,
+    params,
     ...shared,
   };
 }

--- a/apps/cli/src/lib/operation-args.ts
+++ b/apps/cli/src/lib/operation-args.ts
@@ -187,7 +187,7 @@ export function validateValueAgainstTypeSpec(value: unknown, schema: CliTypeSpec
       }
     }
 
-    const propertyEntries = Object.entries(schema.properties);
+    const propertyEntries = schema.properties ? Object.entries(schema.properties) : [];
     const shouldRestrictUnknownKeys = propertyEntries.length > 0 || required.length > 0;
 
     // If no object fields are declared, treat it as an unconstrained JSON object.
@@ -272,7 +272,8 @@ function validateResponseValueAgainstTypeSpec(value: unknown, schema: CliTypeSpe
     }
 
     // Validate known properties but allow additional properties (JSON Schema default).
-    for (const [key, propSchema] of Object.entries(schema.properties)) {
+    const properties = schema.properties ?? {};
+    for (const [key, propSchema] of Object.entries(properties)) {
       if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
       validateResponseValueAgainstTypeSpec(value[key], propSchema, `${path}.${key}`);
     }

--- a/apps/docs/document-engine/sdks.mdx
+++ b/apps/docs/document-engine/sdks.mdx
@@ -287,6 +287,51 @@ Use the explicit `collaboration` object when your server speaks the Hocuspocus p
   </Tab>
 </Tabs>
 
+### Forward custom WebSocket query parameters
+
+Attach arbitrary key-value pairs to the WebSocket connection URL with the `params` field. Use this when your collaboration server expects per-connection metadata (activity tracking, tenant identifiers, feature flags, etc.) that shouldn't live in the document ID.
+
+<Tabs>
+  <Tab title="Node.js">
+    ```typescript
+    const doc = await client.open({
+      collaboration: {
+        providerType: 'y-websocket',
+        url: 'wss://collab.example.com/ws',
+        documentId: 'asset_abc',
+        tokenEnv: 'SUPERDOC_COLLAB_TOKEN',
+        params: {
+          customAttributions: 'agent_id:abc,session_id:def,user_id:ghi',
+          region: 'us-east-1',
+        },
+      },
+    });
+    ```
+  </Tab>
+  <Tab title="Python">
+    ```python
+    doc = await client.open({
+        "collaboration": {
+            "providerType": "y-websocket",
+            "url": "wss://collab.example.com/ws",
+            "documentId": "asset_abc",
+            "tokenEnv": "SUPERDOC_COLLAB_TOKEN",
+            "params": {
+                "customAttributions": "agent_id:abc,session_id:def,user_id:ghi",
+                "region": "us-east-1",
+            },
+        }
+    })
+    ```
+  </Tab>
+</Tabs>
+
+Keys and values must both be strings — query parameters serialize as strings on the URL. The field is supported for `y-websocket` and `hocuspocus`; Liveblocks manages its transport differently and does not accept this field.
+
+<Note>
+  `token` is reserved — the CLI sets it automatically from `tokenEnv`. Passing `token` inside `params` is a validation error; use `tokenEnv` for authentication.
+</Note>
+
 ### Connect to Liveblocks
 
 Liveblocks is configured through an explicit `collaboration` object. Two auth modes are supported:


### PR DESCRIPTION
Adds an optional `params: Record<string, string>` to the CLI collaboration config, forwarded onto the y-websocket / Hocuspocus WebSocket URL so customers can attach per-session metadata (activity tracking, tenant identifiers, etc.) without wrapping the provider themselves.

- y-websocket: merges `params` with the auth token into `providerOptions.params`. Hocuspocus: passed as its native `parameters` option.
- String values only; reserved `token` key rejected with a pointer to `tokenEnv`.
- `normalizeWebSocketProfile` preserves `params` across session reloads; `profileToFingerprint` uses a recursive stable stringify so the session pool distinguishes profiles that differ only in nested `params`.
- Fixed a latent crash in `validateValueAgainstTypeSpec` on `type: 'object'` schemas without an explicit `properties` map — activated by the new params schema and would have broken all `--collaboration-json` usage with websocket providers.
- Unit tests across parse, runtime (mocked providers), session pool, context rehydration, and the validator; end-to-end verified against a real `@hocuspocus/server` — custom params arrived at its `onConnect` hook intact.
- Docs: new section in `apps/docs/document-engine/sdks.mdx`.

Resolves SD-2543, unblocks IT-915.