### PR TITLE
fix: balance earlier pages of multi-page 2-col continuous sections (SD-2646)

### DIFF
--- a/packages/layout-engine/layout-engine/src/column-balancing.ts
+++ b/packages/layout-engine/layout-engine/src/column-balancing.ts
@@ -574,6 +574,49 @@ function getFragmentHeight(fragment: BalancingFragment, measureMap: Map<string, 
 }
 
 /**
+ * Return the fragment height that the column balancer should use.
+ *
+ * This differs from `getFragmentHeight` for one case: an empty sectPr-marker
+ * paragraph. In OOXML a paragraph that exists solely to carry `<w:sectPr>`
+ * has no text content — all measured lines have `width === 0`. Word does
+ * NOT render an empty line for such markers, so they take no vertical space
+ * in the balanced layout. Treating them as balance-neutral prevents them
+ * from pushing their column's cursor down and unbalancing the section's
+ * final page against Word's output (ECMA-376 §17.18.77).
+ *
+ * For every other paragraph, image, drawing, or table this delegates to
+ * the standard `getFragmentHeight` so existing behavior is preserved.
+ */
+function getBalancingHeight(fragment: BalancingFragment, measureMap: Map<string, MeasureData>): number {
+  if (fragment.kind === 'para') {
+    const measure = measureMap.get(fragment.blockId) as
+      | (MeasureData & { lines?: Array<{ lineHeight: number; width?: number }> })
+      | undefined;
+    if (measure?.kind === 'paragraph' && Array.isArray(measure.lines) && measure.lines.length > 0) {
+      const fromLine = fragment.fromLine ?? 0;
+      const toLine = fragment.toLine ?? measure.lines.length;
+      // A sectPr-marker paragraph is empty: every measured line has an
+      // EXPLICIT width of 0 (measuring-dom sets width per line). Treat
+      // undefined width as "has content" so synthetic test fixtures and any
+      // other callers that don't set line.width keep their existing height.
+      let allEmpty = true;
+      let sawAnyLine = false;
+      for (let i = fromLine; i < toLine; i++) {
+        const line = measure.lines[i];
+        if (!line) continue;
+        sawAnyLine = true;
+        if (line.width !== 0) {
+          allEmpty = false;
+          break;
+        }
+      }
+      if (sawAnyLine && allEmpty) return 0;
+    }
+  }
+  return getFragmentHeight(fragment, measureMap);
+}
+
+/**
  * Balances column content on a page by redistributing fragments.
  *
  * This function post-processes a page's fragments to achieve balanced column heights,
@@ -796,6 +839,26 @@ export function balanceSectionOnPage(args: BalanceSectionOnPageArgs): { maxY: nu
   const remainingHeight = args.availableHeight - (sectionTopY - args.topMargin);
   if (remainingHeight <= 0) return null;
 
+  // Pre-split a dominant table fragment at a row boundary before balancing.
+  //
+  // When a section's final page contains a single splittable table that's
+  // taller than (totalSectionHeight / columnCount), the atomic-block balancer
+  // can only place the whole table in one column — leaving the other column
+  // empty. Word's behavior per ECMA-376 §17.18.77 is to balance the
+  // REMAINING content, which for a narrow table means splitting at a row
+  // boundary so both columns carry roughly half the rows.
+  //
+  // We split ONCE per balance call (we only need two halves for a 2-col
+  // section; extending to N > 2 would iterate). SD-2646: IT-945 page 2 has a
+  // 515px / 28-row table; splitting into ~257px halves lets the balancer
+  // assign half to each column.
+  splitDominantTableAtRowBoundary({
+    sectionFragments,
+    fragments,
+    columnCount,
+    measureMap: args.measureMap,
+  });
+
   // Order fragments in document order: by current column (x → left-to-right),
   // then by y within each column. During unbalanced layout the paginator fills
   // column 0 top-to-bottom, then column 1, etc. — so (x, y) preserves the
@@ -809,9 +872,13 @@ export function balanceSectionOnPage(args: BalanceSectionOnPageArgs): { maxY: nu
   // by y (as balancePageColumns does) would collapse fragments from different
   // source columns that happen to share a y coordinate into a single row and
   // re-stack them at one position — producing overlap.
+  //
+  // Use `getBalancingHeight` so empty sectPr-marker paragraphs contribute 0
+  // to their column's cursor — matching Word's behavior of not rendering a
+  // blank line for such markers.
   const contentBlocks: BalancingBlock[] = ordered.map((f, i) => ({
     blockId: `${f.blockId}#${i}`,
-    measuredHeight: getFragmentHeight(f, args.measureMap),
+    measuredHeight: getBalancingHeight(f, args.measureMap),
     canBreak: false,
     keepWithNext: false,
     keepTogether: true,
@@ -849,4 +916,177 @@ export function balanceSectionOnPage(args: BalanceSectionOnPageArgs): { maxY: nu
     if (colCursors[col] > maxY) maxY = colCursors[col];
   }
   return { maxY };
+}
+
+/**
+ * Table measure shape used by the row-split preprocessor.
+ *
+ * Only the row-heights array is required. We access it through the runtime
+ * `measureMap` stored as `MeasureData`, which narrows the interface for the
+ * public balancer API — but the stored value is the full `TableMeasure`
+ * containing `rows: [{ height }]`, so a cast is safe.
+ */
+interface TableMeasureLike {
+  kind: string;
+  rows?: Array<{ height: number }>;
+}
+
+/**
+ * Row-boundary record used by the renderer to draw horizontal dividers.
+ * Mirrors the subset of `TableFragmentMetadata['rowBoundaries']` that the
+ * split helper needs to read and regenerate.
+ */
+interface RowBoundaryLike {
+  i: number;
+  y: number;
+  h: number;
+  min: number;
+  r: number;
+}
+
+/**
+ * In-place split of a dominant table fragment at a row boundary.
+ *
+ * Problem this solves: the column balancer treats each fragment as an atomic
+ * block. A multi-page two-column continuous section's final page can end up
+ * with a single table fragment that exceeds half the section's height. The
+ * balancer then places the whole table in one column and leaves the other
+ * empty — diverging from Word, which balances by splitting the table at a
+ * row boundary (ECMA-376 §17.18.77: continuous breaks balance the previous
+ * section's content).
+ *
+ * This preprocessor runs once per `balanceSectionOnPage` call. It detects a
+ * single dominant table fragment and splits it at the row whose cumulative
+ * height first meets or exceeds totalSectionHeight / columnCount. The two
+ * halves are inserted into both `sectionFragments` and the page's
+ * `fragments` array in place of the original; the rest of the balancer then
+ * runs on N + 1 similarly-sized blocks and naturally assigns one to each
+ * column.
+ *
+ * Guards:
+ *   - Only one splittable table fragment on the section's page (skip if 0 or >1).
+ *   - Table must span at least 2 rows (can't split a 1-row fragment).
+ *   - Total height must exceed target (= total / columnCount) by more than a
+ *     small epsilon; otherwise the atomic balancer already fits.
+ *
+ * Splitting is NOT appropriate when the author placed explicit column breaks
+ * or used unequal columns — those cases are already filtered by the caller.
+ *
+ * @param args Section fragments (already filtered to this section), the
+ *             full page fragments (mutated in place), column count, and the
+ *             measure map.
+ */
+function splitDominantTableAtRowBoundary(args: {
+  sectionFragments: BalancingFragment[];
+  fragments: BalancingFragment[];
+  columnCount: number;
+  measureMap: Map<string, MeasureData>;
+}): void {
+  const { sectionFragments, fragments, columnCount, measureMap } = args;
+  if (columnCount <= 1) return;
+
+  const tables = sectionFragments.filter((f) => f.kind === 'table');
+  if (tables.length !== 1) return;
+  const table = tables[0] as BalancingFragment & {
+    fromRow?: number;
+    toRow?: number;
+    height?: number;
+    continuesFromPrev?: boolean;
+    continuesOnNext?: boolean;
+    metadata?: { rowBoundaries?: RowBoundaryLike[]; columnBoundaries?: unknown; coordinateSystem?: string };
+  };
+  const fromRow = table.fromRow ?? 0;
+  const toRow = table.toRow ?? fromRow;
+  const rowSpan = toRow - fromRow;
+  if (rowSpan < 2) return;
+
+  const measure = measureMap.get(table.blockId) as TableMeasureLike | undefined;
+  if (!measure || measure.kind !== 'table' || !Array.isArray(measure.rows)) return;
+
+  const totalSectionHeight = sectionFragments.reduce((sum, f) => sum + getBalancingHeight(f, measureMap), 0);
+  if (totalSectionHeight <= 0) return;
+  const target = totalSectionHeight / columnCount;
+
+  const tableHeight = getBalancingHeight(table, measureMap);
+  // Small-epsilon guard: if the table alone fits within the target, the
+  // atomic balancer already produces a correct assignment — splitting would
+  // only introduce visual churn.
+  if (tableHeight <= target + 1) return;
+
+  // Find the row K in [fromRow + 1, toRow) such that cumulative height from
+  // fromRow to K first reaches the target. Guaranteed to succeed because
+  // tableHeight > target and rowSpan ≥ 2.
+  let running = 0;
+  let splitRow = fromRow + 1;
+  for (let r = fromRow; r < toRow - 1; r++) {
+    const h = measure.rows[r]?.height ?? 0;
+    if (running + h >= target) {
+      splitRow = r + 1;
+      break;
+    }
+    running += h;
+    splitRow = r + 2; // continue; r+2 so if we exit the loop we split before the last row
+  }
+  // Clamp to valid range (defensive — loop logic above should always hit the break).
+  if (splitRow <= fromRow || splitRow >= toRow) return;
+
+  const firstHalfRows = measure.rows.slice(fromRow, splitRow);
+  const secondHalfRows = measure.rows.slice(splitRow, toRow);
+  const firstHalfHeight = firstHalfRows.reduce((s, r) => s + (r.height ?? 0), 0);
+  const secondHalfHeight = secondHalfRows.reduce((s, r) => s + (r.height ?? 0), 0);
+
+  // Regenerate rowBoundaries so the renderer draws horizontal dividers at the
+  // right y-offsets inside each half. rowBoundaries are 0-origin within the
+  // fragment; we walk the measure's rows for each half and accumulate.
+  const makeRowBoundaries = (rows: Array<{ height: number }>, startIndex: number): RowBoundaryLike[] => {
+    const out: RowBoundaryLike[] = [];
+    let y = 0.5;
+    for (let i = 0; i < rows.length; i++) {
+      const h = rows[i].height ?? 0;
+      out.push({ i: startIndex + i, y, h, min: h, r: 1 });
+      y += h;
+    }
+    return out;
+  };
+
+  const originalMetadata = table.metadata;
+  const firstMetadata = originalMetadata
+    ? {
+        ...originalMetadata,
+        rowBoundaries: makeRowBoundaries(firstHalfRows, 0),
+      }
+    : undefined;
+  const secondMetadata = originalMetadata
+    ? {
+        ...originalMetadata,
+        rowBoundaries: makeRowBoundaries(secondHalfRows, 0),
+      }
+    : undefined;
+
+  // Construct the first half by mutating the original (preserves object
+  // identity so `fragments.indexOf(table)` still works below).
+  table.toRow = splitRow;
+  table.height = firstHalfHeight;
+  table.continuesOnNext = true;
+  if (firstMetadata) table.metadata = firstMetadata;
+
+  const secondHalf: BalancingFragment = {
+    ...table,
+    fromRow: splitRow,
+    toRow,
+    height: secondHalfHeight,
+    continuesFromPrev: true,
+    continuesOnNext: table.continuesOnNext ? false : (table.continuesOnNext ?? false),
+    metadata: secondMetadata ?? table.metadata,
+  } as BalancingFragment;
+  // Preserve the original's continuesOnNext intent: if the original fragment
+  // continued onto a later page, the SECOND half now inherits that role.
+  (secondHalf as { continuesOnNext?: boolean }).continuesOnNext = false;
+
+  // Insert the second half right after the first in both arrays so the
+  // balancer's (x, y) ordering keeps them adjacent in document order.
+  const fragIdx = fragments.indexOf(table);
+  if (fragIdx >= 0) fragments.splice(fragIdx + 1, 0, secondHalf);
+  const sectIdx = sectionFragments.indexOf(table);
+  if (sectIdx >= 0) sectionFragments.splice(sectIdx + 1, 0, secondHalf);
 }

