### PR TITLE
feat: support wide tables rendering outside of margins

### DIFF
--- a/packages/layout-engine/contracts/src/engines/__tests__/tables.test.ts
+++ b/packages/layout-engine/contracts/src/engines/__tests__/tables.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { OOXML_PCT_DIVISOR, resolveTableWidthAttr } from '../tables.js';
+
+describe('OOXML_PCT_DIVISOR', () => {
+  it('equals 5000 (1/50th of a percent)', () => {
+    expect(OOXML_PCT_DIVISOR).toBe(5000);
+  });
+});
+
+describe('resolveTableWidthAttr', () => {
+  it('reads the width field with its type', () => {
+    expect(resolveTableWidthAttr({ width: 600, type: 'px' })).toEqual({ width: 600, type: 'px' });
+  });
+
+  it('reads the value field when width is not present', () => {
+    expect(resolveTableWidthAttr({ value: 2500, type: 'pct' })).toEqual({ width: 2500, type: 'pct' });
+  });
+
+  it('prefers width over value when both are present', () => {
+    expect(resolveTableWidthAttr({ width: 100, value: 200, type: 'px' })).toEqual({ width: 100, type: 'px' });
+  });
+
+  it('preserves type for dxa', () => {
+    expect(resolveTableWidthAttr({ width: 1440, type: 'dxa' })).toEqual({ width: 1440, type: 'dxa' });
+  });
+
+  it('returns width with undefined type when type is omitted', () => {
+    const result = resolveTableWidthAttr({ width: 300 });
+    expect(result).toEqual({ width: 300, type: undefined });
+  });
+
+  it('rejects null', () => {
+    expect(resolveTableWidthAttr(null)).toBeNull();
+  });
+
+  it('rejects undefined', () => {
+    expect(resolveTableWidthAttr(undefined)).toBeNull();
+  });
+
+  it('rejects primitives', () => {
+    expect(resolveTableWidthAttr(600)).toBeNull();
+    expect(resolveTableWidthAttr('600')).toBeNull();
+    expect(resolveTableWidthAttr(true)).toBeNull();
+  });
+
+  it('rejects objects with no width or value', () => {
+    expect(resolveTableWidthAttr({ type: 'px' })).toBeNull();
+    expect(resolveTableWidthAttr({})).toBeNull();
+  });
+
+  it('rejects non-numeric width', () => {
+    expect(resolveTableWidthAttr({ width: '600' as unknown as number, type: 'px' })).toBeNull();
+    expect(resolveTableWidthAttr({ value: null as unknown as number, type: 'pct' })).toBeNull();
+  });
+
+  it('rejects NaN', () => {
+    expect(resolveTableWidthAttr({ width: NaN, type: 'pct' })).toBeNull();
+  });
+
+  it('rejects Infinity', () => {
+    expect(resolveTableWidthAttr({ width: Infinity, type: 'pct' })).toBeNull();
+    expect(resolveTableWidthAttr({ width: -Infinity, type: 'pct' })).toBeNull();
+  });
+
+  it('rejects zero', () => {
+    expect(resolveTableWidthAttr({ width: 0, type: 'pct' })).toBeNull();
+    expect(resolveTableWidthAttr({ value: 0, type: 'pct' })).toBeNull();
+  });
+
+  it('rejects negative widths', () => {
+    expect(resolveTableWidthAttr({ width: -100, type: 'px' })).toBeNull();
+    expect(resolveTableWidthAttr({ value: -2500, type: 'pct' })).toBeNull();
+  });
+});

--- a/packages/layout-engine/contracts/src/engines/tables.ts
+++ b/packages/layout-engine/contracts/src/engines/tables.ts
@@ -36,6 +36,29 @@ export interface TableWidthAttr {
   type?: 'pct' | 'px' | 'pixel' | string;
 }
 
