### PR TITLE
ci(superdoc): add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -223,7 +223,7 @@ jobs:
 
       - run: pnpm --filter @superdoc-dev/superdoc-yjs-collaboration build
 
-      - run: pnpm --filter superdoc exec vitest run --coverage --coverage.provider=v8 --coverage.reporter=lcov
+      - run: pnpm --filter superdoc exec vitest run --coverage
 
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -221,6 +221,8 @@ jobs:
 
       - run: pnpm install
 
+      - run: pnpm --filter @superdoc-dev/superdoc-yjs-collaboration build
+
       - run: pnpm --filter superdoc exec vitest run --coverage --coverage.provider=v8 --coverage.reporter=lcov
 
       - uses: codecov/codecov-action@v5

--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -219,46 +219,15 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.12
+      - run: pnpm install
 
-      - name: Install canvas system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            libcairo2-dev \
-            libpango1.0-dev \
-            libjpeg-dev \
-            libgif-dev \
-            librsvg2-dev \
-            libpixman-1-dev
+      - run: pnpm --filter superdoc exec vitest run --coverage --coverage.provider=v8 --coverage.reporter=lcov
 
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Run superdoc tests with coverage
-        env:
-          NODE_OPTIONS: '--max-old-space-size=4096'
-        run: >-
-          pnpm --filter superdoc exec vitest run
-          --coverage
-          --coverage.provider=v8
-          --coverage.reporter=lcov
-          --coverage.reporter=text-summary
-          --coverage.include='src/**'
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/superdoc/coverage/lcov.info
           flags: superdoc
-          fail_ci_if_error: false
 
   validate:
     if: always()

--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -206,9 +206,63 @@ jobs:
       - name: Run CLI tests
         run: pnpm run test:cli
 
+  coverage:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+
+      - name: Install canvas system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            libcairo2-dev \
+            libpango1.0-dev \
+            libjpeg-dev \
+            libgif-dev \
+            librsvg2-dev \
+            libpixman-1-dev
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Run superdoc tests with coverage
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
+        run: >-
+          pnpm --filter superdoc exec vitest run
+          --coverage
+          --coverage.provider=v8
+          --coverage.reporter=lcov
+          --coverage.reporter=text-summary
+          --coverage.include='src/**'
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/superdoc/coverage/lcov.info
+          flags: superdoc
+          fail_ci_if_error: false
+
   validate:
     if: always()
-    needs: [build, unit-tests, cli-tests]
+    needs: [build, unit-tests, cli-tests, coverage]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -167,6 +167,21 @@ export default defineConfig(({ mode, command }) => {
         '**/*.spec.js',
         'tests/umd-smoke/**',
       ],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text-summary', 'lcov'],
+        include: ['src/**'],
+        exclude: [
+          'src/dev/**',
+          'src/index.js',
+          'src/main.js',
+          'src/types.ts',
+          'src/super-editor.js',
+          'src/headless-toolbar.js',
+          'src/headless-toolbar-react.js',
+          'src/headless-toolbar-vue.js',
+        ],
+      },
     },
     build: {
       target: 'es2022',

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -180,6 +180,9 @@ export default defineConfig(({ mode, command }) => {
           'src/headless-toolbar.js',
           'src/headless-toolbar-react.js',
           'src/headless-toolbar-vue.js',
+          // Pure JSDoc typedef files (body is `export {}`, no runtime code)
+          'src/core/types/**',
+          '**/types.js',
         ],
       },
     },


### PR DESCRIPTION
Adds Codecov coverage reporting for the `superdoc` package. A new `coverage` job in `ci-superdoc.yml` runs vitest with v8 coverage scoped to `packages/superdoc/src/**` and uploads `lcov.info` via `codecov/codecov-action@v5`. The job is wired into the `validate` gate so failures block merge.

- New `codecov.yml` with minimal config: `auto` project + patch targets, 1% threshold
- New `coverage` CI job (depends on `build`, mirrors the `unit-tests` setup: pnpm/node/bun + canvas system deps)
- Coverage uploaded with the `superdoc` flag
- `validate` job now also waits on `coverage`

Requires `CODECOV_TOKEN` to be added as a repo secret before this lands (or relies on tokenless OIDC).