### PR TITLE
feat(layout-engine): resolve PAGEREF tokens in incrementalLayout loop

### DIFF
--- a/packages/layout-engine/layout-bridge/src/featureFlags.ts
+++ b/packages/layout-engine/layout-bridge/src/featureFlags.ts
@@ -65,6 +65,13 @@ export const FeatureFlags = {
   BODY_PAGE_TOKENS: isEnabled('SD_BODY_PAGE_TOKENS', true),
 
   /**
+   * Enable PAGEREF token resolution so TOC entries and other cross-reference
+   * page numbers refresh after edits that change pagination. When disabled,
+   * PAGEREF runs render the text Word baked in at DOCX export time.
+   */
+  BODY_PAGEREFS: isEnabled('SD_BODY_PAGEREFS', true),
+
+  /**
    * Enable header/footer page token resolution.
    * When disabled, headers/footers use painter-time token rendering fallback.
    */

--- a/packages/layout-engine/layout-bridge/src/incrementalLayout.ts
+++ b/packages/layout-engine/layout-bridge/src/incrementalLayout.ts
@@ -17,6 +17,8 @@ import {
   type HeaderFooterConstraints,
   computeDisplayPageNumber,
   resolvePageNumberTokens,
+  buildAnchorMap,
+  resolvePageRefTokens,
   type NumberingContext,
   SEMANTIC_PAGE_HEIGHT_PX,
   SINGLE_COLUMN_DEFAULT,
@@ -749,6 +751,7 @@ export async function incrementalLayout(
     measure?: HeaderFooterMeasureFn;
   },
   previousMeasures?: Measure[] | null,
+  bookmarks?: Map<string, number>,
 ): Promise<IncrementalLayoutResult> {
   const isSemanticFlow = options.flowMode === 'semantic';
 
@@ -1120,8 +1123,11 @@ export async function incrementalLayout(
   let totalRelayoutTime = 0;
   let converged = true;
 
-  // Only run token resolution if feature flag is enabled
-  if (!isSemanticFlow && FeatureFlags.BODY_PAGE_TOKENS) {
+  // Only run token resolution if at least one resolver is enabled.
+  const runPageTokens = !isSemanticFlow && FeatureFlags.BODY_PAGE_TOKENS;
+  const runPageRefs = !isSemanticFlow && FeatureFlags.BODY_PAGEREFS && !!bookmarks && bookmarks.size > 0;
+
+  if (runPageTokens || runPageRefs) {
     while (iteration < maxIterations) {
       // Build numbering context from current layout
       const sections = options.sectionMetadata ?? [];
@@ -1130,28 +1136,48 @@ export async function incrementalLayout(
       // Log iteration start
       PageTokenLogger.logIterationStart(iteration, layout.pages.length);
 
-      // Resolve page number tokens
-      const tokenResult = resolvePageNumberTokens(layout, currentBlocks, currentMeasures, numberingCtx);
+      // Resolve page number tokens (PAGE/NUMPAGES)
+      const tokenResult = runPageTokens
+        ? resolvePageNumberTokens(layout, currentBlocks, currentMeasures, numberingCtx)
+        : { affectedBlockIds: new Set<string>(), updatedBlocks: new Map<string, FlowBlock>() };
+
+      // Resolve PAGEREF tokens (cross-references to bookmarks) using the same
+      // convergence loop: changes in either resolver kind can shift page counts
+      // and require another round of re-measure + re-layout before stability.
+      const pageRefResult = runPageRefs
+        ? resolvePageRefTokens(currentBlocks, buildAnchorMap(bookmarks!, layout))
+        : { affectedBlockIds: new Set<string>(), updatedBlocks: new Map<string, FlowBlock>() };
+
+      const affectedBlockIds = new Set<string>([...tokenResult.affectedBlockIds, ...pageRefResult.affectedBlockIds]);
 
       // Check for convergence
-      if (tokenResult.affectedBlockIds.size === 0) {
+      if (affectedBlockIds.size === 0) {
         perfLog(`[Perf] 4.3 Page token resolution converged after ${iteration} iterations`);
         break;
       }
 
-      perfLog(`[Perf] 4.3.${iteration + 1} Page tokens resolved: ${tokenResult.affectedBlockIds.size} blocks affected`);
+      perfLog(
+        `[Perf] 4.3.${iteration + 1} Page tokens resolved: ${tokenResult.affectedBlockIds.size} PAGE + ${pageRefResult.affectedBlockIds.size} PAGEREF blocks affected`,
+      );
 
       // Log affected blocks
-      const blockSamples = Array.from(tokenResult.affectedBlockIds).slice(0, 5) as string[];
-      PageTokenLogger.logAffectedBlocks(iteration, tokenResult.affectedBlockIds, blockSamples);
+      const blockSamples = Array.from(affectedBlockIds).slice(0, 5) as string[];
+      PageTokenLogger.logAffectedBlocks(iteration, affectedBlockIds, blockSamples);
 
-      totalAffectedBlocks += tokenResult.affectedBlockIds.size;
+      totalAffectedBlocks += affectedBlockIds.size;
 
-      // Apply updated blocks
-      currentBlocks = currentBlocks.map((block) => tokenResult.updatedBlocks.get(block.id) ?? block);
+      // Apply updated blocks. A single block may be updated by both resolvers
+      // (e.g. a header containing both a PAGE token and a PAGEREF) — merge
+      // their run changes so neither overwrites the other.
+      currentBlocks = currentBlocks.map((block) => {
+        const tokenClone = tokenResult.updatedBlocks.get(block.id);
+        const pageRefClone = pageRefResult.updatedBlocks.get(block.id);
+        if (tokenClone && pageRefClone) return mergeRunUpdates(block, tokenClone, pageRefClone);
+        return tokenClone ?? pageRefClone ?? block;
+      });
 
       // Invalidate cache for affected blocks
-      measureCache.invalidate(Array.from(tokenResult.affectedBlockIds));
+      measureCache.invalidate(Array.from(affectedBlockIds));
 
       // Re-measure affected blocks using per-section constraints
       const remeasureStart = performance.now();
@@ -1159,7 +1185,7 @@ export async function incrementalLayout(
       currentMeasures = await remeasureAffectedBlocks(
         currentBlocks,
         currentMeasures,
-        tokenResult.affectedBlockIds,
+        affectedBlockIds,
         currentPerSectionConstraints,
         measureBlock,
         measureCache,
@@ -1168,7 +1194,7 @@ export async function incrementalLayout(
       const remeasureTime = remeasureEnd - remeasureStart;
       totalRemeasureTime += remeasureTime;
       perfLog(`[Perf] 4.3.${iteration + 1}.1 Re-measure: ${remeasureTime.toFixed(2)}ms`);
-      PageTokenLogger.logRemeasure(tokenResult.affectedBlockIds.size, remeasureTime);
+      PageTokenLogger.logRemeasure(affectedBlockIds.size, remeasureTime);
 
       // Check if page count has stabilized
       const oldPageCount = layout.pages.length;
@@ -2315,4 +2341,29 @@ async function remeasureAffectedBlocks(
   }
 
   return updatedMeasures;
+}
+
+/**
+ * Merge two clones of the same block produced by independent token resolvers
+ * (resolvePageNumberTokens + resolvePageRefTokens). Each resolver clones the
+ * block but only modifies runs it understood, so a paragraph containing BOTH
+ * a PAGE token and a PAGEREF token would lose one of the two updates if we
+ * picked a single clone.
+ *
+ * Strategy: take the original block's run array and, for each run, prefer the
+ * version from whichever clone actually changed it (identified by !== run).
+ * Falls back to the first clone's run when neither is distinguishable.
+ */
+function mergeRunUpdates(original: FlowBlock, a: FlowBlock, b: FlowBlock): FlowBlock {
+  if (original.kind !== 'paragraph' || a.kind !== 'paragraph' || b.kind !== 'paragraph') {
+    return a;
+  }
+  const runs = original.runs.map((origRun, i) => {
+    const aRun = a.runs[i];
+    const bRun = b.runs[i];
+    if (aRun !== origRun) return aRun;
+    if (bRun !== origRun) return bRun;
+    return origRun;
+  });
+  return { ...a, runs };
 }

--- a/packages/layout-engine/layout-engine/src/resolvePageRefs.test.ts
+++ b/packages/layout-engine/layout-engine/src/resolvePageRefs.test.ts
@@ -174,16 +174,23 @@ describe('resolvePageRefTokens', () => {
 
     const anchorMap = new Map([['_Toc1', 5]]);
 
-    const affectedBlockIds = resolvePageRefTokens(blocks, anchorMap);
+    const { affectedBlockIds, updatedBlocks } = resolvePageRefTokens(blocks, anchorMap);
 
     expect(affectedBlockIds.size).toBe(1);
     expect(affectedBlockIds.has('0-paragraph')).toBe(true);
-    const block = blocks[0];
-    if (block.kind === 'paragraph') {
-      expect((block.runs[1] as { text?: string }).text).toBe('5');
-      // Verify token metadata is cleared after resolution
-      expect((block.runs[1] as { token?: string }).token).toBeUndefined();
-      expect((block.runs[1] as { pageRefMetadata?: unknown }).pageRefMetadata).toBeUndefined();
+    // Original block should not be mutated.
+    const original = blocks[0];
+    if (original.kind === 'paragraph') {
+      expect((original.runs[1] as { text?: string }).text).toBe('??');
+      expect((original.runs[1] as { token?: string }).token).toBe('pageReference');
+    }
+    // Updated (cloned) block has the resolved text + stripped token metadata.
+    const updated = updatedBlocks.get('0-paragraph');
+    expect(updated).toBeDefined();
+    if (updated && updated.kind === 'paragraph') {
+      expect((updated.runs[1] as { text?: string }).text).toBe('5');
+      expect((updated.runs[1] as { token?: string }).token).toBeUndefined();
+      expect((updated.runs[1] as { pageRefMetadata?: unknown }).pageRefMetadata).toBeUndefined();
     }
   });
 
@@ -232,13 +239,14 @@ describe('resolvePageRefTokens', () => {
       ['_Toc2', 7],
     ]);
 
-    const affectedBlockIds = resolvePageRefTokens(blocks, anchorMap);
+    const { affectedBlockIds, updatedBlocks } = resolvePageRefTokens(blocks, anchorMap);
 
     expect(affectedBlockIds.size).toBe(1);
-    const block = blocks[0];
-    if (block.kind === 'paragraph') {
-      expect((block.runs[1] as { text?: string }).text).toBe('3');
-      expect((block.runs[3] as { text?: string }).text).toBe('7');
+    const updated = updatedBlocks.get('0-paragraph');
+    expect(updated).toBeDefined();
+    if (updated && updated.kind === 'paragraph') {
+      expect((updated.runs[1] as { text?: string }).text).toBe('3');
+      expect((updated.runs[3] as { text?: string }).text).toBe('7');
     }
   });
 
@@ -264,10 +272,11 @@ describe('resolvePageRefTokens', () => {
 
     const anchorMap = new Map([['_TocOther', 5]]);
 
-    const affectedBlockIds = resolvePageRefTokens(blocks, anchorMap);
+    const { affectedBlockIds, updatedBlocks } = resolvePageRefTokens(blocks, anchorMap);
 
     // Block not affected since token wasn't resolved
     expect(affectedBlockIds.size).toBe(0);
+    expect(updatedBlocks.size).toBe(0);
     const block = blocks[0];
     if (block.kind === 'paragraph') {
       expect((block.runs[0] as { text?: string }).text).toBe('??'); // Unchanged
@@ -287,9 +296,10 @@ describe('resolvePageRefTokens', () => {
 
     const anchorMap = new Map();
 
-    const affectedBlockIds = resolvePageRefTokens(blocks, anchorMap);
+    const { affectedBlockIds, updatedBlocks } = resolvePageRefTokens(blocks, anchorMap);
 
     expect(affectedBlockIds.size).toBe(0);
+    expect(updatedBlocks.size).toBe(0);
   });
 
   it('skips runs without pageReference token', () => {
@@ -315,9 +325,41 @@ describe('resolvePageRefTokens', () => {
 
     const anchorMap = new Map();
 
-    const affectedBlockIds = resolvePageRefTokens(blocks, anchorMap);
+    const { affectedBlockIds, updatedBlocks } = resolvePageRefTokens(blocks, anchorMap);
 
     expect(affectedBlockIds.size).toBe(0);
+    expect(updatedBlocks.size).toBe(0);
+  });
+
+  it('is a no-op when resolved page already matches existing text', () => {
+    // Idempotence: if a previous iteration resolved _Toc1 to "5" and the next
+    // iteration sees the same anchor page, the block is not flagged affected
+    // and is not re-cloned. Keeps the convergence loop from running forever.
+    const blocks: FlowBlock[] = [
+      {
+        kind: 'paragraph',
+        id: '0-paragraph',
+        runs: [
+          {
+            text: '5',
+            fontFamily: 'Arial',
+            fontSize: 12,
+            token: 'pageReference',
+            pageRefMetadata: {
+              bookmarkId: '_Toc1',
+              instruction: 'PAGEREF _Toc1 \\h',
+            },
+          },
+        ],
+      },
+    ];
+
+    const anchorMap = new Map([['_Toc1', 5]]);
+
+    const { affectedBlockIds, updatedBlocks } = resolvePageRefTokens(blocks, anchorMap);
+
+    expect(affectedBlockIds.size).toBe(0);
+    expect(updatedBlocks.size).toBe(0);
   });
 });
 

--- a/packages/layout-engine/layout-engine/src/resolvePageRefs.ts
+++ b/packages/layout-engine/layout-engine/src/resolvePageRefs.ts
@@ -1,43 +1,54 @@
 /**
  * Page Reference Resolution Module
  *
- * Handles two-pass layout for dynamic cross-reference resolution:
- * - Pass 1: Build anchor map (bookmark → page number)
- * - Pass 2: Resolve pageReference tokens and re-measure affected paragraphs
+ * Handles PAGEREF token resolution for `<w:instrText>PAGEREF _Bookmark \h</w:instrText>`
+ * fields. Follows the same pattern as `resolvePageTokens.ts` (PAGE/NUMPAGES):
+ * - Pass 1: Build anchor map (bookmark → page number) from the laid-out `Layout`.
+ * - Pass 2: Clone paragraph blocks that contain pageReference tokens, replacing
+ *   the placeholder text with the resolved page number and returning them as a
+ *   `Map<blockId, FlowBlock>` alongside an `affectedBlockIds` set so the caller
+ *   can re-measure + re-paginate the affected paragraphs.
+ *
+ * Callers are expected to run this inside the incrementalLayout convergence
+ * loop so text-width changes that alter wrap and shift bookmark pages cascade
+ * through additional iterations.
  */
 
 import type { Layout, FlowBlock, ParagraphBlock } from '@superdoc/contracts';
 
 /**
- * Build an anchor map from bookmarks and layout fragments.
+ * Result contract matches `ResolvePageTokensResult` from `resolvePageTokens.ts`
+ * so the incremental layout convergence loop can merge the two resolution steps
+ * uniformly.
+ */
+export interface ResolvePageRefsResult {
+  /** Block ids that had at least one pageReference token resolved. */
+  affectedBlockIds: Set<string>;
+  /** Cloned blocks (token text replaced) keyed by id. Original blocks are not mutated. */
+  updatedBlocks: Map<string, FlowBlock>;
+}
+
+/**
+ * Build an anchor map (bookmark name → page number) by scanning which page each
+ * bookmark's PM position falls into.
  *
- * For each bookmark, determines which page it appears on by checking
- * if the bookmark's PM position falls within any fragment's PM range.
- *
- * @param bookmarks - Map of bookmark names to PM positions
- * @param layout - Completed layout with positioned fragments
- * @returns Map of bookmark names to page numbers (1-indexed)
+ * Page numbers are 1-indexed (matches `layout.pages[i].number`).
  */
 export function buildAnchorMap(bookmarks: Map<string, number>, layout: Layout): Map<string, number> {
   const anchorMap = new Map<string, number>();
 
-  // For each bookmark, find which page it's on
   bookmarks.forEach((pmPosition, bookmarkName) => {
-    // Search through all pages and fragments
     for (const page of layout.pages) {
       for (const fragment of page.fragments) {
-        // Only paragraph fragments have PM positions
-        if (fragment.kind === 'para' && fragment.pmStart != null && fragment.pmEnd != null) {
-          // Check if bookmark position falls within this fragment
-          if (pmPosition >= fragment.pmStart && pmPosition < fragment.pmEnd) {
-            anchorMap.set(bookmarkName, page.number);
-            return; // Found it, move to next bookmark
-          }
+        if (fragment.kind !== 'para' || fragment.pmStart == null || fragment.pmEnd == null) continue;
+        if (pmPosition >= fragment.pmStart && pmPosition < fragment.pmEnd) {
+          anchorMap.set(bookmarkName, page.number);
+          return;
         }
       }
     }
-
-    // Bookmark not found in any fragment - log warning but continue
+    // Bookmark not found in any fragment — leave out of the map so the caller
+    // keeps the existing fallback text (Word's baked-in value at import time).
     console.warn(`[resolvePageRefs] Bookmark "${bookmarkName}" at PM position ${pmPosition} not found in layout`);
   });
 
@@ -45,67 +56,81 @@ export function buildAnchorMap(bookmarks: Map<string, number>, layout: Layout): 
 }
 
 /**
- * Resolve pageReference tokens in blocks using the anchor map.
- *
- * Finds all runs with token='pageReference', looks up the target bookmark
- * in the anchor map, and replaces the run's text with the resolved page number.
- *
- * @param blocks - FlowBlocks containing runs with pageReference tokens
- * @param anchorMap - Map of bookmark names to page numbers
- * @returns Array of block IDs that had tokens resolved (for re-measurement)
+ * Resolve every `token: 'pageReference'` run in `blocks` against `anchorMap`.
+ * Returns cloned paragraph blocks for those that had at least one token
+ * resolved; originals are never mutated.
  */
-export function resolvePageRefTokens(blocks: FlowBlock[], anchorMap: Map<string, number>): Set<string> {
+export function resolvePageRefTokens(blocks: FlowBlock[], anchorMap: Map<string, number>): ResolvePageRefsResult {
   const affectedBlockIds = new Set<string>();
+  const updatedBlocks = new Map<string, FlowBlock>();
 
   for (const block of blocks) {
     if (block.kind !== 'paragraph') continue;
+    if (!hasPageRefTokens(block)) continue;
 
-    let blockModified = false;
-
-    for (const run of block.runs) {
-      // Type guard: only TextRun can have token
-      if ('token' in run && run.token === 'pageReference' && run.pageRefMetadata) {
-        const bookmarkId = run.pageRefMetadata.bookmarkId;
-        const resolvedPage = anchorMap.get(bookmarkId);
-
-        if (resolvedPage != null) {
-          // Replace placeholder text with actual page number
-          run.text = String(resolvedPage);
-          // Clear token metadata to treat as normal text after resolution
-          delete run.token;
-          delete run.pageRefMetadata;
-          blockModified = true;
-        } else {
-          // Bookmark not found in anchor map - keep placeholder
-          console.warn(`[resolvePageRefs] Cannot resolve PAGEREF to "${bookmarkId}" - bookmark not found`);
-          // Keep the fallback text (already set during PM adapter processing)
-        }
-      }
-    }
-
-    if (blockModified) {
+    const clone = cloneBlockWithResolvedPageRefs(block, anchorMap);
+    if (clone) {
+      updatedBlocks.set(block.id, clone);
       affectedBlockIds.add(block.id);
     }
   }
 
-  return affectedBlockIds;
+  return { affectedBlockIds, updatedBlocks };
 }
 
 /**
- * Filter blocks to only include TOC entries that need re-measurement.
- *
- * @param blocks - All FlowBlocks
- * @param affectedBlockIds - Set of block IDs that had tokens resolved
- * @returns Array of ParagraphBlocks that are TOC entries and were affected
+ * Filter blocks to those that are TOC entries and were affected by PAGEREF
+ * resolution. Useful for targeted re-measurement UI (e.g. a highlight pulse on
+ * updated TOC entries) but not required for correctness — the incrementalLayout
+ * loop re-measures all affected blocks via `affectedBlockIds` already.
  */
 export function getTocBlocksForRemeasurement(blocks: FlowBlock[], affectedBlockIds: Set<string>): ParagraphBlock[] {
   const tocBlocks: ParagraphBlock[] = [];
-
   for (const block of blocks) {
     if (block.kind === 'paragraph' && block.attrs?.isTocEntry === true && affectedBlockIds.has(block.id)) {
       tocBlocks.push(block);
     }
   }
-
   return tocBlocks;
+}
+
+function hasPageRefTokens(block: ParagraphBlock): boolean {
+  for (const run of block.runs) {
+    if ('token' in run && run.token === 'pageReference') return true;
+  }
+  return false;
+}
+
+/**
+ * Clone a paragraph block, replacing the text of every pageReference run whose
+ * bookmark is present in the anchor map. Runs whose bookmark didn't resolve
+ * (missing from the map) are left alone so the Word-baked fallback stays.
+ *
+ * Returns null if no run was actually changed.
+ */
+function cloneBlockWithResolvedPageRefs(block: ParagraphBlock, anchorMap: Map<string, number>): ParagraphBlock | null {
+  let anyChanged = false;
+
+  const clonedRuns = block.runs.map((run) => {
+    if (!('token' in run) || run.token !== 'pageReference' || !run.pageRefMetadata) return run;
+    const bookmarkId = run.pageRefMetadata.bookmarkId;
+    const resolvedPage = anchorMap.get(bookmarkId);
+    if (resolvedPage == null) {
+      // Keep the fallback text. Leave token metadata in place so a later
+      // iteration with a stabilized layout may resolve it.
+      console.warn(`[resolvePageRefs] Cannot resolve PAGEREF to "${bookmarkId}" - bookmark not found`);
+      return run;
+    }
+    const newText = String(resolvedPage);
+    if (run.text === newText) return run;
+    anyChanged = true;
+    // Strip the token metadata after a successful resolution so subsequent
+    // convergence iterations don't re-resolve the same run. Matches the
+    // resolvePageNumberTokens pattern.
+    const { token: _token, pageRefMetadata: _meta, ...runWithoutToken } = run as Record<string, unknown>;
+    return { ...(runWithoutToken as object), text: newText } as typeof run;
+  });
+
+  if (!anyChanged) return null;
+  return { ...block, runs: clonedRuns };
 }

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -4273,6 +4273,7 @@ export class PresentationEditor extends EventEmitter {
           (block: FlowBlock, constraints: { maxWidth: number; maxHeight: number }) => measureBlock(block, constraints),
           headerFooterInput ?? undefined,
           previousMeasures,
+          bookmarks,
         );
         const incrementalLayoutEnd = perfNow();
         perfLog(`[Perf] incrementalLayout: ${(incrementalLayoutEnd - incrementalLayoutStart).toFixed(2)}ms`);


### PR DESCRIPTION
## Summary
Wires `buildAnchorMap` + `resolvePageRefTokens` into the existing two-pass convergence loop in `incrementalLayout`, so PAGEREF fields (TOC page numbers and other cross-references) refresh after edits that change pagination — instead of remaining stuck at whatever page number Word baked in at DOCX export time.

## Motivation
`packages/layout-engine/layout-engine/src/resolvePageRefs.ts` exports `buildAnchorMap` and `resolvePageRefTokens`. Both are fully implemented and tested in isolation, but before this PR they were **not called anywhere in production code** — only from their own test file and the `index.ts` barrel. A grep across `packages/` and `apps/` confirms zero runtime importers.

Observable impact: after a user edits the document in a way that shifts pagination (insert/delete paragraphs, toggle large conditional blocks, etc.), every TOC entry's page number stays at the pre-edit value. Word TOCs typically carry `PAGEREF _Toc<id> \h`, whose rendered page number needs the current layout to compute.

## Approach
Mirror the existing PAGE/NUMPAGES resolution pattern exactly:

1. **Refactor `resolvePageRefTokens` to match `resolvePageNumberTokens`'s contract.** Returns `{ affectedBlockIds, updatedBlocks: Map<blockId, FlowBlock> }` with cloned blocks, rather than mutating in place and returning a `Set`. This is required for the convergence loop to be correct — the loop rewrites `currentBlocks` from updates each iteration; a mutation-style resolver double-counts.
2. **Thread `bookmarks` into `incrementalLayout`.** New trailing optional param. `PresentationEditor` already tracks the bookmarks map on `#layoutState.bookmarks` and just needs to forward it.
3. **Add `FeatureFlags.BODY_PAGEREFS`** (env `SD_BODY_PAGEREFS`, default `true`). Disabling reverts to the pre-PR behavior where PAGEREF runs keep the Word-baked fallback text.
4. **Merge PAGEREF into the convergence loop.** Both resolvers run each iteration on the current blocks; their `affectedBlockIds` are unioned and `updatedBlocks` merged via a tiny `mergeRunUpdates` helper that covers the rare case of a single block touched by both resolvers (e.g., a header containing both `PAGE` and `PAGEREF`).

Convergence semantics remain identical to the existing PAGE/NUMPAGES loop: iterate up to 3 times, break when no blocks change, break when page count stabilizes after the first pass.

## Test plan
- [x] `resolvePageRefs.test.ts` updated for the new return shape; added an idempotence test (re-running with the same anchor map and already-resolved text is a no-op). **12 pass, 0 fail.**
- [x] Full `@superdoc/layout-engine` suite: **614 pass, 1 skip, 0 fail.**
- [x] Full `@superdoc/layout-bridge` suite (the package that owns `incrementalLayout`): **1169 pass, 0 fail.**
- [x] `pnpm run format:check` — clean.
- [x] `pnpm run lint` — 0 errors (371 pre-existing `any` warnings elsewhere, unchanged).
- [ ] End-to-end demo video to follow in a comment — recording now with a retrofitted DOCX that has a TOC.

## Out of scope
- **TOC / Index of Defined Terms entry regeneration.** This PR refreshes the page-number PART of a TOC entry but does not rebuild the entry list itself (e.g. if a heading is renamed or deleted). That's a separate, deeper architectural change.
- **F9 semantics.** The new behavior makes PAGEREF refresh automatic on every layout pass, so F9 support for PAGEREF is no longer necessary. If you'd prefer a more conservative rollout where PAGEREF only resolves on F9 (like NUMWORDS), let me know and I'll move it to the `field-update` extension instead.