### PR TITLE
[15/16] refactor(painter): provider callback receives ResolvedPage instead of Page

### DIFF
--- a/packages/layout-engine/contracts/src/resolved-layout.ts
+++ b/packages/layout-engine/contracts/src/resolved-layout.ts
@@ -1,18 +1,23 @@
 import type {
   DrawingBlock,
+  DrawingFragment,
   FlowMode,
   Fragment,
   ImageBlock,
+  ImageFragment,
   ImageFragmentMetadata,
   Line,
   ListBlock,
+  ListItemFragment,
   ListMeasure,
   PageMargins,
+  ParaFragment,
   ParagraphBlock,
   ParagraphBorders,
   ParagraphMeasure,
   SectionVerticalAlign,
   TableBlock,
+  TableFragment,
   TableMeasure,
 } from './index.js';
 
@@ -135,6 +140,8 @@ export type ResolvedFragmentItem = {
   block?: ParagraphBlock | ListBlock;
   /** Pre-extracted measure for paragraph (ParagraphMeasure) or list-item (ListMeasure) fragments. */
   measure?: ParagraphMeasure | ListMeasure;
+  /** Back-pointer to source Fragment. Painter render methods consume Fragment shape. */
+  fragment: ParaFragment | ListItemFragment;
 };
 
 /** Resolved paragraph content for non-table paragraph/list-item fragments. */
@@ -253,6 +260,8 @@ export type ResolvedTableItem = {
   sdtContainerKey?: string | null;
   /** Pre-computed change-detection signature (blockVersion + fragment-specific data). */
   version?: string;
+  /** Back-pointer to source Fragment. Painter render methods consume Fragment shape. */
+  fragment: TableFragment;
 };
 
 /**
@@ -293,6 +302,8 @@ export type ResolvedImageItem = {
   sdtContainerKey?: string | null;
   /** Pre-computed change-detection signature (blockVersion + fragment-specific data). */
   version?: string;
+  /** Back-pointer to source Fragment. Painter render methods consume Fragment shape. */
+  fragment: ImageFragment;
 };
 
 /**
@@ -331,6 +342,8 @@ export type ResolvedDrawingItem = {
   sdtContainerKey?: string | null;
   /** Pre-computed change-detection signature (blockVersion + fragment-specific data). */
   version?: string;
+  /** Back-pointer to source Fragment. Painter render methods consume Fragment shape. */
+  fragment: DrawingFragment;
 };
 
 /** Type guard: checks whether a resolved paint item is a ResolvedTableItem. */

--- a/packages/layout-engine/layout-bridge/src/benchmarks/index.ts
+++ b/packages/layout-engine/layout-bridge/src/benchmarks/index.ts
@@ -96,7 +96,7 @@ export async function runBenchmarkScenario(config: BenchmarkConfig): Promise<Ben
     blocks: doc.blocks,
     measures: initial.measures,
   });
-  painter.paint({ resolvedLayout: initialResolved, sourceLayout: initial.layout }, mount);
+  painter.paint({ resolvedLayout: initialResolved }, mount);
 
   previousBlocks = doc.blocks;
   previousLayout = initial.layout;
@@ -121,7 +121,7 @@ export async function runBenchmarkScenario(config: BenchmarkConfig): Promise<Ben
       blocks: nextBlocks,
       measures: result.measures,
     });
-    painter.paint({ resolvedLayout: resolved, sourceLayout: result.layout }, mount);
+    painter.paint({ resolvedLayout: resolved }, mount);
     const duration = performance.now() - start;
     durations.push(duration);
 

--- a/packages/layout-engine/layout-resolved/src/resolveDrawing.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveDrawing.ts
@@ -30,6 +30,7 @@ export function resolveDrawingItem(
     blockId: fragment.blockId,
     fragmentIndex,
     block,
+    fragment,
   };
   if (fragment.pmStart != null) item.pmStart = fragment.pmStart;
   if (fragment.pmEnd != null) item.pmEnd = fragment.pmEnd;

--- a/packages/layout-engine/layout-resolved/src/resolveImage.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveImage.ts
@@ -30,6 +30,7 @@ export function resolveImageItem(
     blockId: fragment.blockId,
     fragmentIndex,
     block,
+    fragment,
   };
   if (fragment.pmStart != null) item.pmStart = fragment.pmStart;
   if (fragment.pmEnd != null) item.pmEnd = fragment.pmEnd;

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.ts
@@ -236,6 +236,7 @@ export function resolveFragmentItem(
         blockId: fragment.blockId,
         fragmentIndex,
         content: resolveParagraphContentIfApplicable(fragment, blockMap),
+        fragment: fragment as ParaFragment | ListItemFragment,
       };
       if (sdtContainerKey != null) item.sdtContainerKey = sdtContainerKey;
 

--- a/packages/layout-engine/layout-resolved/src/resolveTable.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveTable.ts
@@ -41,6 +41,7 @@ export function resolveTableItem(
     measure,
     cellSpacingPx: measure.cellSpacingPx ?? getCellSpacingPx(block.attrs?.cellSpacing),
     effectiveColumnWidths: fragment.columnWidths ?? measure.columnWidths,
+    fragment,
   };
   if (fragment.pmStart != null) item.pmStart = fragment.pmStart;
   if (fragment.pmEnd != null) item.pmEnd = fragment.pmEnd;

--- a/packages/layout-engine/painters/dom/README.md
+++ b/packages/layout-engine/painters/dom/README.md
@@ -31,11 +31,11 @@ const resolvedLayout = resolveLayout({
   measures,    // Measures (parallel to blocks)
 });
 
