### PR TITLE
ci: give every validate job a unique check context

### DIFF
--- a/.github/workflows/ci-behavior.yml
+++ b/.github/workflows/ci-behavior.yml
@@ -75,12 +75,14 @@ jobs:
         working-directory: tests/behavior
 
   validate:
+    name: Behavior Tests / validate
     if: always()
     needs: [test]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "One or more required jobs did not succeed."
             exit 1
           fi

--- a/.github/workflows/ci-demos.yml
+++ b/.github/workflows/ci-demos.yml
@@ -84,12 +84,14 @@ jobs:
         run: DEMO=${{ matrix.demo }} npx playwright test
 
   validate:
+    name: CI Demos / validate
     if: always()
     needs: [smoke-test]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "One or more required jobs did not succeed."
             exit 1
           fi

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   validate:
+    name: CI Docs / validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-document-api.yml
+++ b/.github/workflows/ci-document-api.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   validate:
+    name: CI Document API / validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-esign.yml
+++ b/.github/workflows/ci-esign.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   validate:
+    name: CI eSign / validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -172,12 +172,14 @@ jobs:
         run: npx tsx src/index.test.ts
 
   validate:
+    name: CI Examples / validate
     if: always()
     needs: [getting-started, collaboration, features, advanced-headless-toolbar, headless]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "One or more required jobs did not succeed."
             exit 1
           fi

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   validate:
+    name: CI MCP / validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-react.yml
+++ b/.github/workflows/ci-react.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   validate:
+    name: CI React / validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-sdk.yml
+++ b/.github/workflows/ci-sdk.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   validate:
+    name: CI SDK / validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -232,12 +232,14 @@ jobs:
           flags: superdoc
 
   validate:
+    name: CI SuperDoc / validate
     if: always()
     needs: [build, unit-tests, cli-tests, coverage]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "One or more required jobs did not succeed."
             exit 1
           fi

--- a/.github/workflows/ci-template-builder.yml
+++ b/.github/workflows/ci-template-builder.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   validate:
+    name: CI Template Builder / validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-vscode-ext.yml
+++ b/.github/workflows/ci-vscode-ext.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   validate:
+    name: CI VS Code Extension / validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -17,6 +17,7 @@ on:
       - 'tests/visual/**'
       - 'shared/**'
       - '!**/*.md'
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -126,12 +127,14 @@ jobs:
             }
 
   validate:
+    name: Visual Tests / validate
     if: always()
     needs: [visual]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "One or more required jobs did not succeed."
             exit 1
           fi


### PR DESCRIPTION
The `require-ci` ruleset requires one check context named `validate`, but 13 workflows all emit a job with that name. With duplicate check names, GitHub's required-check matching is ambiguous: any one of the 13 can satisfy the rule, so PRs can merge while most workflows are still red or not running.

This rename gives every `validate` job a workflow-prefixed name so each becomes its own required context, and hardens the five aggregate validators to fail on any non-success result (cancelled and skipped included, not just failure). `visual-test.yml` gains a `merge_group` trigger so its validate context can be required in the merge queue.

**Scope is intentionally narrow.** Path-filter skips (a workflow that doesn't match a PR's touched paths never produces a check at all) are a separate class of bug and need a gate-job pattern to fix safely. That's the follow-up. Once gates land, the ruleset can require the full set without blocking unrelated PRs.

**Rollout note — ruleset must move with the merge.** After this merges, no check is named `validate` anymore, so the current ruleset's single `validate` requirement matches nothing and every PR blocks on a missing check. Admin bypass is also needed to merge this PR itself (only 4 of 13 workflows trigger on `.github/workflows/**`). Sequence:

1. Admin updates the ruleset to require the new unique contexts (command below).
2. Admin bypass-merges this PR.
3. Follow-up PR adds path-filter gates so required checks resolve on skip.