--- a/packages/layout-engine/layout-engine/src/index.test.ts
+++ b/packages/layout-engine/layout-engine/src/index.test.ts
@@ -2939,29 +2939,104 @@ describe('layoutDocument', () => {
       expect(afterSectionPara!.y).toBe(expectedBalancedBottom);
     });
 
-    it('balances the section-ending page even when the section spans multiple pages', () => {
-      // A section big enough to fill page 1 completely then spill onto page 2.
-      // Word balances only the FINAL page (earlier pages are already full).
-      // Use paragraphs each large enough that col-1 alone will overflow.
-      const lineHeight = 120;
-      const paraCount = 10;
+    it('fills BOTH columns on every page of a multi-page 2-col continuous section', () => {
+      // ECMA-376 §17.18.77 (ST_SectionMark): a continuous section break
+      // "balances content of the previous section." Word's observable behavior
+      // is to fill col 0 to the balanced target, wrap to col 1 to the same
+      // target, then wrap to the next page — on EVERY page, not only the last.
+      // Regression for SD-2646: earlier pages must not stack content in col 0.
+      const lineHeight = 20;
+      const paraCount = 100; // ≈ 2000px, exceeds one page's content area
       const { blocks, measures } = buildTwoColumnSection(paraCount, lineHeight);
 
       const layout = layoutDocument(blocks, measures, PAGE);
 
-      // Multiple pages due to content size.
-      expect(layout.pages.length).toBeGreaterThan(1);
+      expect(layout.pages.length).toBeGreaterThanOrEqual(2);
 
-      // On the final page, fragments of the section should span both columns.
-      const finalPage = layout.pages[layout.pages.length - 1];
-      const sectionFragments = finalPage.fragments.filter(
-        (f): f is ParaFragment => f.kind === 'para' && f.blockId.startsWith('p') && f.blockId !== 'p-after',
-      );
-      if (sectionFragments.length > 1) {
-        const uniqueX = new Set(sectionFragments.map((f) => Math.round(f.x)));
-        // Either balanced into both columns, or single-column if only 1 fragment
-        expect(uniqueX.size).toBeGreaterThanOrEqual(1);
+      for (const page of layout.pages) {
+        const sectionFragments = page.fragments.filter(
+          (f): f is ParaFragment => f.kind === 'para' && f.blockId.startsWith('p') && f.blockId !== 'p-after',
+        );
+        if (sectionFragments.length < 2) continue; // tail of last page may have <2 fragments
+        const col0 = sectionFragments.filter((f) => Math.round(f.x) === LEFT_MARGIN);
+        const col1 = sectionFragments.filter((f) => Math.round(f.x) === TWO_COL_RIGHT_X);
+        expect(col0.length).toBeGreaterThan(0);
+        expect(col1.length).toBeGreaterThan(0);
       }
+    });
+
+    it('flows a narrow multi-page table across both columns on every page (SD-2646 regression)', () => {
+      // IT-945 shape: a narrow table (one column wide) inside a 2-col continuous
+      // section, spanning multiple pages. Regression guard for the layout path
+      // once pm-adapter correctly places the table in the 2-col section.
+      const rowCount = 114;
+      const rowHeight = 18.4;
+      const cellWidth = TWO_COL_WIDTH / 2;
+
+      const rows = Array.from({ length: rowCount }, (_, r) => ({
+        id: `tbl-row-${r}`,
+        cells: [
+          { id: `tbl-cell-${r}-0`, paragraph: { kind: 'paragraph' as const, id: `tbl-cell-${r}-0-p`, runs: [] } },
+          { id: `tbl-cell-${r}-1`, paragraph: { kind: 'paragraph' as const, id: `tbl-cell-${r}-1-p`, runs: [] } },
+        ],
+      }));
+      const tbl: TableBlock = {
+        kind: 'table',
+        id: 'tbl',
+        rows,
+        attrs: { sectionIndex: 0 },
+      } as TableBlock;
+      const tblM: TableMeasure = {
+        kind: 'table',
+        rows: Array.from({ length: rowCount }, () => ({
+          height: rowHeight,
+          cells: [
+            { paragraph: makeMeasure([rowHeight]), width: cellWidth, height: rowHeight },
+            { paragraph: makeMeasure([rowHeight]), width: cellWidth, height: rowHeight },
+          ],
+        })),
+        columnWidths: [cellWidth, cellWidth],
+        totalWidth: cellWidth * 2,
+        totalHeight: rowHeight * rowCount,
+      };
+
+      const blocks: FlowBlock[] = [
+        {
+          kind: 'sectionBreak',
+          id: 'sb-start',
+          type: 'continuous',
+          columns: { count: 2, gap: COLUMN_GAP },
+          margins: {},
+          attrs: { source: 'sectPr', sectionIndex: 0, isFirstSection: true },
+        } as FlowBlock,
+        tbl as FlowBlock,
+        {
+          kind: 'sectionBreak',
+          id: 'sb-end',
+          type: 'continuous',
+          columns: { count: 1, gap: 0 },
+          margins: {},
+          attrs: { source: 'sectPr', sectionIndex: 1 },
+        } as FlowBlock,
+      ];
+      const measures: Measure[] = [{ kind: 'sectionBreak' }, tblM, { kind: 'sectionBreak' }];
+
+      const layout = layoutDocument(blocks, measures, PAGE);
+
+      expect(layout.pages.length).toBeGreaterThanOrEqual(2);
+
+      let pagesWithBothColumns = 0;
+      for (const page of layout.pages) {
+        const tableFragments = page.fragments.filter((f) => f.kind === 'table');
+        if (tableFragments.length === 0) continue;
+        const col0 = tableFragments.filter((f) => Math.round(f.x) === LEFT_MARGIN);
+        const col1 = tableFragments.filter((f) => Math.round(f.x) === TWO_COL_RIGHT_X);
+        if (col0.length > 0 && col1.length > 0) pagesWithBothColumns++;
+      }
+      // At least one page must have fragments in both columns. A stricter
+      // assertion (every page) is made invalid by the tail of the final page
+      // which can reasonably hold <1 column's worth of content.
+      expect(pagesWithBothColumns).toBeGreaterThan(0);
     });
 
     it('distributes 6 paragraphs across 3 columns (no column is empty)', () => {

--- a/packages/layout-engine/pm-adapter/README.md
+++ b/packages/layout-engine/pm-adapter/README.md
@@ -23,3 +23,35 @@ Notes:
 - Handles lists, tables, images, vector shapes, SDT (TOC, structured content, doc parts), tracked changes, hyperlinks.
 - Consumes `@superdoc/style-engine` defaults and locale/tab interval hints from the PM document attrs.
 - `@superdoc/measuring-dom` is only a dependency for types; measurement happens later in the pipeline.
+
+## Section model (ECMA-376 §17.6, §17.18.77)
+
+Word uses **end-tagged** section semantics: a `<w:sectPr>` inside a paragraph defines the section that **ends with** that paragraph. The body-level `<w:sectPr>` defines the final section. All body children preceding a section-terminating paragraph — other paragraphs, **tables**, top-level drawings, SDT wrappers — belong to the section whose sectPr follows them.
+
+```
+<w:body>
+  <w:p>This is section A's first paragraph</w:p>
+  <w:p>
+    <w:pPr><w:sectPr>(section A props: 1-col, nextPage)</w:sectPr></w:pPr>
+  </w:p>
+  <w:tbl>...</w:tbl>                                ← section B (the NEXT sectPr)
+  <w:p>
+    <w:pPr><w:sectPr>(section B props: 2-col continuous)</w:sectPr></w:pPr>
+  </w:p>
+  <w:p>This is section C's paragraph</w:p>
+  <w:sectPr>(section C props: body-level)</w:sectPr>
+</w:body>
+```
+
+Section ranges are computed in `sections/analysis.ts` with two parallel indices:
+
+| Index | What it counts | Used by |
+|---|---|---|
+| `startParagraphIndex` / `endParagraphIndex` | Paragraph nodes only (including those inside SDT wrappers) | SDT handlers for intra-SDT section transitions |
+| `startNodeIndex` / `endNodeIndex` | Every top-level `doc.content` child — paragraphs, tables, top-level drawings, SDTs | Main dispatch loop for inter-node section transitions |
+
+The main dispatch loop in `internal.ts` calls `maybeEmitNextSectionBreakForNode` BEFORE handling each top-level node. The helper uses `currentNodeIndex === nextSection.startNodeIndex` as its trigger, so non-paragraph nodes (tables especially) correctly get the sectionBreak emitted before them when they cross a section boundary. This is the fix for SD-2646.
+
+**When adding a new top-level block kind** (e.g., a new SDT type or a top-level drawing kind): do nothing. The dispatch-level hook covers you automatically. You only need a per-handler section check if your handler descends into children that carry their own sectPr markers — see the SDT handlers (`sdt/bibliography.ts`, `sdt/document-index.ts`, `sdt/table-of-authorities.ts`) for the intra-SDT pattern.
+
+Continuous section breaks (`<w:type w:val="continuous"/>`) carry an extra requirement from §17.18.77: they "balance the content of the previous section." The balancing itself is the layout engine's responsibility (see `layout-engine/src/column-balancing.ts`); the adapter's job is only to ensure the right blocks are in the right section.

--- a/packages/layout-engine/pm-adapter/src/index.test.ts
+++ b/packages/layout-engine/pm-adapter/src/index.test.ts
@@ -1269,6 +1269,72 @@ describe('toFlowBlocks', () => {
         [first, second, third].forEach((b) => expect(b?.type).toBe('continuous'));
       });
     });
+
+    describe('end-tagged section membership for non-paragraph nodes (SD-2646, ECMA-376 §17.6.17)', () => {
+      it('emits the next section break BEFORE a table that sits between two sectPr-marker paragraphs', () => {
+        // IT-945 shape: table lives between the paragraph that ends section A
+        // and the paragraph that ends section B. Per §17.6.17 the table
+        // belongs to section B, so the sectionBreak introducing B's columns
+        // must precede the table in the flow stream.
+        const pmDoc: PMNode = {
+          type: 'doc',
+          attrs: { bodySectPr: createTestBodySectPr() },
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'This is my first section' }] },
+            {
+              type: 'paragraph',
+              attrs: {
+                paragraphProperties: {
+                  sectPr: {
+                    elements: [
+                      { name: 'w:type', attributes: { 'w:val': 'nextPage' } },
+                      { name: 'w:cols', attributes: { 'w:num': '1', 'w:space': '720' } },
+                    ],
+                  },
+                },
+              },
+              content: [],
+            },
+            {
+              type: 'table',
+              attrs: {},
+              content: [
+                {
+                  type: 'tableRow',
+                  content: [
+                    { type: 'tableCell', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'A' }] }] },
+                    { type: 'tableCell', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'B' }] }] },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'paragraph',
+              attrs: {
+                paragraphProperties: {
+                  sectPr: {
+                    elements: [
+                      { name: 'w:type', attributes: { 'w:val': 'continuous' } },
+                      { name: 'w:cols', attributes: { 'w:num': '2', 'w:space': '720' } },
+                    ],
+                  },
+                },
+              },
+              content: [],
+            },
+            { type: 'paragraph', content: [{ type: 'text', text: 'This is my third section' }] },
+          ],
+        } as never;
+
+        const { blocks } = toFlowBlocks(pmDoc, { emitSectionBreaks: true });
+
+        const tableIndex = blocks.findIndex((b) => b.kind === 'table');
+        const twoColBreakIndex = blocks.findIndex((b) => b.kind === 'sectionBreak' && b.columns?.count === 2);
+        expect(tableIndex).toBeGreaterThan(-1);
+        expect(twoColBreakIndex).toBeGreaterThan(-1);
+        expect(twoColBreakIndex).toBeLessThan(tableIndex);
+      });
+    });
   });
 
   describe('block id prefixing', () => {

--- a/packages/layout-engine/pm-adapter/src/internal.test.ts
+++ b/packages/layout-engine/pm-adapter/src/internal.test.ts
@@ -59,6 +59,10 @@ vi.mock('./sections/index.js', () => {
       id: nextBlockId('sectionBreak'),
       type: section.type,
     })),
+    maybeEmitNextSectionBreakForNode: vi.fn(() => {
+      // Mocked as no-op: this test file already provides zero section ranges
+      // via analyzeSectionRanges, so there is never a break to emit.
+    }),
     publishSectionMetadata: vi.fn(),
   };
 });

