### PR TITLE
fix: prevent corrupt docx export for legacy w:pict vml rect content

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/mc/altermateContent/alternate-content-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/mc/altermateContent/alternate-content-translator.js
@@ -57,6 +57,9 @@ function encode(params) {
 function decode(params) {
   const { node } = params;
   const { drawingContent } = node.attrs;
+  if (!hasValidDrawingContent(drawingContent)) {
+    return null;
+  }
 
   // Handle modern DrawingML content (existing logic)
   const drawing = {
@@ -70,9 +73,19 @@ function decode(params) {
     elements: [drawing],
   };
 
+  const fallback = {
+    name: 'mc:Fallback',
+    elements: [
+      {
+        name: 'w:drawing',
+        elements: carbonCopy(drawing.elements || []),
+      },
+    ],
+  };
+
   return {
     name: 'mc:AlternateContent',
-    elements: [choice],
+    elements: [choice, fallback],
   };
 }
 
@@ -138,4 +151,19 @@ function buildPath(existingPath = [], node, branch) {
   if (node) path.push(node);
   if (branch) path.push(branch);
   return path;
+}
+
+/**
+ * @param {unknown} drawingContent
+ * @returns {boolean}
+ */
+function hasValidDrawingContent(drawingContent) {
+  const drawingChildren = drawingContent?.elements;
+  if (!Array.isArray(drawingChildren) || drawingChildren.length === 0) {
+    return false;
+  }
+
+  return drawingChildren.some(
+    (child) => child && typeof child === 'object' && (child.name === 'wp:inline' || child.name === 'wp:anchor'),
+  );
 }

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/mc/altermateContent/alternate-content-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/mc/altermateContent/alternate-content-translator.test.js
@@ -125,7 +125,7 @@ describe('mc:AltermateContent translator', () => {
   });
 
   describe('decode', () => {
-    it('returns mc:AlternateContent structure with w:drawing inside mc:Choice', () => {
+    it('returns mc:AlternateContent with valid choice and fallback drawing branches', () => {
       const params = {
         node: {
           attrs: {
@@ -149,29 +149,24 @@ describe('mc:AltermateContent translator', () => {
               },
             ],
           },
-        ],
-      });
-    });
-
-    it('handles empty drawingContent gracefully', () => {
-      const params = { node: { attrs: {} } };
-      const result = translator.decode(params);
-
-      expect(result).toEqual({
-        name: 'mc:AlternateContent',
-        elements: [
           {
-            name: 'mc:Choice',
-            attributes: { Requires: 'wps' },
+            name: 'mc:Fallback',
             elements: [
               {
                 name: 'w:drawing',
-                elements: [],
+                elements: [{ name: 'wp:inline' }],
               },
             ],
           },
         ],
       });
+    });
+
+    it('returns null when drawingContent is missing/invalid', () => {
+      const params = { node: { attrs: {} } };
+      const result = translator.decode(params);
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/pict/helpers/translate-content-block.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/pict/helpers/translate-content-block.js
@@ -8,15 +8,41 @@ import { wrapTextInRun } from '@converter/exporter';
  */
 export function translateContentBlock(params) {
   const { node } = params;
-  const { vmlAttributes, horizontalRule } = node.attrs;
+  const { vmlAttributes, horizontalRule, attributes, style } = node.attrs;
+  const hasLegacyVmlMarkers = detectLegacyVmlRectMarkers(attributes, style);
 
   // Handle VML v:rect elements (like horizontal rules)
-  if (vmlAttributes || horizontalRule) {
+  if (vmlAttributes || horizontalRule || hasLegacyVmlMarkers) {
     return translateVRectContentBlock(params);
   }
 
   const alternateContent = alternateChoiceTranslator.decode(params);
+  if (!alternateContent) {
+    return null;
+  }
   return wrapTextInRun(alternateContent);
+}
+
+/**
+ * Detects legacy VML rect signatures preserved in contentBlock attrs.
+ * This prevents generic legacy w:pict content from being routed into
+ * DrawingML alternate-content export paths.
+ *
+ * @param {Record<string, unknown>|null|undefined} rawAttributes
+ * @param {unknown} style
+ * @returns {boolean}
+ */
+function detectLegacyVmlRectMarkers(rawAttributes, style) {
+  if (style) return true;
+  if (!rawAttributes || typeof rawAttributes !== 'object') return false;
+
+  const attrs = rawAttributes;
+
+  if (typeof attrs.style === 'string' && attrs.style.trim().length > 0) return true;
+  if (attrs.fillcolor != null) return true;
+  if (attrs.stroked != null) return true;
+
+  return Object.keys(attrs).some((key) => key.startsWith('o:'));
 }
 
 // Nominal full-width value for VML style. Word ignores this when o:hr="t"

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/pict/helpers/translate-content-block.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/pict/helpers/translate-content-block.test.js
@@ -63,6 +63,42 @@ describe('translateContentBlock', () => {
     expect(alternateChoiceTranslator.decode).not.toHaveBeenCalled();
     expect(result.elements[0].name).toBe('w:pict');
   });
+
+  it('should use translateVRectContentBlock when legacy VML markers exist in attributes', () => {
+    const params = {
+      node: {
+        attrs: {
+          attributes: {
+            style: 'position:absolute;width:100pt;height:20pt',
+            fillcolor: 'yellow',
+            stroked: 'f',
+          },
+        },
+      },
+    };
+
+    generateRandomSigned32BitIntStrId.mockReturnValue('12345678');
+
+    const result = translateContentBlock(params);
+
+    expect(alternateChoiceTranslator.decode).not.toHaveBeenCalled();
+    expect(result.elements[0].name).toBe('w:pict');
+  });
+
+  it('should return null when alternateChoiceTranslator returns null', () => {
+    alternateChoiceTranslator.decode.mockReturnValue(null);
+
+    const params = {
+      node: {
+        attrs: {},
+      },
+    };
+
+    const result = translateContentBlock(params);
+
+    expect(result).toBeNull();
+    expect(wrapTextInRun).not.toHaveBeenCalled();
+  });
 });
 
 describe('translateVRectContentBlock', () => {

--- a/packages/super-editor/src/editors/v1/extensions/content-block/content-block.js
+++ b/packages/super-editor/src/editors/v1/extensions/content-block/content-block.js
@@ -142,6 +142,16 @@ export const ContentBlock = Node.create({
         rendered: false,
       },
 
+      vmlAttributes: {
+        default: null,
+        rendered: false,
+      },
+
+      style: {
+        default: null,
+        rendered: false,
+      },
+
       attributes: {
         rendered: false,
       },

--- a/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
+++ b/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
@@ -986,6 +986,10 @@ export interface ContentBlockAttrs extends InlineNodeAttributes {
   size?: ContentBlockSize | null;
   /** Background color */
   background?: string | null;
+  /** @internal VML attributes for legacy w:pict round-trip */
+  vmlAttributes?: Record<string, unknown> | null;
+  /** @internal Preserved inline style for legacy VML content */
+  style?: string | null;
   /** @internal Drawing content data */
   drawingContent?: unknown;
   /** @internal Attributes storage */


### PR DESCRIPTION
Linear: SD-2652

Fixes issue where import→export of DOCX files containing legacy `w:pict/v:rect` could produce invalid `mc:AlternateContent` with empty `w:drawing`, causing Word corruption errors.

What changed:
- Preserved legacy VML metadata on `contentBlock` (`vmlAttributes`, `style`) to avoid attribute loss during PM normalization.
- Added legacy VML routing guard in `translateContentBlock()` so `contentBlock` with VML markers exports via `w:pict/v:rect` path.
- Hardened `mc:AlternateContent` decode:
  - returns `null` for missing/invalid drawing content,
  - emits `mc:Fallback` for valid alternate-content branches.
- Added/updated unit tests for new routing and decode behavior.