### PR TITLE
test(superdoc): tighten assertions + adjust codecov policy

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,9 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: 90%
         threshold: 1%
     patch:
       default:
-        target: auto
-        threshold: 1%
+        target: 90%
+        threshold: 0%

--- a/packages/superdoc/src/core/create-app-edges.test.js
+++ b/packages/superdoc/src/core/create-app-edges.test.js
@@ -19,11 +19,7 @@ vi.mock('../SuperDoc.vue', () => ({ default: { name: 'SuperDocMock' } }));
 
 const setupAppMocks = () => {
   const originalUnmount = vi.fn();
-  const app = {
-    use: vi.fn(),
-    directive: vi.fn(),
-    unmount: originalUnmount,
-  };
+  const app = { use: vi.fn(), directive: vi.fn(), unmount: originalUnmount };
   createAppMock.mockReturnValue(app);
   createPiniaMock.mockReturnValue({});
   useSuperdocStoreMock.mockReturnValue({});
@@ -34,12 +30,10 @@ const setupAppMocks = () => {
 
 const safeDelete = (key) => {
   const desc = Object.getOwnPropertyDescriptor(globalThis, key);
-  if (!desc || desc.configurable !== false) {
-    delete globalThis[key];
-  }
+  if (!desc || desc.configurable !== false) delete globalThis[key];
 };
 
-describe('createSuperdocVueApp edge cases', () => {
+describe('createSuperdocVueApp', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
@@ -52,49 +46,7 @@ describe('createSuperdocVueApp edge cases', () => {
     safeDelete('__VUE_DEVTOOLS_PLUGINS__');
   });
 
-  it('handles queue replacement via property setter', async () => {
-    const { app } = setupAppMocks();
-    const { createSuperdocVueApp } = await import('./create-app.js');
-    createSuperdocVueApp({ disablePiniaDevtools: true });
-
-    const newQueue = [];
-    globalThis.__VUE_DEVTOOLS_PLUGINS__ = newQueue;
-    newQueue.push([{ id: 'dev.esm.pinia', app }, vi.fn()]);
-    expect(newQueue).toHaveLength(0);
-
-    const otherApp = {};
-    newQueue.push([{ id: 'dev.esm.pinia', app: otherApp }, vi.fn()]);
-    expect(newQueue).toHaveLength(1);
-  });
-
-  it('handles multiple unmount calls safely', async () => {
-    const { app } = setupAppMocks();
-    const { createSuperdocVueApp } = await import('./create-app.js');
-    createSuperdocVueApp({ disablePiniaDevtools: true });
-    app.unmount();
-    app.unmount(); // second call — no-op via ref count guard
-    expect(true).toBe(true);
-  });
-
-  it('handles non-array pre-existing queue', async () => {
-    globalThis.__VUE_DEVTOOLS_PLUGINS__ = { notAnArray: true };
-    const { app } = setupAppMocks();
-    const { createSuperdocVueApp } = await import('./create-app.js');
-    expect(() => createSuperdocVueApp({ disablePiniaDevtools: true })).not.toThrow();
-  });
-
-  it('emits unrelated events without suppression', async () => {
-    const emitSpy = vi.fn(() => 'emitted');
-    globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__ = { emit: emitSpy };
-    const { app } = setupAppMocks();
-    const { createSuperdocVueApp } = await import('./create-app.js');
-    createSuperdocVueApp({ disablePiniaDevtools: true });
-    const hook = globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__;
-    expect(hook.emit('other-event', { id: 'other', app: {} })).toBe('emitted');
-    expect(emitSpy).toHaveBeenCalled();
-  });
-
-  it('returns app + stores from factory', async () => {
+  it('returns the Vue app with all stores', async () => {
     const { app } = setupAppMocks();
     const { createSuperdocVueApp } = await import('./create-app.js');
     const result = createSuperdocVueApp({ disablePiniaDevtools: false });
@@ -105,36 +57,61 @@ describe('createSuperdocVueApp edge cases', () => {
     expect(result.highContrastModeStore).toBeDefined();
   });
 
-  it('replacing hook at runtime picks up new hook instance', async () => {
+  // Outcome-focused: when suppressed, the Pinia devtools plugin for this app
+  // is never surfaced via the hook or queue. The test does not pin the
+  // specific suppression mechanism (hook-emit patch vs. queue-push patch),
+  // so it survives refactors of the strategy.
+  it('keeps the Pinia devtools plugin hidden from consumers when suppressed', async () => {
+    const emitSpy = vi.fn(() => 'emitted');
+    globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__ = { emit: emitSpy };
     const { app } = setupAppMocks();
     const { createSuperdocVueApp } = await import('./create-app.js');
     createSuperdocVueApp({ disablePiniaDevtools: true });
 
-    const firstEmit = vi.fn(() => 'a');
-    globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__ = { emit: firstEmit };
-    let hook = globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__;
+    const hook = globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__;
+    // Hook emit for this app is swallowed
     expect(hook.emit('devtools-plugin:setup', { id: 'dev.esm.pinia', app }, vi.fn())).toBeUndefined();
+    expect(emitSpy).not.toHaveBeenCalled();
 
-    const secondEmit = vi.fn(() => 'b');
-    globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__ = { emit: secondEmit };
-    hook = globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__;
-    expect(hook.emit('devtools-plugin:setup', { id: 'dev.esm.pinia', app }, vi.fn())).toBeUndefined();
+    // Queue pushes for this app are dropped
+    const queue = globalThis.__VUE_DEVTOOLS_PLUGINS__;
+    queue.push([{ id: 'dev.esm.pinia', app }, vi.fn()]);
+    expect(queue).toHaveLength(0);
+
+    // Unrelated apps are not suppressed
+    const otherApp = {};
+    expect(hook.emit('devtools-plugin:setup', { id: 'dev.esm.pinia', app: otherApp }, vi.fn())).toBe('emitted');
+    queue.push([{ id: 'dev.esm.pinia', app: otherApp }, vi.fn()]);
+    expect(queue).toHaveLength(1);
+
+    // Suppression lifts after unmount
+    app.unmount();
+    expect(hook.emit('devtools-plugin:setup', { id: 'dev.esm.pinia', app }, vi.fn())).toBe('emitted');
   });
 
-  it('replacement queue also intercepts pinia setup for suppressed app', async () => {
+  it('does not suppress anything when disablePiniaDevtools is false', async () => {
+    const emitSpy = vi.fn(() => 'emitted');
+    globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__ = { emit: emitSpy };
     const { app } = setupAppMocks();
     const { createSuperdocVueApp } = await import('./create-app.js');
-    createSuperdocVueApp({ disablePiniaDevtools: true });
+    createSuperdocVueApp({ disablePiniaDevtools: false });
 
-    const replacement1 = [];
-    globalThis.__VUE_DEVTOOLS_PLUGINS__ = replacement1;
-    replacement1.push([{ id: 'dev.esm.pinia', app }, vi.fn()]);
-    expect(replacement1).toHaveLength(0);
+    const hook = globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__;
+    expect(hook.emit('devtools-plugin:setup', { id: 'dev.esm.pinia', app }, vi.fn())).toBe('emitted');
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
 
-    // Replace again — new queue should also get patched
-    const replacement2 = [];
-    globalThis.__VUE_DEVTOOLS_PLUGINS__ = replacement2;
-    replacement2.push([{ id: 'dev.esm.pinia', app }, vi.fn()]);
-    expect(replacement2).toHaveLength(0);
+  it('cleans up suppression state when app initialization throws', async () => {
+    const emitSpy = vi.fn(() => 'emitted');
+    globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__ = { emit: emitSpy };
+    const { app } = setupAppMocks();
+    app.use.mockImplementation(() => {
+      throw new Error('init failed');
+    });
+    const { createSuperdocVueApp } = await import('./create-app.js');
+    expect(() => createSuperdocVueApp({ disablePiniaDevtools: true })).toThrow('init failed');
+
+    const hook = globalThis.__VUE_DEVTOOLS_GLOBAL_HOOK__;
+    expect(hook.emit('devtools-plugin:setup', { id: 'dev.esm.pinia', app }, vi.fn())).toBe('emitted');
   });
 });

--- a/packages/superdoc/src/core/whiteboard/WhiteboardPage-deep.test.js
+++ b/packages/superdoc/src/core/whiteboard/WhiteboardPage-deep.test.js
@@ -50,12 +50,14 @@ const makeLayer = () => {
 
 const makeStage = () => {
   const stageListeners = new Map();
+  const layers = [];
   const stage = makeNode();
   stage.on = vi.fn((events, fn) => events.split(' ').forEach((e) => stageListeners.set(e, fn)));
-  stage.add = vi.fn();
+  stage.add = vi.fn((l) => layers.push(l));
   stage.size = vi.fn();
   stage.getPointerPosition = vi.fn(() => ({ x: 10, y: 10 }));
   stage._listeners = stageListeners;
+  stage._layers = layers;
   return stage;
 };
 
@@ -86,6 +88,9 @@ const makeRenderer = () => {
   return { Stage, Layer, Line, Text, Image, Transformer };
 };
 
+const mountedPages = [];
+const mountedContainers = [];
+
 const mountPage = (opts = {}) => {
   const renderer = opts.Renderer ?? makeRenderer();
   const page = new WhiteboardPage({
@@ -99,6 +104,8 @@ const mountPage = (opts = {}) => {
   const container = document.createElement('div');
   document.body.appendChild(container);
   page.mount(container);
+  mountedPages.push(page);
+  mountedContainers.push(container);
   return { page, renderer, container };
 };
 
@@ -123,6 +130,10 @@ describe('WhiteboardPage: image async + transform paths', () => {
   });
 
   afterEach(() => {
+    // Destroy mounted pages so the window keydown listeners they installed
+    // are removed. Leaking them across tests causes cross-test coupling.
+    while (mountedPages.length) mountedPages.pop().destroy();
+    while (mountedContainers.length) mountedContainers.pop().remove();
     window.Image = originalImage;
   });
 
@@ -133,7 +144,7 @@ describe('WhiteboardPage: image async + transform paths', () => {
     });
     page.render();
     // Flush microtasks so onload fires
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
     expect(renderer.Image).toHaveBeenCalled();
   });
 
@@ -151,7 +162,7 @@ describe('WhiteboardPage: image async + transform paths', () => {
     const { page, renderer } = mountPage();
     page.applyData({ images: [{ id: 'i1', xN: 0, yN: 0, src: '/x.png' }] });
     page.render();
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
     expect(renderer.Image).not.toHaveBeenCalled();
   });
 
@@ -161,7 +172,7 @@ describe('WhiteboardPage: image async + transform paths', () => {
       images: [{ id: 'i1', xN: 0.1, yN: 0.1, src: '/x.png', widthN: 0.5, heightN: 0.5 }],
     });
     page.render();
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
     const callsBefore = renderer.Image.mock.calls.length;
 
     // Re-render with same id — should update existing, not recreate
@@ -169,7 +180,7 @@ describe('WhiteboardPage: image async + transform paths', () => {
       images: [{ id: 'i1', xN: 0.2, yN: 0.2, src: '/x.png', widthN: 0.5, heightN: 0.5 }],
     });
     page.render();
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
     expect(renderer.Image.mock.calls.length).toBe(callsBefore);
   });
 
@@ -182,15 +193,17 @@ describe('WhiteboardPage: image async + transform paths', () => {
       ],
     });
     page.render();
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
+    const createdNodes = renderer.Image.mock.results.map((r) => r.value);
+    const i1Node = createdNodes.find((n) => n._whiteboardId === 'i1');
+    expect(i1Node).toBeDefined();
 
-    // Now remove i1
+    // Drop i1 from the model and re-render
     page.applyData({ images: [{ id: 'i2', xN: 0, yN: 0, src: '/b.png' }] });
     page.render();
-    await new Promise((r) => setTimeout(r, 0));
-    // i1 node should have been destroyed during renderImages cleanup; no assertion on count
-    // (Konva mock doesn't expose destroy counts per node id here) — just ensure render does not throw.
-    expect(true).toBe(true);
+    await Promise.resolve();
+    expect(i1Node.destroy).toHaveBeenCalled();
+    expect(page.images.map((i) => i.id)).toEqual(['i2']);
   });
 
   it('image node transformend recomputes normalized width/height/position', async () => {
@@ -198,7 +211,7 @@ describe('WhiteboardPage: image async + transform paths', () => {
     const { page, renderer } = mountPage({ onChange });
     page.applyData({ images: [{ id: 'i1', xN: 0, yN: 0, src: '/a.png' }] });
     page.render();
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
     const imageNode = renderer.Image.mock.results.at(-1).value;
     imageNode.scaleX(2);
     imageNode.scaleY(2);
@@ -218,7 +231,7 @@ describe('WhiteboardPage: image async + transform paths', () => {
     const { page, renderer } = mountPage({ onChange });
     page.applyData({ images: [{ id: 'i1', xN: 0, yN: 0, src: '/a.png' }] });
     page.render();
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
     const imageNode = renderer.Image.mock.results.at(-1).value;
     imageNode.x(50);
     imageNode.y(50);
@@ -227,15 +240,19 @@ describe('WhiteboardPage: image async + transform paths', () => {
     expect(page.images[0].xN).toBeCloseTo(0.5);
   });
 
-  it('clicking an image node selects it', async () => {
+  it('clicking an image node in select mode attaches a selection overlay', async () => {
     const { page, renderer } = mountPage();
     page.setTool('select');
     page.applyData({ images: [{ id: 'i1', xN: 0, yN: 0, src: '/a.png' }] });
     page.render();
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
     const imageNode = renderer.Image.mock.results.at(-1).value;
+    const stage = renderer.Stage.mock.results[0].value;
+    const layer = stage._layers[0];
+    const childCountBefore = layer._children.length;
     imageNode._listeners.get('click')({});
-    expect(renderer.Transformer).toHaveBeenCalled();
+    // Selection attaches a Transformer node to the visible layer
+    expect(layer._children.length).toBe(childCountBefore + 1);
   });
 
   it('text node transform keeps height fixed (text resize only horizontally)', () => {
@@ -326,7 +343,7 @@ describe('WhiteboardPage: image async + transform paths', () => {
     page.setTool('select');
     page.applyData({ images: [{ id: 'i1', xN: 0, yN: 0, src: '/a.png' }] });
     page.render();
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
     const imageNode = renderer.Image.mock.results.at(-1).value;
     imageNode._whiteboardId = 'i1';
     imageNode._listeners.get('click')({});

--- a/packages/superdoc/src/core/whiteboard/WhiteboardPage.test.js
+++ b/packages/superdoc/src/core/whiteboard/WhiteboardPage.test.js
@@ -659,14 +659,21 @@ describe('WhiteboardPage', () => {
     });
 
     it('ignores key presses from input/textarea target', () => {
-      const page = makePage();
+      const onChange = vi.fn();
+      const page = makePage({ onChange });
+      page.setSize({ width: 200, height: 300 });
+      page.applyData({
+        text: [{ id: 't1', xN: 0.1, yN: 0.2, content: 'hi', fontSizeN: 0.05 }],
+      });
       mountWithSize(page);
       const target = document.createElement('input');
       document.body.appendChild(target);
       const e = new KeyboardEvent('keydown', { key: 'Delete' });
       Object.defineProperty(e, 'target', { value: target });
       window.dispatchEvent(e);
-      expect(true).toBe(true); // no throw
+      // The text item was NOT deleted because the keydown came from an input element
+      expect(page.text.find((t) => t.id === 't1')).toBeDefined();
+      expect(onChange).not.toHaveBeenCalled();
       target.remove();
     });
   });


### PR DESCRIPTION
Follow-up to #2840, addressing review feedback from an external consultation of the new test suite.

**This PR stacks on top of #2840 — please merge #2840 first, then rebase this on main.**

- Replace tautological assertions (`expect(true).toBe(true)`) and does-not-throw placeholders with observable-state assertions
- Fix window keydown listener leak in WhiteboardPage-deep tests by destroying mounted pages in afterEach
- Rewrite the image-selection test to assert the overlay is attached to the visible layer, not just that the Transformer constructor was called
- Trim create-app-edges from 7 queue-mechanics tests to 4 outcome tests that survive refactors of the suppression strategy
- Migrate `setTimeout(r, 0)` microtask flushing to `await Promise.resolve()`
- codecov.yml: set project and patch targets to 90% (from `auto`) — avoids coverage-gaming incentives and sets a sustainable bar for new code

Coverage: 91.48% (vs 91.52% on #2840 — 0.04pp drop from trimming 3 implementation-detail tests, a deliberate trade for better test quality). All tests pass.