### PR TITLE
ci: upload coverage to Codecov on push to main

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -1,0 +1,41 @@
+name: Coverage
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/superdoc/src/**'
+      - 'packages/superdoc/vite.config.js'
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install
+
+      - run: pnpm --filter @superdoc-dev/superdoc-yjs-collaboration build
+
+      - run: pnpm --filter superdoc exec vitest run --coverage
+
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/superdoc/coverage/lcov.info
+          flags: superdoc


### PR DESCRIPTION
The existing CI SuperDoc workflow only runs on pull requests. This means coverage never gets uploaded from the main branch, so the Codecov badge stays stale.

Adds a lightweight `ci-coverage.yml` that runs on push to main (only when superdoc source changes) and uploads lcov to Codecov. No lint, build, or unit-test gates — just the coverage job.