-painter.paint({ resolvedLayout, sourceLayout: layout }, mountElement);
+painter.paint({ resolvedLayout }, mountElement);
 painter.setProviders(newHeader, newFooter); // optional helper for provider changes
 ```
 
 Notes:
-- The painter takes a pre-computed `DomPainterInput` (`{ resolvedLayout, sourceLayout }`). Callers run `resolveLayout` (from `@superdoc/layout-resolved`) to convert a raw `Layout` + blocks/measures into the resolved form before painting.
+- The painter takes a pre-computed `DomPainterInput` (`{ resolvedLayout }`). Callers run `resolveLayout` (from `@superdoc/layout-resolved`) to convert a raw `Layout` + blocks/measures into the resolved form before painting.
 - Virtualization is opt-in and only supported in vertical mode (windowed pages with spacers).
 - Renderer is read-only: no editing/input handling is included here.

--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -105,7 +105,6 @@ function createTestPainter(opts: { blocks?: FlowBlock[]; measures?: Measure[] } 
           });
       const input: DomPainterInput = {
         resolvedLayout: effectiveResolved,
-        sourceLayout: layout,
       };
       painter.paint(input, mount, mapping as any);
     },
@@ -4711,6 +4710,7 @@ describe('DomPainter', () => {
               fragmentIndex: 0,
               block: listBlock as import('@superdoc/contracts').ListBlock,
               measure: listMeasure as import('@superdoc/contracts').ListMeasure,
+              fragment: initialLayout.pages[0].fragments[0] as import('@superdoc/contracts').ListItemFragment,
             },
           ],
         },
@@ -4742,6 +4742,7 @@ describe('DomPainter', () => {
               fragmentIndex: 0,
               block: listBlock as import('@superdoc/contracts').ListBlock,
               measure: listMeasure as import('@superdoc/contracts').ListMeasure,
+              fragment: updatedLayout.pages[0].fragments[0] as import('@superdoc/contracts').ListItemFragment,
             },
           ],
         },
@@ -4857,6 +4858,7 @@ describe('DomPainter', () => {
               blockId: 'drawing-anchored',
               fragmentIndex: 0,
               block: anchoredDrawingBlock as import('@superdoc/contracts').DrawingBlock,
+              fragment: drawingLayout.pages[0].fragments[0] as import('@superdoc/contracts').DrawingFragment,
             },
             {
               kind: 'fragment',
@@ -4871,6 +4873,7 @@ describe('DomPainter', () => {
               blockId: 'drawing-inline',
               fragmentIndex: 1,
               block: inlineDrawingBlock as import('@superdoc/contracts').DrawingBlock,
+              fragment: drawingLayout.pages[0].fragments[1] as import('@superdoc/contracts').DrawingFragment,
             },
           ],
         },
@@ -4944,6 +4947,7 @@ describe('DomPainter', () => {
         fragmentIndex: 0,
         block: paragraphBlock as import('@superdoc/contracts').ParagraphBlock,
         measure: paragraphMeasure as import('@superdoc/contracts').ParagraphMeasure,
+        fragment: paragraphLayout.pages[0].fragments[0] as import('@superdoc/contracts').ParaFragment,
         content: {
           lines: [
             {
@@ -5039,6 +5043,7 @@ describe('DomPainter', () => {
         fragmentIndex: 0,
         block: paragraphBlock as import('@superdoc/contracts').ParagraphBlock,
         measure: paragraphMeasure as import('@superdoc/contracts').ParagraphMeasure,
+        fragment: paragraphLayout.pages[0].fragments[0] as import('@superdoc/contracts').ParaFragment,
         content: {
           lines: [
             {
@@ -5134,6 +5139,7 @@ describe('DomPainter', () => {
         fragmentIndex: 0,
         block: paragraphBlock as import('@superdoc/contracts').ParagraphBlock,
         measure: paragraphMeasure as import('@superdoc/contracts').ParagraphMeasure,
+        fragment: paragraphLayout.pages[0].fragments[0] as import('@superdoc/contracts').ParaFragment,
         content: {
           lines: [
             {

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -16,14 +16,12 @@ import type {
   ImageFragment,
   ImageHyperlink,
   ImageRun,
-  Layout,
   Line,
   LineSegment,
   ListBlock,
   ListItemFragment,
   ListMeasure,
   Measure,
-  Page,
   PageMargins,
   ParaFragment,
   ParagraphAttrs,
@@ -233,13 +231,11 @@ export type RenderedLineInfo = {
 /**
  * Input to `DomPainter.paint()`.
  *
- * `resolvedLayout` is the canonical resolved data the painter reads from.
- * `sourceLayout` is the raw Layout retained for legacy internal access paths.
+ * The painter reads only from `resolvedLayout`. All page metadata, dimensions,
+ * and fragment data are projected onto `ResolvedPage` / `ResolvedPaintItem`.
  */
 export type DomPainterInput = {
   resolvedLayout: ResolvedLayout;
-  /** Raw Layout for internal fragment access. */
-  sourceLayout: Layout;
 };
 
 export type PageDecorationPayload = {
@@ -1207,7 +1203,7 @@ export class DomPainter {
   private mount: HTMLElement | null = null;
   private doc: Document | null = null;
   private pageStates: PageDomState[] = [];
-  private currentLayout: Layout | null = null;
+  private hasRenderedOnce = false;
   private changedBlocks = new Set<string>();
   private readonly layoutMode: LayoutMode;
   private readonly isSemanticFlow: boolean;
@@ -1378,6 +1374,17 @@ export class DomPainter {
     return this.resolvedLayout?.pages[pageIndex] ?? null;
   }
 
+  /** Extracts Fragment list from a ResolvedPage's items (fragment items only, in order). */
+  private fragmentsFromResolvedPage(resolvedPage: ResolvedPage): Fragment[] {
+    const fragments: Fragment[] = [];
+    for (const item of resolvedPage.items) {
+      if (item.kind === 'fragment' && 'fragment' in item) {
+        fragments.push((item as { fragment: Fragment }).fragment);
+      }
+    }
+    return fragments;
+  }
+
   /** Returns the resolved fragment item for a given page/fragment index, or undefined. */
   private getResolvedFragmentItem(pageIndex: number, fragmentIndex: number): ResolvedPaintItem | undefined {
     const page = this.getResolvedPage(pageIndex);
@@ -1416,15 +1423,15 @@ export class DomPainter {
     this.onPaintSnapshotCallback?.(snapshot);
   }
 
-  private beginPaintSnapshot(layout: Layout): void {
+  private beginPaintSnapshot(resolvedLayout: ResolvedLayout): void {
     this.paintSnapshotBuilder = {
       formatVersion: 1,
       lineCount: 0,
       markerCount: 0,
       tabCount: 0,
-      pages: layout.pages.map((page, index) => ({
+      pages: resolvedLayout.pages.map((resolvedPage, index) => ({
         index,
-        pageNumber: Number.isFinite(page.number) ? page.number : null,
+        pageNumber: Number.isFinite(resolvedPage.number) ? resolvedPage.number : null,
         lineCount: 0,
         lines: [],
       })),
@@ -1557,8 +1564,8 @@ export class DomPainter {
   }
 
   public paint(input: DomPainterInput, mount: HTMLElement, mapping?: PositionMapping): void {
-    const layout = input.sourceLayout;
-    this.resolvedLayout = input.resolvedLayout;
+    const resolvedLayout = input.resolvedLayout;
+    this.resolvedLayout = resolvedLayout;
     this.changedBlocks.clear();
 
     if (!(mount instanceof HTMLElement)) {
@@ -1577,7 +1584,7 @@ export class DomPainter {
     const isSimpleTransaction = mapping && mapping.maps.length === 1;
     if (mapping && !isSimpleTransaction) {
       // Complex transaction, force all body fragments to rebuild (safe fallback).
-      for (const page of input.resolvedLayout.pages) {
+      for (const page of resolvedLayout.pages) {
         for (const item of page.items) {
           if ('blockId' in item) this.changedBlocks.add(item.blockId);
         }
@@ -1603,23 +1610,24 @@ export class DomPainter {
     }
     this.layoutVersion += 1;
 
-    this.layoutEpoch = this.resolvedLayout?.layoutEpoch ?? layout.layoutEpoch ?? 0;
+    this.layoutEpoch = resolvedLayout.layoutEpoch ?? 0;
     this.mount = mount;
-    this.beginPaintSnapshot(layout);
+    this.beginPaintSnapshot(resolvedLayout);
 
-    this.totalPages = layout.pages.length;
+    const hadPriorLayout = this.hasRenderedOnce;
+    this.totalPages = resolvedLayout.pages.length;
     if (this.isSemanticFlow) {
       // Semantic mode always renders as a single continuous surface.
       applyStyles(mount, containerStyles);
       mount.style.gap = '0px';
       mount.style.alignItems = 'stretch';
-      if (!this.currentLayout || this.pageStates.length === 0) {
-        this.fullRender(layout);
+      if (!hadPriorLayout || this.pageStates.length === 0) {
+        this.fullRender(resolvedLayout);
       } else {
-        this.patchLayout(layout);
+        this.patchLayout(resolvedLayout);
       }
-      this.setMountedPageIndices(this.createAllPageIndices(layout.pages.length));
-      this.currentLayout = layout;
+      this.setMountedPageIndices(this.createAllPageIndices(resolvedLayout.pages.length));
+      this.hasRenderedOnce = true;
       this.changedBlocks.clear();
       this.currentMapping = null;
       return;
@@ -1631,10 +1639,10 @@ export class DomPainter {
       applyStyles(mount, containerStylesHorizontal);
       // Use configured page gap for horizontal rendering
       mount.style.gap = `${this.pageGap}px`;
-      this.renderHorizontal(layout, mount);
+      this.renderHorizontal(resolvedLayout, mount);
       this.finalizePaintSnapshotFromBuilder(mount);
-      this.setMountedPageIndices(this.createAllPageIndices(layout.pages.length));
-      this.currentLayout = layout;
+      this.setMountedPageIndices(this.createAllPageIndices(resolvedLayout.pages.length));
+      this.hasRenderedOnce = true;
       this.pageStates = [];
       this.changedBlocks.clear();
       this.currentMapping = null;
@@ -1642,10 +1650,10 @@ export class DomPainter {
     }
     if (mode === 'book') {
       applyStyles(mount, containerStyles);
-      this.renderBookMode(layout, mount);
+      this.renderBookMode(resolvedLayout, mount);
       this.finalizePaintSnapshotFromBuilder(mount);
-      this.setMountedPageIndices(this.createAllPageIndices(layout.pages.length));
-      this.currentLayout = layout;
+      this.setMountedPageIndices(this.createAllPageIndices(resolvedLayout.pages.length));
+      this.hasRenderedOnce = true;
       this.pageStates = [];
       this.changedBlocks.clear();
       this.currentMapping = null;
@@ -1658,21 +1666,21 @@ export class DomPainter {
     if (this.virtualEnabled) {
       // Keep container gap at 0 so spacer elements don't introduce extra offsets.
       mount.style.gap = '0px';
-      this.renderVirtualized(layout, mount);
+      this.renderVirtualized(resolvedLayout, mount);
       useDomSnapshotFallback = true;
-      this.currentLayout = layout;
+      this.hasRenderedOnce = true;
       this.changedBlocks.clear();
       this.currentMapping = null;
     } else {
       // Use configured page gap for normal vertical rendering
       mount.style.gap = `${this.pageGap}px`;
-      if (!this.currentLayout || this.pageStates.length === 0) {
-        this.fullRender(layout);
+      if (!hadPriorLayout || this.pageStates.length === 0) {
+        this.fullRender(resolvedLayout);
       } else {
-        this.patchLayout(layout);
+        this.patchLayout(resolvedLayout);
         useDomSnapshotFallback = true;
       }
-      this.setMountedPageIndices(this.createAllPageIndices(layout.pages.length));
+      this.setMountedPageIndices(this.createAllPageIndices(resolvedLayout.pages.length));
     }
 
     if (useDomSnapshotFallback) {
@@ -1682,7 +1690,7 @@ export class DomPainter {
       this.finalizePaintSnapshotFromBuilder(mount);
     }
 
-    this.currentLayout = layout;
+    this.hasRenderedOnce = true;
     this.changedBlocks.clear();
     this.currentMapping = null;
   }
@@ -1690,10 +1698,10 @@ export class DomPainter {
   // ----------------
   // Virtualized path
   // ----------------
-  private renderVirtualized(layout: Layout, mount: HTMLElement): void {
+  private renderVirtualized(resolvedLayout: ResolvedLayout, mount: HTMLElement): void {
     if (!this.doc) return;
-    // Always keep the latest layout reference for handlers
-    this.currentLayout = layout;
+    // Always keep the latest resolved layout reference for handlers
+    this.resolvedLayout = resolvedLayout;
 
     // First-time init, mount changed, or spacers were detached (e.g., by innerHTML='' on zero-page layout)
     const needsInit =
@@ -1796,13 +1804,10 @@ export class DomPainter {
   }
 
   private computeVirtualMetrics(): void {
-    if (!this.currentLayout) return;
-    const N = this.currentLayout.pages.length;
+    if (!this.resolvedLayout) return;
+    const N = this.resolvedLayout.pages.length;
     if (N !== this.virtualHeights.length) {
-      this.virtualHeights = this.currentLayout.pages.map((p, i) => {
-        const resolved = this.getResolvedPage(i);
-        return resolved?.height ?? p.size?.h ?? this.currentLayout!.pageSize.h;
-      });
+      this.virtualHeights = this.resolvedLayout.pages.map((resolvedPage) => resolvedPage.height);
     }
     // Build offsets where offsets[i] = sum_{k < i} (height[k] + gap).
     // Use virtualGap to match CSS gap on virtualPagesEl.
@@ -1851,9 +1856,10 @@ export class DomPainter {
   }
 
   private updateVirtualWindow(): void {
-    if (!this.mount || !this.topSpacerEl || !this.bottomSpacerEl || !this.virtualPagesEl || !this.currentLayout) return;
-    const layout = this.currentLayout;
-    const N = layout.pages.length;
+    if (!this.mount || !this.topSpacerEl || !this.bottomSpacerEl || !this.virtualPagesEl || !this.resolvedLayout)
+      return;
+    const resolvedLayout = this.resolvedLayout;
+    const N = resolvedLayout.pages.length;
 
     if (N === 0) {
       this.mount.innerHTML = '';
@@ -1960,13 +1966,12 @@ export class DomPainter {
 
     // Insert or patch needed pages
     for (const i of mounted) {
-      const page = layout.pages[i];
-      const resolved = this.getResolvedPage(i);
-      const pageSize = resolved ? { w: resolved.width, h: resolved.height } : (page.size ?? layout.pageSize);
+      const resolvedPage = resolvedLayout.pages[i];
+      const pageSize = { w: resolvedPage.width, h: resolvedPage.height };
       const existing = this.pageIndexToState.get(i);
       if (!existing) {
-        const newState = this.createPageState(page, pageSize, i);
-        newState.element.dataset.pageNumber = String(page.number);
+        const newState = this.createPageState(resolvedPage, pageSize, i);
+        newState.element.dataset.pageNumber = String(resolvedPage.number);
         newState.element.dataset.pageIndex = String(i);
         // Ensure virtualization uses page margin 0
         applyStyles(newState.element, pageStyles(pageSize.w, pageSize.h, this.getEffectivePageStyles()));
@@ -1974,7 +1979,7 @@ export class DomPainter {
         this.pageIndexToState.set(i, newState);
       } else {
         // Patch in place
-        this.patchPage(existing, page, pageSize, i);
+        this.patchPage(existing, resolvedPage, pageSize, i);
       }
     }
 
@@ -2059,28 +2064,23 @@ export class DomPainter {
     this.virtualGapSpacers = [];
   }
 
-  private renderHorizontal(layout: Layout, mount: HTMLElement): void {
+  private renderHorizontal(resolvedLayout: ResolvedLayout, mount: HTMLElement): void {
     if (!this.doc) return;
     mount.innerHTML = '';
-    layout.pages.forEach((page, pageIndex) => {
-      const resolved = this.getResolvedPage(pageIndex);
-      const pageSize = resolved ? { w: resolved.width, h: resolved.height } : (page.size ?? layout.pageSize);
-      const pageEl = this.renderPage(pageSize.w, pageSize.h, page, pageIndex);
+    resolvedLayout.pages.forEach((resolvedPage, pageIndex) => {
+      const pageEl = this.renderPage(resolvedPage.width, resolvedPage.height, resolvedPage, pageIndex);
       mount.appendChild(pageEl);
     });
   }
 
-  private renderBookMode(layout: Layout, mount: HTMLElement): void {
+  private renderBookMode(resolvedLayout: ResolvedLayout, mount: HTMLElement): void {
     if (!this.doc) return;
     mount.innerHTML = '';
-    const pages = layout.pages;
+    const pages = resolvedLayout.pages;
     if (pages.length === 0) return;
 
-    const firstResolved = this.getResolvedPage(0);
-    const firstPageSize = firstResolved
-      ? { w: firstResolved.width, h: firstResolved.height }
-      : (pages[0].size ?? layout.pageSize);
-    const firstPageEl = this.renderPage(firstPageSize.w, firstPageSize.h, pages[0], 0);
+    const firstPage = pages[0];
+    const firstPageEl = this.renderPage(firstPage.width, firstPage.height, firstPage, 0);
     mount.appendChild(firstPageEl);
 
     for (let i = 1; i < pages.length; i += 2) {
@@ -2089,20 +2089,12 @@ export class DomPainter {
       applyStyles(spreadEl, spreadStyles);
 
       const leftPage = pages[i];
-      const leftResolved = this.getResolvedPage(i);
-      const leftPageSize = leftResolved
-        ? { w: leftResolved.width, h: leftResolved.height }
-        : (leftPage.size ?? layout.pageSize);
-      const leftPageEl = this.renderPage(leftPageSize.w, leftPageSize.h, leftPage, i);
+      const leftPageEl = this.renderPage(leftPage.width, leftPage.height, leftPage, i);
       spreadEl.appendChild(leftPageEl);
 
       if (i + 1 < pages.length) {
         const rightPage = pages[i + 1];
-        const rightResolved = this.getResolvedPage(i + 1);
-        const rightPageSize = rightResolved
-          ? { w: rightResolved.width, h: rightResolved.height }
-          : (rightPage.size ?? layout.pageSize);
-        const rightPageEl = this.renderPage(rightPageSize.w, rightPageSize.h, rightPage, i + 1);
+        const rightPageEl = this.renderPage(rightPage.width, rightPage.height, rightPage, i + 1);
         spreadEl.appendChild(rightPageEl);
       }
 
@@ -2110,47 +2102,47 @@ export class DomPainter {
     }
   }
 
-  private renderPage(width: number, height: number, page: Page, pageIndex: number): HTMLElement {
+  private renderPage(width: number, height: number, resolvedPage: ResolvedPage, pageIndex: number): HTMLElement {
     if (!this.doc) {
       throw new Error('DomPainter: document is not available');
     }
-    const resolvedPage = this.getResolvedPage(pageIndex);
     const el = this.doc.createElement('div');
     el.classList.add(CLASS_NAMES.page);
     applyStyles(el, pageStyles(width, height, this.getEffectivePageStyles()));
     this.applySemanticPageOverrides(el);
     el.dataset.layoutEpoch = String(this.layoutEpoch);
-    el.dataset.pageNumber = String(page.number);
+    el.dataset.pageNumber = String(resolvedPage.number);
     el.dataset.pageIndex = String(pageIndex);
 
     // Render per-page ruler if enabled (suppressed in semantic flow mode)
     if (!this.isSemanticFlow && this.options.ruler?.enabled) {
-      const rulerEl = this.renderPageRuler(width, page, resolvedPage);
+      const rulerEl = this.renderPageRuler(width, resolvedPage);
       if (rulerEl) {
         el.appendChild(rulerEl);
       }
     }
 
     const contextBase: FragmentRenderContext = {
-      pageNumber: page.number,
+      pageNumber: resolvedPage.number,
       totalPages: this.totalPages,
       section: 'body',
-      pageNumberText: resolvedPage?.numberText ?? page.numberText,
+      pageNumberText: resolvedPage.numberText,
       pageIndex,
     };
 
-    const resolvedItems = resolvedPage?.items ?? [];
-    const sdtBoundaries = computeSdtBoundaries(page.fragments, resolvedItems, this.sdtLabelsRendered);
-    const betweenBorderFlags = computeBetweenBorderFlags(page.fragments, resolvedItems);
+    const fragments = this.fragmentsFromResolvedPage(resolvedPage);
+    const resolvedItems = resolvedPage.items;
+    const sdtBoundaries = computeSdtBoundaries(fragments, resolvedItems, this.sdtLabelsRendered);
+    const betweenBorderFlags = computeBetweenBorderFlags(fragments, resolvedItems);
 
-    page.fragments.forEach((fragment, index) => {
+    fragments.forEach((fragment, index) => {
       const sdtBoundary = sdtBoundaries.get(index);
       const resolvedItem = this.getResolvedFragmentItem(pageIndex, index);
       el.appendChild(
         this.renderFragment(fragment, contextBase, sdtBoundary, betweenBorderFlags.get(index), resolvedItem),
       );
     });
-    this.renderDecorationsForPage(el, page, pageIndex, resolvedPage);
+    this.renderDecorationsForPage(el, resolvedPage, pageIndex);
     return el;
   }
 
@@ -2161,7 +2153,7 @@ export class DomPainter {
    * The ruler is positioned at the top of the page and displays inch measurements.
    *
    * @param pageWidthPx - Page width in pixels
-   * @param page - Page data containing margins and optional size information
+   * @param resolvedPage - Resolved page data (margins, dimensions)
    * @returns Ruler element, or null if this.doc is unavailable or page margins are missing
    *
    * Side effects:
@@ -2169,18 +2161,18 @@ export class DomPainter {
    * - May invoke the onMarginChange callback if interactive mode is enabled
    *
    * Fallback behavior:
-   * - Uses DEFAULT_PAGE_HEIGHT_PX (1056px = 11 inches) if page.size.h is not available
+   * - Uses DEFAULT_PAGE_HEIGHT_PX (1056px = 11 inches) if resolvedPage.height is not available
    * - Defaults margins to 0 if not explicitly provided
    */
-  private renderPageRuler(pageWidthPx: number, page: Page, resolvedPage?: ResolvedPage | null): HTMLElement | null {
+  private renderPageRuler(pageWidthPx: number, resolvedPage: ResolvedPage): HTMLElement | null {
     if (!this.doc) {
       console.warn('[renderPageRuler] Cannot render ruler: document is not available.');
       return null;
     }
 
-    const margins = resolvedPage?.margins ?? page.margins;
+    const margins = resolvedPage.margins;
     if (!margins) {
-      console.warn(`[renderPageRuler] Cannot render ruler for page ${page.number}: margins not available.`);
+      console.warn(`[renderPageRuler] Cannot render ruler for page ${resolvedPage.number}: margins not available.`);
       return null;
     }
 
@@ -2190,7 +2182,7 @@ export class DomPainter {
     try {
       const rulerDefinition = generateRulerDefinitionFromPx({
         pageWidthPx,
-        pageHeightPx: page.size?.h ?? DEFAULT_PAGE_HEIGHT_PX,
+        pageHeightPx: resolvedPage.height ?? DEFAULT_PAGE_HEIGHT_PX,
         leftMarginPx: leftMargin,
         rightMarginPx: rightMargin,
       });
@@ -2222,24 +2214,19 @@ export class DomPainter {
       rulerEl.style.top = '0';
       rulerEl.style.left = '0';
       rulerEl.style.zIndex = '20';
-      rulerEl.dataset.pageNumber = String(page.number);
+      rulerEl.dataset.pageNumber = String(resolvedPage.number);
 
       return rulerEl;
     } catch (error) {
-      console.error(`[renderPageRuler] Failed to create ruler for page ${page.number}:`, error);
+      console.error(`[renderPageRuler] Failed to create ruler for page ${resolvedPage.number}:`, error);
       return null;
     }
   }
 
-  private renderDecorationsForPage(
-    pageEl: HTMLElement,
-    page: Page,
-    pageIndex: number,
-    resolvedPage?: ResolvedPage | null,
-  ): void {
+  private renderDecorationsForPage(pageEl: HTMLElement, resolvedPage: ResolvedPage, pageIndex: number): void {
     if (this.isSemanticFlow) return;
-    this.renderDecorationSection(pageEl, page, pageIndex, 'header', resolvedPage);
-    this.renderDecorationSection(pageEl, page, pageIndex, 'footer', resolvedPage);
+    this.renderDecorationSection(pageEl, resolvedPage, pageIndex, 'header');
+    this.renderDecorationSection(pageEl, resolvedPage, pageIndex, 'footer');
   }
 
   /**
@@ -2270,46 +2257,40 @@ export class DomPainter {
    */
   private getDecorationAnchorPageOriginY(
     pageEl: HTMLElement,
-    page: Page,
+    resolvedPage: ResolvedPage,
     kind: 'header' | 'footer',
     effectiveOffset: number,
-    resolvedPage?: ResolvedPage | null,
   ): number {
     if (kind === 'header') {
       return effectiveOffset;
     }
 
-    const pageMargins = resolvedPage?.margins ?? page.margins;
+    const pageMargins = resolvedPage.margins;
     const bottomMargin = pageMargins?.bottom;
     if (bottomMargin == null) {
       return effectiveOffset;
     }
 
-    const footnoteReserve = resolvedPage?.footnoteReserved ?? page.footnoteReserved ?? 0;
+    const footnoteReserve = resolvedPage.footnoteReserved ?? 0;
     const adjustedBottomMargin = Math.max(0, bottomMargin - footnoteReserve);
     const styledPageHeight = Number.parseFloat(pageEl.style.height || '');
     const pageHeight =
-      page.size?.h ??
-      this.currentLayout?.pageSize?.h ??
-      (Number.isFinite(styledPageHeight) ? styledPageHeight : pageEl.clientHeight);
+      resolvedPage.height ?? (Number.isFinite(styledPageHeight) ? styledPageHeight : pageEl.clientHeight);
 
     return Math.max(0, pageHeight - adjustedBottomMargin);
   }
 
   private renderDecorationSection(
     pageEl: HTMLElement,
-    page: Page,
+    resolvedPage: ResolvedPage,
     pageIndex: number,
     kind: 'header' | 'footer',
-    resolvedPage?: ResolvedPage | null,
   ): void {
     if (!this.doc) return;
     const provider = kind === 'header' ? this.headerProvider : this.footerProvider;
     const className = kind === 'header' ? CLASS_NAMES.pageHeader : CLASS_NAMES.pageFooter;
     const existing = pageEl.querySelector(`.${className}`);
-    const data = provider
-      ? provider(resolvedPage?.number ?? page.number, resolvedPage?.margins ?? page.margins, resolvedPage ?? undefined)
-      : null;
+    const data = provider ? provider(resolvedPage.number, resolvedPage.margins, resolvedPage) : null;
 
     if (!data || data.fragments.length === 0) {
       existing?.remove();
@@ -2321,7 +2302,7 @@ export class DomPainter {
     container.innerHTML = '';
     const baseOffset = data.offset ?? (kind === 'footer' ? pageEl.clientHeight - data.height : 0);
     const marginLeft = data.marginLeft ?? 0;
-    const pageMargins = resolvedPage?.margins ?? page.margins;
+    const pageMargins = resolvedPage.margins;
     const marginRight = pageMargins?.right ?? 0;
 
     // For footers, if content is taller than reserved space, expand container upward
@@ -2362,7 +2343,7 @@ export class DomPainter {
     // Header page-relative anchors use raw inner-layout Y and are handled with
     // the simpler effectiveOffset subtraction (unchanged from the baseline).
     const footerAnchorPageOriginY =
-      kind === 'footer' ? this.getDecorationAnchorPageOriginY(pageEl, page, kind, effectiveOffset, resolvedPage) : 0;
+      kind === 'footer' ? this.getDecorationAnchorPageOriginY(pageEl, resolvedPage, kind, effectiveOffset) : 0;
     const footerAnchorContainerOffsetY = kind === 'footer' ? footerAnchorPageOriginY - effectiveOffset : 0;
 
     // For footers, calculate offset to push content to bottom of container
@@ -2385,10 +2366,10 @@ export class DomPainter {
     }
 
     const context: FragmentRenderContext = {
-      pageNumber: page.number,
+      pageNumber: resolvedPage.number,
       totalPages: this.totalPages,
       section: kind,
-      pageNumberText: resolvedPage?.numberText ?? page.numberText,
+      pageNumberText: resolvedPage.numberText,
       pageIndex,
     };
 
@@ -2510,7 +2491,8 @@ export class DomPainter {
       this.mount.innerHTML = '';
     }
     this.pageStates = [];
-    this.currentLayout = null;
+    this.hasRenderedOnce = false;
+    this.resolvedLayout = null;
     this.pageIndexToState.clear();
     this.topSpacerEl = null;
     this.bottomSpacerEl = null;
@@ -2526,45 +2508,43 @@ export class DomPainter {
     this.mountedPageIndices = [];
   }
 
-  private fullRender(layout: Layout): void {
+  private fullRender(resolvedLayout: ResolvedLayout): void {
     if (!this.mount || !this.doc) return;
     this.mount.innerHTML = '';
     this.pageStates = [];
 
-    layout.pages.forEach((page, pageIndex) => {
-      const resolved = this.getResolvedPage(pageIndex);
-      const pageSize = resolved ? { w: resolved.width, h: resolved.height } : (page.size ?? layout.pageSize);
-      const pageState = this.createPageState(page, pageSize, pageIndex);
-      pageState.element.dataset.pageNumber = String(page.number);
+    resolvedLayout.pages.forEach((resolvedPage, pageIndex) => {
+      const pageSize = { w: resolvedPage.width, h: resolvedPage.height };
+      const pageState = this.createPageState(resolvedPage, pageSize, pageIndex);
+      pageState.element.dataset.pageNumber = String(resolvedPage.number);
       pageState.element.dataset.pageIndex = String(pageIndex);
       this.mount!.appendChild(pageState.element);
       this.pageStates.push(pageState);
     });
   }
 
-  private patchLayout(layout: Layout): void {
+  private patchLayout(resolvedLayout: ResolvedLayout): void {
     if (!this.mount || !this.doc) return;
 
     const nextStates: PageDomState[] = [];
 
-    layout.pages.forEach((page, index) => {
-      const resolved = this.getResolvedPage(index);
-      const pageSize = resolved ? { w: resolved.width, h: resolved.height } : (page.size ?? layout.pageSize);
+    resolvedLayout.pages.forEach((resolvedPage, index) => {
+      const pageSize = { w: resolvedPage.width, h: resolvedPage.height };
       const prevState = this.pageStates[index];
       if (!prevState) {
-        const newState = this.createPageState(page, pageSize, index);
-        newState.element.dataset.pageNumber = String(page.number);
+        const newState = this.createPageState(resolvedPage, pageSize, index);
+        newState.element.dataset.pageNumber = String(resolvedPage.number);
         newState.element.dataset.pageIndex = String(index);
         this.mount!.insertBefore(newState.element, this.mount!.children[index] ?? null);
         nextStates.push(newState);
         return;
       }
-      this.patchPage(prevState, page, pageSize, index);
+      this.patchPage(prevState, resolvedPage, pageSize, index);
       nextStates.push(prevState);
     });
 
-    if (this.pageStates.length > layout.pages.length) {
-      for (let i = layout.pages.length; i < this.pageStates.length; i += 1) {
+    if (this.pageStates.length > resolvedLayout.pages.length) {
+      for (let i = resolvedLayout.pages.length; i < this.pageStates.length; i += 1) {
         this.pageStates[i]?.element.remove();
       }
     }
@@ -2572,30 +2552,35 @@ export class DomPainter {
     this.pageStates = nextStates;
   }
 
-  private patchPage(state: PageDomState, page: Page, pageSize: { w: number; h: number }, pageIndex: number): void {
-    const resolvedPage = this.getResolvedPage(pageIndex);
+  private patchPage(
+    state: PageDomState,
+    resolvedPage: ResolvedPage,
+    pageSize: { w: number; h: number },
+    pageIndex: number,
+  ): void {
     const pageEl = state.element;
     applyStyles(pageEl, pageStyles(pageSize.w, pageSize.h, this.getEffectivePageStyles()));
     this.applySemanticPageOverrides(pageEl);
-    pageEl.dataset.pageNumber = String(page.number);
+    pageEl.dataset.pageNumber = String(resolvedPage.number);
     pageEl.dataset.layoutEpoch = String(this.layoutEpoch);
     // pageIndex is already set during creation and doesn't change during patch
 
     const existing = new Map(state.fragments.map((frag) => [frag.key, frag]));
     const nextFragments: FragmentDomState[] = [];
-    const resolvedItems = resolvedPage?.items ?? [];
-    const sdtBoundaries = computeSdtBoundaries(page.fragments, resolvedItems, this.sdtLabelsRendered);
-    const betweenBorderFlags = computeBetweenBorderFlags(page.fragments, resolvedItems);
+    const fragments = this.fragmentsFromResolvedPage(resolvedPage);
+    const resolvedItems = resolvedPage.items;
+    const sdtBoundaries = computeSdtBoundaries(fragments, resolvedItems, this.sdtLabelsRendered);
+    const betweenBorderFlags = computeBetweenBorderFlags(fragments, resolvedItems);
 
     const contextBase: FragmentRenderContext = {
-      pageNumber: page.number,
+      pageNumber: resolvedPage.number,
       totalPages: this.totalPages,
       section: 'body',
-      pageNumberText: resolvedPage?.numberText ?? page.numberText,
+      pageNumberText: resolvedPage.numberText,
       pageIndex,
     };
 
-    page.fragments.forEach((fragment, index) => {
+    fragments.forEach((fragment, index) => {
       const key = fragmentKey(fragment);
       const current = existing.get(key);
       const sdtBoundary = sdtBoundaries.get(index);
@@ -2670,7 +2655,7 @@ export class DomPainter {
     });
 
     state.fragments = nextFragments;
-    this.renderDecorationsForPage(pageEl, page, pageIndex, resolvedPage);
+    this.renderDecorationsForPage(pageEl, resolvedPage, pageIndex);
   }
 
   /**
@@ -2726,11 +2711,14 @@ export class DomPainter {
     }
   }
 
-  private createPageState(page: Page, pageSize: { w: number; h: number }, pageIndex: number): PageDomState {
+  private createPageState(
+    resolvedPage: ResolvedPage,
+    pageSize: { w: number; h: number },
+    pageIndex: number,
+  ): PageDomState {
     if (!this.doc) {
       throw new Error('DomPainter.createPageState requires a document');
     }
-    const resolvedPage = this.getResolvedPage(pageIndex);
     const el = this.doc.createElement('div');
     el.classList.add(CLASS_NAMES.page);
     applyStyles(el, pageStyles(pageSize.w, pageSize.h, this.getEffectivePageStyles()));
@@ -2738,17 +2726,18 @@ export class DomPainter {
     el.dataset.layoutEpoch = String(this.layoutEpoch);
 
     const contextBase: FragmentRenderContext = {
-      pageNumber: page.number,
+      pageNumber: resolvedPage.number,
       totalPages: this.totalPages,
       section: 'body',
-      pageNumberText: resolvedPage?.numberText ?? page.numberText,
+      pageNumberText: resolvedPage.numberText,
       pageIndex,
     };
 
-    const resolvedItems = resolvedPage?.items ?? [];
-    const sdtBoundaries = computeSdtBoundaries(page.fragments, resolvedItems, this.sdtLabelsRendered);
-    const betweenBorderFlags = computeBetweenBorderFlags(page.fragments, resolvedItems);
-    const fragmentStates: FragmentDomState[] = page.fragments.map((fragment, index) => {
+    const fragments = this.fragmentsFromResolvedPage(resolvedPage);
+    const resolvedItems = resolvedPage.items;
+    const sdtBoundaries = computeSdtBoundaries(fragments, resolvedItems, this.sdtLabelsRendered);
+    const betweenBorderFlags = computeBetweenBorderFlags(fragments, resolvedItems);
+    const fragmentStates: FragmentDomState[] = fragments.map((fragment, index) => {
       const sdtBoundary = sdtBoundaries.get(index);
       const resolvedItem = this.getResolvedFragmentItem(pageIndex, index);
       const fragmentEl = this.renderFragment(
@@ -2769,7 +2758,7 @@ export class DomPainter {
       };
     });
 
-    this.renderDecorationsForPage(el, page, pageIndex, resolvedPage);
+    this.renderDecorationsForPage(el, resolvedPage, pageIndex);
     return { element: el, fragments: fragmentStates };
   }
 

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -271,13 +271,13 @@ export type PageDecorationPayload = {
  *
  * @param {number} pageNumber - The page number (1-indexed)
  * @param {PageMargins} [pageMargins] - Page margin configuration
- * @param {Page} [page] - Full page object from the layout
+ * @param {ResolvedPage} [resolvedPage] - Resolved page from the layout
  * @returns {PageDecorationPayload | null} Decoration payload containing fragments and layout info, or null if no decoration
  */
 export type PageDecorationProvider = (
   pageNumber: number,
   pageMargins?: PageMargins,
-  page?: Page,
+  resolvedPage?: ResolvedPage,
 ) => PageDecorationPayload | null;
 
 /**
@@ -2307,8 +2307,9 @@ export class DomPainter {
     const provider = kind === 'header' ? this.headerProvider : this.footerProvider;
     const className = kind === 'header' ? CLASS_NAMES.pageHeader : CLASS_NAMES.pageFooter;
     const existing = pageEl.querySelector(`.${className}`);
-    // Provider still receives legacy page — its signature is not changed in this PR
-    const data = provider ? provider(page.number, page.margins, page) : null;
+    const data = provider
+      ? provider(resolvedPage?.number ?? page.number, resolvedPage?.margins ?? page.margins, resolvedPage ?? undefined)
+      : null;
 
     if (!data || data.fragments.length === 0) {
       existing?.remove();

--- a/packages/layout-engine/painters/dom/src/test-utils/test-painter.ts
+++ b/packages/layout-engine/painters/dom/src/test-utils/test-painter.ts
@@ -2,10 +2,10 @@
  * Test-only bridge around `createDomPainter`.
  *
  * The production painter accepts a pre-computed `DomPainterInput`
- * (`{ resolvedLayout, sourceLayout }`). Most tests, however, still express
- * their fixtures as `{ blocks, measures }` plus a raw `Layout`. This helper
- * lets those tests keep that shape by running `resolveLayout` internally
- * on every `paint(layout, mount)` call.
+ * (`{ resolvedLayout }`). Most tests, however, still express their fixtures
+ * as `{ blocks, measures }` plus a raw `Layout`. This helper lets those tests
+ * keep that shape by running `resolveLayout` internally on every
+ * `paint(layout, mount)` call.
  *
  * Use this in tests only. Production code must call `createDomPainter`
  * directly with a `DomPainterInput`.
@@ -54,7 +54,6 @@ export function createTestPainter(opts: TestPainterOptions): TestPainterHandle {
                     blocks: currentBlocks,
                     measures: currentMeasures,
                   }),
-            sourceLayout: input,
           };
       painter.paint(resolvedInput, mount, mapping);
     },
@@ -72,5 +71,5 @@ export function createTestPainter(opts: TestPainterOptions): TestPainterHandle {
 }
 
 function isDomPainterInput(value: DomPainterInput | Layout): value is DomPainterInput {
-  return typeof value === 'object' && value !== null && 'resolvedLayout' in value && 'sourceLayout' in value;
+  return typeof value === 'object' && value !== null && 'resolvedLayout' in value;
 }

--- a/packages/layout-engine/painters/dom/src/virtualization.test.ts
+++ b/packages/layout-engine/painters/dom/src/virtualization.test.ts
@@ -33,7 +33,6 @@ function createTestPainter(opts: { blocks?: FlowBlock[]; measures?: Measure[] } 
             });
       const input: DomPainterInput = {
         resolvedLayout: effectiveResolved,
-        sourceLayout: layout,
       };
       painter.paint(input, mount, mapping as any);
     },

--- a/packages/layout-engine/pm-adapter/src/integration.test.ts
+++ b/packages/layout-engine/pm-adapter/src/integration.test.ts
@@ -489,7 +489,7 @@ describe('PM → FlowBlock → Measure integration', () => {
 
     const painter = createDomPainter({});
     const resolvedLayout = resolveLayout({ layout, flowMode: 'paginated', blocks, measures });
-    painter.paint({ resolvedLayout, sourceLayout: layout }, mount);
+    painter.paint({ resolvedLayout }, mount);
 
     expect(mount.children.length).toBeGreaterThan(0);
     expect(mount.textContent).toContain('This is a simple paragraph');
@@ -545,7 +545,7 @@ describe('PM → FlowBlock → Measure integration', () => {
 
     const painter = createDomPainter({});
     const resolvedLayout = resolveLayout({ layout, flowMode: 'paginated', blocks, measures });
-    painter.paint({ resolvedLayout, sourceLayout: layout }, mount);
+    painter.paint({ resolvedLayout }, mount);
 
     const fragment = mount.querySelector('.superdoc-fragment') as HTMLElement;
     const shadingLayer = fragment.querySelector('.superdoc-paragraph-shading') as HTMLElement;
@@ -758,7 +758,7 @@ describe('page break integration tests', () => {
 
     const painter = createDomPainter({});
     const resolvedLayout = resolveLayout({ layout, flowMode: 'paginated', blocks, measures });
-    painter.paint({ resolvedLayout, sourceLayout: layout }, mount);
+    painter.paint({ resolvedLayout }, mount);
 
     // Verify multiple pages were created in DOM
     const pages = mount.querySelectorAll('.superdoc-page');

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -4386,7 +4386,6 @@ export class PresentationEditor extends EventEmitter {
       const painterPaintStart = perfNow();
       const paintInput: DomPainterInput = {
         resolvedLayout,
-        sourceLayout: layout,
       };
       this.#painterAdapter.paint(paintInput, this.#painterHost, mapping ?? undefined);
       const painterPaintEnd = perfNow();

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -102,6 +102,7 @@ import type {
   Layout,
   Measure,
   Page,
+  ResolvedLayout,
   SectionMetadata,
   TrackedChangesMode,
   Fragment,
@@ -4365,7 +4366,7 @@ export class PresentationEditor extends EventEmitter {
       // Process per-rId header/footer content and decoration providers (paginated only)
       if (!isSemanticFlow) {
         await this.#layoutPerRIdHeaderFooters(headerFooterInput, layout, sectionMetadata);
-        this.#updateDecorationProviders(layout);
+        this.#updateDecorationProviders(layout, resolvedLayout);
       }
 
       this.#ensurePainter();
@@ -5532,8 +5533,8 @@ export class PresentationEditor extends EventEmitter {
    * Update decoration providers for header/footer.
    * Delegates to HeaderFooterSessionManager which handles provider creation.
    */
-  #updateDecorationProviders(layout: Layout) {
-    this.#headerFooterSession?.updateDecorationProviders(layout);
+  #updateDecorationProviders(layout: Layout, resolvedLayout: ResolvedLayout) {
+    this.#headerFooterSession?.updateDecorationProviders(layout, resolvedLayout);
   }
 
   /**

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/header-footer/HeaderFooterSessionManager.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/header-footer/HeaderFooterSessionManager.ts
@@ -19,6 +19,8 @@ import type {
   SectionMetadata,
   Fragment,
   ResolvedHeaderFooterLayout,
+  ResolvedLayout,
+  ResolvedPage,
 } from '@superdoc/contracts';
 import type { PageDecorationProvider } from '@superdoc/painter-dom';
 import { resolveHeaderFooterLayout } from '@superdoc/layout-resolved';
@@ -234,6 +236,9 @@ export class HeaderFooterSessionManager {
   // Decoration providers
   #headerDecorationProvider: PageDecorationProvider | undefined;
   #footerDecorationProvider: PageDecorationProvider | undefined;
+
+  // Cached resolved layout (used to supply ResolvedPage to providers & regions)
+  #currentResolvedLayout: ResolvedLayout | null = null;
 
   // Region tracking
   #headerRegions: Map<number, HeaderFooterRegion> = new Map();
@@ -548,21 +553,28 @@ export class HeaderFooterSessionManager {
     const defaultMargins = this.#options.defaultMargins;
 
     layout.pages.forEach((page, pageIndex) => {
+      const resolvedPage = this.#currentResolvedLayout?.pages[pageIndex] ?? null;
       const margins = page.margins ?? layoutOptions.margins ?? defaultMargins;
-      const actualPageHeight = page.size?.h ?? pageHeight;
+      const actualPageHeight = resolvedPage?.height ?? page.size?.h ?? pageHeight;
       const sectionIndex = page.sectionIndex ?? 0;
       const sectionId = sectionIdBySectionIndex.get(sectionIndex) ?? `section-${sectionIndex}`;
 
       // Header region
-      const headerPayload = this.#headerDecorationProvider?.(page.number, margins, page);
+      const headerPayload = this.#headerDecorationProvider?.(page.number, margins, resolvedPage ?? undefined);
       const headerBox = this.#computeDecorationBox('header', margins, actualPageHeight);
       const displayPageNumber = page.numberText ?? String(page.number);
+
+      // Minimal ResolvedPage for sectionType helper when a matching resolved
+      // page is unavailable (falls back to values from the Layout Page).
+      const resolvedForSectionType: ResolvedPage =
+        resolvedPage ?? ({ number: page.number, sectionIndex: page.sectionIndex } as ResolvedPage);
 
       this.#headerRegions.set(pageIndex, {
         kind: 'header',
         headerFooterRefId: headerPayload?.headerFooterRefId,
         sectionType:
-          headerPayload?.sectionType ?? this.#computeExpectedSectionType('header', page, sectionFirstPageNumbers),
+          headerPayload?.sectionType ??
+          this.#computeExpectedSectionType('header', resolvedForSectionType, sectionFirstPageNumbers),
         sectionId,
         sectionIndex,
         pageIndex,
@@ -575,14 +587,15 @@ export class HeaderFooterSessionManager {
       });
 
       // Footer region
-      const footerPayload = this.#footerDecorationProvider?.(page.number, margins, page);
-      const footerBoxMargins = this.#stripFootnoteReserveFromBottomMargin(margins, page);
+      const footerPayload = this.#footerDecorationProvider?.(page.number, margins, resolvedPage ?? undefined);
+      const footerBoxMargins = this.#stripFootnoteReserveFromBottomMargin(margins, resolvedPage);
       const footerBox = this.#computeDecorationBox('footer', footerBoxMargins, actualPageHeight);
       this.#footerRegions.set(pageIndex, {
         kind: 'footer',
         headerFooterRefId: footerPayload?.headerFooterRefId,
         sectionType:
-          footerPayload?.sectionType ?? this.#computeExpectedSectionType('footer', page, sectionFirstPageNumbers),
+          footerPayload?.sectionType ??
+          this.#computeExpectedSectionType('footer', resolvedForSectionType, sectionFirstPageNumbers),
         sectionId,
         sectionIndex,
         pageIndex,
@@ -1370,11 +1383,11 @@ export class HeaderFooterSessionManager {
 
   #computeExpectedSectionType(
     kind: 'header' | 'footer',
-    page: Page,
+    resolvedPage: ResolvedPage,
     sectionFirstPageNumbers: Map<number, number>,
   ): string {
-    const pageNumber = page.number;
-    const sectionIndex = page.sectionIndex ?? 0;
+    const pageNumber = resolvedPage.number;
+    const sectionIndex = resolvedPage.sectionIndex ?? 0;
     const firstPageInSection = sectionFirstPageNumbers.get(sectionIndex);
     const isFirstPageOfSection = firstPageInSection === pageNumber;
 
@@ -1392,17 +1405,17 @@ export class HeaderFooterSessionManager {
       return 'first';
     }
     if (hasAlternateHeaders) {
-      return page.number % 2 === 0 ? 'even' : 'odd';
+      return pageNumber % 2 === 0 ? 'even' : 'odd';
     }
     return 'default';
   }
 
   #stripFootnoteReserveFromBottomMargin(
     margins: HeaderFooterLayoutOptions['margins'],
-    page: Page,
+    resolvedPage: ResolvedPage | null,
   ): HeaderFooterLayoutOptions['margins'] {
     // Note: property is 'footnoteReserved' (with 'd') as defined in @superdoc/contracts
-    const footnoteReserved = page.footnoteReserved ?? 0;
+    const footnoteReserved = resolvedPage?.footnoteReserved ?? 0;
     if (footnoteReserved <= 0) return margins;
 
     const currentBottom = margins?.bottom ?? this.#options.defaultMargins.bottom ?? 0;
@@ -1608,7 +1621,8 @@ export class HeaderFooterSessionManager {
    * Update decoration providers for header and footer.
    * Creates new providers based on layout results and sets them on this manager.
    */
-  updateDecorationProviders(layout: Layout): void {
+  updateDecorationProviders(layout: Layout, resolvedLayout: ResolvedLayout): void {
+    this.#currentResolvedLayout = resolvedLayout;
     this.#headerDecorationProvider = this.createDecorationProvider('header', layout);
     this.#footerDecorationProvider = this.createDecorationProvider('footer', layout);
     this.rebuildRegions(layout);
@@ -1645,8 +1659,8 @@ export class HeaderFooterSessionManager {
       }
     }
 
-    return (pageNumber, pageMargins, page) => {
-      const sectionIndex = page?.sectionIndex ?? 0;
+    return (pageNumber, pageMargins, resolvedPage) => {
+      const sectionIndex = resolvedPage?.sectionIndex ?? 0;
       const firstPageInSection = sectionFirstPageNumbers.get(sectionIndex);
       const sectionPageNumber =
         typeof firstPageInSection === 'number' ? pageNumber - firstPageInSection + 1 : pageNumber;
@@ -1656,23 +1670,25 @@ export class HeaderFooterSessionManager {
 
       // Resolve section-specific rId using Word's OOXML inheritance model
       let sectionRId: string | undefined;
-      if (page?.sectionRefs && kind === 'header') {
-        sectionRId = page.sectionRefs.headerRefs?.[headerFooterType as keyof typeof page.sectionRefs.headerRefs];
+      if (resolvedPage?.sectionRefs && kind === 'header') {
+        sectionRId =
+          resolvedPage.sectionRefs.headerRefs?.[headerFooterType as keyof typeof resolvedPage.sectionRefs.headerRefs];
         if (!sectionRId && headerFooterType && headerFooterType !== 'default' && sectionIndex > 0 && multiSectionId) {
           const prevSectionIds = multiSectionId.sectionHeaderIds.get(sectionIndex - 1);
           sectionRId = prevSectionIds?.[headerFooterType as keyof typeof prevSectionIds] ?? undefined;
         }
         if (!sectionRId && headerFooterType !== 'default') {
-          sectionRId = page.sectionRefs.headerRefs?.default;
+          sectionRId = resolvedPage.sectionRefs.headerRefs?.default;
         }
-      } else if (page?.sectionRefs && kind === 'footer') {
-        sectionRId = page.sectionRefs.footerRefs?.[headerFooterType as keyof typeof page.sectionRefs.footerRefs];
+      } else if (resolvedPage?.sectionRefs && kind === 'footer') {
+        sectionRId =
+          resolvedPage.sectionRefs.footerRefs?.[headerFooterType as keyof typeof resolvedPage.sectionRefs.footerRefs];
         if (!sectionRId && headerFooterType && headerFooterType !== 'default' && sectionIndex > 0 && multiSectionId) {
           const prevSectionIds = multiSectionId.sectionFooterIds.get(sectionIndex - 1);
           sectionRId = prevSectionIds?.[headerFooterType as keyof typeof prevSectionIds] ?? undefined;
         }
         if (!sectionRId && headerFooterType !== 'default') {
-          sectionRId = page.sectionRefs.footerRefs?.default;
+          sectionRId = resolvedPage.sectionRefs.footerRefs?.default;
         }
       }
 
@@ -1705,10 +1721,11 @@ export class HeaderFooterSessionManager {
               );
             }
             const alignedItems = resolvedItems && resolvedItems.length === fragments.length ? resolvedItems : undefined;
-            const pageHeight = page?.size?.h ?? layout.pageSize?.h ?? layoutOptions.pageSize?.h ?? defaultPageSize.h;
+            const pageHeight =
+              resolvedPage?.height ?? layout.pageSize?.h ?? layoutOptions.pageSize?.h ?? defaultPageSize.h;
             const margins = pageMargins ?? layout.pages[0]?.margins ?? layoutOptions.margins ?? defaultMargins;
             const decorationMargins =
-              kind === 'footer' ? this.#stripFootnoteReserveFromBottomMargin(margins, page ?? null) : margins;
+              kind === 'footer' ? this.#stripFootnoteReserveFromBottomMargin(margins, resolvedPage ?? null) : margins;
             const box = this.#computeDecorationBox(kind, decorationMargins, pageHeight);
 
             // When a table grid width exceeds the section content width, the layout
@@ -1768,10 +1785,10 @@ export class HeaderFooterSessionManager {
       const alignedVariantItems =
         resolvedVariantItems && resolvedVariantItems.length === fragments.length ? resolvedVariantItems : undefined;
 
-      const pageHeight = page?.size?.h ?? layout.pageSize?.h ?? layoutOptions.pageSize?.h ?? defaultPageSize.h;
+      const pageHeight = resolvedPage?.height ?? layout.pageSize?.h ?? layoutOptions.pageSize?.h ?? defaultPageSize.h;
       const margins = pageMargins ?? layout.pages[0]?.margins ?? layoutOptions.margins ?? defaultMargins;
       const decorationMargins =
-        kind === 'footer' ? this.#stripFootnoteReserveFromBottomMargin(margins, page ?? null) : margins;
+        kind === 'footer' ? this.#stripFootnoteReserveFromBottomMargin(margins, resolvedPage ?? null) : margins;
       const box = this.#computeDecorationBox(kind, decorationMargins, pageHeight);
 
       const rawLayoutHeight = variant.layout.height ?? 0;


### PR DESCRIPTION
## Summary

Addresses [@luccas-harbour's review](https://github.com/superdoc-dev/superdoc/pull/2810#discussion_r4292241097) on PR #2810. The `PageDecorationProvider` callback still received the legacy `Page` object even though every field it reads lives on `ResolvedPage` (lifted in PR 1).

## What changed

- `PageDecorationProvider` type: 3rd arg is now `resolvedPage?: ResolvedPage` (was `page?: Page`)
- `renderer.ts`: passes `resolvedPage` to the provider
- `HeaderFooterSessionManager.createDecorationProvider`: reads all page data from `resolvedPage` (sectionIndex, sectionRefs, height, margins, etc.)
- Helpers `#stripFootnoteReserveFromBottomMargin` and `#computeExpectedSectionType`: signatures updated to take `ResolvedPage`
- `rebuildRegions`: caches `#currentResolvedLayout` and maps pageIndex → resolvedPage for both region construction and provider invocation
- `PresentationEditor` threads `resolvedLayout` into `updateDecorationProviders`

