### PR TITLE
docs(sd-2451): brand-voice pass on AI docs

### DIFF
--- a/apps/docs/ai/agents/best-practices.mdx
+++ b/apps/docs/ai/agents/best-practices.mdx
@@ -81,7 +81,7 @@ When you need to create multiple headings and paragraphs in one operation, use `
 
 After inserting, apply formatting in a single `superdoc_mutations` batch using `format.apply` steps — one step per block or range. This reduces a workflow that might otherwise take 40+ calls down to 4: read, search, insert, format.
 
-## Use focused tools; `superdoc_mutations` is an escape hatch
+## Use focused tools — `superdoc_mutations` is an escape hatch
 
 For straightforward edits, use the focused intent tools (`superdoc_edit`, `superdoc_format`, `superdoc_create`, `superdoc_list`, `superdoc_comment`). They validate arguments, give clear errors, and are easier for models to call correctly.
 

--- a/apps/docs/ai/agents/eval-results.mdx
+++ b/apps/docs/ai/agents/eval-results.mdx
@@ -10,7 +10,7 @@ SuperDoc's Document API exposes [360+ operations](/document-api/available-operat
 <Tip>
 **Recommended models**
 
-- **Best overall accuracy — GPT-5.4 (OpenAI):** 100% tool quality score with the full system prompt. Use this for batch processing, async pipelines, and any scenario where latency is not the primary constraint.
+- **Best overall accuracy — GPT-5.4 (OpenAI):** 100% tool quality score with the full system prompt. Use this for batch processing, async pipelines, and any case where speed doesn't matter.
 - **Best for fast responses — Gemini 2.5 Flash (Google):** 94% tool quality score at lower latency. Use this for real-time, interactive editing where speed matters.
 
 Claude Haiku 4.5 (Anthropic) is a strong alternative for fast use cases — 90% accuracy with the smallest prompt dependency gap (-13 points), meaning it degrades least when the system prompt is trimmed.

--- a/apps/docs/ai/agents/llm-tools.mdx
+++ b/apps/docs/ai/agents/llm-tools.mdx
@@ -156,7 +156,7 @@ The generated catalog currently contains 9 grouped intent tools. Most tools use 
 | `superdoc_mutations` | `preview`, `apply` | Execute multi-step atomic edits as a batch |
 
 <Note>
-More tools are being added as we expand coverage — tables, images, hyperlinks, and more. You can also [create custom tools](#creating-custom-tools) for any `doc.*` operation today.
+Built-in tools cover the core operations. For tables, images, hyperlinks, and anything else, [create custom tools](#creating-custom-tools) that call any `doc.*` operation today.
 </Note>
 
 ## Dispatching tool calls
@@ -187,7 +187,7 @@ More tools are being added as we expand coverage — tables, images, hyperlinks,
   </Tab>
 </Tabs>
 
-The dispatcher validates required parameters, enforces mutual exclusivity constraints, and throws descriptive errors if arguments are invalid, so the LLM gets actionable feedback.
+The dispatcher validates required parameters, checks that arguments are compatible, and throws descriptive errors the LLM can act on.
 
 ## System prompt
 

--- a/apps/docs/ai/agents/skills.mdx
+++ b/apps/docs/ai/agents/skills.mdx
@@ -1,7 +1,6 @@
 ---
 title: Skills
 sidebarTitle: Skills
-tag: COMING SOON
 description: Reusable prompt templates that teach LLMs how to edit documents with SuperDoc tools
 keywords: "llm skills, prompt templates, ai document editing, superdoc skills"
 ---
@@ -9,7 +8,7 @@ keywords: "llm skills, prompt templates, ai document editing, superdoc skills"
 Skills are reusable prompt files that teach LLMs how to use SuperDoc tools effectively. A skill contains editing instructions, tool usage patterns, and best practices — so your LLM agent knows how to query, mutate, and format documents without trial and error.
 
 <Info>
-Skills are coming soon. Check back for updates.
+We haven't shipped skills yet. Follow the repo for updates.
 </Info>
 
 ## Related


### PR DESCRIPTION
Small voice / phrasing pass over the new AI and MCP docs against brand.md. No content added or removed — five edits that match existing brand rules more directly.

- \`skills.mdx\` — drop \`tag: COMING SOON\` and rephrase "Skills are coming soon" to "We haven't shipped skills yet" per brand rule preferring "we haven't built that yet" over roadmap language
- \`llm-tools.mdx\` Note — "more tools are being added…" led with what doesn't exist yet; rewritten to lead with what works today and point at the custom-tools escape hatch
- \`llm-tools.mdx\` — "enforces mutual exclusivity constraints" → "checks that arguments are compatible"
- \`eval-results.mdx\` — "any scenario where latency is not the primary constraint" → "any case where speed doesn't matter"
- \`best-practices.mdx\` — split a semicolon heading per brand rule #2

Targets \`andrii/sd-2451-refactor-mcp-set-up\` so these land on top of #2711 if useful.