### PR TITLE
feat(math): expose equation font via --sd-math-font-family (SD-2634)

### DIFF
--- a/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.test.ts
@@ -40,6 +40,19 @@ describe('convertOmmlToMathml', () => {
     expect(mi!.textContent).toBe('x');
   });
 
+  it('emits font-family via --sd-math-font-family with Cambria Math fallback (SD-2634)', () => {
+    // Consumers override the math font via the --sd-math-font-family CSS
+    // variable. When the variable is unset, the var() fallback resolves to
+    // Cambria Math so embedders of the painter without the superdoc
+    // stylesheet still render correctly.
+    const omml = {
+      name: 'm:oMath',
+      elements: [{ name: 'm:r', elements: [{ name: 'm:t', elements: [{ type: 'text', text: 'x' }] }] }],
+    };
+    const result = convertOmmlToMathml(omml, doc);
+    expect(result!.getAttribute('style')).toBe('font-family: var(--sd-math-font-family, "Cambria Math", math)');
+  });
+
   it('classifies numbers as <mn>', () => {
     const omml = {
       name: 'm:oMath',

--- a/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.ts
+++ b/packages/layout-engine/painters/dom/src/features/math/omml-to-mathml.ts
@@ -177,7 +177,10 @@ export function convertOmmlToMathml(ommlJson: unknown, doc: Document): Element |
 
   const root = ommlJson as OmmlJsonNode;
   const mathEl = doc.createElementNS(MATHML_NS, 'math');
-  mathEl.setAttribute('style', 'font-family: "Cambria Math", math');
+  // Fallback chain covers consumers that embed painter-dom without the
+  // superdoc stylesheet — the `var()` still resolves to Cambria Math then
+  // the generic `math` family.
+  mathEl.setAttribute('style', 'font-family: var(--sd-math-font-family, "Cambria Math", math)');
 
   if (root.name === 'm:oMathPara') {
     mathEl.setAttribute('display', 'block');

--- a/packages/superdoc/src/assets/styles/helpers/variables.css
+++ b/packages/superdoc/src/assets/styles/helpers/variables.css
@@ -295,4 +295,7 @@
   --sd-proofing-style-color: #805ad5;
   --sd-proofing-underline-thickness: 1.5px;
   --sd-proofing-underline-offset: 2px;
+
+  /* Math: rendered equation font */
+  --sd-math-font-family: 'Cambria Math', math;
 }


### PR DESCRIPTION
Consumer CSS couldn't override the hardcoded `font-family: "Cambria Math", math` on rendered `<math>` elements without `!important`. Swaps the inline style to `var(--sd-math-font-family, "Cambria Math", math)` and registers the token with the existing Cambria Math default in `variables.css`. Painter-dom embedders that don't ship the superdoc stylesheet still get the same rendering via the var() fallback — no behavior change for anyone who doesn't opt in.

**Rejected**: dropping the inline style entirely in favor of a stylesheet rule. The painter-dom bundle is consumed standalone by some integrations (MCP/CLI rendering pipelines) without the main superdoc CSS, so the inline `var()` + fallback is the only place the default reliably lands for all consumers.
**Review**: token placement in `variables.css` — I put it next to `--sd-proofing-*` since it's document-content tier, not UI. Open to moving it.
**Verified**: 184/184 unit (+1 regression test pinning the style attribute), 74/74 math behavior tests, type-check clean.