## Why this closes the ticket

SD-2563's done-criterion: *"painter does not depend on upstream internal data beyond its intended contract"*. The Painter's contract is `ResolvedLayout`. The provider callback was the last surface where the painter handed legacy `Page` data to an external handler. After this PR, the resolved path is the only one — the `Page` parameter is completely gone from the provider contract.

## Verification

- ✅ painter-dom: 952/952 tests
- ✅ layout-resolved: 103/103 tests
- ✅ super-editor: 11350/11361 tests (13 pre-existing skipped)
- ✅ pm-adapter: 1723/1723 tests
- ✅ layout-bridge: 1162/1162 tests
- ✅ All packages build clean
- ✅ `pnpm layout:compare --input-root test-corpus --reference v.1.26.0-next.18` → **0 changed / 407 unchanged** (byte-identical rendering)

## PR Stack (SD-2563: Dumb Painter Refactor)

| # | PR | Title | Status |
|---|-----|-------|--------|
| 1 | #2810 | Lift page metadata into ResolvedPage | |
| 2 | #2811 | Lift fragment metadata into resolved paint items | |
| 3 | #2812 | Pre-compute SDT container keys in resolved layout | |
| 4 | #2813 | Pre-compute paragraph border data in resolved layout | |
| 5 | #2814 | Move change detection into resolved layout stage | |
| 6 | #2818 | Lift paragraph/list block and measure into resolved items | |
| 7 | #2819 | Extract block/measure resolution helper | |
| 8 | #2820 | Remove body blocks/measures from DomPainterInput | |
| 9 | #2826 | Add resolveHeaderFooterLayout helper | |
| 10 | #2827 | Deliver resolved items to decoration provider callback | |
| 11 | #2828 | Remove blockLookup — painter reads only resolved data | |
| 12 | #2829 | Delete dead hash helpers after blockLookup removal | |
| 13 | #2845 | Testing cleanup + alignment tests | |
| 14 | #2853 | Remove legacy createDomPainter wrapper API | |
| **15** | **#2906** | **Provider callback receives ResolvedPage instead of Page** | **👈 this PR** |
| 16 | #2909 | Eliminate Page and sourceLayout from DomPainter | |
