### PR TITLE
feat(esign): expose SuperDocESign as a named export

### DIFF
--- a/packages/esign/src/index.tsx
+++ b/packages/esign/src/index.tsx
@@ -527,4 +527,5 @@ const SuperDocESign = forwardRef<Types.SuperDocESignHandle, Types.SuperDocESignP
 
 SuperDocESign.displayName = 'SuperDocESign';
 
+export { SuperDocESign };
 export default SuperDocESign;


### PR DESCRIPTION
Adds a named export for `SuperDocESign` alongside the existing default export so consumers can do either:

```ts
import SuperDocESign from '@superdoc-dev/esign';
import { SuperDocESign } from '@superdoc-dev/esign';
```

Non-breaking. Also intentionally uses `feat:` so semantic-release will cut the minor-bump release that picks up the `superdoc@^1.28.0` peer dep bump merged in #2912 (that one used `chore:` and didn't trigger a publish).