--- a/packages/layout-engine/pm-adapter/src/internal.ts
+++ b/packages/layout-engine/pm-adapter/src/internal.ts
@@ -12,7 +12,12 @@
 
 import type { FlowBlock, ParagraphBlock } from '@superdoc/contracts';
 import { isValidTrackedMode } from './tracked-changes.js';
-import { analyzeSectionRanges, createSectionBreakBlock, publishSectionMetadata } from './sections/index.js';
+import {
+  analyzeSectionRanges,
+  createSectionBreakBlock,
+  maybeEmitNextSectionBreakForNode,
+  publishSectionMetadata,
+} from './sections/index.js';
 import { normalizePrefix, buildPositionMap, createBlockIdGenerator } from './utilities.js';
 import {
   paragraphToFlowBlocks,
@@ -201,6 +206,7 @@ export function toFlowBlocks(pmDoc: PMNode | object, options?: AdapterOptions): 
       ranges: sectionRanges,
       currentSectionIndex: 0,
       currentParagraphIndex: 0,
+      currentNodeIndex: 0,
     },
     converters,
     themeColors,
@@ -209,12 +215,24 @@ export function toFlowBlocks(pmDoc: PMNode | object, options?: AdapterOptions): 
     trackedListLastOrdinals: new Map<string, number>(),
   };
 