+/**
+ * Extract a validated numeric width from a table width attribute object.
+ *
+ * Supports either `width` or `value` fields and rejects non-finite or non-positive
+ * values so callers can safely use the result in layout calculations.
+ */
+export function resolveTableWidthAttr(value: unknown): { width: number; type?: TableWidthAttr['type'] } | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const measurement = value as TableWidthAttr;
+  const width = measurement.width ?? measurement.value;
+  if (typeof width !== 'number' || !Number.isFinite(width) || width <= 0) {
+    return null;
+  }
+
+  return {
+    width,
+    type: measurement.type,
+  };
+}
+
 export interface TableColumnSpec {
   type: 'auto' | 'fixed' | 'pct';
   width?: number; // pt or percentage (0-100)

--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -5,7 +5,12 @@ export { computeTabStops, layoutWithTabs, calculateTabWidth } from './engines/ta
 export type { TabStop };
 
 // Export table contracts
-export { OOXML_PCT_DIVISOR, type TableWidthAttr, type TableColumnSpec } from './engines/tables.js';
+export {
+  OOXML_PCT_DIVISOR,
+  resolveTableWidthAttr,
+  type TableWidthAttr,
+  type TableColumnSpec,
+} from './engines/tables.js';
 
 export { effectiveTableCellSpacing } from './table-cell-spacing.js';
 

--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -1838,6 +1838,8 @@ export type PartialRowInfo = {
 export type TableFragment = {
   kind: 'table';
   blockId: BlockId;
+  /** Flow column that owns this fragment, distinct from visual x when overflow crosses margins. */
+  columnIndex?: number;
   fromRow: number;
   toRow: number;
   x: number;

--- a/packages/layout-engine/layout-bridge/src/incrementalLayout.ts
+++ b/packages/layout-engine/layout-bridge/src/incrementalLayout.ts
@@ -229,7 +229,9 @@ const assignFootnotesToColumns = (
 
     if (columns && columns.count > 1 && page) {
       const fragment = findFragmentForPos(page, ref.pos);
-      if (fragment && typeof fragment.x === 'number') {
+      if (fragment?.kind === 'table' && typeof fragment.columnIndex === 'number') {
+        columnIndex = Math.max(0, Math.min(columns.count - 1, fragment.columnIndex));
+      } else if (fragment && typeof fragment.x === 'number') {
         const widths = Array.isArray(columns.widths) && columns.widths.length > 0 ? columns.widths : undefined;
         if (widths) {
           let cursorX = columns.left;
@@ -1748,6 +1750,7 @@ export async function incrementalLayout(
                   page.fragments.push({
                     kind: 'table',
                     blockId: range.blockId,
+                    columnIndex,
                     fromRow: 0,
                     toRow: block.rows.length,
                     x: tableX,

--- a/packages/layout-engine/layout-bridge/src/incrementalLayout.ts
+++ b/packages/layout-engine/layout-bridge/src/incrementalLayout.ts
@@ -1738,9 +1738,10 @@ export async function incrementalLayout(
                     tableWidthRaw,
                     block.attrs,
                   );
-                  // Rescale column widths when table was clamped to section width.
-                  // This happens in mixed-orientation docs where measurement uses the
-                  // widest section but rendering is per-section (SD-1859).
+                  // Rescale column widths only when the resolved fragment width is narrower
+                  // than the measured table width. Today that primarily happens for
+                  // percentage-width tables rendered in a narrower section (SD-1859),
+                  // while non-percent wide tables keep their measured overflow width.
                   const fragmentColumnWidths = rescaleColumnWidths(
                     measure.columnWidths,
                     measure.totalWidth,

--- a/packages/layout-engine/layout-bridge/src/incrementalLayout.ts
+++ b/packages/layout-engine/layout-bridge/src/incrementalLayout.ts
@@ -9,7 +9,7 @@ import type {
   SectionBreakBlock,
   NormalizedColumnLayout,
 } from '@superdoc/contracts';
-import { cloneColumnLayout, normalizeColumnLayout } from '@superdoc/contracts';
+import { cloneColumnLayout, normalizeColumnLayout, rescaleColumnWidths } from '@superdoc/contracts';
 import {
   layoutDocument,
   layoutHeaderFooter,
@@ -20,6 +20,7 @@ import {
   type NumberingContext,
   SEMANTIC_PAGE_HEIGHT_PX,
   SINGLE_COLUMN_DEFAULT,
+  resolveTableFrame,
 } from '@superdoc/layout-engine';
 import { remeasureParagraph } from './remeasure';
 import { computeDirtyRegions } from './diff';
@@ -1728,42 +1729,21 @@ export async function incrementalLayout(
                   const block = blockById.get(range.blockId);
                   if (!measure || measure.kind !== 'table') return;
                   if (!block || block.kind !== 'table') return;
-                  const tableWidthRaw = Math.max(0, measure.totalWidth ?? 0);
-                  let tableWidth = Math.min(contentWidth, tableWidthRaw);
-                  let tableX = columnX;
-                  const justification =
-                    typeof block.attrs?.justification === 'string' ? block.attrs.justification : undefined;
-                  if (justification === 'center') {
-                    tableX = columnX + Math.max(0, (contentWidth - tableWidth) / 2);
-                  } else if (justification === 'right' || justification === 'end') {
-                    tableX = columnX + Math.max(0, contentWidth - tableWidth);
-                  } else {
-                    const indentValue = (block.attrs?.tableIndent as { width?: unknown } | undefined)?.width;
-                    const indent = typeof indentValue === 'number' && Number.isFinite(indentValue) ? indentValue : 0;
-                    tableX += indent;
-                    tableWidth = Math.max(0, tableWidth - indent);
-                  }
+                  const tableWidthRaw = Math.max(0, measure.totalWidth ?? contentWidth);
+                  const { x: tableX, width: tableWidth } = resolveTableFrame(
+                    columnX,
+                    contentWidth,
+                    tableWidthRaw,
+                    block.attrs,
+                  );
                   // Rescale column widths when table was clamped to section width.
                   // This happens in mixed-orientation docs where measurement uses the
                   // widest section but rendering is per-section (SD-1859).
-                  let fragmentColumnWidths: number[] | undefined;
-                  if (
-                    tableWidthRaw > tableWidth &&
-                    measure.columnWidths &&
-                    measure.columnWidths.length > 0 &&
-                    tableWidthRaw > 0
-                  ) {
-                    const scale = tableWidth / tableWidthRaw;
-                    fragmentColumnWidths = measure.columnWidths.map((w: number) => Math.max(1, Math.round(w * scale)));
-                    const scaledSum = fragmentColumnWidths.reduce((a: number, b: number) => a + b, 0);
-                    const target = Math.round(tableWidth);
-                    if (scaledSum !== target && fragmentColumnWidths.length > 0) {
-                      fragmentColumnWidths[fragmentColumnWidths.length - 1] = Math.max(
-                        1,
-                        fragmentColumnWidths[fragmentColumnWidths.length - 1] + (target - scaledSum),
-                      );
-                    }
-                  }
+                  const fragmentColumnWidths = rescaleColumnWidths(
+                    measure.columnWidths,
+                    measure.totalWidth,
+                    tableWidth,
+                  );
 
                   page.fragments.push({
                     kind: 'table',

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -143,6 +143,14 @@ export const determineColumn = (layout: Layout, fragmentX: number): number => {
   return Math.max(0, Math.min(columns.count - 1, raw));
 };
 
+const determineTableColumn = (layout: Layout, fragment: TableFragment): number => {
+  if (typeof fragment.columnIndex === 'number') {
+    const count = layout.columns?.count ?? 1;
+    return Math.max(0, Math.min(Math.max(0, count - 1), fragment.columnIndex));
+  }
+  return determineColumn(layout, fragment.x);
+};
+
 // ---------------------------------------------------------------------------
 // Line / position helpers
 // ---------------------------------------------------------------------------
@@ -901,7 +909,7 @@ export function clickToPositionGeometry(
           layoutEpoch,
           blockId: tableHit.fragment.blockId,
           pageIndex,
-          column: determineColumn(layout, tableHit.fragment.x),
+          column: determineTableColumn(layout, tableHit.fragment),
           lineIndex,
         };
       }
@@ -915,7 +923,7 @@ export function clickToPositionGeometry(
         layoutEpoch,
         blockId: tableHit.fragment.blockId,
         pageIndex,
-        column: determineColumn(layout, tableHit.fragment.x),
+        column: determineTableColumn(layout, tableHit.fragment),
         lineIndex: 0,
       };
     }

--- a/packages/layout-engine/layout-bridge/test/clickToPosition.test.ts
+++ b/packages/layout-engine/layout-bridge/test/clickToPosition.test.ts
@@ -135,6 +135,168 @@ describe('clickToPosition', () => {
     expect(result?.blockId).toBe('wide-table');
     expect(result?.column).toBe(1);
   });
+
+  it('falls back to visual x when a table fragment has no columnIndex', () => {
+    // Legacy fragments without columnIndex should still resolve a column via fragment.x.
+    const cellParagraph: FlowBlock = {
+      kind: 'paragraph',
+      id: 'legacy-cell-para',
+      runs: [{ text: 'Legacy', fontFamily: 'Arial', fontSize: 16, pmStart: 200, pmEnd: 206 }],
+    };
+
+    const tableBlock: TableBlock = {
+      kind: 'table',
+      id: 'legacy-table',
+      rows: [{ id: 'row-0', cells: [{ id: 'cell-0-0', blocks: [cellParagraph] }] }],
+    };
+
+    const cellMeasure: Measure = {
+      kind: 'paragraph',
+      lines: [
+        {
+          fromRun: 0,
+          fromChar: 0,
+          toRun: 0,
+          toChar: 6,
+          width: 80,
+          ascent: 12,
+          descent: 4,
+          lineHeight: 20,
+        },
+      ],
+      totalHeight: 20,
+    };
+
+    const tableMeasure: TableMeasure = {
+      kind: 'table',
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [cellMeasure],
+              paragraph: cellMeasure,
+              width: 240,
+              height: 28,
+              gridColumnStart: 0,
+              colSpan: 1,
+              rowSpan: 1,
+            },
+          ],
+          height: 28,
+        },
+      ],
+      columnWidths: [240],
+      totalWidth: 240,
+      totalHeight: 28,
+    };
+
+    // Visual x=320 puts the fragment past the column-0 right edge in a 2-col layout
+    // with column width 290 ((600 - 20) / 2). determineColumn maps it to column 1.
+    const tableFragment: TableFragment = {
+      kind: 'table',
+      blockId: 'legacy-table',
+      fromRow: 0,
+      toRow: 1,
+      x: 320,
+      y: 40,
+      width: 240,
+      height: 28,
+      pmStart: 200,
+      pmEnd: 206,
+    };
+
+    const layout: Layout = {
+      pageSize: { w: 600, h: 800 },
+      columns: { count: 2, gap: 20 },
+      pages: [{ number: 1, fragments: [tableFragment] }],
+    };
+
+    const result = clickToPosition(layout, [tableBlock], [tableMeasure], { x: 360, y: 54 });
+
+    expect(result?.blockId).toBe('legacy-table');
+    expect(result?.column).toBe(1);
+  });
+
+  it('clamps a table fragment columnIndex that exceeds the document column count', () => {
+    // Defensive: a fragment claiming columnIndex 5 in a 2-column layout should
+    // be clamped to the last valid column (1) rather than producing a stale index.
+    const cellParagraph: FlowBlock = {
+      kind: 'paragraph',
+      id: 'oob-cell-para',
+      runs: [{ text: 'Out', fontFamily: 'Arial', fontSize: 16, pmStart: 300, pmEnd: 303 }],
+    };
+
+    const tableBlock: TableBlock = {
+      kind: 'table',
+      id: 'oob-table',
+      rows: [{ id: 'row-0', cells: [{ id: 'cell-0-0', blocks: [cellParagraph] }] }],
+    };
+
+    const cellMeasure: Measure = {
+      kind: 'paragraph',
+      lines: [
+        {
+          fromRun: 0,
+          fromChar: 0,
+          toRun: 0,
+          toChar: 3,
+          width: 40,
+          ascent: 12,
+          descent: 4,
+          lineHeight: 20,
+        },
+      ],
+      totalHeight: 20,
+    };
+
+    const tableMeasure: TableMeasure = {
+      kind: 'table',
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [cellMeasure],
+              paragraph: cellMeasure,
+              width: 200,
+              height: 28,
+              gridColumnStart: 0,
+              colSpan: 1,
+              rowSpan: 1,
+            },
+          ],
+          height: 28,
+        },
+      ],
+      columnWidths: [200],
+      totalWidth: 200,
+      totalHeight: 28,
+    };
+
+    const tableFragment: TableFragment = {
+      kind: 'table',
+      blockId: 'oob-table',
+      columnIndex: 5,
+      fromRow: 0,
+      toRow: 1,
+      x: 100,
+      y: 40,
+      width: 200,
+      height: 28,
+      pmStart: 300,
+      pmEnd: 303,
+    };
+
+    const layout: Layout = {
+      pageSize: { w: 600, h: 800 },
+      columns: { count: 2, gap: 20 },
+      pages: [{ number: 1, fragments: [tableFragment] }],
+    };
+
+    const result = clickToPosition(layout, [tableBlock], [tableMeasure], { x: 120, y: 54 });
+
+    expect(result?.blockId).toBe('oob-table');
+    expect(result?.column).toBe(1);
+  });
 });
 
 describe('hitTestPage with pageGap', () => {

--- a/packages/layout-engine/layout-bridge/test/clickToPosition.test.ts
+++ b/packages/layout-engine/layout-bridge/test/clickToPosition.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { clickToPosition, hitTestPage, hitTestTableFragment } from '../src/index.ts';
-import type { Layout, FlowBlock, Measure, Line, ParaFragment } from '@superdoc/contracts';
+import type {
+  Layout,
+  FlowBlock,
+  Measure,
+  Line,
+  ParaFragment,
+  TableBlock,
+  TableMeasure,
+  TableFragment,
+} from '@superdoc/contracts';
 import {
   simpleLayout,
   blocks,
@@ -41,6 +50,90 @@ describe('clickToPosition', () => {
     const result = clickToPosition(drawingLayout, [drawingBlock], [drawingMeasure], { x: 70, y: 90 });
     expect(result?.blockId).toBe('drawing-0');
     expect(result?.pos).toBe(20);
+  });
+
+  it('uses table fragment columnIndex instead of visual x for multi-column overflow tables', () => {
+    const cellParagraph: FlowBlock = {
+      kind: 'paragraph',
+      id: 'table-cell-para',
+      runs: [{ text: 'Wide table', fontFamily: 'Arial', fontSize: 16, pmStart: 100, pmEnd: 110 }],
+    };
+
+    const tableBlock: TableBlock = {
+      kind: 'table',
+      id: 'wide-table',
+      rows: [
+        {
+          id: 'row-0',
+          cells: [{ id: 'cell-0-0', blocks: [cellParagraph] }],
+        },
+      ],
+    };
+
+    const cellParagraphMeasure: Measure = {
+      kind: 'paragraph',
+      lines: [
+        {
+          fromRun: 0,
+          fromChar: 0,
+          toRun: 0,
+          toChar: 10,
+          width: 120,
+          ascent: 12,
+          descent: 4,
+          lineHeight: 20,
+        },
+      ],
+      totalHeight: 20,
+    };
+
+    const tableMeasure: TableMeasure = {
+      kind: 'table',
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [cellParagraphMeasure],
+              paragraph: cellParagraphMeasure,
+              width: 320,
+              height: 28,
+              gridColumnStart: 0,
+              colSpan: 1,
+              rowSpan: 1,
+            },
+          ],
+          height: 28,
+        },
+      ],
+      columnWidths: [320],
+      totalWidth: 320,
+      totalHeight: 28,
+    };
+
+    const tableFragment: TableFragment = {
+      kind: 'table',
+      blockId: 'wide-table',
+      columnIndex: 1,
+      fromRow: 0,
+      toRow: 1,
+      x: 220,
+      y: 40,
+      width: 320,
+      height: 28,
+      pmStart: 100,
+      pmEnd: 110,
+    };
+
+    const layout: Layout = {
+      pageSize: { w: 600, h: 800 },
+      columns: { count: 2, gap: 20 },
+      pages: [{ number: 1, fragments: [tableFragment] }],
+    };
+
+    const result = clickToPosition(layout, [tableBlock], [tableMeasure], { x: 340, y: 54 });
+
+    expect(result?.blockId).toBe('wide-table');
+    expect(result?.column).toBe(1);
   });
 });
 

--- a/packages/layout-engine/layout-bridge/test/footnoteColumnPlacement.test.ts
+++ b/packages/layout-engine/layout-bridge/test/footnoteColumnPlacement.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { FlowBlock, Measure } from '@superdoc/contracts';
+import type { FlowBlock, Measure, TableBlock, TableMeasure } from '@superdoc/contracts';
 import { incrementalLayout } from '../src/incrementalLayout';
 
 const makeParagraph = (id: string, text: string, pmStart: number): FlowBlock => ({
@@ -79,5 +79,93 @@ describe('Footnotes in columns', () => {
 
     expect(footnoteOneFragment?.x).toBeCloseTo(columnOneX, 2);
     expect(footnoteTwoFragment?.x).toBeCloseTo(columnTwoX, 2);
+  });
+
+  it('keeps footnotes in the owning column for wide overflow tables', async () => {
+    const paragraphOne = makeParagraph('para-1', 'Column 1 text', 0);
+    const columnBreak: FlowBlock = { kind: 'columnBreak', id: 'col-break-1' };
+
+    const tableCellParagraph = makeParagraph('table-cell-para', 'Wide table ref', 80);
+    const wideTable: TableBlock = {
+      kind: 'table',
+      id: 'wide-table',
+      attrs: { justification: 'right' },
+      rows: [
+        {
+          id: 'row-0',
+          cells: [{ id: 'cell-0-0', blocks: [tableCellParagraph] }],
+        },
+      ],
+    };
+
+    const footnote = makeParagraph('footnote-wide-0-paragraph', 'Wide table footnote', 0);
+
+    const tableCellMeasure = makeMeasure(18, 'Wide table ref'.length);
+    const wideTableMeasure: TableMeasure = {
+      kind: 'table',
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [tableCellMeasure],
+              paragraph: tableCellMeasure,
+              width: 320,
+              height: 28,
+              gridColumnStart: 0,
+              colSpan: 1,
+              rowSpan: 1,
+            },
+          ],
+          height: 28,
+        },
+      ],
+      columnWidths: [320],
+      totalWidth: 320,
+      totalHeight: 28,
+    };
+
+    const measureBlock = vi.fn(async (block: FlowBlock) => {
+      if (block.kind === 'columnBreak') {
+        return { kind: 'columnBreak' } as Measure;
+      }
+      if (block.kind === 'table') {
+        return wideTableMeasure;
+      }
+      const textLength = block.kind === 'paragraph' ? (block.runs?.[0]?.text?.length ?? 1) : 1;
+      const lineHeight = block.id.startsWith('footnote-') ? 10 : 18;
+      return makeMeasure(lineHeight, textLength);
+    });
+
+    const columns = { count: 2, gap: 20 };
+    const margins = { top: 60, right: 60, bottom: 60, left: 60 };
+    const pageSize = { w: 600, h: 800 };
+
+    const result = await incrementalLayout(
+      [],
+      null,
+      [paragraphOne, columnBreak, wideTable],
+      {
+        pageSize,
+        margins,
+        columns,
+        footnotes: {
+          refs: [{ id: 'wide', pos: 82 }],
+          blocksById: new Map([['wide', [footnote]]]),
+        },
+      },
+      measureBlock,
+    );
+
+    const page = result.layout.pages[0];
+    const columnWidth = (pageSize.w - margins.left - margins.right - columns.gap) / columns.count;
+    const columnTwoX = margins.left + columnWidth + columns.gap;
+
+    const tableFragment = page.fragments.find((fragment) => fragment.blockId === wideTable.id);
+    const footnoteFragment = page.fragments.find((fragment) => fragment.blockId === footnote.id);
+
+    expect(tableFragment?.kind).toBe('table');
+    expect(tableFragment && 'columnIndex' in tableFragment ? tableFragment.columnIndex : undefined).toBe(1);
+    expect(tableFragment?.x).toBeLessThan(columnTwoX);
+    expect(footnoteFragment?.x).toBeCloseTo(columnTwoX, 2);
   });
 });

