### PR TITLE
fix(test): scope m:nary supHide assertion to operator wrapper

### DIFF
--- a/tests/behavior/tests/importing/math-equations.spec.ts
+++ b/tests/behavior/tests/importing/math-equations.spec.ts
@@ -957,14 +957,18 @@ test.describe('m:nary (n-ary operator) rendering', () => {
       const math = document.querySelectorAll('math')[5];
       const munder = math?.querySelector('munder');
       if (!munder) return null;
+      // The n-ary body contains m:sSub (Aᵢ), which legitimately renders as <msub>.
+      // Assert only on the n-ary's own wrapper — the element parenting <mo>⋃</mo>.
+      const unionOp = Array.from(math.querySelectorAll('mo')).find((m) => m.textContent === '\u22C3');
+      const naryWrapperTag = unionOp?.parentElement?.tagName.toLowerCase();
       return {
-        hasMsub: math?.querySelector('msub') !== null,
+        naryWrapperTag,
         opChar: munder.children[0]?.textContent,
         under: munder.children[1]?.textContent,
       };
     });
     expect(data).not.toBeNull();
-    expect(data!.hasMsub).toBe(false);
+    expect(data!.naryWrapperTag).toBe('munder');
     expect(data!.opChar).toBe('\u22C3');
     expect(data!.under).toBe('i');
   });


### PR DESCRIPTION
The behavior test `math-equations.spec.ts:951` (\"union with supHide renders as <munder>\") has been failing on main and every PR since it landed in #2752. The converter is correct — the test assertion was overly broad.

- Scenario 6 in `math-nary-tests.docx` has `<m:sSub>` (Aᵢ) in the n-ary body `<m:e>`, which legitimately renders as `<msub>` via the m:sSub converter (#2635).
- The old assertion `math.querySelector('msub') !== null` picked up that body `<msub>`, not the n-ary's own wrapper choice, so it always failed.
- New assertion locates the `<mo>⋃</mo>` and checks its parent tag is `<munder>` — which is what the test actually intends to verify.
- Verified locally: failing test now passes; all 72 math-equations tests pass on chromium.