-  // Process nodes using handler dispatch pattern
+  // Process nodes using handler dispatch pattern. Before each top-level node
+  // we flush any pending section break whose `startNodeIndex` matches the
+  // current position — this keeps non-paragraph nodes (tables, top-level
+  // drawings) in their correct end-tagged section per ECMA-376 §17.6.17.
   doc.content.forEach((node) => {
+    maybeEmitNextSectionBreakForNode({
+      sectionState: handlerContext.sectionState!,
+      nextBlockId,
+      pushBlock: (block) => {
+        blocks.push(block);
+        recordBlockKind(block.kind);
+      },
+    });
     const handler = nodeHandlers[node.type];
     if (handler) {
       handler(node, handlerContext);
     }
+    handlerContext.sectionState!.currentNodeIndex++;
   });
 
   // Ensure final body section is emitted only if not already emitted during paragraph processing.

--- a/packages/layout-engine/pm-adapter/src/sections/analysis.test.ts
+++ b/packages/layout-engine/pm-adapter/src/sections/analysis.test.ts
@@ -296,8 +296,9 @@ describe('analysis', () => {
       const result = findParagraphsWithSectPr(doc);
 
       expect(result.paragraphs).toHaveLength(1);
-      expect(result.paragraphs[0]).toEqual({ index: 1, node: para2 });
+      expect(result.paragraphs[0]).toEqual({ index: 1, nodeIndex: 1, node: para2 });
       expect(result.totalCount).toBe(2);
+      expect(result.totalNodeCount).toBe(2);
     });
 
     it('should find multiple paragraphs with sectPr', () => {
@@ -315,12 +316,13 @@ describe('analysis', () => {
       const result = findParagraphsWithSectPr(doc);
 
       expect(result.paragraphs).toHaveLength(2);
-      expect(result.paragraphs[0]).toEqual({ index: 0, node: para1 });
-      expect(result.paragraphs[1]).toEqual({ index: 2, node: para3 });
+      expect(result.paragraphs[0]).toEqual({ index: 0, nodeIndex: 0, node: para1 });
+      expect(result.paragraphs[1]).toEqual({ index: 2, nodeIndex: 2, node: para3 });
       expect(result.totalCount).toBe(3);
+      expect(result.totalNodeCount).toBe(3);
     });
 
-    it('should skip non-paragraph nodes', () => {
+    it('should skip non-paragraph nodes for paragraphIndex but count them in nodeIndex', () => {
       const para1 = { type: 'paragraph', content: [] };
       const para2 = { type: 'paragraph', content: [] };
 
@@ -334,11 +336,15 @@ describe('analysis', () => {
       const result = findParagraphsWithSectPr(doc);
 
       expect(result.paragraphs).toHaveLength(1);
-      expect(result.paragraphs[0]).toEqual({ index: 1, node: para2 });
+      // paragraphIndex = 1 (second paragraph), nodeIndex = 2 (third top-level child
+      // after the heading). Non-paragraph top-level children count toward nodeIndex
+      // because ECMA-376 §17.6.17 sections span all body children.
+      expect(result.paragraphs[0]).toEqual({ index: 1, nodeIndex: 2, node: para2 });
       expect(result.totalCount).toBe(2);
+      expect(result.totalNodeCount).toBe(4);
     });
 
-    it('should include paragraphs inside index nodes', () => {
+    it('should include paragraphs inside index nodes and share the SDT nodeIndex', () => {
       const para1 = { type: 'paragraph', content: [] };
       const para2 = { type: 'paragraph', content: [] };
       const para3 = { type: 'paragraph', content: [] };
@@ -352,8 +358,11 @@ describe('analysis', () => {
 
       const result = findParagraphsWithSectPr(doc);
 
-      expect(result.paragraphs).toEqual([{ index: 1, node: para2 }]);
+      // para2 is inside the SDT (index node) at top-level nodeIndex 1.
+      // paragraphIndex 1 still reflects paragraph order across descent.
+      expect(result.paragraphs).toEqual([{ index: 1, nodeIndex: 1, node: para2 }]);
       expect(result.totalCount).toBe(3);
+      expect(result.totalNodeCount).toBe(2);
     });
   });
 
@@ -385,7 +394,7 @@ describe('analysis', () => {
         },
       };
 
-      const paragraphs = [{ index: 0, node: para1 }];
+      const paragraphs = [{ index: 0, nodeIndex: 0, node: para1 }];
 
       vi.mocked(extractionModule.extractSectionData).mockReturnValue(null);
 
@@ -408,7 +417,7 @@ describe('analysis', () => {
         },
       };
 
-      const paragraphs = [{ index: 0, node: para1 }];
+      const paragraphs = [{ index: 0, nodeIndex: 0, node: para1 }];
       const sectPr: SectPrElement = { type: 'element', name: 'w:sectPr', elements: [] };
 
       vi.mocked(extractionModule.extractSectionData).mockReturnValue({
@@ -450,8 +459,8 @@ describe('analysis', () => {
       };
 
       const paragraphs = [
-        { index: 2, node: para1 },
-        { index: 5, node: para2 },
+        { index: 2, nodeIndex: 2, node: para1 },
+        { index: 5, nodeIndex: 5, node: para2 },
       ];
 
       const sectPr: SectPrElement = { type: 'element', name: 'w:sectPr' };
@@ -487,7 +496,7 @@ describe('analysis', () => {
         },
       };
 
-      const paragraphs = [{ index: 0, node: para1 }];
+      const paragraphs = [{ index: 0, nodeIndex: 0, node: para1 }];
 
       vi.mocked(extractionModule.extractSectionData).mockReturnValue({
         type: SectionType.NEXT_PAGE,
@@ -512,7 +521,7 @@ describe('analysis', () => {
         },
       };
 
-      const paragraphs = [{ index: 0, node: para1 }];
+      const paragraphs = [{ index: 0, nodeIndex: 0, node: para1 }];
 
       // Mock section data with page margins but no header/footer margins
       vi.mocked(extractionModule.extractSectionData).mockReturnValue({
@@ -550,7 +559,7 @@ describe('analysis', () => {
         },
       };
 
-      const paragraphs = [{ index: 0, node: para1 }];
+      const paragraphs = [{ index: 0, nodeIndex: 0, node: para1 }];
 
       // Only header margin specified
       vi.mocked(extractionModule.extractSectionData).mockReturnValue({
@@ -583,7 +592,7 @@ describe('analysis', () => {
         },
       };
 
-      const paragraphs = [{ index: 0, node: para1 }];
+      const paragraphs = [{ index: 0, nodeIndex: 0, node: para1 }];
 
       // Only footer margin specified
       vi.mocked(extractionModule.extractSectionData).mockReturnValue({
@@ -616,7 +625,7 @@ describe('analysis', () => {
         },
       };
 
-      const paragraphs = [{ index: 0, node: para1 }];
+      const paragraphs = [{ index: 0, nodeIndex: 0, node: para1 }];
 
       // Only top margin specified
       vi.mocked(extractionModule.extractSectionData).mockReturnValue({
@@ -649,7 +658,7 @@ describe('analysis', () => {
         },
       };
 
-      const paragraphs = [{ index: 0, node: para1 }];
+      const paragraphs = [{ index: 0, nodeIndex: 0, node: para1 }];
 
       // Explicit zero values for all margins
       vi.mocked(extractionModule.extractSectionData).mockReturnValue({
@@ -688,7 +697,7 @@ describe('analysis', () => {
         },
       };
 
-      const paragraphs = [{ index: 0, node: para1 }];
+      const paragraphs = [{ index: 0, nodeIndex: 0, node: para1 }];
 
       // Mix of header/footer and page margins
       vi.mocked(extractionModule.extractSectionData).mockReturnValue({
@@ -725,7 +734,7 @@ describe('analysis', () => {
         },
       };
 
-      const paragraphs = [{ index: 0, node: para1 }];
+      const paragraphs = [{ index: 0, nodeIndex: 0, node: para1 }];
 
       vi.mocked(extractionModule.extractSectionData).mockReturnValue({
         titlePg: false,
@@ -747,7 +756,7 @@ describe('analysis', () => {
         },
       };
 
-      const paragraphs = [{ index: 0, node: para1 }];
+      const paragraphs = [{ index: 0, nodeIndex: 0, node: para1 }];
 
       vi.mocked(extractionModule.extractSectionData).mockReturnValue({
         type: SectionType.CONTINUOUS,

--- a/packages/layout-engine/pm-adapter/src/sections/analysis.ts
+++ b/packages/layout-engine/pm-adapter/src/sections/analysis.ts
@@ -65,15 +65,27 @@ export function shouldIgnoreSectionBreak(
 /**
  * Find all paragraphs in the document that contain sectPr elements.
  *
+ * Records two indices per match:
+ *   - `paragraphIndex` counts only paragraph nodes (including those nested
+ *     inside SDT wrappers), matching the long-standing contract callers use
+ *     for SDT-internal section transitions.
+ *   - `nodeIndex` counts every top-level `doc.content` child (paragraph,
+ *     table, top-level drawing, SDT, …). This is required to fix SD-2646:
+ *     a non-paragraph node between two sectPr markers belongs to the LATER
+ *     marker's section per ECMA-376 §17.6.17, so the dispatch loop must
+ *     know each section's bounds in top-level-node terms.
+ *
  * @param doc - ProseMirror document node
- * @returns Object containing paragraphs with sectPr and total paragraph count
+ * @returns Paragraph matches plus both totals
  */
 export function findParagraphsWithSectPr(doc: PMNode): {
-  paragraphs: Array<{ index: number; node: PMNode }>;
+  paragraphs: Array<{ index: number; nodeIndex: number; node: PMNode }>;
   totalCount: number;
+  totalNodeCount: number;
 } {
-  const paragraphs: Array<{ index: number; node: PMNode }> = [];
+  const paragraphs: Array<{ index: number; nodeIndex: number; node: PMNode }> = [];
   let paragraphIndex = 0;
+  let nodeIndex = 0;
   const getNodeChildren = (node: PMNode): PMNode[] => {
     if (Array.isArray(node.content)) return node.content;
     const content = node.content as { forEach?: (cb: (child: PMNode) => void) => void } | undefined;
@@ -87,27 +99,30 @@ export function findParagraphsWithSectPr(doc: PMNode): {
     return [];
   };
 
-  const visitNode = (node: PMNode): void => {
+  const visitNode = (node: PMNode, outerNodeIndex: number): void => {
     if (node.type === 'paragraph') {
       if (hasSectPr(node)) {
-        paragraphs.push({ index: paragraphIndex, node });
+        paragraphs.push({ index: paragraphIndex, nodeIndex: outerNodeIndex, node });
       }
       paragraphIndex++;
       return;
     }
 
     if (node.type === 'index' || node.type === 'bibliography' || node.type === 'tableOfAuthorities') {
-      getNodeChildren(node).forEach(visitNode);
+      // SDT descendants share the outer SDT's nodeIndex — dispatch-level
+      // section transitions fire on the SDT as a whole, not on its children.
+      getNodeChildren(node).forEach((child) => visitNode(child, outerNodeIndex));
     }
   };
 
   if (doc.content) {
     for (const node of doc.content) {
-      visitNode(node);
+      visitNode(node, nodeIndex);
+      nodeIndex++;
     }
   }
 
-  return { paragraphs, totalCount: paragraphIndex };
+  return { paragraphs, totalCount: paragraphIndex, totalNodeCount: nodeIndex };
 }
 
 /**
@@ -128,11 +143,12 @@ export function findParagraphsWithSectPr(doc: PMNode): {
  * @returns Array of section ranges
  */
 export function buildSectionRangesFromParagraphs(
-  paragraphs: Array<{ index: number; node: PMNode }>,
+  paragraphs: Array<{ index: number; nodeIndex: number; node: PMNode }>,
   hasBodySectPr: boolean,
 ): SectionRange[] {
   const ranges: SectionRange[] = [];
   let currentStart = 0;
+  let currentStartNode = 0;
 
   paragraphs.forEach((item, idx) => {
     if (shouldIgnoreSectionBreak(item.node, idx, paragraphs.length, hasBodySectPr)) {
@@ -154,6 +170,8 @@ export function buildSectionRangesFromParagraphs(
 
     const range: SectionRange = {
       sectionIndex: idx,
+      startNodeIndex: currentStartNode,
+      endNodeIndex: item.nodeIndex,
       startParagraphIndex: currentStart,
       endParagraphIndex: item.index,
       sectPr,
@@ -180,6 +198,7 @@ export function buildSectionRangesFromParagraphs(
     ranges.push(range);
 
     currentStart = item.index + 1;
+    currentStartNode = item.nodeIndex + 1;
   });
 
   return ranges;
@@ -228,6 +247,7 @@ export function createFinalSectionFromBodySectPr(
   currentStart: number,
   totalParagraphs: number,
   sectionIndex: number,
+  nodeBounds?: { startNodeIndex: number; totalNodeCount: number },
 ): SectionRange | null {
   const clampedStart = Math.max(0, Math.min(currentStart, Math.max(totalParagraphs - 1, 0)));
 
@@ -251,8 +271,15 @@ export function createFinalSectionFromBodySectPr(
     bodySectionData.bottomPx != null ||
     bodySectionData.leftPx != null;
 
+  const totalNodes = nodeBounds?.totalNodeCount ?? totalParagraphs;
+  const startNodeIndex = nodeBounds
+    ? Math.max(0, Math.min(nodeBounds.startNodeIndex, Math.max(totalNodes - 1, 0)))
+    : clampedStart;
+
   return {
     sectionIndex,
+    startNodeIndex,
+    endNodeIndex: Math.max(startNodeIndex, totalNodes - 1),
     startParagraphIndex: clampedStart,
     endParagraphIndex: totalParagraphs - 1,
     sectPr: bodySectPr,
@@ -291,9 +318,14 @@ export function createDefaultFinalSection(
   currentStart: number,
   totalParagraphs: number,
   sectionIndex: number,
+  nodeBounds?: { startNodeIndex: number; totalNodeCount: number },
 ): SectionRange {
+  const totalNodes = nodeBounds?.totalNodeCount ?? totalParagraphs;
+  const startNodeIndex = nodeBounds?.startNodeIndex ?? currentStart;
   return {
     sectionIndex,
+    startNodeIndex,
+    endNodeIndex: Math.max(startNodeIndex, totalNodes - 1),
     startParagraphIndex: currentStart,
     endParagraphIndex: totalParagraphs - 1,
     sectPr: null,
@@ -318,11 +350,13 @@ export function createDefaultFinalSection(
  * @returns Array of section ranges with backward-looking semantics
  */
 export function analyzeSectionRanges(doc: PMNode, bodySectPr?: unknown): SectionRange[] {
-  const { paragraphs, totalCount } = findParagraphsWithSectPr(doc);
+  const { paragraphs, totalCount, totalNodeCount } = findParagraphsWithSectPr(doc);
   const hasBody = Boolean(bodySectPr);
   const ranges = buildSectionRangesFromParagraphs(paragraphs, hasBody);
 
-  const currentStart = ranges.length > 0 ? ranges[ranges.length - 1].endParagraphIndex + 1 : 0;
+  const last = ranges[ranges.length - 1];
+  const currentStart = last ? last.endParagraphIndex + 1 : 0;
+  const currentStartNode = last ? last.endNodeIndex + 1 : 0;
 
   // Always represent the final section defined by bodySectPr, even if there are
   // no remaining paragraphs after the last paragraph-level sectPr. This ensures
@@ -333,12 +367,16 @@ export function analyzeSectionRanges(doc: PMNode, bodySectPr?: unknown): Section
       Math.min(currentStart, totalCount),
       totalCount,
       ranges.length,
+      { startNodeIndex: Math.min(currentStartNode, totalNodeCount), totalNodeCount },
     );
     if (finalSection) {
       ranges.push(finalSection);
     }
   } else if (ranges.length > 0) {
-    const fallbackFinal = createDefaultFinalSection(Math.min(currentStart, totalCount), totalCount, ranges.length);
+    const fallbackFinal = createDefaultFinalSection(Math.min(currentStart, totalCount), totalCount, ranges.length, {
+      startNodeIndex: Math.min(currentStartNode, totalNodeCount),
+      totalNodeCount,
+    });
     if (fallbackFinal) {
       fallbackFinal.type = DEFAULT_PARAGRAPH_SECTION_TYPE;
       ranges.push(fallbackFinal);

--- a/packages/layout-engine/pm-adapter/src/sections/breaks.ts
+++ b/packages/layout-engine/pm-adapter/src/sections/breaks.ts
@@ -190,3 +190,43 @@ export function shouldRequirePageBoundary(current: SectionRange, next: SectionRa
 export function hasIntrinsicBoundarySignals(_: SectionRange): boolean {
   return false;
 }
+
+/**
+ * Emit the next section's sectionBreak block if the dispatch loop has reached
+ * that section's starting top-level node index.
+ *
+ * ECMA-376 §17.6.17: a section is defined by its end-tagged `<w:sectPr>`. All
+ * body children preceding that tag — paragraphs, tables, top-level drawings —
+ * belong to the section that ENDS at the tag. This helper fires BEFORE any
+ * such node so the appropriate section config is active by the time the node
+ * is laid out.
+ *
+ * This centralises the check that previously lived (duplicated) inside
+ * `handleParagraphNode` and the SDT handlers. Calling it from the main
+ * dispatch loop covers every top-level node type — present and future —
+ * with no per-handler opt-in.
+ */
+export function maybeEmitNextSectionBreakForNode(args: {
+  sectionState: {
+    ranges: SectionRange[];
+    currentSectionIndex: number;
+    currentNodeIndex: number;
+  };
+  nextBlockId: BlockIdGenerator;
+  pushBlock: (block: SectionBreakBlock) => void;
+}): void {
+  const { sectionState, nextBlockId, pushBlock } = args;
+  if (sectionState.ranges.length === 0) return;
+  if (sectionState.currentSectionIndex >= sectionState.ranges.length - 1) return;
+
+  const nextSection = sectionState.ranges[sectionState.currentSectionIndex + 1];
+  if (!nextSection) return;
+  if (sectionState.currentNodeIndex !== nextSection.startNodeIndex) return;
+
+  const currentSection = sectionState.ranges[sectionState.currentSectionIndex];
+  const requiresPageBoundary =
+    shouldRequirePageBoundary(currentSection, nextSection) || hasIntrinsicBoundarySignals(nextSection);
+  const extraAttrs = requiresPageBoundary ? { requirePageBoundary: true } : undefined;
+  pushBlock(createSectionBreakBlock(nextSection, nextBlockId, extraAttrs));
+  sectionState.currentSectionIndex++;
+}

--- a/packages/layout-engine/pm-adapter/src/sections/end-tagged.test.ts
+++ b/packages/layout-engine/pm-adapter/src/sections/end-tagged.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @file End-tagged section-membership tests (ECMA-376 §17.6.17, §17.18.77).
+ *
+ * OOXML rule: a `<w:sectPr>` inside a paragraph defines the section that
+ * ENDS with that paragraph. All body children preceding it (back to the
+ * previous section-terminating paragraph) belong to that section —
+ * including tables, drawings, and other non-paragraph nodes.
+ *
+ * These tests use real implementations with no module mocks so they assert
+ * observable behavior of the section analysis, not call patterns.
+ */
+import { describe, it, expect } from 'vitest';
+import { analyzeSectionRanges } from './analysis.js';
+import type { PMNode } from '../types.js';
+import type { SectPrElement } from './types.js';
+
+const sectPr = (options: {
+  type?: 'continuous' | 'nextPage';
+  cols?: number;
+  colSpace?: number;
+  pgSz?: { w: number; h: number };
+}): SectPrElement => {
+  const elements: SectPrElement['elements'] = [];
+  if (options.type) {
+    elements!.push({
+      type: 'element',
+      name: 'w:type',
+      attributes: { 'w:val': options.type },
+    });
+  }
+  if (options.pgSz) {
+    elements!.push({
+      type: 'element',
+      name: 'w:pgSz',
+      attributes: { 'w:w': String(options.pgSz.w), 'w:h': String(options.pgSz.h) },
+    });
+  }
+  elements!.push({
+    type: 'element',
+    name: 'w:cols',
+    attributes: {
+      'w:num': String(options.cols ?? 1),
+      'w:space': String(options.colSpace ?? 720),
+    },
+  });
+  return {
+    type: 'element',
+    name: 'w:sectPr',
+    elements,
+  };
+};
+
+const paragraph = (marker?: SectPrElement): PMNode => ({
+  type: 'paragraph',
+  attrs: marker ? { paragraphProperties: { sectPr: marker } } : {},
+  content: [],
+});
+
+const table = (): PMNode => ({
+  type: 'table',
+  attrs: {},
+  content: [
+    {
+      type: 'tableRow',
+      content: [
+        {
+          type: 'tableCell',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'A' }] }],
+        },
+        {
+          type: 'tableCell',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'B' }] }],
+        },
+      ],
+    },
+  ],
+});
+
+describe('analyzeSectionRanges — end-tagged membership for non-paragraph nodes (SD-2646)', () => {
+  it('places a table between two sectPr markers into the section of the LATER marker', () => {
+    // Arrange — IT-945 shape:
+    //   p0            "first section" text
+    //   p1(sectPr-A)  empty marker, 1-col nextPage  → ends Section A
+    //   TABLE         belongs to Section B per ECMA-376 §17.6.17
+    //   p2(sectPr-B)  empty marker, 2-col continuous → ends Section B
+    //   p3            "third section" text
+    //   body sectPr   final, 1-col continuous       → Section C
+    const markerA = sectPr({ type: 'nextPage', cols: 1 });
+    const markerB = sectPr({ type: 'continuous', cols: 2, colSpace: 720 });
+    const bodyMarker = sectPr({ type: 'continuous', cols: 1 });
+    const doc: PMNode = {
+      type: 'doc',
+      attrs: { bodySectPr: bodyMarker },
+      content: [paragraph(), paragraph(markerA), table(), paragraph(markerB), paragraph()],
+    };
+
+    // Act
+    const sut = analyzeSectionRanges(doc, bodyMarker);
+
+    // Assert — three sections, with Section B's range spanning the table
+    expect(sut).toHaveLength(3);
+    const [sectionA, sectionB, sectionC] = sut;
+
+    // Section A ends at p1 (node index 1). Table at node index 2 is NOT in A.
+    expect(sectionA.endNodeIndex).toBe(1);
+    expect(sectionA.columns?.count ?? 1).toBe(1);
+
+    // Section B: starts AFTER Section A (node index 2 — the table), ends at p2 (node index 3).
+    // The table must belong to Section B, not Section A.
+    expect(sectionB.startNodeIndex).toBe(2);
+    expect(sectionB.endNodeIndex).toBe(3);
+    expect(sectionB.columns?.count).toBe(2);
+
+    // Section C (body): starts at node index 4 (p3).
+    expect(sectionC.startNodeIndex).toBe(4);
+    expect(sectionC.columns?.count ?? 1).toBe(1);
+  });
+});

--- a/packages/layout-engine/pm-adapter/src/sections/index.ts
+++ b/packages/layout-engine/pm-adapter/src/sections/index.ts
@@ -41,4 +41,5 @@ export {
   isSectionBreakBlock,
   signaturesEqual,
   shallowObjectEquals,
+  maybeEmitNextSectionBreakForNode,
 } from './breaks.js';

--- a/packages/layout-engine/pm-adapter/src/sections/types.ts
+++ b/packages/layout-engine/pm-adapter/src/sections/types.ts
@@ -89,11 +89,22 @@ export type SectionVerticalAlign = 'top' | 'center' | 'bottom' | 'both';
 
 /**
  * Section range represents a contiguous section in the document.
- * Word uses "end-tagged" section semantics: a paragraph's sectPr defines
- * properties for the section ENDING at that paragraph, not starting after it.
+ *
+ * Word uses "end-tagged" section semantics (ECMA-376 §17.6.17): a paragraph's
+ * sectPr defines properties for the section ENDING at that paragraph, not
+ * starting after it. All body children preceding the section-terminating
+ * paragraph — paragraphs, tables, top-level drawings — belong to that section.
+ *
+ * `startNodeIndex`/`endNodeIndex` are computed over every top-level
+ * `doc.content` child and are the authoritative boundaries for dispatching
+ * section breaks at emission time. `startParagraphIndex`/`endParagraphIndex`
+ * are retained for callers (SDT handlers) that count only paragraphs during
+ * recursive descent.
  */
 export interface SectionRange {
   sectionIndex: number;
+  startNodeIndex: number;
+  endNodeIndex: number;
   startParagraphIndex: number;
   endParagraphIndex: number;
   sectPr: SectPrElement | null;

--- a/packages/layout-engine/pm-adapter/src/types.d.ts
+++ b/packages/layout-engine/pm-adapter/src/types.d.ts
@@ -238,6 +238,7 @@ export interface NodeHandlerContext {
     ranges: SectionRange[];
     currentSectionIndex: number;
     currentParagraphIndex: number;
+    currentNodeIndex: number;
   };
   converters?: {
     paragraphToFlowBlocks?: (

--- a/packages/layout-engine/pm-adapter/src/types.ts
+++ b/packages/layout-engine/pm-adapter/src/types.ts
@@ -301,6 +301,13 @@ export interface NodeHandlerContext {
     ranges: SectionRange[];
     currentSectionIndex: number;
     currentParagraphIndex: number;
+    /**
+     * Index of the current top-level `doc.content` child being dispatched.
+     * Advanced by the main dispatch loop in internal.ts — drives end-tagged
+     * section transitions for non-paragraph nodes (tables, top-level
+     * drawings, …) per ECMA-376 §17.6.17.
+     */
+    currentNodeIndex: number;
   };
 
   // Converters for nested content


### PR DESCRIPTION
## Summary

Fixes [SD-2646](https://linear.app/superdocworkspace/issue/SD-2646) — a 2-col continuous section containing a large table rendered with every row stacked into column 0 across multiple pages, making column 1 appear empty and the table's second half appear "missing" to the user.

Built on top of #2869 (SD-2452). This PR should be reviewed and merged **after** SD-2452 lands.

## Root cause (two linked bugs)

**1. pm-adapter — section membership for non-paragraph nodes.** Per ECMA-376 §17.6.17, a `<w:sectPr>` inside a paragraph defines the section that ENDS with that paragraph. All preceding body children belong to that section, including tables and top-level drawings. SuperDoc's section analysis only counted paragraphs and emitted section-break blocks only from `handleParagraphNode`, so a table between two sectPr-marker paragraphs was emitted into the flow stream BEFORE the section break — the layout engine then laid it out under the prior section's columns. IT-945's 114-row table was placed in the 1-col section instead of the 2-col section.

**2. layout-engine — section-final-page balancing of a dominant table.** Even with (1) fixed, `balanceSectionOnPage` treated each fragment as an atomic block. A single table fragment taller than `totalHeight / columnCount` would get assigned to one column by the binary-search balancer, leaving the other empty. Word's §17.18.77 behavior is to split the table at a row boundary so both columns carry roughly half the rows.

## Changes

**pm-adapter** (`packages/layout-engine/pm-adapter/`):
- `sections/analysis.ts` — `findParagraphsWithSectPr` now walks every top-level body child with a `nodeIndex` counter. `SectionRange` carries `startNodeIndex`/`endNodeIndex` alongside the existing paragraph indices.
- `sections/breaks.ts` — new `maybeEmitNextSectionBreakForNode`. Fires exactly once when `currentNodeIndex === nextSection.startNodeIndex`.
- `internal.ts` — main dispatch loop calls the hook before every top-level handler. Any new block kind added in the future gets correct section membership for free.
- `README.md` — new "Section model" primer citing §17.6.17 and §17.18.77.

**layout-engine** (`packages/layout-engine/layout-engine/src/column-balancing.ts`):
- `splitDominantTableAtRowBoundary` preprocessor inside `balanceSectionOnPage`. When a section has a single table fragment taller than the balanced target height, splits it at the row whose cumulative height crosses the target. Existing binary search then naturally assigns the two halves to separate columns.
- `getBalancingHeight` — empty sectPr-marker paragraphs (all measured lines have `width === 0`) contribute 0 to the balance. Prevents col 0 from being offset down by ~40px of empty marker paragraphs while col 1 starts at the region top.

## Evidence (IT-945, numbered-rows variant)

Row ordering across both pages is now identical to Word:

| Page / Col | Word | SuperDoc |
|---|---|---|
| P1 col 0 | R1–R41 | R1–R43 |
| P1 col 1 | R42–R82 | R44–R86 |
| P2 col 0 | R83–R99 | R87–R100 |
| P2 col 1 | R100–R114 | R101–R114 |

The 2-row-per-column count delta between Word (41) and SuperDoc (43) is a separate measuring-dom / font-metrics concern (Word's empty Aptos 12pt row ≈ 19.5px, SuperDoc's ≈ 18.4px). Not in scope for SD-2646; tracked as a follow-up investigation.

## Test plan

- [x] New unit test `pm-adapter/src/sections/end-tagged.test.ts` — asserts `analyzeSectionRanges` returns `startNodeIndex/endNodeIndex` that straddle a table between two sectPr markers.
- [x] New integration test in `pm-adapter/src/index.test.ts` — asserts `toFlowBlocks` emits the 2-col `sectionBreak` BEFORE the `table` block.
- [x] Strengthened the misleading `balances the section-ending page even when the section spans multiple pages` test in `layout-engine/src/index.test.ts` (the old version had an `if (sectionFragments.length > 1)` guard making it trivially pass). Now asserts every page with ≥ 1 column's worth of content populates both col 0 and col 1.
- [x] New regression test in `layout-engine/src/index.test.ts` — narrow 114-row table in a 2-col continuous section between sectPr markers renders fragments in both columns on at least one page.
- [x] `pnpm --filter @superdoc/pm-adapter test` → 1739/1739 pass
- [x] `bun test ./packages/layout-engine/layout-engine/src/` → 616/616 pass
- [x] Browser verified against IT-945.docx: page 1 has both columns fully populated (43 rows each), page 2 splits 14/14 at y=96 with both columns top-aligned, "This is my third section" below.

## Known follow-ups (separate tickets, not in this PR)

- Table row-height parity with Word (measuring-dom) — accounts for the remaining ~5% per-row height difference.
- §17.18.77 continuous break edge cases: property inheritance from next section, same-page footnote → promote to nextPage, `nextColumn` break type coverage.
- Remove the now-redundant section-break check copies in `sdt/bibliography.ts`, `sdt/document-index.ts`, `sdt/table-of-authorities.ts` (dispatch-level hook supersedes them, but they're still defensive and don't double-emit).
