### PR TITLE
fix(style-engine): fall back to built-in defaults for Heading1-9 (#2805)

### DIFF
--- a/packages/layout-engine/style-engine/src/ooxml/built-in-styles.ts
+++ b/packages/layout-engine/style-engine/src/ooxml/built-in-styles.ts
@@ -1,0 +1,96 @@
+/**
+ * Built-in (latent) Word style defaults.
+ *
+ * Word ships with ~260 built-in style ids that documents are allowed to reference
+ * without including a matching `w:style` entry in `styles.xml`. ECMA-376 §17.7.4.9
+ * expects a reading application to fall back to the built-in defaults in that case.
+ *
+ * In the wild this happens with documents emitted by python-docx, pandoc and other
+ * generators: they set `<w:pStyle w:val="Heading1"/>` on a paragraph but never write
+ * the corresponding style block, and SuperDoc was rendering the headings as plain
+ * body text (issue #2805).
+ *
+ * The values below mirror the Word 2016+ default template (Calibri / Calibri Light
+ * with the standard blue accents). They intentionally cover only the most common
+ * case — Heading 1 through Heading 9 — since those are the ones that actually move
+ * the needle for users. Other latent styles can be added on demand.
+ *
+ * Each definition has `basedOn: 'Normal'`, so the existing cascade keeps working
+ * naturally: if the document does define `Normal`, those properties still flow in,
+ * and if it doesn't, the chain just terminates without throwing.
+ */
+
+import type { StyleDefinition } from './styles-types.ts';
+
+/** Half-points (Word's `w:sz` unit). 28 → 14pt, 26 → 13pt, etc. */
+const HP = (pt: number): number => Math.round(pt * 2);
+
+/** Twentieths of a point (Word's `w:before` / `w:after` unit). */
+const TWIPS = (pt: number): number => Math.round(pt * 20);
+
+const HEADING_BLUE = '2F5496';
+const HEADING_DARK_BLUE = '1F3864';
+const HEADING_DARK_GREY = '272727';
+
+const buildHeading = (
+  level: number,
+  fontSize: number,
+  color: string,
+  options: { bold?: boolean; italic?: boolean; spacingBeforePt?: number } = {},
+): StyleDefinition => {
+  const { bold = false, italic = false, spacingBeforePt = 2 } = options;
+  return {
+    type: 'paragraph',
+    styleId: `Heading${level}`,
+    name: `heading ${level}`,
+    basedOn: 'Normal',
+    next: 'Normal',
+    qFormat: true,
+    uiPriority: 9,
+    paragraphProperties: {
+      keepNext: true,
+      keepLines: true,
+      spacing: { before: TWIPS(spacingBeforePt), after: 0 },
+      outlineLvl: level - 1,
+    },
+    runProperties: {
+      ...(bold ? { bold: true } : {}),
+      ...(italic ? { italic: true } : {}),
+      fontSize: HP(fontSize),
+      color: { val: color },
+    },
+  };
+};
+
+/**
+ * Word 2016+ default heading styles.
+ * Heading 1 gets a more generous spacing-before; the lower levels share the
+ * tighter 2pt spacing the Office template uses.
+ */
+const BUILT_IN_STYLES: Readonly<Record<string, StyleDefinition>> = {
+  Heading1: buildHeading(1, 14, HEADING_BLUE, { bold: true, spacingBeforePt: 12 }),
+  Heading2: buildHeading(2, 13, HEADING_BLUE, { bold: true }),
+  Heading3: buildHeading(3, 12, HEADING_DARK_BLUE, { bold: true }),
+  Heading4: buildHeading(4, 11, HEADING_BLUE, { bold: true, italic: true }),
+  Heading5: buildHeading(5, 11, HEADING_BLUE, { bold: true }),
+  Heading6: buildHeading(6, 11, HEADING_DARK_BLUE, { bold: true }),
+  Heading7: buildHeading(7, 11, HEADING_DARK_BLUE, { italic: true }),
+  Heading8: buildHeading(8, 10.5, HEADING_DARK_GREY),
+  Heading9: buildHeading(9, 10.5, HEADING_DARK_GREY, { italic: true }),
+};
+
+/**
+ * Returns the built-in `StyleDefinition` for a well-known styleId, or `undefined`
+ * if `styleId` is not one of the recognized latent styles.
+ *
+ * The returned object is owned by this module — callers must not mutate it.
+ */
+export function getBuiltInStyleDefinition(styleId: string | undefined): StyleDefinition | undefined {
+  if (!styleId) return undefined;
+  return BUILT_IN_STYLES[styleId];
+}
+
+/** Test-only: list of styleIds that have a built-in default. */
+export function listBuiltInStyleIds(): string[] {
+  return Object.keys(BUILT_IN_STYLES);
+}

--- a/packages/layout-engine/style-engine/src/ooxml/index.test.ts
+++ b/packages/layout-engine/style-engine/src/ooxml/index.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'bun:test';
 import {
   DEFAULT_TBL_LOOK,
+  getBuiltInStyleDefinition,
+  listBuiltInStyleIds,
   resolveStyleChain,
   getNumberingProperties,
   resolveDocxFontFamily,
@@ -59,6 +61,104 @@ describe('ooxml - resolveStyleChain', () => {
     const params = buildParams();
     const result = resolveStyleChain('runProperties', params, 'MissingStyle');
     expect(result).toEqual({});
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Built-in (latent) style fallback — issue #2805
+//
+// python-docx, pandoc and similar generators reference Heading1..Heading9
+// without writing the matching <w:style> blocks. ECMA-376 §17.7.4.9 expects
+// readers to fall back to Word's built-in defaults; without the fallback,
+// SuperDoc rendered those headings as plain body text.
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ooxml - built-in heading style fallback (#2805)', () => {
+  it('falls back to built-in Heading1 run props when styles.xml has no Heading1 entry', () => {
+    const params = buildParams();
+    const runProps = resolveStyleChain('runProperties', params, 'Heading1');
+    // Word's default Heading 1 is a 14pt bold blue heading.
+    expect(runProps.bold).toBe(true);
+    expect(runProps.fontSize).toBe(28); // half-points = 14pt
+    expect(runProps.color).toEqual({ val: '2F5496' });
+  });
+
+  it('falls back to built-in Heading1 paragraph props (spacing, outline, keep-together)', () => {
+    const params = buildParams();
+    const pPr = resolveStyleChain('paragraphProperties', params, 'Heading1');
+    expect(pPr.keepNext).toBe(true);
+    expect(pPr.keepLines).toBe(true);
+    expect(pPr.outlineLvl).toBe(0);
+    expect(pPr.spacing?.before).toBe(240); // 12pt in twips
+  });
+
+  it('provides defaults for every Heading1..Heading9', () => {
+    const params = buildParams();
+    for (let level = 1; level <= 9; level++) {
+      const styleId = `Heading${level}`;
+      const pPr = resolveStyleChain('paragraphProperties', params, styleId);
+      const rPr = resolveStyleChain('runProperties', params, styleId);
+      expect(pPr.outlineLvl, `${styleId} outlineLvl`).toBe(level - 1);
+      expect(rPr.fontSize, `${styleId} fontSize`).toBeGreaterThan(0);
+    }
+  });
+
+  it('document-defined Heading1 still wins over the built-in default', () => {
+    const params = buildParams({
+      translatedLinkedStyles: {
+        ...emptyStyles,
+        styles: {
+          Heading1: { runProperties: { fontSize: 99, color: { val: 'FF00FF' } } },
+        },
+      },
+    });
+    const result = resolveStyleChain('runProperties', params, 'Heading1');
+    // Document override takes priority — no leakage of the 28/2F5496 defaults.
+    expect(result.fontSize).toBe(99);
+    expect(result.color).toEqual({ val: 'FF00FF' });
+    expect(result.bold).toBeUndefined();
+  });
+
+  it('still returns empty object for unknown styleIds (no false positives)', () => {
+    const params = buildParams();
+    expect(resolveStyleChain('runProperties', params, 'NotAHeading')).toEqual({});
+    expect(resolveStyleChain('runProperties', params, 'Heading10')).toEqual({});
+    expect(resolveStyleChain('runProperties', params, 'heading1')).toEqual({}); // case-sensitive
+  });
+
+  it('built-in basedOn=Normal still picks up document Normal properties', () => {
+    const params = buildParams({
+      translatedLinkedStyles: {
+        ...emptyStyles,
+        styles: {
+          Normal: { default: true, runProperties: { fontFamily: { ascii: 'Calibri' } } },
+        },
+      },
+    });
+    // Heading1 isn't defined, but its built-in basedOn='Normal' chains into the
+    // document's Normal so the heading inherits the project font.
+    const result = resolveStyleChain('runProperties', params, 'Heading1');
+    expect(result.bold).toBe(true);
+    expect(result.fontSize).toBe(28);
+    expect(result.fontFamily).toEqual({ ascii: 'Calibri' });
+  });
+
+  it('rendering as a paragraph: built-in Heading1 produces visible heading formatting end-to-end', () => {
+    // Reproduces the python-docx scenario from #2805: a paragraph references
+    // Heading1 by styleId only, and styles.xml has no Heading1 block.
+    const params = buildParams();
+    const result = resolveParagraphProperties(params, { styleId: 'Heading1' }, null);
+    expect(result.outlineLvl).toBe(0);
+    expect(result.spacing?.before).toBe(240);
+    expect(result.keepNext).toBe(true);
+  });
+
+  it('exposes the built-in catalog via the public helper', () => {
+    expect(getBuiltInStyleDefinition('Heading1')?.styleId).toBe('Heading1');
+    expect(getBuiltInStyleDefinition('NotAHeading')).toBeUndefined();
+    expect(getBuiltInStyleDefinition(undefined)).toBeUndefined();
+    expect(listBuiltInStyleIds()).toContain('Heading1');
+    expect(listBuiltInStyleIds()).toContain('Heading9');
   });
 });
 

--- a/packages/layout-engine/style-engine/src/ooxml/index.ts
+++ b/packages/layout-engine/style-engine/src/ooxml/index.ts
@@ -17,6 +17,7 @@ import type {
   TableLookProperties,
   TableCellProperties,
 } from './styles-types.ts';
+import { getBuiltInStyleDefinition } from './built-in-styles.js';
 
 export { combineIndentProperties, combineProperties, combineRunProperties };
 export type { PropertyObject };
@@ -35,6 +36,7 @@ export {
   resolvePreferredNewTableStyleId,
 } from './table-style-selection.js';
 export type { ResolvedStyle, ResolvedStyleSource } from './table-style-selection.js';
+export { getBuiltInStyleDefinition, listBuiltInStyleIds } from './built-in-styles.js';
 
 export interface OoxmlResolverParams {
   translatedNumbering: NumberingProperties | null | undefined;
@@ -272,6 +274,15 @@ export function resolveParagraphProperties(
   return finalProps;
 }
 
+/**
+ * Look up a style definition by id, preferring the document's own styles and
+ * falling back to Word's built-in latent style defaults (e.g. Heading1..Heading9
+ * when the generator omitted them, see #2805 / ECMA-376 §17.7.4.9).
+ */
+function lookupStyleDefinition(params: OoxmlResolverParams, styleId: string): StyleDefinition | undefined {
+  return params.translatedLinkedStyles?.styles?.[styleId] ?? getBuiltInStyleDefinition(styleId);
+}
+
 export function resolveStyleChain<T extends PropertyObject>(
   propertyType: 'paragraphProperties' | 'runProperties' | 'tableProperties',
   params: OoxmlResolverParams,
@@ -280,7 +291,7 @@ export function resolveStyleChain<T extends PropertyObject>(
 ): T {
   if (!styleId) return {} as T;
 
-  const styleDef = params.translatedLinkedStyles?.styles?.[styleId];
+  const styleDef = lookupStyleDefinition(params, styleId);
   if (!styleDef) return {} as T;
 
   const styleProps = (styleDef[propertyType as keyof typeof styleDef] ?? {}) as T;
@@ -294,7 +305,7 @@ export function resolveStyleChain<T extends PropertyObject>(
       break;
     }
     seenStyles.add(nextBasedOn as string);
-    const basedOnStyleDef = params.translatedLinkedStyles?.styles?.[nextBasedOn];
+    const basedOnStyleDef = lookupStyleDefinition(params, nextBasedOn);
     const basedOnProps = basedOnStyleDef?.[propertyType as keyof typeof basedOnStyleDef] as T;
 
     if (basedOnProps && Object.keys(basedOnProps).length) {


### PR DESCRIPTION
Closes #2805.

## What's going on

Word documents created by python-docx, pandoc and a few other generators set
`<w:pStyle w:val="Heading1"/>` on paragraphs without writing the matching
`<w:style>` block in `styles.xml`. ECMA-376 §17.7.4.9 says applications should
fall back to the built-in (latent) defaults for these well-known styleIds, but
`resolveStyleChain` was returning `{}` and headings were rendering as plain body
text — no bold, no spacing, no outline level.

## What this PR does

- Adds a small `built-in-styles.ts` module with the Word 2016+ defaults for
  `Heading1` through `Heading9` (Calibri / Calibri Light, the standard blue
  accents, `keepNext` / `keepLines` / `outlineLvl`, the usual spacing).
- Wires `resolveStyleChain` through a tiny `lookupStyleDefinition` helper that
  prefers the document's own `styles` and only falls back to the built-in
  catalog when the document doesn't define the style. Both the initial lookup
  and the `basedOn` walk go through the same helper, so a built-in
  `basedOn: 'Normal'` will pick up the document's `Normal` properties
  automatically.

## Why it's safe

- Document-defined styles still take priority (covered by a regression test).
- Unknown styleIds (`NotAHeading`, `Heading10`, lowercase variants) still
  return `{}` — we don't paper over unrelated bugs.
- The `basedOn` chain still terminates safely: if `Normal` isn't defined
  anywhere, the loop just exits without throwing.
- Built-in objects are not mutated by `combineProperties` (which spreads into a
  fresh object), so sharing them between calls is fine.

## Tests

8 new tests in `packages/layout-engine/style-engine/src/ooxml/index.test.ts`:

- `Heading1` falls back to built-in run + paragraph properties when missing.
- All `Heading1`..`Heading9` produce sensible defaults (`outlineLvl`, font size).
- Document-defined `Heading1` still wins over the built-in default.
- Unknown styleIds still return `{}`.
- Built-in `basedOn: 'Normal'` chains into the document's `Normal` style.
- End-to-end: `resolveParagraphProperties({ styleId: 'Heading1' })` produces
  visible heading formatting.
- Public helpers (`getBuiltInStyleDefinition`, `listBuiltInStyleIds`) behave.

```
bun test src/ooxml/index.test.ts
73 pass / 0 fail / 140 expect()
```

Full package suite (`bun test`) is green: 137/137.

## Repro

```python
from docx import Document
d = Document()
d.add_heading('Title', level=1)
d.add_heading('Sub',   level=2)
d.add_paragraph('Body')
d.save('repro.docx')
```

Before this PR: all three paragraphs render with body styling.
After: Heading 1/2 get the standard Word heading look.
