### PR TITLE
chore(template-builder): bump superdoc peer dep to ^1.28.0

### DIFF
--- a/packages/template-builder/package.json
+++ b/packages/template-builder/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "superdoc": "^1.24.2"
+    "superdoc": "^1.28.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "catalog:",


### PR DESCRIPTION
Bumps the `superdoc` peerDependency floor in `@superdoc-dev/template-builder` from `^1.24.2` to `^1.28.0` so the published package advertises the latest stable as its minimum supported host version.

- Targeting `stable` so it ships with the current release train; the stable-to-main sync workflow will carry it back to `main`.
- No runtime code change; semver-compatible bump of the lower bound only.