### PR TITLE
fix: via.placeholder.com shut down in 2024 (now connection-refused)

### DIFF
--- a/apps/docs/snippets/extensions/node-resizer.mdx
+++ b/apps/docs/snippets/extensions/node-resizer.mdx
@@ -6,7 +6,7 @@ import { SuperDocEditor } from '/snippets/components/superdoc-editor.jsx'
 
 <SuperDocEditor
   html={`<p>Select an image to see resize handles:</p>
-<p><img src="https://via.placeholder.com/300x200" alt="Sample image" /></p>
+<p><img src="https://placehold.co/300x200" alt="Sample image" /></p>
 <p>Drag the corner handles to resize. The aspect ratio is automatically maintained.</p>`}
   height="400px"
 />


### PR DESCRIPTION
`apps/docs/snippets/extensions/node-resizer.mdx` references `via.placeholder.com/...` URLs. The service was shut down in 2024 and the DNS record no longer resolves.

---

#### Why this is needed

`via.placeholder.com` was shut down in 2024 and its DNS record no longer resolves — every request now hangs or returns a connection error. Browsers render a broken-image icon in place of the intended placeholder.

Verify in any shell:

```
curl -sI --max-time 3 https://via.placeholder.com/300x200 || echo 'connection refused / DNS gone'
```

#### What this PR changes

Fixes the `<img>` in the node-resizer extension docs snippet so the resize-handles demo renders a real image users can drag to resize.

#### Replacement details

Docs-only. Same 300×200 dimensions. Node-resizer's value prop depends on the reader actually seeing an image to resize — a broken image defeats the demo.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** introduced as a dependency by this PR — the diff uses the dependency-free canonical replacement domain. If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering the broader broken-placeholder landscape: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
