### PR TITLE
chore(renovate): ignore demos, examples, and visual-testing

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,6 +8,13 @@
   ],
   "schedule": ["before 7am on monday"],
   "prConcurrentLimit": 5,
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "demos/**",
+    "examples/**",
+    "devtools/visual-testing/**"
+  ],
   "ignoreDeps": ["pdfjs-dist", "@hocuspocus/provider"],
   "packageRules": [
     {
@@ -18,12 +25,7 @@
       "groupName": "dev dependencies (patch)"
     },
     {
-      "description": "Ignore demos and examples — not shipped to users",
-      "matchFileNames": ["demos/**", "examples/**"],
-      "enabled": false
-    },
-    {
-      "description": "Don't touch vite — overridden with rolldown-vite",
+      "description": "Don't touch vite - overridden with rolldown-vite",
       "matchPackageNames": ["vite"],
       "enabled": false
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,11 @@
   "ignorePaths": [
     "**/node_modules/**",
     "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**",
     "demos/**",
     "examples/**",
     "devtools/visual-testing/**"


### PR DESCRIPTION
Renovate keeps failing to update `devtools/visual-testing/pnpm-lock.yaml` because the harness there pulls in `superdoc` via a locally-built tarball at `packages/superdoc/superdoc.tgz`, which doesn't exist in Renovate's clean checkout. That shows up as the `renovate/artifacts` failure on dep PRs (e.g. #2953). Skipping that subtree, plus the already-non-shipped `demos/` and `examples/`, keeps Renovate focused on dependencies that actually ship.

Replaces the previous demos/examples `matchFileNames` packageRule with a single top-level `ignorePaths` block.

**Verified**: `pnpm dlx --package renovate renovate-config-validator renovate.json5` -> config validated successfully.