### PR TITLE
ci(behavior): always run on PRs to main and stable

### DIFF
--- a/.github/workflows/ci-behavior.yml
+++ b/.github/workflows/ci-behavior.yml
@@ -6,16 +6,6 @@ permissions:
 on:
   pull_request:
     branches: [main, stable]
-    paths:
-      - 'packages/superdoc/**'
-      - 'packages/layout-engine/**'
-      - 'packages/super-editor/**'
-      - 'packages/word-layout/**'
-      - 'packages/preset-geometry/**'
-      - 'tests/behavior/**'
-      - 'shared/**'
-      - '.github/workflows/ci-behavior.yml'
-      - '!**/*.md'
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
GitHub's required-status-check rule is name-only. When `ci-behavior.yml` is skipped by `paths`, the required `Behavior Tests / validate` check stays pending and the PR is blocked forever, which has been hitting dep-only and other path-irrelevant PRs (e.g. #2949). Dropping the path filter makes the workflow run on every PR so the required check always reports a real status.

Trade-off: extra CI minutes on PRs that don't touch behavior-relevant code. We considered a job-level path filter with an always-reporting `validate`, but that just relocates the maintenance cost (keeping a path list in sync with the repo) into the workflow. Run-it-always is simpler now and trivial to revert if CI cost ever bites.