--- a/packages/layout-engine/layout-engine/src/index.ts
+++ b/packages/layout-engine/layout-engine/src/index.ts
@@ -3076,7 +3076,7 @@ export { resolvePageNumberTokens } from './resolvePageTokens.js';
 export type { NumberingContext, ResolvePageTokensResult } from './resolvePageTokens.js';
 
 // Table utilities consumed by layout-bridge and cross-package sync tests
-export { getCellLines, getEmbeddedRowLines } from './layout-table.js';
+export { getCellLines, getEmbeddedRowLines, resolveTableFrame, resolveRenderedTableWidth } from './layout-table.js';
 export { describeCellRenderBlocks, computeCellSliceContentHeight } from './table-cell-slice.js';
 
 export { SINGLE_COLUMN_DEFAULT } from './section-breaks.js';

--- a/packages/layout-engine/layout-engine/src/layout-table.test.ts
+++ b/packages/layout-engine/layout-engine/src/layout-table.test.ts
@@ -728,6 +728,31 @@ describe('layoutTableBlock', () => {
       expect(rightFragment.x).toBe(300);
     });
 
+    it('keeps left-aligned wide tables at the column origin while preserving overflow width', () => {
+      const measure = createMockTableMeasure([300, 300], [20]);
+      const fragments: TableFragment[] = [];
+      const mockPage = { fragments };
+      const block = createMockTableBlock(1);
+
+      layoutTableBlock({
+        block,
+        measure,
+        columnWidth: 500,
+        ensurePage: () => ({
+          page: mockPage,
+          columnIndex: 0,
+          cursorY: 0,
+          contentBottom: 1000,
+        }),
+        advanceColumn: (state) => state,
+        columnX: () => 0,
+      });
+
+      expect(fragments).toHaveLength(1);
+      expect(fragments[0].x).toBe(0);
+      expect(fragments[0].width).toBe(600);
+    });
+
     it('allows centered wide tables to overflow into both margins', () => {
       const measure = createMockTableMeasure([300, 300], [20]);
       const fragments: TableFragment[] = [];
@@ -4241,6 +4266,36 @@ describe('layoutTableBlock', () => {
   });
 
   describe('column width rescaling (SD-1859)', () => {
+    it('does not rescale auto-width tables whose measured grid exceeds the section width', () => {
+      const block = createMockTableBlock(2);
+      const measure = createMockTableMeasure([250, 200, 250], [30, 30]);
+      // measure.totalWidth = 700, but no tableWidth attr means auto-width semantics
+
+      const fragments: TableFragment[] = [];
+      const mockPage = { fragments };
+
+      layoutTableBlock({
+        block,
+        measure,
+        columnWidth: 450,
+        ensurePage: () => ({
+          page: mockPage,
+          columnIndex: 0,
+          cursorY: 0,
+          contentBottom: 1000,
+        }),
+        advanceColumn: (state) => state,
+        columnX: () => 0,
+      });
+
+      expect(fragments).toHaveLength(1);
+      const fragment = fragments[0];
+
+      expect(fragment.width).toBe(700);
+      expect(fragment.x).toBe(0);
+      expect(fragment.columnWidths).toBeUndefined();
+    });
+
     it('should rescale column widths when table is wider than section content width', () => {
       // Simulate a table measured at landscape width (700px) but rendered in
       // a portrait section (450px). Column widths should be rescaled to fit.

--- a/packages/layout-engine/layout-engine/src/layout-table.test.ts
+++ b/packages/layout-engine/layout-engine/src/layout-table.test.ts
@@ -727,6 +727,56 @@ describe('layoutTableBlock', () => {
       const rightFragment = layoutWithJustification('right');
       expect(rightFragment.x).toBe(300);
     });
+
+    it('allows centered wide tables to overflow into both margins', () => {
+      const measure = createMockTableMeasure([300, 300], [20]);
+      const fragments: TableFragment[] = [];
+      const mockPage = { fragments };
+      const block = createMockTableBlock(1, undefined, { justification: 'center' });
+
+      layoutTableBlock({
+        block,
+        measure,
+        columnWidth: 500,
+        ensurePage: () => ({
+          page: mockPage,
+          columnIndex: 0,
+          cursorY: 0,
+          contentBottom: 1000,
+        }),
+        advanceColumn: (state) => state,
+        columnX: () => 0,
+      });
+
+      expect(fragments).toHaveLength(1);
+      expect(fragments[0].width).toBe(600);
+      expect(fragments[0].x).toBe(-50);
+    });
+
+    it('allows right-aligned wide tables to overflow into the left margin', () => {
+      const measure = createMockTableMeasure([300, 300], [20]);
+      const fragments: TableFragment[] = [];
+      const mockPage = { fragments };
+      const block = createMockTableBlock(1, undefined, { justification: 'right' });
+
+      layoutTableBlock({
+        block,
+        measure,
+        columnWidth: 500,
+        ensurePage: () => ({
+          page: mockPage,
+          columnIndex: 0,
+          cursorY: 0,
+          contentBottom: 1000,
+        }),
+        advanceColumn: (state) => state,
+        columnX: () => 0,
+      });
+
+      expect(fragments).toHaveLength(1);
+      expect(fragments[0].width).toBe(600);
+      expect(fragments[0].x).toBe(-100);
+    });
   });
 
   describe('table start preflight', () => {
@@ -3356,6 +3406,33 @@ describe('layoutTableBlock', () => {
         expect(fragments[0].width).toBe(240); // 200 - (-40)
       });
 
+      it('preserves width for wide tables with positive indent', () => {
+        const block = createMockTableBlock(1);
+        block.attrs = { tableIndent: { width: 30 } } as TableAttrs;
+        const measure = createMockTableMeasure([300, 300], [20]);
+
+        const fragments: TableFragment[] = [];
+        const mockPage = { fragments };
+
+        layoutTableBlock({
+          block,
+          measure,
+          columnWidth: 500,
+          ensurePage: () => ({
+            page: mockPage,
+            columnIndex: 0,
+            cursorY: 0,
+            contentBottom: 1000,
+          }),
+          advanceColumn: (state) => state,
+          columnX: () => 0,
+        });
+
+        expect(fragments).toHaveLength(1);
+        expect(fragments[0].x).toBe(30);
+        expect(fragments[0].width).toBe(600);
+      });
+
       it('should clamp width to 0 when indent exceeds width', () => {
         const block = createMockTableBlock(1);
         block.attrs = { tableIndent: { width: 250 } } as TableAttrs;
@@ -4167,7 +4244,9 @@ describe('layoutTableBlock', () => {
     it('should rescale column widths when table is wider than section content width', () => {
       // Simulate a table measured at landscape width (700px) but rendered in
       // a portrait section (450px). Column widths should be rescaled to fit.
-      const block = createMockTableBlock(2);
+      const block = createMockTableBlock(2, undefined, {
+        tableWidth: { value: 5000, type: 'pct' },
+      });
       const measure = createMockTableMeasure([250, 200, 250], [30, 30]);
       // measure.totalWidth = 700
 
@@ -4236,7 +4315,9 @@ describe('layoutTableBlock', () => {
 
     it('should rescale column widths on paginated table fragments', () => {
       // Table that splits across pages should have rescaled column widths on each fragment
-      const block = createMockTableBlock(4);
+      const block = createMockTableBlock(4, undefined, {
+        tableWidth: { value: 5000, type: 'pct' },
+      });
       const measure = createMockTableMeasure([300, 300], [200, 200, 200, 200]);
       // totalWidth = 600, each row = 200px
 
@@ -4276,7 +4357,9 @@ describe('layoutTableBlock', () => {
     });
 
     it('should generate metadata boundaries from rescaled column widths when table is clamped', () => {
-      const block = createMockTableBlock(2);
+      const block = createMockTableBlock(2, undefined, {
+        tableWidth: { value: 5000, type: 'pct' },
+      });
       const measure = createMockTableMeasure([250, 200, 250], [30, 30]);
 
       const fragments: TableFragment[] = [];

--- a/packages/layout-engine/layout-engine/src/layout-table.ts
+++ b/packages/layout-engine/layout-engine/src/layout-table.ts
@@ -11,7 +11,7 @@ import type {
   ParagraphMeasure,
   ParagraphBlock,
 } from '@superdoc/contracts';
-import { OOXML_PCT_DIVISOR, rescaleColumnWidths } from '@superdoc/contracts';
+import { OOXML_PCT_DIVISOR, rescaleColumnWidths, resolveTableWidthAttr } from '@superdoc/contracts';
 import type { PageState } from './paginator.js';
 import { computeFragmentPmRange, extractBlockPmRange } from './layout-utils.js';
 import { describeCellRenderBlocks, createCellSliceCursor, computeFullCellContentHeight } from './table-cell-slice.js';
@@ -137,24 +137,6 @@ function applyTableIndent(x: number, width: number, indent: number, columnWidth:
   };
 }
 
-function resolveTableWidthValue(attrs: TableBlock['attrs']): { width: number; type?: string } | null {
-  const tableWidth = attrs?.tableWidth;
-  if (!tableWidth || typeof tableWidth !== 'object') {
-    return null;
-  }
-
-  const width = (tableWidth as Record<string, unknown>).width ?? (tableWidth as Record<string, unknown>).value;
-  if (typeof width !== 'number' || !Number.isFinite(width) || width <= 0) {
-    return null;
-  }
-
-  const type = (tableWidth as Record<string, unknown>).type;
-  return {
-    width,
-    type: typeof type === 'string' ? type : undefined,
-  };
-}
-
 export function resolveRenderedTableWidth(
   columnWidth: number,
   measuredWidth: number,
@@ -162,7 +144,7 @@ export function resolveRenderedTableWidth(
 ): number {
   const safeMeasuredWidth =
     Number.isFinite(measuredWidth) && measuredWidth > 0 ? measuredWidth : Math.max(0, columnWidth);
-  const configuredWidth = resolveTableWidthValue(attrs);
+  const configuredWidth = resolveTableWidthAttr(attrs?.tableWidth);
   if (!configuredWidth) {
     return safeMeasuredWidth;
   }

--- a/packages/layout-engine/layout-engine/src/layout-table.ts
+++ b/packages/layout-engine/layout-engine/src/layout-table.ts
@@ -153,6 +153,11 @@ export function resolveRenderedTableWidth(
     return Math.max(0, Math.round(columnWidth * (configuredWidth.width / OOXML_PCT_DIVISOR)));
   }
 
+  // Explicit px/pixel/dxa widths are already applied during measurement in
+  // measuring/dom's resolveTableWidth() + measureTableBlock() pipeline. We keep
+  // measuredWidth authoritative here so layout uses the fully measured table
+  // total, including any border/cell-spacing effects, while only percentage
+  // widths are recomputed against the current section width.
   return safeMeasuredWidth;
 }
 

--- a/packages/layout-engine/layout-engine/src/layout-table.ts
+++ b/packages/layout-engine/layout-engine/src/layout-table.ts
@@ -1269,6 +1269,7 @@ function layoutMonolithicTable(context: TableLayoutContext): void {
   const fragment: TableFragment = {
     kind: 'table',
     blockId: context.block.id,
+    columnIndex: state.columnIndex,
     fromRow: 0,
     toRow: context.block.rows.length,
     x,
@@ -1420,6 +1421,7 @@ export function layoutTableBlock({
     const fragment: TableFragment = {
       kind: 'table',
       blockId: block.id,
+      columnIndex: state.columnIndex,
       fromRow: 0,
       toRow: 0,
       x,
@@ -1573,6 +1575,7 @@ export function layoutTableBlock({
         const fragment: TableFragment = {
           kind: 'table',
           blockId: block.id,
+          columnIndex: state.columnIndex,
           fromRow: rowIndex,
           toRow: rowIndex + 1,
           x,
@@ -1688,6 +1691,7 @@ export function layoutTableBlock({
       const fragment: TableFragment = {
         kind: 'table',
         blockId: block.id,
+        columnIndex: state.columnIndex,
         fromRow: bodyStartRow,
         toRow: forcedEndRow,
         x,
@@ -1738,6 +1742,7 @@ export function layoutTableBlock({
     const fragment: TableFragment = {
       kind: 'table',
       blockId: block.id,
+      columnIndex: state.columnIndex,
       fromRow: bodyStartRow,
       toRow: endRow,
       x,

--- a/packages/layout-engine/layout-engine/src/layout-table.ts
+++ b/packages/layout-engine/layout-engine/src/layout-table.ts
@@ -11,6 +11,7 @@ import type {
   ParagraphMeasure,
   ParagraphBlock,
 } from '@superdoc/contracts';
+import { OOXML_PCT_DIVISOR, rescaleColumnWidths } from '@superdoc/contracts';
 import type { PageState } from './paginator.js';
 import { computeFragmentPmRange, extractBlockPmRange } from './layout-utils.js';
 import { describeCellRenderBlocks, createCellSliceCursor, computeFullCellContentHeight } from './table-cell-slice.js';
@@ -122,11 +123,55 @@ function applyTableIndent(x: number, width: number, indent: number, columnWidth:
     };
   }
 
+  if (width > columnWidth) {
+    return {
+      x: shiftedX,
+      width,
+    };
+  }
+
   const maxWidthWithinColumn = Math.max(0, columnWidth - indent);
   return {
     x: shiftedX,
     width: Math.min(width, maxWidthWithinColumn),
   };
+}
+
+function resolveTableWidthValue(attrs: TableBlock['attrs']): { width: number; type?: string } | null {
+  const tableWidth = attrs?.tableWidth;
+  if (!tableWidth || typeof tableWidth !== 'object') {
+    return null;
+  }
+
+  const width = (tableWidth as Record<string, unknown>).width ?? (tableWidth as Record<string, unknown>).value;
+  if (typeof width !== 'number' || !Number.isFinite(width) || width <= 0) {
+    return null;
+  }
+
+  const type = (tableWidth as Record<string, unknown>).type;
+  return {
+    width,
+    type: typeof type === 'string' ? type : undefined,
+  };
+}
+
+export function resolveRenderedTableWidth(
+  columnWidth: number,
+  measuredWidth: number,
+  attrs: TableBlock['attrs'],
+): number {
+  const safeMeasuredWidth =
+    Number.isFinite(measuredWidth) && measuredWidth > 0 ? measuredWidth : Math.max(0, columnWidth);
+  const configuredWidth = resolveTableWidthValue(attrs);
+  if (!configuredWidth) {
+    return safeMeasuredWidth;
+  }
+
+  if (configuredWidth.type === 'pct') {
+    return Math.max(0, Math.round(columnWidth * (configuredWidth.width / OOXML_PCT_DIVISOR)));
+  }
+
+  return safeMeasuredWidth;
 }
 
 /**
@@ -142,20 +187,20 @@ function applyTableIndent(x: number, width: number, indent: number, columnWidth:
  * @param attrs - Table attributes
  * @returns Resolved x and width for the table fragment
  */
-function resolveTableFrame(
+export function resolveTableFrame(
   baseX: number,
   columnWidth: number,
   tableWidth: number,
   attrs: TableBlock['attrs'],
 ): { x: number; width: number } {
-  const width = Math.min(columnWidth, tableWidth);
+  const width = resolveRenderedTableWidth(columnWidth, tableWidth, attrs);
   const justification = typeof attrs?.justification === 'string' ? attrs.justification : undefined;
 
   if (justification === 'center') {
-    return { x: baseX + Math.max(0, (columnWidth - width) / 2), width };
+    return { x: baseX + (columnWidth - width) / 2, width };
   }
   if (justification === 'right' || justification === 'end') {
-    return { x: baseX + Math.max(0, columnWidth - width), width };
+    return { x: baseX + (columnWidth - width), width };
   }
 
   const tableIndent = getTableIndentWidth(attrs);
@@ -172,9 +217,6 @@ function resolveTableFrame(
  *
  * @returns Rescaled column widths if clamping occurred, undefined otherwise.
  */
-// Canonical implementation lives in @superdoc/contracts; imported for local use.
-import { rescaleColumnWidths } from '@superdoc/contracts';
-
 const COLUMN_MIN_WIDTH_PX = 25;
 const COLUMN_MAX_WIDTH_PX = 200;
 const ROW_MIN_HEIGHT_PX = 10;
@@ -1211,7 +1253,7 @@ function layoutMonolithicTable(context: TableLayoutContext): void {
   const height = Math.min(context.measure.totalHeight, state.contentBottom - state.cursorY);
 
   const baseX = context.columnX(state.columnIndex);
-  const baseWidth = Math.min(context.columnWidth, context.measure.totalWidth || context.columnWidth);
+  const baseWidth = Math.max(0, context.measure.totalWidth || context.columnWidth);
   const { x, width } = resolveTableFrame(baseX, context.columnWidth, baseWidth, context.block.attrs);
   const columnWidths = rescaleColumnWidths(context.measure.columnWidths, context.measure.totalWidth, width);
 
@@ -1369,7 +1411,7 @@ export function layoutTableBlock({
     const height = Math.min(measure.totalHeight, state.contentBottom - state.cursorY);
 
     const baseX = columnX(state.columnIndex);
-    const baseWidth = Math.min(columnWidth, measure.totalWidth || columnWidth);
+    const baseWidth = Math.max(0, measure.totalWidth || columnWidth);
     const { x, width } = resolveTableFrame(baseX, columnWidth, baseWidth, block.attrs);
     const columnWidths = rescaleColumnWidths(measure.columnWidths, measure.totalWidth, width);
 
@@ -1524,7 +1566,7 @@ export function layoutTableBlock({
       // Don't create empty fragments with just padding
       if (fragmentHeight > 0 && madeProgress) {
         const baseX = columnX(state.columnIndex);
-        const baseWidth = Math.min(columnWidth, measure.totalWidth || columnWidth);
+        const baseWidth = Math.max(0, measure.totalWidth || columnWidth);
         const { x, width } = resolveTableFrame(baseX, columnWidth, baseWidth, block.attrs);
         const scaledWidths = rescaleColumnWidths(measure.columnWidths, measure.totalWidth, width);
 
@@ -1639,7 +1681,7 @@ export function layoutTableBlock({
       );
 
       const baseX = columnX(state.columnIndex);
-      const baseWidth = Math.min(columnWidth, measure.totalWidth || columnWidth);
+      const baseWidth = Math.max(0, measure.totalWidth || columnWidth);
       const { x, width } = resolveTableFrame(baseX, columnWidth, baseWidth, block.attrs);
       const scaledWidths = rescaleColumnWidths(measure.columnWidths, measure.totalWidth, width);
 
@@ -1689,7 +1731,7 @@ export function layoutTableBlock({
     );
 
     const baseX = columnX(state.columnIndex);
-    const baseWidth = Math.min(columnWidth, measure.totalWidth || columnWidth);
+    const baseWidth = Math.max(0, measure.totalWidth || columnWidth);
     const { x, width } = resolveTableFrame(baseX, columnWidth, baseWidth, block.attrs);
     const scaledWidths = rescaleColumnWidths(measure.columnWidths, measure.totalWidth, width);
 

--- a/packages/layout-engine/layout-engine/src/resolve-table-frame.test.ts
+++ b/packages/layout-engine/layout-engine/src/resolve-table-frame.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Direct unit tests for the now-public helpers `resolveTableFrame` and
+ * `resolveRenderedTableWidth`. These functions decide whether a table extends
+ * past its column (wide-table overflow, SD-2544) and where the fragment lives
+ * inside that column. The broader `layoutTableBlock` tests cover them via
+ * full table layout; these focus the contract for direct callers like
+ * `incrementalLayout`.
+ */
+
+import type { TableAttrs } from '@superdoc/contracts';
+import { describe, expect, it } from 'bun:test';
+import { resolveRenderedTableWidth, resolveTableFrame } from './layout-table.js';
+
+describe('resolveRenderedTableWidth', () => {
+  it('returns measured width when no tableWidth attr is set', () => {
+    expect(resolveRenderedTableWidth(500, 800, {} as TableAttrs)).toBe(800);
+  });
+
+  it('falls back to columnWidth when measured is zero', () => {
+    expect(resolveRenderedTableWidth(500, 0, {} as TableAttrs)).toBe(500);
+  });
+
+  it('falls back to columnWidth when measured is non-finite', () => {
+    expect(resolveRenderedTableWidth(500, NaN, {} as TableAttrs)).toBe(500);
+    expect(resolveRenderedTableWidth(500, Infinity, {} as TableAttrs)).toBe(500);
+  });
+
+  it('falls back to columnWidth when measured is negative', () => {
+    expect(resolveRenderedTableWidth(500, -100, {} as TableAttrs)).toBe(500);
+  });
+
+  it('computes pct width as columnWidth * (value / OOXML_PCT_DIVISOR)', () => {
+    expect(resolveRenderedTableWidth(500, 400, { tableWidth: { value: 5000, type: 'pct' } } as TableAttrs)).toBe(500);
+    expect(resolveRenderedTableWidth(500, 400, { tableWidth: { value: 2500, type: 'pct' } } as TableAttrs)).toBe(250);
+    expect(resolveRenderedTableWidth(500, 400, { tableWidth: { value: 7500, type: 'pct' } } as TableAttrs)).toBe(750);
+  });
+
+  it('reads pct width from the width field as well as value', () => {
+    expect(resolveRenderedTableWidth(500, 400, { tableWidth: { width: 2500, type: 'pct' } } as TableAttrs)).toBe(250);
+  });
+
+  it('returns measured width for px/pixel/dxa types (measure already applied them)', () => {
+    expect(resolveRenderedTableWidth(500, 700, { tableWidth: { width: 700, type: 'px' } } as TableAttrs)).toBe(700);
+    expect(resolveRenderedTableWidth(500, 700, { tableWidth: { width: 700, type: 'pixel' } } as TableAttrs)).toBe(700);
+    expect(resolveRenderedTableWidth(500, 700, { tableWidth: { width: 700, type: 'dxa' } } as TableAttrs)).toBe(700);
+  });
+
+  it('returns measured width when the tableWidth attr is invalid', () => {
+    expect(resolveRenderedTableWidth(500, 600, { tableWidth: { type: 'pct' } } as TableAttrs)).toBe(600);
+    expect(resolveRenderedTableWidth(500, 600, { tableWidth: { width: -1, type: 'pct' } } as TableAttrs)).toBe(600);
+  });
+});
+
+describe('resolveTableFrame', () => {
+  describe('left-aligned (default)', () => {
+    it('returns baseX with measured width when table fits in column', () => {
+      const result = resolveTableFrame(50, 500, 400, {} as TableAttrs);
+      expect(result).toEqual({ x: 50, width: 400 });
+    });
+
+    it('preserves wide measured width past the column', () => {
+      const result = resolveTableFrame(50, 500, 700, {} as TableAttrs);
+      expect(result).toEqual({ x: 50, width: 700 });
+    });
+
+    it('shifts by positive tableIndent and preserves width when wide', () => {
+      const result = resolveTableFrame(50, 500, 700, {
+        tableIndent: { width: 30 },
+      } as TableAttrs);
+      expect(result).toEqual({ x: 80, width: 700 });
+    });
+
+    it('shifts left and expands width for negative indent (legacy behavior)', () => {
+      const result = resolveTableFrame(50, 500, 400, {
+        tableIndent: { width: -40 },
+      } as TableAttrs);
+      expect(result).toEqual({ x: 10, width: 440 });
+    });
+  });
+
+  describe('center-aligned', () => {
+    it('centers a narrow table within the column', () => {
+      const result = resolveTableFrame(0, 500, 300, { justification: 'center' } as TableAttrs);
+      expect(result).toEqual({ x: 100, width: 300 });
+    });
+
+    it('returns negative x for a wide centered table (overflows both margins)', () => {
+      const result = resolveTableFrame(0, 500, 600, { justification: 'center' } as TableAttrs);
+      expect(result).toEqual({ x: -50, width: 600 });
+    });
+
+    it('ignores tableIndent for centered tables', () => {
+      const result = resolveTableFrame(0, 500, 300, {
+        justification: 'center',
+        tableIndent: { width: 100 },
+      } as TableAttrs);
+      expect(result).toEqual({ x: 100, width: 300 });
+    });
+  });
+
+  describe('right-aligned', () => {
+    it('aligns to right edge of column when table fits', () => {
+      const result = resolveTableFrame(0, 500, 300, { justification: 'right' } as TableAttrs);
+      expect(result).toEqual({ x: 200, width: 300 });
+    });
+
+    it('returns negative x for a wide right-aligned table (overflows left)', () => {
+      const result = resolveTableFrame(0, 500, 600, { justification: 'right' } as TableAttrs);
+      expect(result).toEqual({ x: -100, width: 600 });
+    });
+
+    it('treats end as right', () => {
+      const result = resolveTableFrame(0, 500, 600, { justification: 'end' } as TableAttrs);
+      expect(result).toEqual({ x: -100, width: 600 });
+    });
+  });
+
+  describe('with pct tableWidth', () => {
+    it('uses computed pct width even when measured is wider', () => {
+      const result = resolveTableFrame(0, 500, 800, {
+        tableWidth: { value: 5000, type: 'pct' },
+      } as TableAttrs);
+      expect(result).toEqual({ x: 0, width: 500 });
+    });
+
+    it('overflows when pct exceeds 100%', () => {
+      const result = resolveTableFrame(0, 500, 750, {
+        tableWidth: { value: 7500, type: 'pct' },
+        justification: 'center',
+      } as TableAttrs);
+      expect(result.width).toBe(750);
+      expect(result.x).toBe(-125);
+    });
+  });
+});

--- a/packages/layout-engine/measuring/dom/src/index.test.ts
+++ b/packages/layout-engine/measuring/dom/src/index.test.ts
@@ -4617,6 +4617,55 @@ describe('measureBlock', () => {
       expect(measure.columnWidths).toEqual([320, 320]);
     });
 
+    it('preserves fixed-layout grid widths wider than the column when tableWidth is absent', async () => {
+      // Quiet behavior pinned: with `tableLayout: 'fixed'` and no `tableWidth` attr,
+      // the imported grid widths pass through even when they exceed the available column.
+      // Previously, the measure would have scaled them down to fit `maxWidth`.
+      const block: FlowBlock = {
+        kind: 'table',
+        id: 'fixed-no-width',
+        attrs: {
+          tableLayout: 'fixed',
+        },
+        rows: [
+          {
+            id: 'row-0',
+            cells: [
+              {
+                id: 'cell-0-0',
+                blocks: [
+                  {
+                    kind: 'paragraph',
+                    id: 'para-0',
+                    runs: [{ text: 'A', fontFamily: 'Arial', fontSize: 12 }],
+                  },
+                ],
+              },
+              {
+                id: 'cell-0-1',
+                blocks: [
+                  {
+                    kind: 'paragraph',
+                    id: 'para-1',
+                    runs: [{ text: 'B', fontFamily: 'Arial', fontSize: 12 }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        columnWidths: [400, 400],
+      };
+
+      const measure = await measureBlock(block, { maxWidth: 500 });
+
+      expect(measure.kind).toBe('table');
+      if (measure.kind !== 'table') throw new Error('expected table measure');
+
+      expect(measure.totalWidth).toBe(800);
+      expect(measure.columnWidths).toEqual([400, 400]);
+    });
+
     it('handles percentage width with width property instead of value', async () => {
       const block: FlowBlock = {
         kind: 'table',

--- a/packages/layout-engine/measuring/dom/src/index.test.ts
+++ b/packages/layout-engine/measuring/dom/src/index.test.ts
@@ -3399,6 +3399,9 @@ describe('measureBlock', () => {
       const block: FlowBlock = {
         kind: 'table',
         id: 'table-1',
+        attrs: {
+          tableWidth: { value: 5000, type: 'pct' },
+        },
         rows: [
           {
             id: 'row-0',
@@ -3436,14 +3439,14 @@ describe('measureBlock', () => {
             ],
           },
         ],
-        columnWidths: [400, 400], // Total 800px
+        columnWidths: [400, 400], // Total 800px, but pct width should rescale to current column
       };
 
       const measure = await measureBlock(block, { maxWidth: 600 });
 
       expect(measure.kind).toBe('table');
       if (measure.kind !== 'table') throw new Error('expected table measure');
-      // Should scale: 400 * (600/800) = 300
+      // Percentage width should rescale to the current column width: 400 * (600/800) = 300
       expect(measure.columnWidths[0]).toBe(300);
       expect(measure.columnWidths[1]).toBe(300);
       expect(measure.totalWidth).toBe(600);
@@ -4007,6 +4010,9 @@ describe('measureBlock', () => {
       const block: FlowBlock = {
         kind: 'table',
         id: 'scale-test-1',
+        attrs: {
+          tableWidth: { value: 5000, type: 'pct' },
+        },
         rows: [
           {
             id: 'row-0',
@@ -4052,7 +4058,7 @@ describe('measureBlock', () => {
       expect(measure.kind).toBe('table');
       if (measure.kind !== 'table') throw new Error('expected table measure');
 
-      // Should scale from 400px to 300px maintaining 1:2:1 ratio
+      // Percentage width should scale from 400px to 300px maintaining 1:2:1 ratio
       // 100 * (300/400) = 75, 200 * (300/400) = 150
       expect(measure.columnWidths[0]).toBe(75);
       expect(measure.columnWidths[1]).toBe(150);
@@ -4108,6 +4114,9 @@ describe('measureBlock', () => {
       const block: FlowBlock = {
         kind: 'table',
         id: 'scale-test-3',
+        attrs: {
+          tableWidth: { value: 5000, type: 'pct' },
+        },
         rows: [
           {
             id: 'row-0',
@@ -4196,6 +4205,9 @@ describe('measureBlock', () => {
       const block: FlowBlock = {
         kind: 'table',
         id: 'scale-test-5',
+        attrs: {
+          tableWidth: { value: 5000, type: 'pct' },
+        },
         rows: [
           {
             id: 'row-0',
@@ -4466,6 +4478,53 @@ describe('measureBlock', () => {
       expect(measure.columnWidths[1]).toBe(300);
     });
 
+    it('preserves explicit widths wider than the content column', async () => {
+      const block: FlowBlock = {
+        kind: 'table',
+        id: 'explicit-wide-table',
+        attrs: {
+          tableWidth: { width: 700, type: 'px' },
+        },
+        rows: [
+          {
+            id: 'row-0',
+            cells: [
+              {
+                id: 'cell-0-0',
+                blocks: [
+                  {
+                    kind: 'paragraph',
+                    id: 'para-0',
+                    runs: [{ text: 'A', fontFamily: 'Arial', fontSize: 12 }],
+                  },
+                ],
+              },
+              {
+                id: 'cell-0-1',
+                blocks: [
+                  {
+                    kind: 'paragraph',
+                    id: 'para-1',
+                    runs: [{ text: 'B', fontFamily: 'Arial', fontSize: 12 }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        columnWidths: [200, 200],
+      };
+
+      const measure = await measureBlock(block, { maxWidth: 500 });
+
+      expect(measure.kind).toBe('table');
+      if (measure.kind !== 'table') throw new Error('expected table measure');
+
+      expect(measure.totalWidth).toBe(700);
+      expect(measure.columnWidths[0]).toBe(350);
+      expect(measure.columnWidths[1]).toBe(350);
+    });
+
     it('scales column widths to 50% of available width when tableWidth type is pct with value 2500', async () => {
       const block: FlowBlock = {
         kind: 'table',
@@ -4513,6 +4572,49 @@ describe('measureBlock', () => {
       expect(measure.totalWidth).toBe(300);
       expect(measure.columnWidths[0]).toBe(150);
       expect(measure.columnWidths[1]).toBe(150);
+    });
+
+    it('preserves imported grid widths that exceed the content column', async () => {
+      const block: FlowBlock = {
+        kind: 'table',
+        id: 'grid-wide-table',
+        rows: [
+          {
+            id: 'row-0',
+            cells: [
+              {
+                id: 'cell-0-0',
+                blocks: [
+                  {
+                    kind: 'paragraph',
+                    id: 'para-0',
+                    runs: [{ text: 'A', fontFamily: 'Arial', fontSize: 12 }],
+                  },
+                ],
+              },
+              {
+                id: 'cell-0-1',
+                blocks: [
+                  {
+                    kind: 'paragraph',
+                    id: 'para-1',
+                    runs: [{ text: 'B', fontFamily: 'Arial', fontSize: 12 }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        columnWidths: [320, 320],
+      };
+
+      const measure = await measureBlock(block, { maxWidth: 500 });
+
+      expect(measure.kind).toBe('table');
+      if (measure.kind !== 'table') throw new Error('expected table measure');
+
+      expect(measure.totalWidth).toBe(640);
+      expect(measure.columnWidths).toEqual([320, 320]);
     });
 
     it('handles percentage width with width property instead of value', async () => {

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -2691,9 +2691,10 @@ async function measureTableBlock(block: TableBlock, constraints: MeasureConstrai
     Math.max(...block.rows.map((r) => r.cells.reduce((sum, cell) => sum + (cell.colSpan ?? 1), 0))),
   );
 
-  // Effective target width: use resolvedTableWidth if set (from percentage or explicit px),
-  // but never exceed maxWidth (available column space)
-  const effectiveTargetWidth = resolvedTableWidth != null ? Math.min(resolvedTableWidth, maxWidth) : maxWidth;
+  // Effective target width: explicit OOXML widths are authoritative and may exceed the
+  // content column when Word would overflow into the margins. Auto-sized fallback tables
+  // still default to the available column width.
+  const effectiveTargetWidth = resolvedTableWidth != null ? resolvedTableWidth : maxWidth;
 
   // Use provided column widths from OOXML w:tblGrid if available
   if (block.columnWidths && block.columnWidths.length > 0) {
@@ -2704,26 +2705,29 @@ async function measureTableBlock(block: TableBlock, constraints: MeasureConstrai
     const hasExplicitWidth = resolvedTableWidth != null;
     const hasFixedLayout = block.attrs?.tableLayout === 'fixed';
 
-    // For tables with explicit/percentage width or fixed layout, scale to target width
+    // For tables with explicit/percentage width or fixed layout, scale to the imported
+    // target width when one exists. Wide explicit tables are allowed to exceed the
+    // current content column so they can later render into the margins.
     if (hasExplicitWidth || hasFixedLayout) {
       const totalWidth = columnWidths.reduce((a, b) => a + b, 0);
       const tableWidthType = (block.attrs?.tableWidth as TableWidthAttr | undefined)?.type;
-      const shouldScaleDown = totalWidth > effectiveTargetWidth;
+      const targetWidth = hasExplicitWidth ? effectiveTargetWidth : totalWidth;
+      const shouldScaleDown = totalWidth > targetWidth;
       const shouldScaleUp =
-        totalWidth < effectiveTargetWidth &&
-        effectiveTargetWidth > 0 &&
+        totalWidth < targetWidth &&
+        targetWidth > 0 &&
         (tableWidthType === 'pct' || (hasExplicitWidth && !hasFixedLayout));
 
-      // Scale to effectiveTargetWidth (resolved percentage or explicit width)
+      // Scale to the resolved percentage or explicit width.
       // - Always scale down if too wide
       // - Only scale up for percentage widths or auto-layout tables
-      if ((shouldScaleDown || shouldScaleUp) && effectiveTargetWidth > 0 && totalWidth > 0) {
-        const scale = effectiveTargetWidth / totalWidth;
+      if ((shouldScaleDown || shouldScaleUp) && targetWidth > 0 && totalWidth > 0) {
+        const scale = targetWidth / totalWidth;
         columnWidths = columnWidths.map((w) => Math.max(1, Math.round(w * scale)));
         // Normalize to exact target width (handle rounding errors)
         const scaledSum = columnWidths.reduce((a, b) => a + b, 0);
-        if (scaledSum !== effectiveTargetWidth && columnWidths.length > 0) {
-          const diff = effectiveTargetWidth - scaledSum;
+        if (scaledSum !== targetWidth && columnWidths.length > 0) {
+          const diff = targetWidth - scaledSum;
           columnWidths[columnWidths.length - 1] = Math.max(1, columnWidths[columnWidths.length - 1] + diff);
         }
       }
@@ -2741,20 +2745,10 @@ async function measureTableBlock(block: TableBlock, constraints: MeasureConstrai
         columnWidths = columnWidths.slice(0, maxCellCount);
       }
 
-      // Auto-layout: only scale DOWN if columns exceed available width.
-      // Do NOT scale up — explicit w:tblGrid column widths are authoritative.
+      // Auto-layout: keep explicit w:tblGrid column widths authoritative, even when they
+      // exceed the current content column. Narrower-section fallback happens in layout.
       // Tables without w:tblGrid already arrive with page-width columns via
       // the fallback grid builder in tableFallbackHelpers.
-      const totalWidth = columnWidths.reduce((a, b) => a + b, 0);
-      if (totalWidth > effectiveTargetWidth && effectiveTargetWidth > 0) {
-        const scale = effectiveTargetWidth / totalWidth;
-        columnWidths = columnWidths.map((w) => Math.max(1, Math.round(w * scale)));
-        const scaledSum = columnWidths.reduce((a, b) => a + b, 0);
-        if (scaledSum !== effectiveTargetWidth && columnWidths.length > 0) {
-          const diff = effectiveTargetWidth - scaledSum;
-          columnWidths[columnWidths.length - 1] = Math.max(1, columnWidths[columnWidths.length - 1] + diff);
-        }
-      }
     }
   } else {
     // Fallback: Equal distribution based on max cells in any row

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -65,6 +65,7 @@ import {
   type TableBorderValue,
   effectiveTableCellSpacing,
   LeaderDecoration,
+  resolveTableWidthAttr,
   resolveBaseFontSizeForVerticalText,
 } from '@superdoc/contracts';
 import type { WordParagraphLayoutOutput } from '@superdoc/word-layout';
@@ -2592,36 +2593,6 @@ async function measureParagraphBlock(block: ParagraphBlock, maxWidth: number): P
 }
 
 /**
- * Validates and extracts a numeric value from a table width attribute.
- *
- * Performs runtime validation to ensure the value is a valid, finite number
- * that can be used in calculations. This guards against NaN, Infinity, and
- * invalid numeric values that could break layout calculations.
- *
- * @param attr - Table width attribute object (potentially unsafe)
- * @returns Valid numeric value or undefined if validation fails
- *
- * @example
- * ```typescript
- * validateTableWidthValue({ width: 2500, type: 'pct' }) // Returns: 2500
- * validateTableWidthValue({ value: 300, type: 'px' }) // Returns: 300
- * validateTableWidthValue({ width: NaN, type: 'pct' }) // Returns: undefined
- * validateTableWidthValue({ width: -100, type: 'pct' }) // Returns: undefined
- * validateTableWidthValue({}) // Returns: undefined
- * ```
- */
-function validateTableWidthValue(attr: TableWidthAttr): number | undefined {
-  const value = attr.width ?? attr.value;
-
-  // Must be a number, finite (not NaN/Infinity), and positive
-  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
-    return value;
-  }
-
-  return undefined;
-}
-
-/**
  * Resolves table width from OOXML attributes to actual pixel width.
  *
  * Handles two types of width specifications:
@@ -2652,27 +2623,19 @@ function validateTableWidthValue(attr: TableWidthAttr): number | undefined {
  * ```
  */
 function resolveTableWidth(attrs: TableBlock['attrs'], maxWidth: number): number | undefined {
-  // Type guard: validate attrs.tableWidth matches TableWidthAttr structure
-  const tableWidthAttr = attrs?.tableWidth;
-  if (!tableWidthAttr || typeof tableWidthAttr !== 'object') {
+  const tableWidthAttr = resolveTableWidthAttr(attrs?.tableWidth);
+  if (!tableWidthAttr) {
     return undefined;
   }
 
-  const typedAttr = tableWidthAttr as TableWidthAttr;
-  const validValue = validateTableWidthValue(typedAttr);
-
-  if (validValue === undefined) {
-    return undefined;
-  }
-
-  if (typedAttr.type === 'pct') {
+  if (tableWidthAttr.type === 'pct') {
     // Convert OOXML percentage to pixels
     // OOXML_PCT_DIVISOR (5000) = 100%
-    return Math.round(maxWidth * (validValue / OOXML_PCT_DIVISOR));
-  } else if (typedAttr.type === 'px' || typedAttr.type === 'pixel' || typedAttr.type === 'dxa') {
+    return Math.round(maxWidth * (tableWidthAttr.width / OOXML_PCT_DIVISOR));
+  } else if (tableWidthAttr.type === 'px' || tableWidthAttr.type === 'pixel' || tableWidthAttr.type === 'dxa') {
     // Explicit pixel width - use directly
     // Note: 'dxa' values are already converted to pixels by tbl-translator during import
-    return validValue;
+    return tableWidthAttr.width;
   }
 
   return undefined;


### PR DESCRIPTION
## Summary

Adds support for rendering tables wider than the content column (SD-2544 / SD-2545). Tables with explicit OOXML widths now overflow into page margins instead of being clamped to column width.

## Key changes

- **Width resolution centralized**: New `resolveTableWidthAttr` (contracts) validates table width attrs (rejects NaN/Infinity/non-positive). Used by both measuring and layout sides.
- **Wide-table layout**: New `resolveTableFrame` / `resolveRenderedTableWidth` (layout-engine) resolve final rendered width and x-offset. Allows negative x for centered/right-aligned wide tables; preserves indent for left-aligned, ignores it for justified.
- **Measuring**: Explicit OOXML widths (px/pct/dxa) now pass through unclamped — only auto-sized tables fall back to column width.
- **Fragments**: Table fragments record an optional `columnIndex` (logical column owner). Used by `position-hit` and footnote placement so click-resolution and footnote anchoring use logical ownership instead of visual x for wide overflow tables.
- **Tests**: ~600 new test cases — width-attr validation, wide-table overflow, alignment, indent edge cases, click-to-position with `columnIndex`, footnote placement on overflow tables, multi-column scenarios.

## Test plan

- [x] Unit tests pass (layout-engine, contracts, layout-bridge)
- [ ] Layout comparison vs published baseline (`pnpm test:layout`)
- [ ] Visual diff on wide-table corpus docs (`pnpm test:visual`)