### PR TITLE
fix(test): add textBetween/nodesBetween to plan-engine tr.doc mocks

### DIFF
--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/remap-length.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/remap-length.test.ts
@@ -123,6 +123,10 @@ function makeTr() {
     docChanged: true,
     doc: {
       resolve: () => ({ marks: () => [] }),
+      textBetween: vi.fn((from: number, to: number) => '\x01'.repeat(to - from)),
+      nodesBetween: vi.fn((from: number, to: number, cb: (node: any, pos: number) => void) => {
+        cb({ isText: true, nodeSize: to - from }, from);
+      }),
     },
   };
   tr.replaceWith.mockReturnValue(tr);


### PR DESCRIPTION
The word-diff executor added in #2817 calls `tr.doc.textBetween(...)` and `tr.doc.nodesBetween(...)` in the text.rewrite trim path, but the `tr.doc` mocks in determinism-stress, executor, and preview-parity tests were never updated. That's been breaking \`unit-tests (super-editor, 2/4)\` and \`(super-editor, 3/4)\` on every PR since #2817 landed.

- \`determinism-stress.test.ts\` — add \`textBetween\` + \`nodesBetween\` to \`tr.doc\`
- \`executor.test.ts\` — same, parameterized on \`text\`
- \`preview-parity.test.ts\` — add \`nodesBetween\` (\`textBetween\` was already there)
- Verified locally: all 70 tests across the three files pass.