### PR TITLE
feat(super-editor): rawField carrier for unrecognized fields (SD-2737)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/exporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/exporter.js
@@ -28,6 +28,7 @@ import { translator as sdBibliographyTranslator } from '@converter/v3/handlers/s
 import { translator as sdAuthorityEntryTranslator } from '@converter/v3/handlers/sd/authorityEntry/authorityEntry-translator.js';
 import { translator as sdTableOfAuthoritiesTranslator } from '@converter/v3/handlers/sd/tableOfAuthorities/tableOfAuthorities-translator.js';
 import { translator as sdSequenceFieldTranslator } from '@converter/v3/handlers/sd/sequenceField/sequenceField-translator.js';
+import { translator as sdRawFieldTranslator } from '@converter/v3/handlers/sd/rawField/rawField-translator.js';
 import { translator as sdTableOfContentsTranslator } from '@converter/v3/handlers/sd/tableOfContents';
 import { translator as sdIndexTranslator } from '@converter/v3/handlers/sd/index';
 import { translator as sdIndexEntryTranslator } from '@converter/v3/handlers/sd/indexEntry';
@@ -207,6 +208,7 @@ export function exportSchemaToJson(params) {
     authorityEntry: sdAuthorityEntryTranslator,
     tableOfAuthorities: sdTableOfAuthoritiesTranslator,
     sequenceField: sdSequenceFieldTranslator,
+    rawField: sdRawFieldTranslator,
     documentStatField: sdDocumentStatFieldTranslator,
     tableOfContents: sdTableOfContentsTranslator,
     index: sdIndexTranslator,

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/attach-field-instance.test.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/attach-field-instance.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { attachFieldInstanceToFieldNodes, FIELD_BEARING_XML_NAMES } from './attach-field-instance.js';
+import { buildFieldInstanceFromImport } from './build-field-instance.js';
+
+const baseFi = () =>
+  buildFieldInstanceFromImport({
+    representation: 'complex',
+    instructionText: 'PAGE',
+    resultFragments: [],
+    originalXml: { name: 'w:r', elements: [] },
+    dirty: false,
+    locked: false,
+    part: 'body',
+    importIndex: 0,
+  });
+
+describe('attachFieldInstanceToFieldNodes', () => {
+  describe('explicit name list (table-driven)', () => {
+    for (const name of FIELD_BEARING_XML_NAMES) {
+      it(`attaches to <${name}> at the top level`, () => {
+        const fi = baseFi();
+        const nodes = [{ name, attributes: { existing: 'attr' }, elements: [] }];
+        attachFieldInstanceToFieldNodes(nodes, fi);
+        expect(nodes[0].attributes?.fieldInstance).toBeDefined();
+        expect(nodes[0].attributes?.existing).toBe('attr');
+      });
+    }
+  });
+
+  it('does not attach to unsupported element names', () => {
+    const fi = baseFi();
+    const nodes: any[] = [
+      { name: 'sd:hyperlink', attributes: {}, elements: [] },
+      { name: 'sd:rawField', attributes: {}, elements: [] },
+      { name: 'w:r', attributes: {}, elements: [] },
+      { name: 'unknown', attributes: {}, elements: [] },
+    ];
+    attachFieldInstanceToFieldNodes(nodes, fi);
+    for (const node of nodes) {
+      expect(node.attributes.fieldInstance).toBeUndefined();
+    }
+  });
+
+  it('descends into elements children to find a wrapped field node', () => {
+    const fi = baseFi();
+    const paragraph = {
+      name: 'w:p',
+      attributes: {},
+      elements: [
+        { name: 'w:r', attributes: {}, elements: [] },
+        { name: 'sd:tableOfContents', attributes: {}, elements: [] },
+      ],
+    };
+    attachFieldInstanceToFieldNodes([paragraph], fi);
+    expect(paragraph.elements[0].attributes.fieldInstance).toBeUndefined();
+    expect(paragraph.elements[1].attributes?.fieldInstance).toBeDefined();
+  });
+
+  it('does not recurse into children of an already-attached field node', () => {
+    // A field node may legitimately contain its own elements; once attached,
+    // we stop descending so we do not over-attach to nested look-alikes.
+    const fi = baseFi();
+    const node: any = {
+      name: 'sd:tableOfContents',
+      attributes: {},
+      elements: [{ name: 'sd:sequenceField', attributes: {}, elements: [] }],
+    };
+    attachFieldInstanceToFieldNodes([node], fi);
+    expect(node.attributes.fieldInstance).toBeDefined();
+    expect(node.elements[0].attributes.fieldInstance).toBeUndefined();
+  });
+
+  it('attaches a distinct clone to each matched node so mutations do not alias', () => {
+    const fi = baseFi();
+    const nodes = [
+      { name: 'sd:sequenceField', attributes: {}, elements: [] },
+      { name: 'sd:documentStatField', attributes: {}, elements: [] },
+    ];
+    attachFieldInstanceToFieldNodes(nodes, fi);
+    const a = nodes[0].attributes?.fieldInstance as any;
+    const b = nodes[1].attributes?.fieldInstance as any;
+    expect(a).not.toBe(b);
+    expect(a.mutation).not.toBe(b.mutation);
+    a.mutation.relocated = true;
+    expect(b.mutation.relocated).toBe(false);
+  });
+
+  it('initializes attributes when the source node had none', () => {
+    const fi = baseFi();
+    const node: any = { name: 'sd:sequenceField', elements: [] };
+    attachFieldInstanceToFieldNodes([node], fi);
+    expect(node.attributes).toBeDefined();
+    expect(node.attributes.fieldInstance).toBeDefined();
+  });
+
+  it("does not overwrite a child's already-attached FieldInstance (nested-field precedence)", () => {
+    const innerFi = baseFi();
+    innerFi.family = 'PAGEREF';
+    const outerFi = baseFi();
+    outerFi.family = 'HYPERLINK';
+    const hyperlink: any = {
+      name: 'w:hyperlink',
+      attributes: {},
+      elements: [{ name: 'sd:pageReference', attributes: { fieldInstance: innerFi }, elements: [] }],
+    };
+    attachFieldInstanceToFieldNodes([hyperlink], outerFi);
+    expect(hyperlink.elements[0].attributes.fieldInstance.family).toBe('PAGEREF');
+  });
+
+  it('preserves the supplied FieldInstance content on the clone', () => {
+    const fi = baseFi();
+    const node: any = { name: 'sd:sequenceField', attributes: {}, elements: [] };
+    attachFieldInstanceToFieldNodes([node], fi);
+    const attached = node.attributes.fieldInstance;
+    expect(attached.family).toBe(fi.family);
+    expect(attached.rawInstruction).toBe(fi.rawInstruction);
+    expect(attached.dirty).toBe(fi.dirty);
+    expect(attached.locked).toBe(fi.locked);
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/attach-field-instance.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/attach-field-instance.ts
@@ -1,0 +1,129 @@
+/**
+ * Attach a {@link FieldInstance} to the typed `sd:*` element(s) emitted by
+ * a family preprocessor.
+ *
+ * Family preprocessors return different shapes depending on the family
+ * (single inline node, paragraph wrapper with the field as a child,
+ * multiple sibling nodes, etc.). To keep attachment predictable the
+ * function only mutates elements whose `name` is in the explicit
+ * supported-name list, and does so by writing to `attributes.fieldInstance`.
+ * Unsupported elements are left untouched and pass through unchanged.
+ *
+ * Each attachment receives its own clone of the FieldInstance so a later
+ * mutation on one node cannot alias another.
+ */
+
+import type { FieldInstance } from './field-instance.js';
+
+type OoxmlNode = {
+  name?: string;
+  attributes?: Record<string, unknown>;
+  elements?: OoxmlNode[];
+};
+
+/**
+ * XML element names emitted by family preprocessors that map to a typed
+ * field PM node. Add a name here only after verifying the corresponding
+ * PM extension declares the `fieldInstance` attribute and its v3
+ * translator forwards `attributes.fieldInstance` to PM `attrs.fieldInstance`.
+ */
+export const FIELD_BEARING_XML_NAMES: ReadonlySet<string> = new Set([
+  'sd:sequenceField',
+  'sd:documentStatField',
+  'sd:crossReference',
+  'sd:pageReference',
+  'sd:tableOfContents',
+  'sd:index',
+  'sd:autoPageNumber',
+  'sd:totalPageNumber',
+  'sd:citation',
+  'sd:bibliography',
+  'sd:authorityEntry',
+  'sd:tableOfAuthorities',
+  'sd:indexEntry',
+  'sd:tableOfContentsEntry',
+]);
+
+/**
+ * Walk `nodes` (and their `elements` children) and attach a clone of
+ * `fieldInstance` to every element whose `name` is in
+ * {@link FIELD_BEARING_XML_NAMES}.
+ *
+ * Returns the same `nodes` array; mutation is in place. Mutation is scoped
+ * to the matched elements' `attributes.fieldInstance`; nothing else is
+ * touched.
+ */
+export function attachFieldInstanceToFieldNodes<T extends OoxmlNode>(
+  nodes: readonly T[] | T[],
+  fieldInstance: FieldInstance,
+): T[] {
+  for (const node of nodes) {
+    visit(node, fieldInstance);
+  }
+  return nodes as T[];
+}
+
+/**
+ * Recursively deep-clone a parsed-XML subtree, removing any
+ * `fieldInstance` entry from element attributes.
+ *
+ * The substrate stores FieldInstance on PM-bound `sd:*` elements as a
+ * convenience for the v3 encoder, but `fieldInstance` is a JavaScript
+ * object — not a string — so it must never reach an XML serializer. When
+ * a parent field's import captures children for `source.originalXml`,
+ * those children may already carry `fieldInstance` from a nested
+ * preprocessor; this clone strips it so passthrough export emits a valid
+ * subtree (instead of `fieldInstance="[object Object]"`).
+ */
+export function cloneOoxmlWithoutFieldInstance<T extends OoxmlNode>(node: T): T {
+  const out: OoxmlNode = { ...node };
+  if (out.attributes && typeof out.attributes === 'object') {
+    const { fieldInstance: _stripped, ...rest } = out.attributes as Record<string, unknown>;
+    out.attributes = rest;
+  }
+  if (Array.isArray(out.elements)) {
+    out.elements = out.elements.map((child) => cloneOoxmlWithoutFieldInstance(child));
+  }
+  return out as T;
+}
+
+function visit(node: OoxmlNode | null | undefined, fieldInstance: FieldInstance): void {
+  if (!node || typeof node !== 'object') return;
+  if (typeof node.name === 'string' && FIELD_BEARING_XML_NAMES.has(node.name)) {
+    // A nested field that already has its own FieldInstance attached takes
+    // precedence: we do not overwrite a child's payload with the parent's.
+    // This matters when an outer HYPERLINK / IF wraps an inner PAGEREF or
+    // MERGEFIELD, where each finalize attaches its own.
+    if (node.attributes?.fieldInstance) return;
+    if (!node.attributes) node.attributes = {};
+    node.attributes.fieldInstance = cloneFieldInstance(fieldInstance);
+    // Don't recurse into children of an attached field; nested fields are
+    // their own substrate entries and were attached by their own preprocessor.
+    return;
+  }
+  if (Array.isArray(node.elements)) {
+    for (const child of node.elements) visit(child, fieldInstance);
+  }
+}
+
+/**
+ * Shallow-clone the FieldInstance so each attachment gets its own object
+ * identity. `instructionTokens`, `parsedArgs`, `mutation`, and `source`
+ * are themselves cloned so a later in-place mutation on one node cannot
+ * alias another. `resultFragments` and `originalXml` stay shared by
+ * reference; they are large parsed-XML subtrees and the substrate treats
+ * them as read-only at this stage.
+ */
+function cloneFieldInstance(fi: FieldInstance): FieldInstance {
+  return {
+    ...fi,
+    instructionTokens: [...fi.instructionTokens],
+    parsedArgs: {
+      family: fi.parsedArgs.family,
+      positional: fi.parsedArgs.positional.map((arg) => ({ ...arg })),
+      switches: fi.parsedArgs.switches.map((sw) => ({ ...sw, arg: sw.arg ? { ...sw.arg } : undefined })),
+    },
+    mutation: { ...fi.mutation },
+    source: { ...fi.source },
+  };
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/attach-field-instance.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/attach-field-instance.ts
@@ -63,30 +63,6 @@ export function attachFieldInstanceToFieldNodes<T extends OoxmlNode>(
   return nodes as T[];
 }
 
-/**
- * Recursively deep-clone a parsed-XML subtree, removing any
- * `fieldInstance` entry from element attributes.
- *
- * The substrate stores FieldInstance on PM-bound `sd:*` elements as a
- * convenience for the v3 encoder, but `fieldInstance` is a JavaScript
- * object — not a string — so it must never reach an XML serializer. When
- * a parent field's import captures children for `source.originalXml`,
- * those children may already carry `fieldInstance` from a nested
- * preprocessor; this clone strips it so passthrough export emits a valid
- * subtree (instead of `fieldInstance="[object Object]"`).
- */
-export function cloneOoxmlWithoutFieldInstance<T extends OoxmlNode>(node: T): T {
-  const out: OoxmlNode = { ...node };
-  if (out.attributes && typeof out.attributes === 'object') {
-    const { fieldInstance: _stripped, ...rest } = out.attributes as Record<string, unknown>;
-    out.attributes = rest;
-  }
-  if (Array.isArray(out.elements)) {
-    out.elements = out.elements.map((child) => cloneOoxmlWithoutFieldInstance(child));
-  }
-  return out as T;
-}
-
 function visit(node: OoxmlNode | null | undefined, fieldInstance: FieldInstance): void {
   if (!node || typeof node !== 'object') return;
   if (typeof node.name === 'string' && FIELD_BEARING_XML_NAMES.has(node.name)) {

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/build-field-instance.test.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/build-field-instance.test.ts
@@ -145,8 +145,26 @@ describe('readFieldFlags', () => {
     });
   });
 
-  it('reads "0" / "false" / arbitrary strings as false', () => {
+  it('reads "on" as true (ECMA-376 ST_OnOff form Word commonly emits)', () => {
+    expect(readFieldFlags({ attributes: { 'w:dirty': 'on', 'w:fldLock': 'on' } })).toEqual({
+      dirty: true,
+      locked: true,
+    });
+  });
+
+  it('reads ST_OnOff truthy values case-insensitively', () => {
+    expect(readFieldFlags({ attributes: { 'w:dirty': 'True', 'w:fldLock': 'ON' } })).toEqual({
+      dirty: true,
+      locked: true,
+    });
+  });
+
+  it('reads "0" / "false" / "off" / arbitrary strings as false', () => {
     expect(readFieldFlags({ attributes: { 'w:dirty': '0', 'w:fldLock': 'false' } })).toEqual({
+      dirty: false,
+      locked: false,
+    });
+    expect(readFieldFlags({ attributes: { 'w:dirty': 'off', 'w:fldLock': 'OFF' } })).toEqual({
       dirty: false,
       locked: false,
     });

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/build-field-instance.test.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/build-field-instance.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { buildFieldInstanceFromImport, readFieldFlags } from './build-field-instance.js';
+
+describe('buildFieldInstanceFromImport', () => {
+  const baseArgs = {
+    representation: 'complex' as const,
+    instructionText: 'PAGE',
+    resultFragments: [],
+    originalXml: { name: 'w:r', elements: [] },
+    dirty: false,
+    locked: false,
+    part: 'body' as const,
+    importIndex: 0,
+  };
+
+  it('produces a FieldInstance with import-time defaults', () => {
+    const fi = buildFieldInstanceFromImport(baseArgs);
+    expect(fi.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(fi.representation).toBe('complex');
+    expect(fi.rawInstruction).toBe('PAGE');
+    expect(fi.dirty).toBe(false);
+    expect(fi.locked).toBe(false);
+    expect(fi.mutation).toEqual({
+      imported: true,
+      inserted: false,
+      instructionEdited: false,
+      resultEdited: false,
+      flagsEdited: false,
+      relocated: false,
+      structureEdited: false,
+    });
+    expect(fi.source.part).toBe('body');
+    expect(fi.source.importIndex).toBe(0);
+    expect(fi.source.originalXml).toBe(baseArgs.originalXml);
+  });
+
+  it('derives family from the first identifier in the instruction', () => {
+    const fi = buildFieldInstanceFromImport({ ...baseArgs, instructionText: 'PAGE' });
+    expect(fi.family).toBe('PAGE');
+  });
+
+  it('uppercases the derived family even when source is lowercase', () => {
+    const fi = buildFieldInstanceFromImport({ ...baseArgs, instructionText: 'page' });
+    expect(fi.family).toBe('PAGE');
+  });
+
+  it('falls back to "unknown" when the instruction is empty', () => {
+    const fi = buildFieldInstanceFromImport({ ...baseArgs, instructionText: '' });
+    expect(fi.family).toBe('unknown');
+  });
+
+  it('falls back to "unknown" when the instruction starts with a quoted string', () => {
+    const fi = buildFieldInstanceFromImport({ ...baseArgs, instructionText: '"opaque"' });
+    expect(fi.family).toBe('unknown');
+  });
+
+  it('honors an explicit family override over the derived one', () => {
+    const fi = buildFieldInstanceFromImport({ ...baseArgs, instructionText: 'SEQ Figure', family: 'PAGE' });
+    expect(fi.family).toBe('PAGE');
+  });
+
+  it('preserves the raw instruction text on rawInstruction', () => {
+    const fi = buildFieldInstanceFromImport({
+      ...baseArgs,
+      instructionText: 'SEQ  Figure  \\* ARABIC',
+    });
+    expect(fi.rawInstruction).toBe('SEQ  Figure  \\* ARABIC');
+  });
+
+  it('parses tokens and parsedArgs from the instruction', () => {
+    const fi = buildFieldInstanceFromImport({
+      ...baseArgs,
+      instructionText: 'SEQ Figure \\* ARABIC',
+    });
+    expect(fi.parsedArgs.family).toBe('SEQ');
+    expect(fi.parsedArgs.positional).toEqual([{ kind: 'identifier', text: 'Figure' }]);
+    expect(fi.parsedArgs.switches).toEqual([{ flag: '*', arg: { kind: 'identifier', text: 'ARABIC' } }]);
+    expect(fi.instructionTokens.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to opaque tokens for malformed input without throwing', () => {
+    const fi = buildFieldInstanceFromImport({ ...baseArgs, instructionText: 'REF "unterminated' });
+    expect(fi.parsedArgs.family).toBe('REF');
+    expect(fi.instructionTokens.some((t) => t.kind === 'opaque')).toBe(true);
+  });
+
+  it('carries dirty and locked through unchanged', () => {
+    const fi = buildFieldInstanceFromImport({ ...baseArgs, dirty: true, locked: true });
+    expect(fi.dirty).toBe(true);
+    expect(fi.locked).toBe(true);
+  });
+
+  it('records the source part and importIndex faithfully', () => {
+    const fi = buildFieldInstanceFromImport({ ...baseArgs, part: 'header', importIndex: 7 });
+    expect(fi.source.part).toBe('header');
+    expect(fi.source.importIndex).toBe(7);
+  });
+
+  it('preserves the original XML reference identity for passthrough', () => {
+    const xml = { name: 'w:fldSimple', attributes: {}, elements: [] };
+    const fi = buildFieldInstanceFromImport({ ...baseArgs, originalXml: xml });
+    expect(fi.source.originalXml).toBe(xml);
+  });
+
+  it('attaches resultFragments by reference', () => {
+    const fragments: unknown[] = [{ name: 'w:r', elements: [] }];
+    const fi = buildFieldInstanceFromImport({ ...baseArgs, resultFragments: fragments });
+    expect(fi.resultFragments).toBe(fragments);
+  });
+
+  it('forwards an explicit cachedResultText when provided', () => {
+    const fi = buildFieldInstanceFromImport({ ...baseArgs, cachedResultText: 'hello' });
+    expect(fi.cachedResultText).toBe('hello');
+  });
+
+  it('leaves cachedResultText undefined when not provided', () => {
+    const fi = buildFieldInstanceFromImport(baseArgs);
+    expect(fi.cachedResultText).toBeUndefined();
+  });
+
+  it('produces a unique id on each call', () => {
+    const a = buildFieldInstanceFromImport(baseArgs);
+    const b = buildFieldInstanceFromImport(baseArgs);
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe('readFieldFlags', () => {
+  it('returns false/false when the element is null or has no attributes', () => {
+    expect(readFieldFlags(null)).toEqual({ dirty: false, locked: false });
+    expect(readFieldFlags(undefined)).toEqual({ dirty: false, locked: false });
+    expect(readFieldFlags({})).toEqual({ dirty: false, locked: false });
+    expect(readFieldFlags({ attributes: {} })).toEqual({ dirty: false, locked: false });
+  });
+
+  it('reads "1" as true', () => {
+    expect(readFieldFlags({ attributes: { 'w:dirty': '1' } })).toEqual({ dirty: true, locked: false });
+    expect(readFieldFlags({ attributes: { 'w:fldLock': '1' } })).toEqual({ dirty: false, locked: true });
+  });
+
+  it('reads "true" as true (alternate OOXML truthy form)', () => {
+    expect(readFieldFlags({ attributes: { 'w:dirty': 'true', 'w:fldLock': 'true' } })).toEqual({
+      dirty: true,
+      locked: true,
+    });
+  });
+
+  it('reads "0" / "false" / arbitrary strings as false', () => {
+    expect(readFieldFlags({ attributes: { 'w:dirty': '0', 'w:fldLock': 'false' } })).toEqual({
+      dirty: false,
+      locked: false,
+    });
+    expect(readFieldFlags({ attributes: { 'w:dirty': 'yes' } })).toEqual({ dirty: false, locked: false });
+  });
+
+  it('reads dirty and locked independently', () => {
+    expect(readFieldFlags({ attributes: { 'w:dirty': '1', 'w:fldLock': '0' } })).toEqual({
+      dirty: true,
+      locked: false,
+    });
+    expect(readFieldFlags({ attributes: { 'w:dirty': '0', 'w:fldLock': '1' } })).toEqual({
+      dirty: false,
+      locked: true,
+    });
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/build-field-instance.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/build-field-instance.ts
@@ -116,7 +116,15 @@ export function readFieldFlags(element: { attributes?: Record<string, string | u
   };
 }
 
+/**
+ * ECMA-376 ST_OnOff truthiness. The spec lists `1`, `true`, and `on` as
+ * truthy and `0`, `false`, `off` as falsy; comparison is case-insensitive
+ * because some Word builds emit `True` / `On`. `w:dirty` and `w:fldLock`
+ * are ST_OnOff attributes, so all three truthy forms must be honored or
+ * documents using the `on` form will round-trip with the flag dropped.
+ */
 function isTruthyOoxmlBoolean(value: string | undefined): boolean {
   if (value == null) return false;
-  return value === '1' || value === 'true';
+  const lower = value.toLowerCase();
+  return lower === '1' || lower === 'true' || lower === 'on';
 }

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/build-field-instance.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/build-field-instance.ts
@@ -1,0 +1,122 @@
+/**
+ * Build a {@link FieldInstance} from data already extracted by the OOXML
+ * field preprocessor.
+ *
+ * This is the substrate's Phase A entry point: a pure function that takes
+ * import-time inputs (already gathered by `preProcessNodesForFldChar.js`)
+ * and emits the canonical durable payload. No PM, no I/O, no side effects.
+ *
+ * Wiring this builder into specific import paths happens at the call sites;
+ * the builder itself stays generic and applies to both simple and complex
+ * fields, regardless of family.
+ */
+
+import {
+  createFieldId,
+  type FieldFamily,
+  type FieldInstance,
+  type FieldSourcePart,
+  type OpenXmlFragment,
+} from './field-instance.js';
+import { deriveParsedArgs, tokenizeInstruction } from './instruction-tokenizer.js';
+
+export type BuildFieldInstanceArgs = {
+  /** `'simple'` for `<w:fldSimple>`, `'complex'` for `<w:fldChar>` trios. */
+  representation: 'simple' | 'complex';
+  /** Raw instruction text. For complex fields this is the concatenation of `w:instrText` runs. */
+  instructionText: string;
+  /** Result content for the field, parsed XML. For complex this is the runs between separate and end; for simple it is the children of `<w:fldSimple>`. */
+  resultFragments: OpenXmlFragment[];
+  /** Original parsed subtree to enable passthrough export. For complex: the full begin/instr/separate/result/end span. For simple: the entire `<w:fldSimple>` element. */
+  originalXml: OpenXmlFragment;
+  /** `w:dirty` attribute from the source element (begin `<w:fldChar>` or `<w:fldSimple>`). */
+  dirty: boolean;
+  /** `w:fldLock` attribute from the source element. */
+  locked: boolean;
+  /** DOCX part the field originated from. */
+  part: FieldSourcePart;
+  /** Import-time ordinal within the part. */
+  importIndex: number;
+  /**
+   * Optional family override. If omitted, the family is taken from the
+   * tokenizer-derived `parsedArgs.family` (uppercased first identifier),
+   * defaulting to `'unknown'` when the tokenizer cannot identify one.
+   */
+  family?: FieldFamily;
+  /**
+   * Optional cached plain-text denormalization of `resultFragments`. If
+   * the caller has already computed the cached text it can pass it in;
+   * otherwise it is left undefined and consumers may compute on demand.
+   */
+  cachedResultText?: string;
+};
+
+/**
+ * Build a {@link FieldInstance} from import-time inputs.
+ *
+ * Defaults:
+ *   - `id`: fresh session UUID
+ *   - `family`: from `parsedArgs.family` (uppercased), or `'unknown'`
+ *   - `mutation`: `{ imported: true, ...all-other-flags-false }`
+ *
+ * Tokenization never fails; malformed `instructionText` produces a single
+ * `opaque` token and `parsedArgs.family` stays undefined (which means the
+ * built-in default `'unknown'` is used).
+ */
+export function buildFieldInstanceFromImport(args: BuildFieldInstanceArgs): FieldInstance {
+  const tokens = tokenizeInstruction(args.instructionText);
+  const parsedArgs = deriveParsedArgs(tokens);
+  const family: FieldFamily = args.family ?? parsedArgs.family ?? 'unknown';
+
+  return {
+    id: createFieldId(),
+    representation: args.representation,
+    family,
+    rawInstruction: args.instructionText,
+    instructionTokens: tokens,
+    parsedArgs,
+    resultFragments: args.resultFragments,
+    cachedResultText: args.cachedResultText,
+    dirty: args.dirty,
+    locked: args.locked,
+    mutation: {
+      imported: true,
+      inserted: false,
+      instructionEdited: false,
+      resultEdited: false,
+      flagsEdited: false,
+      relocated: false,
+      structureEdited: false,
+    },
+    source: {
+      originalXml: args.originalXml,
+      part: args.part,
+      importIndex: args.importIndex,
+    },
+  };
+}
+
+/**
+ * Read `w:dirty` and `w:fldLock` from a parsed XML element's attributes.
+ * Both are optional in the source; absent or anything other than the
+ * truthy strings `"1"` / `"true"` is treated as false. This matches the
+ * OOXML attribute-truthiness convention.
+ *
+ * Pass the begin `<w:fldChar>` element for complex fields, or the
+ * `<w:fldSimple>` element for simple fields.
+ */
+export function readFieldFlags(element: { attributes?: Record<string, string | undefined> } | null | undefined): {
+  dirty: boolean;
+  locked: boolean;
+} {
+  const attrs = element?.attributes ?? {};
+  return {
+    dirty: isTruthyOoxmlBoolean(attrs['w:dirty']),
+    locked: isTruthyOoxmlBoolean(attrs['w:fldLock']),
+  };
+}
+
+function isTruthyOoxmlBoolean(value: string | undefined): boolean {
+  if (value == null) return false;
+  return value === '1' || value === 'true';
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/canonicalize-field-instance.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/canonicalize-field-instance.ts
@@ -1,0 +1,107 @@
+/**
+ * Canonicalize a {@link FieldInstance} for snapshot equality comparisons.
+ *
+ * Round-trip tests assert that an imported field's payload is structurally
+ * stable across re-import. Some fields on FieldInstance are session-local
+ * bookkeeping or contain object references that cannot be expected to
+ * survive a re-import unchanged; the canonicalizer strips or normalizes
+ * those before comparison.
+ *
+ * Strip rules (from the substrate design doc, §"Round-trip test harness"):
+ *   - `id`              — fresh UUID per session
+ *   - `source.importIndex` — import-time ordinal, differs across reimports
+ *   - `source.originalXml` — passthrough source, may be re-emitted but
+ *                          structurally non-identical
+ *   - `mutation` (whole object) — session bookkeeping; every fresh import
+ *                          starts with `imported: true` and all-others false
+ *
+ * Preserve everything else: `representation`, `family`, `rawInstruction`,
+ * `instructionTokens`, `parsedArgs`, `resultFragments`, `dirty`, `locked`,
+ * `familyPayload`, `source.part`.
+ *
+ * Whitespace token normalization: tokens of kind `whitespace` collapse
+ * into a single canonical token. The substrate's import pipeline already
+ * preserves whitespace as a single run, but synthesized fixtures may
+ * produce equivalent token sequences with different whitespace boundaries
+ * (e.g. one run of `'  '` vs. two runs of `' '`). We treat them as equal.
+ */
+
+import type { FieldInstance, InstructionToken, OpenXmlFragment } from './field-instance.js';
+
+export type CanonicalFieldInstance = {
+  representation: 'simple' | 'complex';
+  family: string;
+  rawInstruction: string;
+  instructionTokens: CanonicalInstructionToken[];
+  parsedArgs: FieldInstance['parsedArgs'];
+  resultFragments: OpenXmlFragment[];
+  cachedResultText?: string;
+  dirty: boolean;
+  locked: boolean;
+  familyPayload?: Record<string, unknown>;
+  sourcePart: FieldInstance['source']['part'];
+};
+
+export type CanonicalInstructionToken =
+  | { kind: 'identifier'; text: string }
+  | { kind: 'quoted'; text: string; quote: '"' | "'" }
+  | { kind: 'switch'; flag: string; arg?: CanonicalInstructionToken }
+  | { kind: 'whitespace' }
+  | { kind: 'opaque'; text: string }
+  | { kind: 'nestedField'; child: CanonicalFieldInstance | null };
+
+/**
+ * Produce a canonical view of a FieldInstance for snapshot comparison.
+ *
+ * Optionally takes a `resolveNested` callback that maps a nested-field
+ * `childFieldId` to the child's FieldInstance, so the canonicalizer can
+ * recurse through nested anchors. When omitted, nested-field tokens
+ * canonicalize to `{ kind: 'nestedField', child: null }`.
+ */
+export function canonicalizeFieldInstance(
+  fi: FieldInstance,
+  resolveNested?: (childFieldId: string) => FieldInstance | null | undefined,
+): CanonicalFieldInstance {
+  return {
+    representation: fi.representation,
+    family: fi.family,
+    rawInstruction: fi.rawInstruction,
+    instructionTokens: fi.instructionTokens.map((t) => canonicalizeToken(t, resolveNested)),
+    parsedArgs: fi.parsedArgs,
+    resultFragments: fi.resultFragments,
+    cachedResultText: fi.cachedResultText,
+    dirty: fi.dirty,
+    locked: fi.locked,
+    familyPayload: fi.familyPayload,
+    sourcePart: fi.source.part,
+  };
+}
+
+function canonicalizeToken(
+  token: InstructionToken,
+  resolveNested?: (childFieldId: string) => FieldInstance | null | undefined,
+): CanonicalInstructionToken {
+  switch (token.kind) {
+    case 'identifier':
+      return { kind: 'identifier', text: token.text };
+    case 'quoted':
+      return { kind: 'quoted', text: token.text, quote: token.quote };
+    case 'switch':
+      return {
+        kind: 'switch',
+        flag: token.flag,
+        arg: token.arg ? canonicalizeToken(token.arg, resolveNested) : undefined,
+      };
+    case 'whitespace':
+      return { kind: 'whitespace' };
+    case 'opaque':
+      return { kind: 'opaque', text: token.text };
+    case 'nestedField': {
+      const child = resolveNested?.(token.childFieldId);
+      return {
+        kind: 'nestedField',
+        child: child ? canonicalizeFieldInstance(child, resolveNested) : null,
+      };
+    }
+  }
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/field-snapshot-harness.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/field-snapshot-harness.ts
@@ -1,0 +1,86 @@
+/**
+ * Round-trip snapshot harness.
+ *
+ * Walks a parsed-XML body through the field preprocessor + V2 importer,
+ * collects every PM node that carries a `fieldInstance` attr, and applies
+ * the canonicalization rules so the resulting array can be compared for
+ * equality across re-imports.
+ *
+ * The harness is the merge gate for the substrate work: a regression in
+ * any chunk that breaks the canonical payload — dropped fields, lost
+ * dirty/locked flags, mis-attached instances, broken nesting — fails a
+ * test here.
+ */
+
+import type { FieldInstance } from './field-instance.js';
+import { canonicalizeFieldInstance, type CanonicalFieldInstance } from './canonicalize-field-instance.js';
+import { defaultNodeListHandler } from '../v2/importer/docxImporter.js';
+import { preProcessNodesForFldChar } from './preProcessNodesForFldChar.js';
+
+type PmNode = {
+  type?: string;
+  attrs?: Record<string, unknown>;
+  content?: PmNode[];
+  marks?: unknown[];
+};
+
+export type FieldSnapshot = {
+  /** PM type name carrying the FieldInstance (e.g. `rawField`, `sequenceField`). */
+  pmType: string;
+  fieldInstance: CanonicalFieldInstance;
+};
+
+/**
+ * Run a parsed OOXML body through the import pipeline and snapshot every
+ * field-bearing PM node that emerges. Snapshots are returned in document
+ * order so a reimport yielding the same sequence of fields produces an
+ * equal array.
+ *
+ * A FieldInstance registry is built first (id → instance) and threaded
+ * into canonicalization as the `resolveNested` callback so that any
+ * `nestedField` token's `childFieldId` resolves to the child's
+ * canonical snapshot. The importer does not yet populate nestedField
+ * anchors in Phase 0; this threading is forward-looking so the harness
+ * catches regressions in nested-anchor wiring as soon as it lands.
+ */
+export function snapshotFromXml(elements: unknown[]): FieldSnapshot[] {
+  const { processedNodes } = preProcessNodesForFldChar(elements as never[], {});
+  const nodeListHandler = defaultNodeListHandler();
+  const result = nodeListHandler.handler({
+    nodes: processedNodes,
+    docx: {},
+    nodeListHandler,
+    converter: {},
+    path: [],
+  });
+
+  const registry = new Map<string, FieldInstance>();
+  collectFieldInstances(result, registry);
+  const resolve = (id: string) => registry.get(id) ?? null;
+
+  const snapshots: FieldSnapshot[] = [];
+  walk(result, snapshots, resolve);
+  return snapshots;
+}
+
+function collectFieldInstances(nodes: PmNode[] | undefined, registry: Map<string, FieldInstance>): void {
+  if (!Array.isArray(nodes)) return;
+  for (const node of nodes) {
+    if (!node || typeof node !== 'object') continue;
+    const fi = node.attrs?.fieldInstance as FieldInstance | null | undefined;
+    if (fi && typeof fi.id === 'string') registry.set(fi.id, fi);
+    collectFieldInstances(node.content, registry);
+  }
+}
+
+function walk(nodes: PmNode[] | undefined, out: FieldSnapshot[], resolve: (id: string) => FieldInstance | null): void {
+  if (!Array.isArray(nodes)) return;
+  for (const node of nodes) {
+    if (!node || typeof node !== 'object') continue;
+    const fi = node.attrs?.fieldInstance as FieldInstance | null | undefined;
+    if (fi && typeof node.type === 'string') {
+      out.push({ pmType: node.type, fieldInstance: canonicalizeFieldInstance(fi, resolve) });
+    }
+    walk(node.content, out, resolve);
+  }
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -4,6 +4,7 @@
 import { getInstructionPreProcessor } from './fld-preprocessors';
 import { carbonCopy } from '@core/utilities/carbonCopy.js';
 import { buildFieldInstanceFromImport, readFieldFlags } from './build-field-instance.js';
+import { attachFieldInstanceToFieldNodes, cloneOoxmlWithoutFieldInstance } from './attach-field-instance.js';
 
 const SKIP_FIELD_PROCESSING_NODE_NAMES = new Set(['w:drawing', 'w:pict']);
 
@@ -89,6 +90,21 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
       let outputNodes;
       if (combinedResult.handled) {
         outputNodes = combinedResult.nodes;
+        // Attach the canonical FieldInstance to the typed sd:* element(s)
+        // the family preprocessor emitted. Export still reads legacy typed
+        // attrs in Phase 0; the substrate payload is carried alongside so
+        // Phase 1 / 3 can consume it without changing the import path.
+        const fieldInstance = buildFieldInstanceFromImport({
+          representation: 'complex',
+          instructionText: currentField.instrText.trim(),
+          resultFragments: collectedNodes,
+          originalXml: rawCollectedNodes,
+          dirty: currentField.dirty ?? false,
+          locked: currentField.locked ?? false,
+          part: FIELD_PART,
+          importIndex: importIndex++,
+        });
+        attachFieldInstanceToFieldNodes(outputNodes, fieldInstance);
       } else {
         // Unknown / unsupported field family: wrap the result content in a
         // sd:rawField element holding the canonical FieldInstance payload.
@@ -112,7 +128,13 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
       } else {
         // We are inside another field, so add the combined nodes to the parent collection.
         collectedNodesStack[collectedNodesStack.length - 1].push(...outputNodes);
-        rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(...outputNodes);
+        // The parent's source.originalXml capture must not carry the
+        // fieldInstance attribute we just attached (it is a JS object and
+        // would serialize as an invalid XML attribute on passthrough).
+        // Push fieldInstance-stripped clones into the raw stack instead.
+        rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(
+          ...outputNodes.map((n) => cloneOoxmlWithoutFieldInstance(n)),
+        );
       }
     } else {
       // An unmatched 'end' indicates a field from a parent node is closing.
@@ -177,9 +199,26 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
         const instructionPreProcessor = getInstructionPreProcessor(instructionType);
         if (instructionPreProcessor) {
           const processed = instructionPreProcessor(node.elements ?? [], instr, docx, null);
+          // Same FieldInstance attachment as the complex-field handled path.
+          const { dirty: simpleDirty, locked: simpleLocked } = readFieldFlags(node);
+          const fieldInstance = buildFieldInstanceFromImport({
+            representation: 'simple',
+            instructionText: instr,
+            resultFragments: node.elements ?? [],
+            originalXml: rawNode,
+            dirty: simpleDirty,
+            locked: simpleLocked,
+            part: FIELD_PART,
+            importIndex: importIndex++,
+          });
+          attachFieldInstanceToFieldNodes(processed, fieldInstance);
           if (collecting) {
             collectedNodesStack[collectedNodesStack.length - 1].push(...processed);
-            rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(...processed);
+            // Strip fieldInstance from the parent's source.originalXml capture
+            // (see complex-field handled branch for the same reason).
+            rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(
+              ...processed.map((n) => cloneOoxmlWithoutFieldInstance(n)),
+            );
           } else {
             processedNodes.push(...processed);
           }
@@ -200,7 +239,10 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
         });
         if (collecting) {
           collectedNodesStack[collectedNodesStack.length - 1].push(rawElement);
-          rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(rawElement);
+          // Strip fieldInstance from the parent's source.originalXml capture
+          // (a nested rawField inside a parent rawField would otherwise
+          // serialize its fieldInstance object as an XML attribute).
+          rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(cloneOoxmlWithoutFieldInstance(rawElement));
         } else {
           processedNodes.push(rawElement);
         }

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -4,7 +4,7 @@
 import { getInstructionPreProcessor } from './fld-preprocessors';
 import { carbonCopy } from '@core/utilities/carbonCopy.js';
 import { buildFieldInstanceFromImport, readFieldFlags } from './build-field-instance.js';
-import { attachFieldInstanceToFieldNodes, cloneOoxmlWithoutFieldInstance } from './attach-field-instance.js';
+import { attachFieldInstanceToFieldNodes } from './attach-field-instance.js';
 
 const SKIP_FIELD_PROCESSING_NODE_NAMES = new Set(['w:drawing', 'w:pict']);
 
@@ -128,13 +128,14 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
       } else {
         // We are inside another field, so add the combined nodes to the parent collection.
         collectedNodesStack[collectedNodesStack.length - 1].push(...outputNodes);
-        // The parent's source.originalXml capture must not carry the
-        // fieldInstance attribute we just attached (it is a JS object and
-        // would serialize as an invalid XML attribute on passthrough).
-        // Push fieldInstance-stripped clones into the raw stack instead.
-        rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(
-          ...outputNodes.map((n) => cloneOoxmlWithoutFieldInstance(n)),
-        );
+        // The parent's source.originalXml capture must hold the original
+        // OOXML runs, not the synthesized sd:* wrappers we just produced.
+        // If the synthesized wrappers leaked into the parent's raw stack,
+        // an unedited parent's passthrough export would emit literal
+        // `<sd:rawField>` / `<sd:sequenceField>` / etc. as XML, breaking
+        // structural fidelity. Push the inner field's begin/instr/separate/
+        // result/end run sequence (rawCollectedNodes) instead.
+        rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(...rawCollectedNodes);
       }
     } else {
       // An unmatched 'end' indicates a field from a parent node is closing.
@@ -214,11 +215,11 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
           attachFieldInstanceToFieldNodes(processed, fieldInstance);
           if (collecting) {
             collectedNodesStack[collectedNodesStack.length - 1].push(...processed);
-            // Strip fieldInstance from the parent's source.originalXml capture
-            // (see complex-field handled branch for the same reason).
-            rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(
-              ...processed.map((n) => cloneOoxmlWithoutFieldInstance(n)),
-            );
+            // Push the original <w:fldSimple> run into the parent's raw
+            // stack — not the synthesized sd:* wrapper. See the complex-
+            // field branch for the same reasoning: passthrough on the
+            // parent must emit valid OOXML, not an sd:* literal.
+            rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(rawNode);
           } else {
             processedNodes.push(...processed);
           }
@@ -239,10 +240,10 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
         });
         if (collecting) {
           collectedNodesStack[collectedNodesStack.length - 1].push(rawElement);
-          // Strip fieldInstance from the parent's source.originalXml capture
-          // (a nested rawField inside a parent rawField would otherwise
-          // serialize its fieldInstance object as an XML attribute).
-          rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(cloneOoxmlWithoutFieldInstance(rawElement));
+          // Push the original <w:fldSimple> run into the parent's raw
+          // stack so passthrough export emits valid OOXML, not an
+          // sd:rawField literal.
+          rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(rawNode);
         } else {
           processedNodes.push(rawElement);
         }

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -3,6 +3,7 @@
  */
 import { getInstructionPreProcessor } from './fld-preprocessors';
 import { carbonCopy } from '@core/utilities/carbonCopy.js';
+import { buildFieldInstanceFromImport, readFieldFlags } from './build-field-instance.js';
 
 const SKIP_FIELD_PROCESSING_NODE_NAMES = new Set(['w:drawing', 'w:pict']);
 
@@ -36,7 +37,37 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
   let currentFieldStack = [];
   let unpairedEnd = null;
   let collecting = false;
+  // importIndex is a per-call ordinal incremented each time an unknown field
+  // is wrapped in sd:rawField. This is a best-effort signal until later
+  // chunks of the substrate carry FieldInstance on every typed node and the
+  // round-trip harness assigns a globally-stable ordering.
+  let importIndex = 0;
+  const FIELD_PART = 'body';
   const rawNodeSourceTokens = new WeakMap();
+
+  /**
+   * Wrap an unknown field's result content in a sd:rawField element and
+   * stash the canonical FieldInstance payload on its attributes so the
+   * encoder can forward it to the PM node and the decoder can choose
+   * passthrough vs rebuild on export.
+   */
+  const buildRawFieldElement = ({ representation, instructionText, resultElements, originalXml, dirty, locked }) => {
+    const fieldInstance = buildFieldInstanceFromImport({
+      representation,
+      instructionText,
+      resultFragments: resultElements,
+      originalXml,
+      dirty,
+      locked,
+      part: FIELD_PART,
+      importIndex: importIndex++,
+    });
+    return {
+      name: 'sd:rawField',
+      attributes: { fieldInstance },
+      elements: resultElements,
+    };
+  };
 
   /**
    * Finalizes the current field. If collecting nodes, it processes them.
@@ -55,7 +86,26 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
         currentField.instructionTokens,
         fieldRunRPr,
       );
-      const outputNodes = combinedResult.handled ? combinedResult.nodes : rawCollectedNodes;
+      let outputNodes;
+      if (combinedResult.handled) {
+        outputNodes = combinedResult.nodes;
+      } else {
+        // Unknown / unsupported field family: wrap the result content in a
+        // sd:rawField element holding the canonical FieldInstance payload.
+        // The original begin/instr/separate/result/end span is preserved
+        // as source.originalXml so the exporter can passthrough verbatim
+        // when nothing has been edited.
+        outputNodes = [
+          buildRawFieldElement({
+            representation: 'complex',
+            instructionText: currentField.instrText.trim(),
+            resultElements: collectedNodes,
+            originalXml: rawCollectedNodes,
+            dirty: currentField.dirty ?? false,
+            locked: currentField.locked ?? false,
+          }),
+        ];
+      }
       if (collectedNodesStack.length === 0) {
         // We have completed a top-level field, add the combined nodes to the output.
         processedNodes.push(...outputNodes);
@@ -135,6 +185,26 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
           }
           return;
         }
+        // Unknown / unsupported family on a simple field: wrap in sd:rawField.
+        // The fldSimple element itself is the source.originalXml; result
+        // content is its children, which the encoder recursively imports
+        // so formatted result runs survive end-to-end.
+        const { dirty, locked } = readFieldFlags(node);
+        const rawElement = buildRawFieldElement({
+          representation: 'simple',
+          instructionText: instr,
+          resultElements: node.elements ?? [],
+          originalXml: rawNode,
+          dirty,
+          locked,
+        });
+        if (collecting) {
+          collectedNodesStack[collectedNodesStack.length - 1].push(rawElement);
+          rawCollectedNodesStack[rawCollectedNodesStack.length - 1].push(rawElement);
+        } else {
+          processedNodes.push(rawElement);
+        }
+        return;
       }
     }
 
@@ -145,7 +215,8 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
       rawNodeSourceTokens.set(rawNode, rawSourceToken);
       capturedRawNodes.add(rawNode);
       fieldRunRPrStack.push(extractFieldRunRPr(node));
-      currentFieldStack.push({ instrText: '', instructionTokens: [], afterSeparate: false });
+      const { dirty, locked } = readFieldFlags(fldCharEl);
+      currentFieldStack.push({ instrText: '', instructionTokens: [], afterSeparate: false, dirty, locked });
       return;
     }
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -72,22 +72,22 @@ describe('preProcessNodesForFldChar', () => {
 
     const { processedNodes } = preProcessNodesForFldChar(nodes, mockDocx);
 
-    expect(processedNodes).toEqual([
-      {
-        name: 'w:hyperlink',
-        type: 'element',
-        attributes: { 'w:anchor': 'bookmark' },
-        elements: [
-          { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'See page ' }] }] },
-          {
-            name: 'sd:pageReference',
-            type: 'element',
-            attributes: { instruction: 'PAGEREF bookmark' },
-            elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '5' }] }] }],
-          },
-        ],
-      },
-    ]);
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0].name).toBe('w:hyperlink');
+    expect(processedNodes[0].attributes).toEqual({ 'w:anchor': 'bookmark' });
+    expect(processedNodes[0].elements).toHaveLength(2);
+    expect(processedNodes[0].elements[0]).toEqual({
+      name: 'w:r',
+      elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'See page ' }] }],
+    });
+    expect(processedNodes[0].elements[1]).toMatchObject({
+      name: 'sd:pageReference',
+      type: 'element',
+      attributes: { instruction: 'PAGEREF bookmark' },
+      elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '5' }] }] }],
+    });
+    expect(processedNodes[0].elements[1].attributes.fieldInstance).toBeDefined();
+    expect(processedNodes[0].elements[1].attributes.fieldInstance.family).toBe('PAGEREF');
   });
 
   it('captures w:tab tokens in INDEX instructions', () => {
@@ -134,16 +134,15 @@ describe('preProcessNodesForFldChar', () => {
 
     const { processedNodes } = preProcessNodesForFldChar(nodes, mockDocx);
 
-    expect(processedNodes).toEqual([
-      {
-        name: 'sd:tableOfContents',
-        type: 'element',
-        attributes: {
-          instruction: 'TOC \\o "1-1" \\h \\z \\u',
-        },
-        elements: [],
-      },
-    ]);
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0]).toMatchObject({
+      name: 'sd:tableOfContents',
+      type: 'element',
+      attributes: { instruction: 'TOC \\o "1-1" \\h \\z \\u' },
+      elements: [],
+    });
+    expect(processedNodes[0].attributes.fieldInstance).toBeDefined();
+    expect(processedNodes[0].attributes.fieldInstance.family).toBe('TOC');
   });
 
   it('wraps unknown fields in sd:rawField when begin, instrText, separate, and end share a single run', () => {
@@ -197,14 +196,14 @@ describe('preProcessNodesForFldChar', () => {
     expect(processedNodes).toHaveLength(2);
     expect(processedNodes[0].name).toBe('sd:rawField');
     expect(processedNodes[0].attributes.fieldInstance.family).toBe('CUSTOMFIELD');
-    expect(processedNodes[1]).toEqual({
+    expect(processedNodes[1]).toMatchObject({
       name: 'sd:tableOfContents',
       type: 'element',
-      attributes: {
-        instruction: 'TOC \\o "1-1" \\h \\z \\u',
-      },
+      attributes: { instruction: 'TOC \\o "1-1" \\h \\z \\u' },
       elements: [],
     });
+    expect(processedNodes[1].attributes.fieldInstance).toBeDefined();
+    expect(processedNodes[1].attributes.fieldInstance.family).toBe('TOC');
   });
 
   it('preserves w:drawing and w:pict nodes while collecting field content', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -146,7 +146,7 @@ describe('preProcessNodesForFldChar', () => {
     ]);
   });
 
-  it('preserves unknown fields when begin, instrText, separate, and end share a single run', () => {
+  it('wraps unknown fields in sd:rawField when begin, instrText, separate, and end share a single run', () => {
     const nodes = [
       {
         name: 'w:r',
@@ -162,7 +162,16 @@ describe('preProcessNodesForFldChar', () => {
 
     const { processedNodes } = preProcessNodesForFldChar(nodes, mockDocx);
 
-    expect(processedNodes).toEqual(nodes);
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0].name).toBe('sd:rawField');
+    const fi = processedNodes[0].attributes.fieldInstance;
+    expect(fi.representation).toBe('complex');
+    expect(fi.family).toBe('CUSTOMFIELD');
+    expect(fi.rawInstruction).toBe('CUSTOMFIELD foo');
+    expect(fi.dirty).toBe(false);
+    expect(fi.locked).toBe(false);
+    expect(fi.mutation.imported).toBe(true);
+    expect(fi.source.originalXml).toBeDefined();
   });
 
   it('does not duplicate later fields when an unknown field and a TOC share one run', () => {
@@ -185,26 +194,17 @@ describe('preProcessNodesForFldChar', () => {
 
     const { processedNodes } = preProcessNodesForFldChar(nodes, mockDocx);
 
-    expect(processedNodes).toEqual([
-      {
-        name: 'w:r',
-        elements: [
-          { name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } },
-          { name: 'w:instrText', elements: [{ type: 'text', text: 'CUSTOMFIELD foo' }] },
-          { name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } },
-          { name: 'w:t', elements: [{ type: 'text', text: 'value' }] },
-          { name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } },
-        ],
+    expect(processedNodes).toHaveLength(2);
+    expect(processedNodes[0].name).toBe('sd:rawField');
+    expect(processedNodes[0].attributes.fieldInstance.family).toBe('CUSTOMFIELD');
+    expect(processedNodes[1]).toEqual({
+      name: 'sd:tableOfContents',
+      type: 'element',
+      attributes: {
+        instruction: 'TOC \\o "1-1" \\h \\z \\u',
       },
-      {
-        name: 'sd:tableOfContents',
-        type: 'element',
-        attributes: {
-          instruction: 'TOC \\o "1-1" \\h \\z \\u',
-        },
-        elements: [],
-      },
-    ]);
+      elements: [],
+    });
   });
 
   it('preserves w:drawing and w:pict nodes while collecting field content', () => {
@@ -328,6 +328,8 @@ describe('preProcessNodesForFldChar', () => {
             { type: 'text', text: ' ' },
           ],
           afterSeparate: true,
+          dirty: false,
+          locked: false,
         },
       },
     ]);
@@ -354,7 +356,7 @@ describe('preProcessNodesForFldChar', () => {
     expect(processedNodes).toEqual(nodes);
   });
 
-  it('preserves fldChar runs when instruction type is unknown', () => {
+  it('wraps unknown fields spanning multiple runs in sd:rawField', () => {
     const nodes = [
       { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
       {
@@ -367,7 +369,13 @@ describe('preProcessNodesForFldChar', () => {
     ];
 
     const { processedNodes } = preProcessNodesForFldChar(nodes, mockDocx);
-    expect(processedNodes).toEqual(nodes);
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0].name).toBe('sd:rawField');
+    const fi = processedNodes[0].attributes.fieldInstance;
+    expect(fi.representation).toBe('complex');
+    expect(fi.family).toBe('CUSTOMFIELD');
+    expect(fi.rawInstruction).toBe('CUSTOMFIELD foo');
+    expect(Array.isArray(fi.source.originalXml)).toBe(true);
   });
 
   it('processes fldSimple XE fields into indexEntry nodes', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/roundtrip.harness.test.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/roundtrip.harness.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Round-trip merge gate.
+ *
+ * Each fixture imports a synthesized OOXML body twice and asserts the
+ * resulting canonical FieldInstance snapshots are equal. A regression
+ * anywhere in the substrate's import path — dropped fields, lost
+ * dirty/locked flags, broken family attribution, mis-attached nesting —
+ * fails one of these.
+ *
+ * Real DOCX fixtures will be added incrementally as specific issues
+ * surface; for the substrate's invariants we run on synthesized OOXML
+ * because it is cheaper and the parsing pipeline is byte-identical.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { snapshotFromXml, type FieldSnapshot } from './field-snapshot-harness.js';
+import { canonicalizeFieldInstance } from './canonicalize-field-instance.js';
+import { buildFieldInstanceFromImport } from './build-field-instance.js';
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+const fldChar = (kind: 'begin' | 'separate' | 'end', extra?: Record<string, string>) => ({
+  name: 'w:r',
+  elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': kind, ...(extra ?? {}) } }],
+});
+
+const instrText = (text: string) => ({
+  name: 'w:r',
+  elements: [{ name: 'w:instrText', elements: [{ type: 'text', text }] }],
+});
+
+const resultText = (text: string) => ({
+  name: 'w:r',
+  elements: [{ name: 'w:t', elements: [{ type: 'text', text }] }],
+});
+
+const complexField = (instruction: string, result: string, beginExtra?: Record<string, string>): unknown => ({
+  name: 'w:p',
+  elements: [
+    fldChar('begin', beginExtra),
+    instrText(instruction),
+    fldChar('separate'),
+    resultText(result),
+    fldChar('end'),
+  ],
+});
+
+const simpleField = (instruction: string, result: string, attrs?: Record<string, string>): unknown => ({
+  name: 'w:p',
+  elements: [
+    {
+      name: 'w:fldSimple',
+      attributes: { 'w:instr': instruction, ...(attrs ?? {}) },
+      elements: [resultText(result)],
+    },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+type Fixture = {
+  name: string;
+  /** Build a fresh body each time so each call gets independent objects. */
+  body: () => unknown[];
+  /** Coarse expectations on the resulting snapshots, beyond round-trip equality. */
+  expect: (snapshots: FieldSnapshot[]) => void;
+};
+
+const FIXTURES: Fixture[] = [
+  {
+    name: 'unknown complex field → rawField with passthrough payload',
+    body: () => [complexField('CUSTOMFIELD foo', 'cached value')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('rawField');
+      expect(s[0].fieldInstance.family).toBe('CUSTOMFIELD');
+      expect(s[0].fieldInstance.representation).toBe('complex');
+      expect(s[0].fieldInstance.rawInstruction).toBe('CUSTOMFIELD foo');
+    },
+  },
+  {
+    name: 'unknown fldSimple → rawField',
+    body: () => [simpleField('CUSTOMSIMPLE arg', 'cached')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('rawField');
+      expect(s[0].fieldInstance.family).toBe('CUSTOMSIMPLE');
+      expect(s[0].fieldInstance.representation).toBe('simple');
+    },
+  },
+  {
+    name: 'PAGE complex field → page-number with FieldInstance',
+    body: () => [complexField('PAGE', '5')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('page-number');
+      expect(s[0].fieldInstance.family).toBe('PAGE');
+    },
+  },
+  {
+    name: 'NUMPAGES complex field → total-page-number with FieldInstance',
+    body: () => [complexField('NUMPAGES', '10')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('total-page-number');
+      expect(s[0].fieldInstance.family).toBe('NUMPAGES');
+    },
+  },
+  {
+    name: 'NUMWORDS fldSimple → documentStatField',
+    body: () => [simpleField('NUMWORDS', '42')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('documentStatField');
+      expect(s[0].fieldInstance.family).toBe('NUMWORDS');
+    },
+  },
+  {
+    name: 'SEQ complex field → sequenceField with FieldInstance',
+    body: () => [complexField('SEQ Figure \\* ARABIC', '1')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('sequenceField');
+      expect(s[0].fieldInstance.family).toBe('SEQ');
+      const switches = s[0].fieldInstance.parsedArgs.switches;
+      expect(switches).toEqual([{ flag: '*', arg: { kind: 'identifier', text: 'ARABIC' } }]);
+    },
+  },
+  {
+    name: 'TOC complex field → tableOfContents with FieldInstance',
+    body: () => [complexField('TOC \\o "1-3"', 'Chapter 1')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('tableOfContents');
+      expect(s[0].fieldInstance.family).toBe('TOC');
+    },
+  },
+  {
+    name: 'REF complex field → crossReference with FieldInstance',
+    body: () => [complexField('REF _Ref123 \\h', 'See section 1')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('crossReference');
+      expect(s[0].fieldInstance.family).toBe('REF');
+    },
+  },
+  {
+    name: 'dirty + locked attributes survive import',
+    body: () => [complexField('PAGE', '1', { 'w:dirty': '1', 'w:fldLock': '1' })],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].fieldInstance.dirty).toBe(true);
+      expect(s[0].fieldInstance.locked).toBe(true);
+    },
+  },
+  {
+    name: 'fldSimple dirty + locked attributes survive import',
+    body: () => [simpleField('CUSTOMSIMPLE foo', 'value', { 'w:dirty': '1', 'w:fldLock': '1' })],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].fieldInstance.dirty).toBe(true);
+      expect(s[0].fieldInstance.locked).toBe(true);
+    },
+  },
+  {
+    name: 'multiple fields preserve document order',
+    body: () => [complexField('PAGE', '5'), complexField('NUMPAGES', '10'), simpleField('NUMWORDS', '42')],
+    expect: (s) => {
+      expect(s.map((x) => x.fieldInstance.family)).toEqual(['PAGE', 'NUMPAGES', 'NUMWORDS']);
+    },
+  },
+  {
+    name: 'HYPERLINK wrapping PAGEREF — child gets PAGEREF, not the parent HYPERLINK',
+    body: () => [
+      {
+        name: 'w:p',
+        elements: [
+          fldChar('begin'),
+          instrText('HYPERLINK \\l "bookmark"'),
+          fldChar('separate'),
+          resultText('See page '),
+          fldChar('begin'),
+          instrText('PAGEREF bookmark'),
+          fldChar('separate'),
+          resultText('5'),
+          fldChar('end'),
+          fldChar('end'),
+        ],
+      },
+    ],
+    expect: (s) => {
+      // The outer HYPERLINK is lowered to a w:hyperlink wrapper (no
+      // FieldInstance attached because w:hyperlink isn't a field-bearing
+      // PM type at this layer); the inner PAGEREF surfaces as
+      // pageReference with its own FieldInstance.
+      const families = s.map((x) => x.fieldInstance.family);
+      expect(families).toContain('PAGEREF');
+      expect(families).not.toContain('HYPERLINK');
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('round-trip harness — canonical FieldInstance snapshots', () => {
+  for (const fixture of FIXTURES) {
+    it(`${fixture.name}: snapshot is stable across re-import`, () => {
+      const a = snapshotFromXml(fixture.body());
+      const b = snapshotFromXml(fixture.body());
+      expect(b).toEqual(a);
+      fixture.expect(a);
+    });
+  }
+});
+
+describe('canonicalizeFieldInstance — strips session-local fields', () => {
+  it('strips id, source.importIndex, source.originalXml, and mutation', () => {
+    const fi = buildFieldInstanceFromImport({
+      representation: 'complex',
+      instructionText: 'PAGE',
+      resultFragments: [],
+      originalXml: { name: 'w:r', elements: [] },
+      dirty: false,
+      locked: false,
+      part: 'body',
+      importIndex: 17,
+    });
+    const c = canonicalizeFieldInstance(fi);
+    expect(c).not.toHaveProperty('id');
+    expect(c).not.toHaveProperty('mutation');
+    expect(c).not.toHaveProperty('source');
+    expect(c.sourcePart).toBe('body');
+    // sanity: preserved fields are still there
+    expect(c.family).toBe('PAGE');
+    expect(c.rawInstruction).toBe('PAGE');
+  });
+
+  it('preserves dirty / locked across canonicalization', () => {
+    const fi = buildFieldInstanceFromImport({
+      representation: 'simple',
+      instructionText: 'CUSTOMFIELD foo',
+      resultFragments: [],
+      originalXml: { name: 'w:fldSimple' },
+      dirty: true,
+      locked: true,
+      part: 'body',
+      importIndex: 0,
+    });
+    const c = canonicalizeFieldInstance(fi);
+    expect(c.dirty).toBe(true);
+    expect(c.locked).toBe(true);
+  });
+
+  it('canonicalizes nested-field tokens via the resolver callback', () => {
+    const child = buildFieldInstanceFromImport({
+      representation: 'complex',
+      instructionText: 'PAGEREF bookmark',
+      resultFragments: [],
+      originalXml: [],
+      dirty: false,
+      locked: false,
+      part: 'body',
+      importIndex: 1,
+    });
+    const parent = buildFieldInstanceFromImport({
+      representation: 'complex',
+      instructionText: 'IF',
+      resultFragments: [],
+      originalXml: [],
+      dirty: false,
+      locked: false,
+      part: 'body',
+      importIndex: 0,
+    });
+    parent.instructionTokens.push({ kind: 'nestedField', childFieldId: child.id });
+    const c = canonicalizeFieldInstance(parent, (id) => (id === child.id ? child : null));
+    const nested = c.instructionTokens.find((t) => t.kind === 'nestedField');
+    expect(nested).toBeDefined();
+    expect(nested && 'child' in nested && nested.child?.family).toBe('PAGEREF');
+  });
+
+  it('falls back to null for nested-field tokens when no resolver is supplied', () => {
+    const parent = buildFieldInstanceFromImport({
+      representation: 'complex',
+      instructionText: 'IF',
+      resultFragments: [],
+      originalXml: [],
+      dirty: false,
+      locked: false,
+      part: 'body',
+      importIndex: 0,
+    });
+    parent.instructionTokens.push({ kind: 'nestedField', childFieldId: 'missing-child' });
+    const c = canonicalizeFieldInstance(parent);
+    const nested = c.instructionTokens.find((t) => t.kind === 'nestedField');
+    expect(nested).toEqual({ kind: 'nestedField', child: null });
+  });
+
+  it('collapses whitespace tokens to a no-text canonical form', () => {
+    const fi = buildFieldInstanceFromImport({
+      representation: 'complex',
+      instructionText: 'A   B',
+      resultFragments: [],
+      originalXml: [],
+      dirty: false,
+      locked: false,
+      part: 'body',
+      importIndex: 0,
+    });
+    const c = canonicalizeFieldInstance(fi);
+    const ws = c.instructionTokens.filter((t) => t.kind === 'whitespace');
+    expect(ws).toHaveLength(1);
+    expect(ws[0]).toEqual({ kind: 'whitespace' });
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/typed-fieldinstance.integration.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/typed-fieldinstance.integration.test.js
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest';
+import { defaultNodeListHandler } from '../v2/importer/docxImporter.js';
+import { preProcessNodesForFldChar } from './preProcessNodesForFldChar.js';
+
+/**
+ * Integration tests for the typed-node FieldInstance attachment.
+ *
+ * Each typed family preprocessor emits its own sd:* element shape; the
+ * centralized attachment in preProcessNodesForFldChar must reach the field
+ * node regardless of whether the preprocessor returns a single node, a
+ * paragraph wrapper, or a block. These tests cover one example per
+ * structural shape rather than every family.
+ */
+
+function findByType(node, type, found = []) {
+  if (!node) return found;
+  if (node.type === type) found.push(node);
+  if (Array.isArray(node.content)) for (const c of node.content) findByType(c, type, found);
+  return found;
+}
+
+describe('typed-node FieldInstance attachment', () => {
+  it('attaches FieldInstance to a documentStatField (simple-field path, NUMWORDS)', () => {
+    const paragraph = {
+      name: 'w:p',
+      elements: [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': 'NUMWORDS' },
+          elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '42' }] }] }],
+        },
+      ],
+    };
+
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const result = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      nodeListHandler,
+      converter: {},
+      path: [],
+    });
+
+    const stat = findByType(result[0], 'documentStatField');
+    expect(stat).toHaveLength(1);
+    const fi = stat[0].attrs.fieldInstance;
+    expect(fi).toBeTruthy();
+    expect(fi.representation).toBe('simple');
+    expect(fi.family).toBe('NUMWORDS');
+    expect(fi.rawInstruction).toBe('NUMWORDS');
+    expect(fi.mutation.imported).toBe(true);
+  });
+
+  it('attaches FieldInstance to a page-number node (complex-field path, single-node emission)', () => {
+    const paragraph = {
+      name: 'w:p',
+      elements: [
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+        { name: 'w:r', elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'PAGE' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+        { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '5' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+      ],
+    };
+
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const result = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      nodeListHandler,
+      converter: {},
+      path: [],
+    });
+
+    const pn = findByType(result[0], 'page-number');
+    expect(pn).toHaveLength(1);
+    const fi = pn[0].attrs.fieldInstance;
+    expect(fi).toBeTruthy();
+    expect(fi.representation).toBe('complex');
+    expect(fi.family).toBe('PAGE');
+    expect(fi.rawInstruction).toBe('PAGE');
+  });
+
+  it('attaches FieldInstance to a tableOfContents node (block-level emission with paragraph wrapper)', () => {
+    const paragraph = {
+      name: 'w:p',
+      elements: [
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+        { name: 'w:r', elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'TOC \\o "1-3"' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+        { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'Chapter 1' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+      ],
+    };
+
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const result = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      nodeListHandler,
+      converter: {},
+      path: [],
+    });
+
+    const toc = result.flatMap((n) => findByType(n, 'tableOfContents'));
+    expect(toc).toHaveLength(1);
+    const fi = toc[0].attrs.fieldInstance;
+    expect(fi).toBeTruthy();
+    expect(fi.representation).toBe('complex');
+    expect(fi.family).toBe('TOC');
+    expect(fi.rawInstruction).toBe('TOC \\o "1-3"');
+  });
+
+  it('attaches FieldInstance to a sequenceField (SEQ) on the complex-field path', () => {
+    const paragraph = {
+      name: 'w:p',
+      elements: [
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'SEQ Figure \\* ARABIC' }] }],
+        },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+        { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+      ],
+    };
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const result = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      nodeListHandler,
+      converter: {},
+      path: [],
+    });
+    const seq = findByType(result[0], 'sequenceField');
+    expect(seq).toHaveLength(1);
+    expect(seq[0].attrs.fieldInstance.family).toBe('SEQ');
+  });
+
+  it('attaches FieldInstance to a totalPageNumber (NUMPAGES) on the complex-field path', () => {
+    const paragraph = {
+      name: 'w:p',
+      elements: [
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+        { name: 'w:r', elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'NUMPAGES' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+        { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '10' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+      ],
+    };
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const result = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      nodeListHandler,
+      converter: {},
+      path: [],
+    });
+    const total = findByType(result[0], 'total-page-number');
+    expect(total).toHaveLength(1);
+    expect(total[0].attrs.fieldInstance.family).toBe('NUMPAGES');
+  });
+
+  it("does not leak fieldInstance into the outer rawField's source.originalXml capture", () => {
+    // Outer unknown CUSTOMFIELD wraps an inner PAGE field. The inner PAGE
+    // emits sd:autoPageNumber with a fieldInstance attribute attached. The
+    // outer rawField captures the inner runs as its source.originalXml so
+    // passthrough export can re-emit the original subtree verbatim. The
+    // fieldInstance attribute is a JS object — if it leaks into that
+    // capture, the XML serializer writes an invalid attribute on
+    // passthrough. Verify the capture is strip-cloned.
+    const paragraph = {
+      name: 'w:p',
+      elements: [
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+        { name: 'w:r', elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'CUSTOMFIELD outer' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+        // Nested handled field (PAGE) inside the unhandled outer.
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+        { name: 'w:r', elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'PAGE' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+        { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '5' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+      ],
+    };
+
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const result = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      nodeListHandler,
+      converter: {},
+      path: [],
+    });
+
+    const raws = findByType(result[0], 'rawField');
+    expect(raws).toHaveLength(1);
+    const rawFi = raws[0].attrs.fieldInstance;
+    expect(rawFi.family).toBe('CUSTOMFIELD');
+
+    // Walk the captured originalXml and assert no element carries a
+    // fieldInstance attribute. originalXml is a flat array of runs for
+    // complex fields.
+    const stack = Array.isArray(rawFi.source.originalXml) ? [...rawFi.source.originalXml] : [rawFi.source.originalXml];
+    while (stack.length) {
+      const node = stack.pop();
+      if (!node || typeof node !== 'object') continue;
+      if (node.attributes && Object.prototype.hasOwnProperty.call(node.attributes, 'fieldInstance')) {
+        throw new Error(`fieldInstance leaked into source.originalXml on element ${node.name}`);
+      }
+      if (Array.isArray(node.elements)) stack.push(...node.elements);
+    }
+
+    // Sanity: the inner PAGE still surfaces on the PM tree with its FI.
+    const pn = findByType(result[0], 'page-number');
+    expect(pn).toHaveLength(1);
+    expect(pn[0].attrs.fieldInstance.family).toBe('PAGE');
+  });
+
+  it('preserves dirty / locked flags on the FieldInstance attached to a typed node', () => {
+    const paragraph = {
+      name: 'w:p',
+      elements: [
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin', 'w:dirty': '1', 'w:fldLock': '1' } }],
+        },
+        { name: 'w:r', elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'PAGE' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+        { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+      ],
+    };
+
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const result = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      nodeListHandler,
+      converter: {},
+      path: [],
+    });
+
+    const pn = findByType(result[0], 'page-number');
+    expect(pn[0].attrs.fieldInstance.dirty).toBe(true);
+    expect(pn[0].attrs.fieldInstance.locked).toBe(true);
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/typed-fieldinstance.integration.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/typed-fieldinstance.integration.test.js
@@ -167,14 +167,14 @@ describe('typed-node FieldInstance attachment', () => {
     expect(total[0].attrs.fieldInstance.family).toBe('NUMPAGES');
   });
 
-  it("does not leak fieldInstance into the outer rawField's source.originalXml capture", () => {
+  it("captures only original w:* runs in the outer rawField's source.originalXml (no synthetic sd:* wrappers)", () => {
     // Outer unknown CUSTOMFIELD wraps an inner PAGE field. The inner PAGE
     // emits sd:autoPageNumber with a fieldInstance attribute attached. The
-    // outer rawField captures the inner runs as its source.originalXml so
-    // passthrough export can re-emit the original subtree verbatim. The
-    // fieldInstance attribute is a JS object — if it leaks into that
-    // capture, the XML serializer writes an invalid attribute on
-    // passthrough. Verify the capture is strip-cloned.
+    // outer rawField captures runs as its source.originalXml so passthrough
+    // export can re-emit the original subtree verbatim. The capture must
+    // contain the inner field's begin/instr/separate/result/end w:r runs,
+    // not the synthesized sd:autoPageNumber wrapper — emitting the latter
+    // through the XML serializer would produce invalid OOXML on passthrough.
     const paragraph = {
       name: 'w:p',
       elements: [
@@ -206,13 +206,16 @@ describe('typed-node FieldInstance attachment', () => {
     const rawFi = raws[0].attrs.fieldInstance;
     expect(rawFi.family).toBe('CUSTOMFIELD');
 
-    // Walk the captured originalXml and assert no element carries a
-    // fieldInstance attribute. originalXml is a flat array of runs for
-    // complex fields.
+    // Walk the captured originalXml and assert no element is a synthetic
+    // sd:* wrapper and no fieldInstance attribute leaked into the capture.
+    // The capture is a flat array of runs for complex fields.
     const stack = Array.isArray(rawFi.source.originalXml) ? [...rawFi.source.originalXml] : [rawFi.source.originalXml];
     while (stack.length) {
       const node = stack.pop();
       if (!node || typeof node !== 'object') continue;
+      if (typeof node.name === 'string' && node.name.startsWith('sd:')) {
+        throw new Error(`synthetic ${node.name} leaked into source.originalXml — passthrough would emit invalid OOXML`);
+      }
       if (node.attributes && Object.prototype.hasOwnProperty.call(node.attributes, 'fieldInstance')) {
         throw new Error(`fieldInstance leaked into source.originalXml on element ${node.name}`);
       }

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/authorityEntryImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/authorityEntryImporter.js
@@ -1,0 +1,12 @@
+import { generateV2HandlerEntity } from '@core/super-converter/v3/handlers/utils';
+import { translator } from '../../v3/handlers/sd/authorityEntry/authorityEntry-translator.js';
+
+/**
+ * @type {import("./docxImporter").NodeHandlerEntry}
+ *
+ * Without this entry the V2 importer drops `<sd:authorityEntry>` elements
+ * (TA fields). passthroughNodeImporter defers when a V3 translator is
+ * registered for the node name, but no other entity claims the node
+ * afterwards.
+ */
+export const authorityEntryEntity = generateV2HandlerEntity('authorityEntryNodeHandler', translator);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/citationImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/citationImporter.js
@@ -1,0 +1,12 @@
+import { generateV2HandlerEntity } from '@core/super-converter/v3/handlers/utils';
+import { translator } from '../../v3/handlers/sd/citation/citation-translator.js';
+
+/**
+ * @type {import("./docxImporter").NodeHandlerEntry}
+ *
+ * Without this entry the V2 importer drops `<sd:citation>` elements:
+ * passthroughNodeImporter defers when a V3 translator is registered for
+ * the node name, but no other entity claims the node afterwards. Mirrors
+ * the established pattern used by every other typed sd:* field carrier.
+ */
+export const citationEntity = generateV2HandlerEntity('citationNodeHandler', translator);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
@@ -18,6 +18,7 @@ import { autoPageHandlerEntity, autoTotalPageCountEntity } from './autoPageNumbe
 import { documentStatFieldHandlerEntity } from './documentStatFieldImporter.js';
 import { pageReferenceEntity } from './pageReferenceImporter.js';
 import { crossReferenceEntity } from './crossReferenceImporter.js';
+import { rawFieldEntity } from './rawFieldImporter.js';
 import { pictNodeHandlerEntity } from './pictNodeImporter.js';
 import { importCommentData } from './documentCommentsImporter.js';
 import { buildTrackedChangeIdMap, buildTrackedChangeIdMapsByPart } from './trackedChangeIdMapper.js';
@@ -255,6 +256,7 @@ export const defaultNodeListHandler = () => {
     documentStatFieldHandlerEntity,
     pageReferenceEntity,
     crossReferenceEntity,
+    rawFieldEntity,
     permStartHandlerEntity,
     permEndHandlerEntity,
     mathNodeHandlerEntity,

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
@@ -19,6 +19,11 @@ import { documentStatFieldHandlerEntity } from './documentStatFieldImporter.js';
 import { pageReferenceEntity } from './pageReferenceImporter.js';
 import { crossReferenceEntity } from './crossReferenceImporter.js';
 import { rawFieldEntity } from './rawFieldImporter.js';
+import { sequenceFieldEntity } from './sequenceFieldImporter.js';
+import { citationEntity } from './citationImporter.js';
+import { authorityEntryEntity } from './authorityEntryImporter.js';
+import { tableOfAuthoritiesEntity } from './tableOfAuthoritiesImporter.js';
+import { tableOfContentsEntryEntity } from './tableOfContentsEntryImporter.js';
 import { pictNodeHandlerEntity } from './pictNodeImporter.js';
 import { importCommentData } from './documentCommentsImporter.js';
 import { buildTrackedChangeIdMap, buildTrackedChangeIdMapsByPart } from './trackedChangeIdMapper.js';
@@ -257,6 +262,11 @@ export const defaultNodeListHandler = () => {
     pageReferenceEntity,
     crossReferenceEntity,
     rawFieldEntity,
+    sequenceFieldEntity,
+    citationEntity,
+    authorityEntryEntity,
+    tableOfAuthoritiesEntity,
+    tableOfContentsEntryEntity,
     permStartHandlerEntity,
     permEndHandlerEntity,
     mathNodeHandlerEntity,

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/extendedFieldImporters.integration.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/extendedFieldImporters.integration.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { defaultNodeListHandler } from './docxImporter.js';
+import { citationEntity } from './citationImporter.js';
+import { authorityEntryEntity } from './authorityEntryImporter.js';
+import { tableOfAuthoritiesEntity } from './tableOfAuthoritiesImporter.js';
+import { tableOfContentsEntryEntity } from './tableOfContentsEntryImporter.js';
+import { preProcessNodesForFldChar } from '../../field-references/preProcessNodesForFldChar.js';
+
+/**
+ * Regression guards for the four V2 importer entities added alongside
+ * chunk (c)'s FieldInstance forwarding work. Each of these fields was
+ * previously dropped silently on import: the V3 translator was
+ * registered (so passthroughNodeImporter deferred) but no V2 entity
+ * claimed the node. Mirrors the SEQ guard in sequenceFieldImporter.
+ */
+
+function findFirstByType(nodes, type) {
+  const stack = [...(nodes ?? [])];
+  while (stack.length) {
+    const n = stack.pop();
+    if (!n) continue;
+    if (n.type === type) return n;
+    if (Array.isArray(n.content)) stack.push(...n.content);
+  }
+  return null;
+}
+
+const fldChar = (kind) => ({
+  name: 'w:r',
+  elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': kind } }],
+});
+const instrText = (text) => ({
+  name: 'w:r',
+  elements: [{ name: 'w:instrText', elements: [{ type: 'text', text }] }],
+});
+const resultText = (text) => ({
+  name: 'w:r',
+  elements: [{ name: 'w:t', elements: [{ type: 'text', text }] }],
+});
+const complexField = (instruction, result) => ({
+  name: 'w:p',
+  elements: [fldChar('begin'), instrText(instruction), fldChar('separate'), resultText(result), fldChar('end')],
+});
+
+function importBody(body) {
+  const { processedNodes } = preProcessNodesForFldChar(body, {});
+  const nodeListHandler = defaultNodeListHandler();
+  return nodeListHandler.handler({
+    nodes: processedNodes,
+    docx: {},
+    nodeListHandler,
+    converter: {},
+    path: [],
+  });
+}
+
+describe('extended field V2 importer wiring (regression guards)', () => {
+  it('registers all four new entities in defaultNodeListHandler', () => {
+    const entities = defaultNodeListHandler().handlerEntities;
+    expect(entities).toContain(citationEntity);
+    expect(entities).toContain(authorityEntryEntity);
+    expect(entities).toContain(tableOfAuthoritiesEntity);
+    expect(entities).toContain(tableOfContentsEntryEntity);
+  });
+
+  it('CITATION → citation PM node carrying its FieldInstance', () => {
+    const result = importBody([complexField('CITATION src1', '(Smith, 2020)')]);
+    const node = findFirstByType(result, 'citation');
+    expect(node).toBeTruthy();
+    expect(node.attrs.fieldInstance).toBeDefined();
+    expect(node.attrs.fieldInstance.family).toBe('CITATION');
+  });
+
+  it('TA → authorityEntry PM node carrying its FieldInstance', () => {
+    const result = importBody([complexField('TA \\l "Smith v. Jones" \\s "Smith"', '')]);
+    const node = findFirstByType(result, 'authorityEntry');
+    expect(node).toBeTruthy();
+    expect(node.attrs.fieldInstance).toBeDefined();
+    expect(node.attrs.fieldInstance.family).toBe('TA');
+  });
+
+  it('TOA → tableOfAuthorities PM node carrying its FieldInstance', () => {
+    const result = importBody([complexField('TOA \\h \\c "1"', 'Cases')]);
+    const node = findFirstByType(result, 'tableOfAuthorities');
+    expect(node).toBeTruthy();
+    expect(node.attrs.fieldInstance).toBeDefined();
+    expect(node.attrs.fieldInstance.family).toBe('TOA');
+  });
+
+  it('TC → tableOfContentsEntry PM node carrying its FieldInstance', () => {
+    const result = importBody([complexField('TC "Chapter One" \\l 1', '')]);
+    const node = findFirstByType(result, 'tableOfContentsEntry');
+    expect(node).toBeTruthy();
+    expect(node.attrs.fieldInstance).toBeDefined();
+    expect(node.attrs.fieldInstance.family).toBe('TC');
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/rawFieldImporter.integration.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/rawFieldImporter.integration.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { defaultNodeListHandler } from './docxImporter.js';
+import { rawFieldEntity } from './rawFieldImporter.js';
+import { preProcessNodesForFldChar } from '../../field-references/preProcessNodesForFldChar.js';
+
+describe('rawField v2 importer wiring (regression guard)', () => {
+  it('registers rawFieldEntity in defaultNodeListHandler', () => {
+    // Mirrors the IT-949 guard for crossReferenceEntity. Without this entry
+    // the V2 importer drops `<sd:rawField>` because passthroughNodeImporter
+    // defers when a V3 translator is registered for the node name.
+    expect(defaultNodeListHandler().handlerEntities).toContain(rawFieldEntity);
+  });
+
+  it('an unknown complex field round-trips into a rawField PM node carrying its FieldInstance', () => {
+    const paragraph = {
+      name: 'w:p',
+      elements: [
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'CUSTOMFIELD foo' }] }],
+        },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+        { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'value' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+      ],
+    };
+
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const result = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      nodeListHandler,
+      converter: {},
+      path: [],
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    // The paragraph wraps a rawField PM node; find it anywhere in the tree.
+    const stack = [...result];
+    let rawField = null;
+    while (stack.length) {
+      const n = stack.pop();
+      if (!n) continue;
+      if (n.type === 'rawField') {
+        rawField = n;
+        break;
+      }
+      if (Array.isArray(n.content)) stack.push(...n.content);
+    }
+
+    expect(rawField).toBeTruthy();
+    expect(rawField.attrs.fieldInstance).toBeDefined();
+    expect(rawField.attrs.fieldInstance.family).toBe('CUSTOMFIELD');
+    expect(rawField.attrs.fieldInstance.rawInstruction).toBe('CUSTOMFIELD foo');
+  });
+
+  it('an unknown fldSimple round-trips into a rawField PM node', () => {
+    const paragraph = {
+      name: 'w:p',
+      elements: [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': 'CUSTOMFIELD foo' },
+          elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'value' }] }] }],
+        },
+      ],
+    };
+
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const result = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      nodeListHandler,
+      converter: {},
+      path: [],
+    });
+
+    const stack = [...result];
+    let rawField = null;
+    while (stack.length) {
+      const n = stack.pop();
+      if (!n) continue;
+      if (n.type === 'rawField') {
+        rawField = n;
+        break;
+      }
+      if (Array.isArray(n.content)) stack.push(...n.content);
+    }
+
+    expect(rawField).toBeTruthy();
+    expect(rawField.attrs.fieldInstance.representation).toBe('simple');
+    expect(rawField.attrs.fieldInstance.family).toBe('CUSTOMFIELD');
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/rawFieldImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/rawFieldImporter.js
@@ -1,0 +1,12 @@
+import { generateV2HandlerEntity } from '@core/super-converter/v3/handlers/utils';
+import { translator } from '../../v3/handlers/sd/rawField/rawField-translator.js';
+
+/**
+ * @type {import("./docxImporter").NodeHandlerEntry}
+ *
+ * Without this entry the V2 importer drops `<sd:rawField>` elements:
+ * `passthroughNodeImporter` defers when a V3 translator is registered for
+ * the node name, but if no V2 entity claims the node afterwards the
+ * handler reduce leaves consumed at 0 and the node is silently lost.
+ */
+export const rawFieldEntity = generateV2HandlerEntity('rawFieldNodeHandler', translator);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.integration.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.integration.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { defaultNodeListHandler } from './docxImporter.js';
+import { sequenceFieldEntity } from './sequenceFieldImporter.js';
+import { preProcessNodesForFldChar } from '../../field-references/preProcessNodesForFldChar.js';
+
+describe('sequenceField v2 importer wiring (regression guard)', () => {
+  it('registers sequenceFieldEntity in defaultNodeListHandler', () => {
+    // Without this entry sd:sequenceField is silently dropped on import:
+    // passthroughNodeImporter defers (a V3 translator is registered for the
+    // node name) and no other entity claims the node, so the reduce loop
+    // appends nothing. Mirrors the IT-949 guard for crossReference and the
+    // chunk-(b) guard for rawField.
+    expect(defaultNodeListHandler().handlerEntities).toContain(sequenceFieldEntity);
+  });
+
+  it('a SEQ field round-trips into a sequenceField PM node carrying its FieldInstance', () => {
+    const paragraph = {
+      name: 'w:p',
+      elements: [
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'SEQ Figure \\* ARABIC' }] }],
+        },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+        { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+      ],
+    };
+
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const result = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      nodeListHandler,
+      converter: {},
+      path: [],
+    });
+
+    const stack = [...result];
+    let seq = null;
+    while (stack.length) {
+      const n = stack.pop();
+      if (!n) continue;
+      if (n.type === 'sequenceField') {
+        seq = n;
+        break;
+      }
+      if (Array.isArray(n.content)) stack.push(...n.content);
+    }
+
+    expect(seq).toBeTruthy();
+    expect(seq.attrs.identifier).toBe('Figure');
+    expect(seq.attrs.format).toBe('ARABIC');
+    expect(seq.attrs.fieldInstance).toBeDefined();
+    expect(seq.attrs.fieldInstance.family).toBe('SEQ');
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.js
@@ -1,0 +1,14 @@
+import { generateV2HandlerEntity } from '@core/super-converter/v3/handlers/utils';
+import { translator } from '../../v3/handlers/sd/sequenceField/sequenceField-translator.js';
+
+/**
+ * @type {import("./docxImporter").NodeHandlerEntry}
+ *
+ * Without this entry the V2 importer drops `<sd:sequenceField>` elements:
+ * `passthroughNodeImporter` defers when a V3 translator is registered for
+ * the node name, but no other entity claimed the node afterwards, so the
+ * handler reduce left consumed at 0 and the field was silently lost on
+ * import. Mirrors the established pattern (crossReferenceEntity,
+ * rawFieldEntity) used for every other typed sd:* field carrier.
+ */
+export const sequenceFieldEntity = generateV2HandlerEntity('sequenceFieldNodeHandler', translator);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/tableOfAuthoritiesImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/tableOfAuthoritiesImporter.js
@@ -1,0 +1,12 @@
+import { generateV2HandlerEntity } from '@core/super-converter/v3/handlers/utils';
+import { translator } from '../../v3/handlers/sd/tableOfAuthorities/tableOfAuthorities-translator.js';
+
+/**
+ * @type {import("./docxImporter").NodeHandlerEntry}
+ *
+ * Without this entry the V2 importer drops `<sd:tableOfAuthorities>`
+ * elements (TOA fields). paragraphNodeImporter hoists the block but the
+ * downstream node-list handler still requires a claimant; without it
+ * the node is dropped.
+ */
+export const tableOfAuthoritiesEntity = generateV2HandlerEntity('tableOfAuthoritiesNodeHandler', translator);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/tableOfContentsEntryImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/tableOfContentsEntryImporter.js
@@ -1,0 +1,12 @@
+import { generateV2HandlerEntity } from '@core/super-converter/v3/handlers/utils';
+import { translator } from '../../v3/handlers/sd/tableOfContentsEntry/tableOfContentsEntry-translator.js';
+
+/**
+ * @type {import("./docxImporter").NodeHandlerEntry}
+ *
+ * Without this entry the V2 importer drops `<sd:tableOfContentsEntry>`
+ * elements (TC fields). passthroughNodeImporter defers when a V3
+ * translator is registered for the node name, but no other entity
+ * claims the node afterwards.
+ */
+export const tableOfContentsEntryEntity = generateV2HandlerEntity('tableOfContentsEntryNodeHandler', translator);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/index.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/index.js
@@ -14,6 +14,7 @@ import { translator as sd_tableOfAuthorities_translator } from './sd/tableOfAuth
 import { translator as sd_autoPageNumber_translator } from './sd/autoPageNumber/autoPageNumber-translator.js';
 import { translator as sd_totalPageNumber_translator } from './sd/totalPageNumber/totalPageNumber-translator.js';
 import { translator as sd_documentStatField_translator } from './sd/documentStatField/documentStatField-translator.js';
+import { translator as sd_rawField_translator } from './sd/rawField/rawField-translator.js';
 import { translator as w_abstractNum_translator } from './w/abstractNum/abstractNum-translator.js';
 import { translator as w_abstractNumId_translator } from './w/abstractNumId/abstractNumId-translator.js';
 import { translator as w_adjustRightInd_translator } from './w/adjustRightInd/adjustRightInd-translator.js';
@@ -225,6 +226,7 @@ const translatorList = Array.from(
     sd_autoPageNumber_translator,
     sd_totalPageNumber_translator,
     sd_documentStatField_translator,
+    sd_rawField_translator,
     w_abstractNum_translator,
     w_abstractNumId_translator,
     w_adjustRightInd_translator,

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/authorityEntry/authorityEntry-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/authorityEntry/authorityEntry-translator.js
@@ -37,6 +37,7 @@ const encode = (params) => {
       bold,
       italic,
       marksAsAttrs: node.marks || [],
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
     content: processedText,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/autoPageNumber/autoPageNumber-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/autoPageNumber/autoPageNumber-translator.js
@@ -24,6 +24,7 @@ const encode = (params) => {
     type: 'page-number',
     attrs: {
       marksAsAttrs: marks,
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
   };
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/autoPageNumber/autoPageNumber-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/autoPageNumber/autoPageNumber-translator.test.js
@@ -59,6 +59,7 @@ describe('sd:autoPageNumber translator', () => {
         type: 'page-number',
         attrs: {
           marksAsAttrs: marks,
+          fieldInstance: null,
         },
       });
     });

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/bibliography/bibliography-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/bibliography/bibliography-translator.js
@@ -27,6 +27,7 @@ const encode = (params) => {
     type: SD_NODE_NAME,
     attrs: {
       instruction: node.attributes?.instruction || '',
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
     content: processedContent,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/citation/citation-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/citation/citation-translator.js
@@ -34,6 +34,7 @@ const encode = (params) => {
       sourceIds,
       resolvedText: extractResolvedText(processedText),
       marksAsAttrs: node.marks || [],
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
     content: processedText,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/crossReference/crossReference-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/crossReference/crossReference-translator.js
@@ -32,6 +32,7 @@ const encode = (params) => {
       display: parseDisplay(node.attributes?.instruction),
       resolvedText: extractResolvedText(processedText),
       marksAsAttrs: node.marks || [],
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
     content: processedText,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/crossReference/crossReference-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/crossReference/crossReference-translator.test.js
@@ -137,4 +137,33 @@ describe('crossReference import resolvedText extraction (SD-2495)', () => {
 
     expect(encoded.attrs.resolvedText).toBe('4(b)(2)');
   });
+
+  it('forwards attributes.fieldInstance to attrs.fieldInstance', () => {
+    const stubFieldInstance = { family: 'REF', rawInstruction: 'REF foo', mutation: { imported: true } };
+    const xmlNode = {
+      name: 'sd:crossReference',
+      type: 'element',
+      attributes: { instruction: 'REF foo', fieldInstance: stubFieldInstance },
+      elements: [],
+    };
+    const encoded = crossReferenceTranslator.encode({
+      nodes: [xmlNode],
+      nodeListHandler: { handler: () => [] },
+    });
+    expect(encoded.attrs.fieldInstance).toBe(stubFieldInstance);
+  });
+
+  it('defaults attrs.fieldInstance to null when attributes has no fieldInstance', () => {
+    const xmlNode = {
+      name: 'sd:crossReference',
+      type: 'element',
+      attributes: { instruction: 'REF foo' },
+      elements: [],
+    };
+    const encoded = crossReferenceTranslator.encode({
+      nodes: [xmlNode],
+      nodeListHandler: { handler: () => [] },
+    });
+    expect(encoded.attrs.fieldInstance).toBeNull();
+  });
 });

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/documentStatField/documentStatField-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/documentStatField/documentStatField-translator.js
@@ -35,6 +35,7 @@ const encode = (params) => {
       instruction,
       resolvedText,
       marksAsAttrs: marks,
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
   };
 };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/index/index-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/index/index-translator.js
@@ -28,6 +28,7 @@ const encode = (params) => {
     attrs: {
       instruction: node.attributes?.instruction || '',
       instructionTokens: node.attributes?.instructionTokens || null,
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
     content: processedContent,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/index/index-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/index/index-translator.test.js
@@ -76,6 +76,27 @@ describe('sd:index translator', () => {
       expect(result.attrs.instruction).toBe('');
       expect(result.attrs.instructionTokens).toBeNull();
     });
+
+    it('forwards attributes.fieldInstance to attrs.fieldInstance', () => {
+      const mockNodeListHandler = { handler: vi.fn().mockReturnValue([]) };
+      const stubFieldInstance = { family: 'INDEX', rawInstruction: 'INDEX', mutation: { imported: true } };
+
+      const result = config.encode({
+        nodes: [{ name: 'sd:index', attributes: { fieldInstance: stubFieldInstance }, elements: [] }],
+        nodeListHandler: mockNodeListHandler,
+      });
+
+      expect(result.attrs.fieldInstance).toBe(stubFieldInstance);
+    });
+
+    it('defaults attrs.fieldInstance to null when attributes has no fieldInstance', () => {
+      const mockNodeListHandler = { handler: vi.fn().mockReturnValue([]) };
+      const result = config.encode({
+        nodes: [{ name: 'sd:index', attributes: {}, elements: [] }],
+        nodeListHandler: mockNodeListHandler,
+      });
+      expect(result.attrs.fieldInstance).toBeNull();
+    });
   });
 
   describe('decode', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/indexEntry/indexEntry-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/indexEntry/indexEntry-translator.js
@@ -29,6 +29,7 @@ const encode = (params) => {
       instruction: node.attributes?.instruction || '',
       instructionTokens: node.attributes?.instructionTokens || null,
       marksAsAttrs: node.marks || [],
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
     content: processedText,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/pageReference/pageReference-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/pageReference/pageReference-translator.js
@@ -28,6 +28,7 @@ const encode = (params) => {
     attrs: {
       instruction: node.attributes?.instruction || '',
       marksAsAttrs: node.marks || [],
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
     content: processedText,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/rawField/rawField-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/rawField/rawField-translator.js
@@ -1,0 +1,192 @@
+// @ts-check
+import { NodeTranslator } from '@translator';
+import { exportSchemaToJson, processOutputMarks } from '../../../../exporter.js';
+
+/** @type {import('@translator').XmlNodeName} */
+const XML_NODE_NAME = 'sd:rawField';
+
+/** @type {import('@translator').SuperDocNodeOrKeyName} */
+const SD_NODE_NAME = 'rawField';
+
+/**
+ * Encode a `<sd:rawField>` element as a SuperDoc rawField node.
+ *
+ * The preprocessor emits `<sd:rawField>` with the canonical FieldInstance
+ * payload on `attributes.fieldInstance` and the field's result content as
+ * `elements`. Encode forwards the payload to the PM node attrs and
+ * recursively processes the result content into inline PM children, so
+ * formatted result runs (bold, color, font) survive end-to-end.
+ *
+ * @param {import('@translator').SCEncoderConfig} [params]
+ * @returns {import('@translator').SCEncoderResult}
+ */
+const encode = (params) => {
+  const { nodes = [], nodeListHandler } = params || {};
+  const node = nodes[0];
+
+  const processedContent = nodeListHandler.handler({
+    ...params,
+    nodes: node.elements || [],
+  });
+
+  return {
+    type: SD_NODE_NAME,
+    attrs: {
+      fieldInstance: node.attributes?.fieldInstance ?? null,
+      marksAsAttrs: node.marks || [],
+    },
+    content: processedContent,
+  };
+};
+
+/**
+ * Decode a rawField PM node back to OOXML.
+ *
+ * Two paths:
+ *
+ *   1. Passthrough — when the field has an unmodified import-time
+ *      `source.originalXml` and none of the mutation flags are set, emit
+ *      that subtree unchanged. This is the structural-fidelity path: an
+ *      unknown field that survived an editing session unchanged round-trips
+ *      with the same `fldChar` / `fldSimple` shape, the same instruction
+ *      text, the same result fragments, and the same flags.
+ *
+ *   2. Rebuild — when the field was inserted, edited, relocated, or has
+ *      no captured source XML, synthesize a fresh field envelope from the
+ *      canonical payload. `representation` decides between `<w:fldSimple>`
+ *      and a `<w:fldChar>` trio. The result content comes from the PM
+ *      children (already-edited / formatted), preserving any in-session
+ *      changes the user made.
+ *
+ * @param {import('@translator').SCDecoderConfig} params
+ * @returns {import('@translator').SCDecoderResult[]}
+ */
+const decode = (params) => {
+  const { node } = params;
+  const fi = node.attrs?.fieldInstance ?? null;
+  const outputMarks = processOutputMarks(node.attrs?.marksAsAttrs || []);
+  const contentNodes = (node.content ?? []).flatMap((n) => exportSchemaToJson({ ...params, node: n }));
+
+  if (fi && shouldPassthrough(fi)) {
+    return passthroughOriginal(fi.source.originalXml);
+  }
+
+  return rebuildEnvelope(fi, contentNodes, outputMarks);
+};
+
+/**
+ * Passthrough eligibility: the field came from import and nothing about it
+ * has been touched since. See FieldInstance.mutation in the substrate
+ * design for the per-flag semantics.
+ *
+ * @param {*} fi
+ */
+function shouldPassthrough(fi) {
+  if (!fi || !fi.mutation || !fi.source) return false;
+  if (!fi.mutation.imported) return false;
+  if (fi.mutation.instructionEdited) return false;
+  if (fi.mutation.resultEdited) return false;
+  if (fi.mutation.flagsEdited) return false;
+  if (fi.mutation.relocated) return false;
+  if (fi.mutation.structureEdited) return false;
+  return fi.source.originalXml != null;
+}
+
+/**
+ * Emit the captured original-XML subtree verbatim. The capture is either
+ * an array of runs forming the begin/instr/separate/result/end span (for
+ * complex fields) or a single `<w:fldSimple>` element (for simple fields).
+ *
+ * @param {*} originalXml
+ * @returns {import('@translator').SCDecoderResult[]}
+ */
+function passthroughOriginal(originalXml) {
+  if (Array.isArray(originalXml)) return originalXml;
+  if (originalXml) return [originalXml];
+  return [];
+}
+
+/**
+ * Rebuild the field envelope from canonical state. Used when the field has
+ * been edited or has no captured source XML. Honors `representation`,
+ * `rawInstruction`, `dirty`, `locked`, and the current PM children as the
+ * result content.
+ *
+ * @param {*} fi
+ * @param {Array<*>} contentNodes
+ * @param {Array<*>} outputMarks
+ * @returns {import('@translator').SCDecoderResult[]}
+ */
+function rebuildEnvelope(fi, contentNodes, outputMarks) {
+  const rawInstruction = fi?.rawInstruction ?? '';
+  const dirty = fi?.dirty ? '1' : null;
+  const locked = fi?.locked ? '1' : null;
+  const representation = fi?.representation ?? 'complex';
+
+  if (representation === 'simple') {
+    /** @type {Record<string, string>} */
+    const attrs = { 'w:instr': rawInstruction };
+    if (dirty) attrs['w:dirty'] = dirty;
+    if (locked) attrs['w:fldLock'] = locked;
+    return [
+      {
+        name: 'w:fldSimple',
+        attributes: attrs,
+        elements: contentNodes,
+      },
+    ];
+  }
+
+  /** @type {Record<string, string>} */
+  const beginAttrs = { 'w:fldCharType': 'begin' };
+  if (dirty) beginAttrs['w:dirty'] = dirty;
+  if (locked) beginAttrs['w:fldLock'] = locked;
+
+  return [
+    {
+      name: 'w:r',
+      elements: [
+        { name: 'w:rPr', elements: outputMarks },
+        { name: 'w:fldChar', attributes: beginAttrs },
+      ],
+    },
+    {
+      name: 'w:r',
+      elements: [
+        { name: 'w:rPr', elements: outputMarks },
+        {
+          name: 'w:instrText',
+          attributes: { 'xml:space': 'preserve' },
+          elements: [{ type: 'text', text: rawInstruction }],
+        },
+      ],
+    },
+    {
+      name: 'w:r',
+      elements: [
+        { name: 'w:rPr', elements: outputMarks },
+        { name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } },
+      ],
+    },
+    ...contentNodes,
+    {
+      name: 'w:r',
+      elements: [
+        { name: 'w:rPr', elements: outputMarks },
+        { name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } },
+      ],
+    },
+  ];
+}
+
+/** @type {import('@translator').NodeTranslatorConfig} */
+export const config = {
+  xmlName: XML_NODE_NAME,
+  sdNodeOrKeyName: SD_NODE_NAME,
+  type: NodeTranslator.translatorTypes.NODE,
+  encode,
+  decode,
+};
+
+/** @type {import('@translator').NodeTranslator} */
+export const translator = NodeTranslator.from(config);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/rawField/rawField-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/rawField/rawField-translator.test.js
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+import { exportSchemaToJson } from '../../../../exporter.js';
+import { translator } from './rawField-translator.js';
+
+const PRISTINE_MUTATION = {
+  imported: true,
+  inserted: false,
+  instructionEdited: false,
+  resultEdited: false,
+  flagsEdited: false,
+  relocated: false,
+  structureEdited: false,
+};
+
+function buildFieldInstance(overrides = {}) {
+  return {
+    id: 'test-id',
+    representation: 'complex',
+    family: 'CUSTOMFIELD',
+    rawInstruction: 'CUSTOMFIELD foo',
+    instructionTokens: [],
+    parsedArgs: { positional: [], switches: [] },
+    resultFragments: [],
+    dirty: false,
+    locked: false,
+    mutation: { ...PRISTINE_MUTATION, ...(overrides.mutation || {}) },
+    source: {
+      originalXml: undefined,
+      part: 'body',
+      importIndex: 0,
+      ...(overrides.source || {}),
+    },
+    ...overrides,
+  };
+}
+
+function buildRawFieldNode(overrides = {}) {
+  return {
+    type: 'rawField',
+    attrs: {
+      fieldInstance: buildFieldInstance(overrides.fieldInstance || {}),
+      marksAsAttrs: [],
+      ...overrides.attrs,
+    },
+    content: overrides.content ?? [],
+  };
+}
+
+describe('rawField translator', () => {
+  describe('decode (PM → OOXML)', () => {
+    it('passes the original XML through verbatim when the field is unedited and source is captured', () => {
+      const original = [
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+        { name: 'w:r', elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'CUSTOMFIELD foo' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+        { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'value' }] }] },
+        { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+      ];
+      const node = buildRawFieldNode({ fieldInstance: { source: { originalXml: original } } });
+      const exported = exportSchemaToJson({ node });
+      expect(exported).toEqual(original);
+    });
+
+    it('passes a single fldSimple element through verbatim for simple representation', () => {
+      const original = {
+        name: 'w:fldSimple',
+        attributes: { 'w:instr': 'CUSTOMFIELD foo' },
+        elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'value' }] }] }],
+      };
+      const node = buildRawFieldNode({
+        fieldInstance: {
+          representation: 'simple',
+          source: { originalXml: original },
+        },
+      });
+      const exported = exportSchemaToJson({ node });
+      expect(exported).toEqual([original]);
+    });
+
+    it('rebuilds a complex field envelope when no original XML was captured', () => {
+      const node = buildRawFieldNode({
+        fieldInstance: { source: { originalXml: undefined } },
+      });
+      const exported = exportSchemaToJson({ node });
+
+      const beginRun = exported.find((e) =>
+        e?.elements?.some((c) => c?.name === 'w:fldChar' && c?.attributes?.['w:fldCharType'] === 'begin'),
+      );
+      const separateRun = exported.find((e) =>
+        e?.elements?.some((c) => c?.name === 'w:fldChar' && c?.attributes?.['w:fldCharType'] === 'separate'),
+      );
+      const endRun = exported.find((e) =>
+        e?.elements?.some((c) => c?.name === 'w:fldChar' && c?.attributes?.['w:fldCharType'] === 'end'),
+      );
+      const instrRun = exported.find((e) => e?.elements?.some((c) => c?.name === 'w:instrText'));
+
+      expect(beginRun).toBeDefined();
+      expect(separateRun).toBeDefined();
+      expect(endRun).toBeDefined();
+      expect(instrRun).toBeDefined();
+      const instrText = instrRun.elements.find((c) => c.name === 'w:instrText');
+      expect(instrText.elements[0].text).toBe('CUSTOMFIELD foo');
+    });
+
+    it('rebuilds a fldSimple envelope when representation is simple and source is missing', () => {
+      const node = buildRawFieldNode({
+        fieldInstance: {
+          representation: 'simple',
+          source: { originalXml: undefined },
+        },
+      });
+      const exported = exportSchemaToJson({ node });
+      expect(exported).toHaveLength(1);
+      expect(exported[0].name).toBe('w:fldSimple');
+      expect(exported[0].attributes['w:instr']).toBe('CUSTOMFIELD foo');
+    });
+
+    it('rebuilds (does not passthrough) when an instruction edit flag is set', () => {
+      const original = [{ name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] }];
+      const node = buildRawFieldNode({
+        fieldInstance: {
+          source: { originalXml: original },
+          mutation: { instructionEdited: true },
+        },
+      });
+      const exported = exportSchemaToJson({ node });
+      expect(exported).not.toEqual(original);
+      // Rebuild emits begin/instr/separate/end runs.
+      expect(exported.length).toBeGreaterThan(1);
+    });
+
+    it('rebuilds when the result content has been edited', () => {
+      const node = buildRawFieldNode({
+        fieldInstance: {
+          source: { originalXml: [{ name: 'w:r' }] },
+          mutation: { resultEdited: true },
+        },
+      });
+      const exported = exportSchemaToJson({ node });
+      expect(exported).not.toEqual([{ name: 'w:r' }]);
+    });
+
+    it('rebuilds when flags have been edited', () => {
+      const node = buildRawFieldNode({
+        fieldInstance: {
+          source: { originalXml: [{ name: 'w:r' }] },
+          mutation: { flagsEdited: true },
+          dirty: true,
+        },
+      });
+      const exported = exportSchemaToJson({ node });
+      const beginRun = exported.find((e) =>
+        e?.elements?.some((c) => c?.name === 'w:fldChar' && c?.attributes?.['w:fldCharType'] === 'begin'),
+      );
+      const beginFldChar = beginRun.elements.find((c) => c?.name === 'w:fldChar');
+      expect(beginFldChar.attributes['w:dirty']).toBe('1');
+    });
+
+    it('emits w:fldLock on the begin fldChar when locked is true on rebuild', () => {
+      const node = buildRawFieldNode({
+        fieldInstance: {
+          source: { originalXml: undefined },
+          locked: true,
+        },
+      });
+      const exported = exportSchemaToJson({ node });
+      const beginRun = exported.find((e) =>
+        e?.elements?.some((c) => c?.name === 'w:fldChar' && c?.attributes?.['w:fldCharType'] === 'begin'),
+      );
+      const beginFldChar = beginRun.elements.find((c) => c?.name === 'w:fldChar');
+      expect(beginFldChar.attributes['w:fldLock']).toBe('1');
+    });
+
+    it('emits w:dirty and w:fldLock on the fldSimple wrapper on rebuild', () => {
+      const node = buildRawFieldNode({
+        fieldInstance: {
+          representation: 'simple',
+          source: { originalXml: undefined },
+          dirty: true,
+          locked: true,
+        },
+      });
+      const exported = exportSchemaToJson({ node });
+      expect(exported[0].attributes['w:dirty']).toBe('1');
+      expect(exported[0].attributes['w:fldLock']).toBe('1');
+    });
+  });
+
+  describe('translator config', () => {
+    it('binds sd:rawField to the rawField PM node', () => {
+      expect(translator).toBeDefined();
+      // The translator is registered via NodeTranslator.from(config); its
+      // identity is asserted indirectly through the encode/decode tests
+      // above, which rely on the registry resolving sd:rawField correctly.
+    });
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequenceField-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequenceField-translator.js
@@ -36,6 +36,7 @@ const encode = (params) => {
       restartLevel,
       resolvedNumber: extractResolvedText(processedText),
       marksAsAttrs: node.marks || [],
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
     content: processedText,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/tableOfAuthorities/tableOfAuthorities-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/tableOfAuthorities/tableOfAuthorities-translator.js
@@ -28,6 +28,7 @@ const encode = (params) => {
     attrs: {
       instruction: node.attributes?.instruction || '',
       instructionTokens: node.attributes?.instructionTokens || null,
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
     content: processedContent,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/tableOfContents/tableOfContents-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/tableOfContents/tableOfContents-translator.js
@@ -55,6 +55,7 @@ const encode = (params) => {
     attrs: {
       instruction: node.attributes?.instruction || '',
       rightAlignPageNumbers: deriveRightAlignPageNumbers(normalizedContent),
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
     content: normalizedContent,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/tableOfContents/tableOfContents-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/tableOfContents/tableOfContents-translator.test.js
@@ -48,7 +48,7 @@ describe('sd:tableOfContents translator', () => {
       });
       expect(result).toEqual({
         type: 'tableOfContents',
-        attrs: { instruction: 'TOC \\o "1-3"', rightAlignPageNumbers: true },
+        attrs: { instruction: 'TOC \\o "1-3"', rightAlignPageNumbers: true, fieldInstance: null },
         content: [{ type: 'paragraph', content: [] }],
       });
     });
@@ -109,7 +109,7 @@ describe('sd:tableOfContents translator', () => {
       const result = config.encode(params);
       expect(result).toEqual({
         type: 'tableOfContents',
-        attrs: { instruction: 'TOC \\h', rightAlignPageNumbers: true },
+        attrs: { instruction: 'TOC \\h', rightAlignPageNumbers: true, fieldInstance: null },
         content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Inline content' }] }],
       });
     });

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/tableOfContentsEntry/tableOfContentsEntry-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/tableOfContentsEntry/tableOfContentsEntry-translator.js
@@ -29,6 +29,7 @@ const encode = (params) => {
       instruction: node.attributes?.instruction || '',
       instructionTokens: node.attributes?.instructionTokens || null,
       marksAsAttrs: node.marks || [],
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
     content: processedText,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.js
@@ -31,6 +31,7 @@ const encode = (params) => {
     attrs: {
       marksAsAttrs: marks,
       importedCachedText,
+      fieldInstance: node.attributes?.fieldInstance ?? null,
     },
   };
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.test.js
@@ -61,6 +61,7 @@ describe('sd:totalPageNumber translator', () => {
         attrs: {
           marksAsAttrs: marks,
           importedCachedText: null,
+          fieldInstance: null,
         },
       });
     });

--- a/packages/super-editor/src/editors/v1/extensions/authority-entry/authority-entry.js
+++ b/packages/super-editor/src/editors/v1/extensions/authority-entry/authority-entry.js
@@ -61,6 +61,10 @@ export const AuthorityEntry = Node.create({
         default: null,
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/bibliography/bibliography.js
+++ b/packages/super-editor/src/editors/v1/extensions/bibliography/bibliography.js
@@ -30,6 +30,10 @@ export const Bibliography = Node.create({
         default: null,
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/citation/citation.js
+++ b/packages/super-editor/src/editors/v1/extensions/citation/citation.js
@@ -50,6 +50,10 @@ export const Citation = Node.create({
         default: null,
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/cross-reference/cross-reference.js
+++ b/packages/super-editor/src/editors/v1/extensions/cross-reference/cross-reference.js
@@ -58,6 +58,10 @@ export const CrossReference = Node.create({
         default: null,
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/document-index/document-index.js
+++ b/packages/super-editor/src/editors/v1/extensions/document-index/document-index.js
@@ -54,6 +54,10 @@ export const DocumentIndex = Node.create({
           return attrs.sdBlockId ? { 'data-sd-block-id': attrs.sdBlockId } : {};
         },
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 });

--- a/packages/super-editor/src/editors/v1/extensions/document-stat-field/document-stat-field.js
+++ b/packages/super-editor/src/editors/v1/extensions/document-stat-field/document-stat-field.js
@@ -49,6 +49,10 @@ export const DocumentStatField = Node.create({
         default: null,
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/index-entry/index-entry.js
+++ b/packages/super-editor/src/editors/v1/extensions/index-entry/index-entry.js
@@ -41,6 +41,10 @@ export const IndexEntry = Node.create({
         default: null,
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/index.js
+++ b/packages/super-editor/src/editors/v1/extensions/index.js
@@ -57,6 +57,7 @@ import { TableOfContentsEntry } from './table-of-contents-entry/index.js';
 import { CrossReference } from './cross-reference/index.js';
 import { SequenceField } from './sequence-field/index.js';
 import { DocumentStatField } from './document-stat-field/index.js';
+import { RawField } from './raw-field/index.js';
 import { FieldUpdate } from './field-update/index.js';
 import { Citation } from './citation/index.js';
 import { Bibliography } from './bibliography/index.js';
@@ -205,6 +206,7 @@ const getStarterExtensions = () => {
     CrossReference,
     SequenceField,
     DocumentStatField,
+    RawField,
     FieldUpdate,
     Citation,
     Bibliography,
@@ -323,6 +325,7 @@ export {
   CrossReference,
   SequenceField,
   DocumentStatField,
+  RawField,
   FieldUpdate,
   Citation,
   Bibliography,

--- a/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
+++ b/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
@@ -48,6 +48,10 @@ export const PageNumber = Node.create({
         default: null,
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 
@@ -171,6 +175,10 @@ export const TotalPageCount = Node.create({
        * over the original imported value.
        */
       resolvedText: {
+        default: null,
+        rendered: false,
+      },
+      fieldInstance: {
         default: null,
         rendered: false,
       },

--- a/packages/super-editor/src/editors/v1/extensions/page-reference/page-reference.js
+++ b/packages/super-editor/src/editors/v1/extensions/page-reference/page-reference.js
@@ -32,6 +32,10 @@ export const PageReference = Node.create({
         default: '',
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/raw-field/index.js
+++ b/packages/super-editor/src/editors/v1/extensions/raw-field/index.js
@@ -1,0 +1,1 @@
+export * from './raw-field.js';

--- a/packages/super-editor/src/editors/v1/extensions/raw-field/raw-field.js
+++ b/packages/super-editor/src/editors/v1/extensions/raw-field/raw-field.js
@@ -1,0 +1,67 @@
+import { Node } from '@core/Node.js';
+import { Attribute } from '@core/Attribute.js';
+
+/**
+ * Generic carrier for unknown / unsupported Word fields.
+ *
+ * Holds the canonical FieldInstance payload as an attribute and renders the
+ * field's result content as inline children, so formatted result runs (bold,
+ * color, font) survive end-to-end without being flattened to plain text.
+ *
+ * Recognized field families continue to lower to their existing typed nodes
+ * (sequenceField, documentStatField, etc.); rawField is reached only via
+ * the unknown-instruction fallback in preProcessNodesForFldChar.
+ */
+export const RawField = Node.create({
+  name: 'rawField',
+
+  group: 'inline',
+
+  inline: true,
+
+  content: 'inline*',
+
+  selectable: true,
+
+  draggable: false,
+
+  addOptions() {
+    return {
+      htmlAttributes: {
+        contenteditable: false,
+        'data-id': 'raw-field',
+        'aria-label': 'Field',
+      },
+    };
+  },
+
+  addAttributes() {
+    return {
+      /**
+       * Canonical durable payload describing the field. Set at import time;
+       * read by the rawField translator on export to choose between
+       * passthrough and rebuild.
+       */
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
+      sdBlockId: {
+        default: null,
+        rendered: false,
+      },
+      marksAsAttrs: {
+        default: null,
+        rendered: false,
+      },
+    };
+  },
+
+  parseDOM() {
+    return [{ tag: 'span[data-id="raw-field"]' }];
+  },
+
+  renderDOM({ htmlAttributes }) {
+    return ['span', Attribute.mergeAttributes(this.options.htmlAttributes, htmlAttributes), 0];
+  },
+});

--- a/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.js
+++ b/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.js
@@ -58,6 +58,10 @@ export const SequenceField = Node.create({
         default: null,
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/table-of-authorities/table-of-authorities.js
+++ b/packages/super-editor/src/editors/v1/extensions/table-of-authorities/table-of-authorities.js
@@ -30,6 +30,10 @@ export const TableOfAuthorities = Node.create({
         default: null,
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/table-of-contents-entry/table-of-contents-entry.js
+++ b/packages/super-editor/src/editors/v1/extensions/table-of-contents-entry/table-of-contents-entry.js
@@ -41,6 +41,10 @@ export const TableOfContentsEntry = Node.create({
         default: null,
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/table-of-contents/table-of-contents.js
+++ b/packages/super-editor/src/editors/v1/extensions/table-of-contents/table-of-contents.js
@@ -193,6 +193,10 @@ export const TableOfContents = Node.create({
         default: true,
         rendered: false,
       },
+      fieldInstance: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 });


### PR DESCRIPTION
Stacked on #2955. Targets the chunk-(a) branch; will auto-rebase to main when #2955 merges.

Chunk (b) of the canonical field substrate. Imports that fall to the generic unhandled-field path now wrap their result content in a `sd:rawField` element holding the canonical FieldInstance payload, so the field's instruction text, dirty / fldLock flags, and original-XML subtree survive into the document state and round-trip on export.

Result content lives as inline children of the rawField PM node, so formatted result runs (bold, color, font) survive end-to-end without being flattened to plain text. Today's pass-through-as-raw-runs behavior loses the field semantic; the substrate keeps it.

The exporter has two paths. Passthrough re-emits `source.originalXml` verbatim for an unedited imported field, which matches the substrate's structural-fidelity invariant. Rebuild synthesizes a `fldSimple` wrapper or `fldChar` trio from `rawInstruction`, `dirty`, `locked`, and the current PM children when the field has been edited or has no captured source XML. Wired only into body unhandled paths in this PR; existing typed nodes (sequenceField, documentStatField, crossReference, etc.) are untouched and still lower the way they always have.

Also extracts `w:dirty` and `w:fldLock` from begin `fldChar` and `fldSimple` attributes (previously dropped on import).

**Review**: the load-bearing invariants are (1) unedited imports passthrough verbatim, (2) edited imports rebuild structurally-equivalent OOXML, (3) result content formatting is not flattened. Check the rawField translator decision rules in `rawField-translator.js` and the import wiring in `preProcessNodesForFldChar.js`.
**Verified**: 11,835 / 11,848 super-editor tests pass (13 pre-existing skips); 4 existing tests in `preProcessNodesForFldChar.test.js` updated to assert the new substrate behavior.