### PR TITLE
docs(toolbar): clarify how fonts work in SuperDoc

### DIFF
--- a/apps/docs/getting-started/fonts.mdx
+++ b/apps/docs/getting-started/fonts.mdx
@@ -1,7 +1,40 @@
 ---
-title: Font Support
+title: Font support
+sidebarTitle: Fonts
 ---
 
-Loading toolbar <a href="/modules/toolbar#font-configuration">font config</a>...
+A `.docx` file carries font *names*, not font data. Word renders documents correctly on desktop because Office bundles its own fonts — Cambria, Calibri, Aptos — with the application. Browsers don't have that library. If your page doesn't load a font, `font-family: Cambria` falls back to the browser's CSS generic (usually Arial or Helvetica).
 
-{(() => { window.location.href = '/modules/toolbar#font-configuration'; })()}
+SuperDoc doesn't load any fonts automatically. You decide what's available by loading web fonts on your host page and registering them in the toolbar.
+
+## Add a font
+
+Any font loaded on your host page is available to the editor. Register it in the toolbar so users can select it:
+
+```html
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap" />
+```
+
+```javascript
+new SuperDoc({
+  selector: '#editor',
+  document: 'contract.docx',
+  toolbar: '#toolbar',
+  modules: {
+    toolbar: {
+      fonts: [{ label: 'Inter', key: 'Inter, sans-serif' }]
+    }
+  }
+});
+```
+
+## Microsoft Office fonts
+
+Most `.docx` files use Cambria, Calibri, or Aptos. Those fonts ship with Word on desktop and aren't available to browsers. Google hosts free metric-compatible substitutes you can alias:
+
+| Office font | Free substitute |
+|---|---|
+| Calibri | [Carlito](https://fonts.google.com/specimen/Carlito) (metric-identical) |
+| Cambria | [Tinos](https://fonts.google.com/specimen/Tinos) or [Gelasio](https://fonts.google.com/specimen/Gelasio) |
+
+See [Font configuration](/modules/toolbar/built-in#font-configuration) for the `@font-face` alias pattern that maps the document's original font names to these substitutes.

--- a/apps/docs/getting-started/fonts.mdx
+++ b/apps/docs/getting-started/fonts.mdx
@@ -1,40 +1,7 @@
 ---
-title: Font support
-sidebarTitle: Fonts
+title: Font Support
 ---
 
-A `.docx` file carries font *names*, not font data. Word renders documents correctly on desktop because Office bundles its own fonts — Cambria, Calibri, Aptos — with the application. Browsers don't have that library. If your page doesn't load a font, `font-family: Cambria` falls back to the browser's CSS generic (usually Arial or Helvetica).
+Loading toolbar <a href="/modules/toolbar/built-in#font-configuration">font config</a>...
 
-SuperDoc doesn't load any fonts automatically. You decide what's available by loading web fonts on your host page and registering them in the toolbar.
-
-## Add a font
-
-Any font loaded on your host page is available to the editor. Register it in the toolbar so users can select it:
-
-```html
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap" />
-```
-
-```javascript
-new SuperDoc({
-  selector: '#editor',
-  document: 'contract.docx',
-  toolbar: '#toolbar',
-  modules: {
-    toolbar: {
-      fonts: [{ label: 'Inter', key: 'Inter, sans-serif' }]
-    }
-  }
-});
-```
-
-## Microsoft Office fonts
-
-Most `.docx` files use Cambria, Calibri, or Aptos. Those fonts ship with Word on desktop and aren't available to browsers. Google hosts free metric-compatible substitutes you can alias:
-
-| Office font | Free substitute |
-|---|---|
-| Calibri | [Carlito](https://fonts.google.com/specimen/Carlito) (metric-identical) |
-| Cambria | [Tinos](https://fonts.google.com/specimen/Tinos) or [Gelasio](https://fonts.google.com/specimen/Gelasio) |
-
-See [Font configuration](/modules/toolbar/built-in#font-configuration) for the `@font-face` alias pattern that maps the document's original font names to these substitutes.
+{(() => { window.location.href = '/modules/toolbar/built-in#font-configuration'; })()}

--- a/apps/docs/modules/toolbar/built-in.mdx
+++ b/apps/docs/modules/toolbar/built-in.mdx
@@ -323,23 +323,21 @@ Icons should be 24x24 viewBox SVGs with `fill="currentColor"` for proper theming
 
 ## Font configuration
 
+The toolbar dropdown lists only what you register in `fonts`. Imported documents don't auto-populate the list — if a user opens a `.docx` that uses Cambria and Cambria isn't registered, the current-selection indicator shows "Cambria" but the user can't pick it from the dropdown.
+
 <ParamField path="fonts" type="Array">
   <Expandable title="Font object properties">
     <ParamField path="label" type="string" required>
-      Display name
+      Display name shown in the dropdown
     </ParamField>
     <ParamField path="key" type="string" required>
-      Font-family CSS value
+      Font-family CSS value applied to text
     </ParamField>
     <ParamField path="fontWeight" type="number">
       Font weight
     </ParamField>
   </Expandable>
 </ParamField>
-
-<Info>
-SuperDoc does not load fonts automatically. Custom fonts from imported DOCX files will display in the toolbar, but won't be selectable unless you load them in your application (via CSS `@font-face`, Google Fonts, etc.) and add them to the `fonts` array.
-</Info>
 
 ```javascript
 fonts: [
@@ -348,6 +346,55 @@ fonts: [
   { label: 'Brand Font', key: 'BrandFont, sans-serif', fontWeight: 400 }
 ]
 ```
+
+<Info>
+  Registering a font in `fonts` makes it **selectable**. It doesn't load any font files. To make the font actually render with its real glyphs, load it on your host page via `@font-face` or a `<link>` to a font service. Fonts the browser can't find fall back to the CSS generic.
+</Info>
+
+### Loading web fonts
+
+Any font loaded on your host page is available inside the editor. Load it, then register it in `fonts`:
+
+```html
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap" />
+```
+
+```javascript
+modules: {
+  toolbar: {
+    fonts: [{ label: 'Inter', key: 'Inter, sans-serif' }]
+  }
+}
+```
+
+### Substituting Microsoft Office fonts
+
+Most `.docx` files use Cambria, Calibri, or Aptos — fonts bundled with Word on desktop but not present in browsers. Google hosts free metric-compatible replacements:
+
+| Office font | Free substitute | Notes |
+|---|---|---|
+| Calibri | [Carlito](https://fonts.google.com/specimen/Carlito) | Sans-serif, metric-identical — designed as a direct drop-in |
+| Cambria | [Tinos](https://fonts.google.com/specimen/Tinos) or [Gelasio](https://fonts.google.com/specimen/Gelasio) | Serif |
+| Aptos | [Carlito](https://fonts.google.com/specimen/Carlito) or [Inter](https://fonts.google.com/specimen/Inter) | Sans-serif — no free metric-identical match exists yet |
+
+Download the `.woff2` files from Google Fonts, host them with your app, and alias each substitute to the original Word name via `@font-face`. The browser will then render real Carlito/Tinos glyphs whenever the document asks for Calibri/Cambria — no document or SuperDoc changes needed.
+
+```html
+<style>
+  @font-face {
+    font-family: 'Calibri';
+    src: url('/fonts/Carlito-Regular.woff2') format('woff2');
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'Cambria';
+    src: url('/fonts/Tinos-Regular.woff2') format('woff2');
+    font-display: swap;
+  }
+</style>
+```
+
+Self-hosting the `.woff2` files is more reliable than linking to Google Fonts CDN URLs directly — those URLs change when Google updates a font version.
 
 ## Responsive behavior
 


### PR DESCRIPTION
A `.docx` carries font names, not font data. Consumers hit this constantly — most commonly when a document uses Cambria/Calibri/Aptos and the rendered text falls back to Helvetica in the browser because those fonts ship with Office, not with the docx or with browsers. The existing docs made this worse: `getting-started/fonts` was an empty redirect stub, and the toolbar `Font configuration` section had an Info callout claiming imported DOCX fonts auto-populate the dropdown (they don't).

- Rewrites `getting-started/fonts` into a real page: explains the `.docx` font model, shows how to add a font, and points at the Office-font substitute pattern.
- Rewrites the toolbar `Font configuration` section to separate two concerns cleanly: **registration** (selectability via `fonts`) vs. **loading** (real glyphs via `@font-face` or `<link>`).
- Adds a working `@font-face` alias example and a table of free metric-compatible substitutes (Carlito for Calibri, Tinos/Gelasio for Cambria, Carlito/Inter for Aptos).

**Verified in practice**: instrumented the dev app to load Carlito + Tinos via `@font-face` aliasing `Calibri` → Carlito and `Cambria` → Tinos. `document.fonts` reports both as `loaded`, and canvas-measurement confirms the aliased names now resolve to real glyphs instead of the sans-serif fallback.

**Rejected**: recommending consumers license Cambria/Calibri directly from Microsoft (possible but restricted and rarely worth it); recommending SuperDoc ship its own font library (against the existing "you control what fonts are available" philosophy).

**Review**: confirm the Office-font substitute table is accurate, especially the Aptos row (no free metric-identical match exists — I list Carlito/Inter as reasonable stand-ins).