### PR TITLE
fix(test): update tracked-replace assertion to match word-diff behavior

### DIFF
--- a/tests/behavior/tests/comments/programmatic-tracked-change.spec.ts
+++ b/tests/behavior/tests/comments/programmatic-tracked-change.spec.ts
@@ -60,7 +60,12 @@ test('tracked replace via document-api', async ({ superdoc }) => {
   assertMutationSucceeded('replaceText', receipt);
   await superdoc.waitForStable();
 
-  await expect.poll(() => getDocumentText(superdoc.page)).toContain('new fancy');
+  // word-diff (PR #2817) fragments multi-word tracked replacements into per-word
+  // insert/delete pairs, so "new fancy" appears as two separate inserts around
+  // the surviving space token. Assert both inserted words are present rather
+  // than a contiguous substring, which was the pre-word-diff assumption.
+  await expect.poll(() => getDocumentText(superdoc.page)).toContain('new');
+  await expect.poll(() => getDocumentText(superdoc.page)).toContain('fancy');
   await assertTrackChangeTypeCount(superdoc, 'insert');
 
   await superdoc.snapshot('programmatic-tc-replaced');


### PR DESCRIPTION
The \`tracked replace via document-api\` behavior test has been red on main across all three browsers since #2817 (word-level diffing) landed. Word-diff intentionally fragments multi-word tracked replacements into per-word insert/delete pairs, so "new fancy" is no longer a contiguous substring in the document — the test just wasn't updated alongside the feature.

- Replace the \`.toContain('new fancy')\` assertion with individual \`.toContain('new')\` and \`.toContain('fancy')\` checks, matching the new per-word change shape.
- Leave a short comment pointing at #2817 so future readers don't have to dig through history.
- Other tests in the file (\`tracked delete\`, \`direct insert\`, \`tracked insert at cursor\`, \`addToHistory:false\`) all still pass — ran the whole file in chromium locally.

**Rejected**: changing word-diff itself (splits multi-word replacements on purpose for granular tracked changes — behaviour feels right, test was stale).