### PR TITLE
ci(behavior): parallelize tests by browser x shard matrix

### DIFF
--- a/.github/workflows/ci-behavior.yml
+++ b/.github/workflows/ci-behavior.yml
@@ -15,6 +15,7 @@ on:
       - 'packages/preset-geometry/**'
       - 'tests/behavior/**'
       - 'shared/**'
+      - '.github/workflows/ci-behavior.yml'
       - '!**/*.md'
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/ci-behavior.yml
+++ b/.github/workflows/ci-behavior.yml
@@ -29,7 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        browser: [chromium, firefox, webkit]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v6
 
@@ -56,20 +57,20 @@ jobs:
         id: pw-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-${{ matrix.browser }}
 
-      - name: Install Playwright browsers
+      - name: Install Playwright browser
         if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium firefox webkit
+        run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
         working-directory: tests/behavior
 
       - name: Install Playwright system deps
         if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium firefox webkit
+        run: pnpm exec playwright install-deps ${{ matrix.browser }}
         working-directory: tests/behavior
 
-      - name: Run behavior tests (shard ${{ matrix.shard }}/3)
-        run: pnpm exec playwright test --shard=${{ matrix.shard }}/3
+      - name: Run behavior tests (${{ matrix.browser }} shard ${{ matrix.shard }}/4)
+        run: pnpm exec playwright test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}/4
         working-directory: tests/behavior
 
   validate:


### PR DESCRIPTION
Fans the behavior test job out from 3 shards (each running all browsers) to 12 jobs (3 browsers x 4 shards) so each runner does ~1/12 of the suite instead of ~1/3. The last passing run took ~22 min wall; the new shape should land around 7-8 min.

Each job installs only its own browser and uses a browser-scoped Playwright cache key so the jobs don't fight over one cache entry. The validate job is unchanged - `needs: [test]` still fans in across the whole matrix.

Picked 4 shards per browser (not 3) because webkit/firefox typically run 20-30% slower per test than chromium; 3x3 would have been right at the 10-min edge for those browsers. Local measurement: a 1/9 slice (chromium, 145 tests, 2 workers) ran in 4m 9s, which scales to ~6.5 min on ubuntu-latest, so 1/12 should be ~5 min of tests + 2.5 min setup.

**Review**: confirm matrix shape + cache key; no functional change to what runs.
**Verified**: `playwright test --list --project=<each>` reports 433 tests per browser evenly.