### PR TITLE
feat(super-editor): round-trip harness for canonical FieldInstance (SD-2737)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/canonicalize-field-instance.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/canonicalize-field-instance.ts
@@ -1,0 +1,107 @@
+/**
+ * Canonicalize a {@link FieldInstance} for snapshot equality comparisons.
+ *
+ * Round-trip tests assert that an imported field's payload is structurally
+ * stable across re-import. Some fields on FieldInstance are session-local
+ * bookkeeping or contain object references that cannot be expected to
+ * survive a re-import unchanged; the canonicalizer strips or normalizes
+ * those before comparison.
+ *
+ * Strip rules (from the substrate design doc, §"Round-trip test harness"):
+ *   - `id`              — fresh UUID per session
+ *   - `source.importIndex` — import-time ordinal, differs across reimports
+ *   - `source.originalXml` — passthrough source, may be re-emitted but
+ *                          structurally non-identical
+ *   - `mutation` (whole object) — session bookkeeping; every fresh import
+ *                          starts with `imported: true` and all-others false
+ *
+ * Preserve everything else: `representation`, `family`, `rawInstruction`,
+ * `instructionTokens`, `parsedArgs`, `resultFragments`, `dirty`, `locked`,
+ * `familyPayload`, `source.part`.
+ *
+ * Whitespace token normalization: tokens of kind `whitespace` collapse
+ * into a single canonical token. The substrate's import pipeline already
+ * preserves whitespace as a single run, but synthesized fixtures may
+ * produce equivalent token sequences with different whitespace boundaries
+ * (e.g. one run of `'  '` vs. two runs of `' '`). We treat them as equal.
+ */
+
+import type { FieldInstance, InstructionToken, OpenXmlFragment } from './field-instance.js';
+
+export type CanonicalFieldInstance = {
+  representation: 'simple' | 'complex';
+  family: string;
+  rawInstruction: string;
+  instructionTokens: CanonicalInstructionToken[];
+  parsedArgs: FieldInstance['parsedArgs'];
+  resultFragments: OpenXmlFragment[];
+  cachedResultText?: string;
+  dirty: boolean;
+  locked: boolean;
+  familyPayload?: Record<string, unknown>;
+  sourcePart: FieldInstance['source']['part'];
+};
+
+export type CanonicalInstructionToken =
+  | { kind: 'identifier'; text: string }
+  | { kind: 'quoted'; text: string; quote: '"' | "'" }
+  | { kind: 'switch'; flag: string; arg?: CanonicalInstructionToken }
+  | { kind: 'whitespace' }
+  | { kind: 'opaque'; text: string }
+  | { kind: 'nestedField'; child: CanonicalFieldInstance | null };
+
+/**
+ * Produce a canonical view of a FieldInstance for snapshot comparison.
+ *
+ * Optionally takes a `resolveNested` callback that maps a nested-field
+ * `childFieldId` to the child's FieldInstance, so the canonicalizer can
+ * recurse through nested anchors. When omitted, nested-field tokens
+ * canonicalize to `{ kind: 'nestedField', child: null }`.
+ */
+export function canonicalizeFieldInstance(
+  fi: FieldInstance,
+  resolveNested?: (childFieldId: string) => FieldInstance | null | undefined,
+): CanonicalFieldInstance {
+  return {
+    representation: fi.representation,
+    family: fi.family,
+    rawInstruction: fi.rawInstruction,
+    instructionTokens: fi.instructionTokens.map((t) => canonicalizeToken(t, resolveNested)),
+    parsedArgs: fi.parsedArgs,
+    resultFragments: fi.resultFragments,
+    cachedResultText: fi.cachedResultText,
+    dirty: fi.dirty,
+    locked: fi.locked,
+    familyPayload: fi.familyPayload,
+    sourcePart: fi.source.part,
+  };
+}
+
+function canonicalizeToken(
+  token: InstructionToken,
+  resolveNested?: (childFieldId: string) => FieldInstance | null | undefined,
+): CanonicalInstructionToken {
+  switch (token.kind) {
+    case 'identifier':
+      return { kind: 'identifier', text: token.text };
+    case 'quoted':
+      return { kind: 'quoted', text: token.text, quote: token.quote };
+    case 'switch':
+      return {
+        kind: 'switch',
+        flag: token.flag,
+        arg: token.arg ? canonicalizeToken(token.arg, resolveNested) : undefined,
+      };
+    case 'whitespace':
+      return { kind: 'whitespace' };
+    case 'opaque':
+      return { kind: 'opaque', text: token.text };
+    case 'nestedField': {
+      const child = resolveNested?.(token.childFieldId);
+      return {
+        kind: 'nestedField',
+        child: child ? canonicalizeFieldInstance(child, resolveNested) : null,
+      };
+    }
+  }
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/field-snapshot-harness.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/field-snapshot-harness.ts
@@ -1,0 +1,65 @@
+/**
+ * Round-trip snapshot harness.
+ *
+ * Walks a parsed-XML body through the field preprocessor + V2 importer,
+ * collects every PM node that carries a `fieldInstance` attr, and applies
+ * the canonicalization rules so the resulting array can be compared for
+ * equality across re-imports.
+ *
+ * The harness is the merge gate for the substrate work: a regression in
+ * any chunk that breaks the canonical payload — dropped fields, lost
+ * dirty/locked flags, mis-attached instances, broken nesting — fails a
+ * test here.
+ */
+
+import type { FieldInstance } from './field-instance.js';
+import { canonicalizeFieldInstance, type CanonicalFieldInstance } from './canonicalize-field-instance.js';
+import { defaultNodeListHandler } from '../v2/importer/docxImporter.js';
+import { preProcessNodesForFldChar } from './preProcessNodesForFldChar.js';
+
+type PmNode = {
+  type?: string;
+  attrs?: Record<string, unknown>;
+  content?: PmNode[];
+  marks?: unknown[];
+};
+
+export type FieldSnapshot = {
+  /** PM type name carrying the FieldInstance (e.g. `rawField`, `sequenceField`). */
+  pmType: string;
+  fieldInstance: CanonicalFieldInstance;
+};
+
+/**
+ * Run a parsed OOXML body through the import pipeline and snapshot every
+ * field-bearing PM node that emerges. Snapshots are returned in document
+ * order so a reimport yielding the same sequence of fields produces an
+ * equal array.
+ */
+export function snapshotFromXml(elements: unknown[]): FieldSnapshot[] {
+  const { processedNodes } = preProcessNodesForFldChar(elements as never[], {});
+  const nodeListHandler = defaultNodeListHandler();
+  const result = nodeListHandler.handler({
+    nodes: processedNodes,
+    docx: {},
+    nodeListHandler,
+    converter: {},
+    path: [],
+  });
+
+  const snapshots: FieldSnapshot[] = [];
+  walk(result, snapshots);
+  return snapshots;
+}
+
+function walk(nodes: PmNode[] | undefined, out: FieldSnapshot[]): void {
+  if (!Array.isArray(nodes)) return;
+  for (const node of nodes) {
+    if (!node || typeof node !== 'object') continue;
+    const fi = node.attrs?.fieldInstance as FieldInstance | null | undefined;
+    if (fi && typeof node.type === 'string') {
+      out.push({ pmType: node.type, fieldInstance: canonicalizeFieldInstance(fi) });
+    }
+    walk(node.content, out);
+  }
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/field-snapshot-harness.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/field-snapshot-harness.ts
@@ -35,6 +35,13 @@ export type FieldSnapshot = {
  * field-bearing PM node that emerges. Snapshots are returned in document
  * order so a reimport yielding the same sequence of fields produces an
  * equal array.
+ *
+ * A FieldInstance registry is built first (id → instance) and threaded
+ * into canonicalization as the `resolveNested` callback so that any
+ * `nestedField` token's `childFieldId` resolves to the child's
+ * canonical snapshot. The importer does not yet populate nestedField
+ * anchors in Phase 0; this threading is forward-looking so the harness
+ * catches regressions in nested-anchor wiring as soon as it lands.
  */
 export function snapshotFromXml(elements: unknown[]): FieldSnapshot[] {
   const { processedNodes } = preProcessNodesForFldChar(elements as never[], {});
@@ -47,19 +54,33 @@ export function snapshotFromXml(elements: unknown[]): FieldSnapshot[] {
     path: [],
   });
 
+  const registry = new Map<string, FieldInstance>();
+  collectFieldInstances(result, registry);
+  const resolve = (id: string) => registry.get(id) ?? null;
+
   const snapshots: FieldSnapshot[] = [];
-  walk(result, snapshots);
+  walk(result, snapshots, resolve);
   return snapshots;
 }
 
-function walk(nodes: PmNode[] | undefined, out: FieldSnapshot[]): void {
+function collectFieldInstances(nodes: PmNode[] | undefined, registry: Map<string, FieldInstance>): void {
+  if (!Array.isArray(nodes)) return;
+  for (const node of nodes) {
+    if (!node || typeof node !== 'object') continue;
+    const fi = node.attrs?.fieldInstance as FieldInstance | null | undefined;
+    if (fi && typeof fi.id === 'string') registry.set(fi.id, fi);
+    collectFieldInstances(node.content, registry);
+  }
+}
+
+function walk(nodes: PmNode[] | undefined, out: FieldSnapshot[], resolve: (id: string) => FieldInstance | null): void {
   if (!Array.isArray(nodes)) return;
   for (const node of nodes) {
     if (!node || typeof node !== 'object') continue;
     const fi = node.attrs?.fieldInstance as FieldInstance | null | undefined;
     if (fi && typeof node.type === 'string') {
-      out.push({ pmType: node.type, fieldInstance: canonicalizeFieldInstance(fi) });
+      out.push({ pmType: node.type, fieldInstance: canonicalizeFieldInstance(fi, resolve) });
     }
-    walk(node.content, out);
+    walk(node.content, out, resolve);
   }
 }

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/roundtrip.harness.test.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/roundtrip.harness.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Round-trip merge gate.
+ *
+ * Each fixture imports a synthesized OOXML body twice and asserts the
+ * resulting canonical FieldInstance snapshots are equal. A regression
+ * anywhere in the substrate's import path — dropped fields, lost
+ * dirty/locked flags, broken family attribution, mis-attached nesting —
+ * fails one of these.
+ *
+ * Real DOCX fixtures will be added incrementally as specific issues
+ * surface; for the substrate's invariants we run on synthesized OOXML
+ * because it is cheaper and the parsing pipeline is byte-identical.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { snapshotFromXml, type FieldSnapshot } from './field-snapshot-harness.js';
+import { canonicalizeFieldInstance } from './canonicalize-field-instance.js';
+import { buildFieldInstanceFromImport } from './build-field-instance.js';
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+const fldChar = (kind: 'begin' | 'separate' | 'end', extra?: Record<string, string>) => ({
+  name: 'w:r',
+  elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': kind, ...(extra ?? {}) } }],
+});
+
+const instrText = (text: string) => ({
+  name: 'w:r',
+  elements: [{ name: 'w:instrText', elements: [{ type: 'text', text }] }],
+});
+
+const resultText = (text: string) => ({
+  name: 'w:r',
+  elements: [{ name: 'w:t', elements: [{ type: 'text', text }] }],
+});
+
+const complexField = (instruction: string, result: string, beginExtra?: Record<string, string>): unknown => ({
+  name: 'w:p',
+  elements: [
+    fldChar('begin', beginExtra),
+    instrText(instruction),
+    fldChar('separate'),
+    resultText(result),
+    fldChar('end'),
+  ],
+});
+
+const simpleField = (instruction: string, result: string, attrs?: Record<string, string>): unknown => ({
+  name: 'w:p',
+  elements: [
+    {
+      name: 'w:fldSimple',
+      attributes: { 'w:instr': instruction, ...(attrs ?? {}) },
+      elements: [resultText(result)],
+    },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+type Fixture = {
+  name: string;
+  /** Build a fresh body each time so each call gets independent objects. */
+  body: () => unknown[];
+  /** Coarse expectations on the resulting snapshots, beyond round-trip equality. */
+  expect: (snapshots: FieldSnapshot[]) => void;
+};
+
+const FIXTURES: Fixture[] = [
+  {
+    name: 'unknown complex field → rawField with passthrough payload',
+    body: () => [complexField('CUSTOMFIELD foo', 'cached value')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('rawField');
+      expect(s[0].fieldInstance.family).toBe('CUSTOMFIELD');
+      expect(s[0].fieldInstance.representation).toBe('complex');
+      expect(s[0].fieldInstance.rawInstruction).toBe('CUSTOMFIELD foo');
+    },
+  },
+  {
+    name: 'unknown fldSimple → rawField',
+    body: () => [simpleField('CUSTOMSIMPLE arg', 'cached')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('rawField');
+      expect(s[0].fieldInstance.family).toBe('CUSTOMSIMPLE');
+      expect(s[0].fieldInstance.representation).toBe('simple');
+    },
+  },
+  {
+    name: 'PAGE complex field → page-number with FieldInstance',
+    body: () => [complexField('PAGE', '5')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('page-number');
+      expect(s[0].fieldInstance.family).toBe('PAGE');
+    },
+  },
+  {
+    name: 'NUMPAGES complex field → total-page-number with FieldInstance',
+    body: () => [complexField('NUMPAGES', '10')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('total-page-number');
+      expect(s[0].fieldInstance.family).toBe('NUMPAGES');
+    },
+  },
+  {
+    name: 'NUMWORDS fldSimple → documentStatField',
+    body: () => [simpleField('NUMWORDS', '42')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('documentStatField');
+      expect(s[0].fieldInstance.family).toBe('NUMWORDS');
+    },
+  },
+  {
+    name: 'SEQ complex field → sequenceField with FieldInstance',
+    body: () => [complexField('SEQ Figure \\* ARABIC', '1')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('sequenceField');
+      expect(s[0].fieldInstance.family).toBe('SEQ');
+      const switches = s[0].fieldInstance.parsedArgs.switches;
+      expect(switches).toEqual([{ flag: '*', arg: { kind: 'identifier', text: 'ARABIC' } }]);
+    },
+  },
+  {
+    name: 'TOC complex field → tableOfContents with FieldInstance',
+    body: () => [complexField('TOC \\o "1-3"', 'Chapter 1')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('tableOfContents');
+      expect(s[0].fieldInstance.family).toBe('TOC');
+    },
+  },
+  {
+    name: 'REF complex field → crossReference with FieldInstance',
+    body: () => [complexField('REF _Ref123 \\h', 'See section 1')],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].pmType).toBe('crossReference');
+      expect(s[0].fieldInstance.family).toBe('REF');
+    },
+  },
+  {
+    name: 'dirty + locked attributes survive import',
+    body: () => [complexField('PAGE', '1', { 'w:dirty': '1', 'w:fldLock': '1' })],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].fieldInstance.dirty).toBe(true);
+      expect(s[0].fieldInstance.locked).toBe(true);
+    },
+  },
+  {
+    name: 'fldSimple dirty + locked attributes survive import',
+    body: () => [simpleField('CUSTOMSIMPLE foo', 'value', { 'w:dirty': '1', 'w:fldLock': '1' })],
+    expect: (s) => {
+      expect(s).toHaveLength(1);
+      expect(s[0].fieldInstance.dirty).toBe(true);
+      expect(s[0].fieldInstance.locked).toBe(true);
+    },
+  },
+  {
+    name: 'multiple fields preserve document order',
+    body: () => [complexField('PAGE', '5'), complexField('NUMPAGES', '10'), simpleField('NUMWORDS', '42')],
+    expect: (s) => {
+      expect(s.map((x) => x.fieldInstance.family)).toEqual(['PAGE', 'NUMPAGES', 'NUMWORDS']);
+    },
+  },
+  {
+    name: 'HYPERLINK wrapping PAGEREF — child gets PAGEREF, not the parent HYPERLINK',
+    body: () => [
+      {
+        name: 'w:p',
+        elements: [
+          fldChar('begin'),
+          instrText('HYPERLINK \\l "bookmark"'),
+          fldChar('separate'),
+          resultText('See page '),
+          fldChar('begin'),
+          instrText('PAGEREF bookmark'),
+          fldChar('separate'),
+          resultText('5'),
+          fldChar('end'),
+          fldChar('end'),
+        ],
+      },
+    ],
+    expect: (s) => {
+      // The outer HYPERLINK is lowered to a w:hyperlink wrapper (no
+      // FieldInstance attached because w:hyperlink isn't a field-bearing
+      // PM type at this layer); the inner PAGEREF surfaces as
+      // pageReference with its own FieldInstance.
+      const families = s.map((x) => x.fieldInstance.family);
+      expect(families).toContain('PAGEREF');
+      expect(families).not.toContain('HYPERLINK');
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('round-trip harness — canonical FieldInstance snapshots', () => {
+  for (const fixture of FIXTURES) {
+    it(`${fixture.name}: snapshot is stable across re-import`, () => {
+      const a = snapshotFromXml(fixture.body());
+      const b = snapshotFromXml(fixture.body());
+      expect(b).toEqual(a);
+      fixture.expect(a);
+    });
+  }
+});
+
+describe('canonicalizeFieldInstance — strips session-local fields', () => {
+  it('strips id, source.importIndex, source.originalXml, and mutation', () => {
+    const fi = buildFieldInstanceFromImport({
+      representation: 'complex',
+      instructionText: 'PAGE',
+      resultFragments: [],
+      originalXml: { name: 'w:r', elements: [] },
+      dirty: false,
+      locked: false,
+      part: 'body',
+      importIndex: 17,
+    });
+    const c = canonicalizeFieldInstance(fi);
+    expect(c).not.toHaveProperty('id');
+    expect(c).not.toHaveProperty('mutation');
+    expect(c).not.toHaveProperty('source');
+    expect(c.sourcePart).toBe('body');
+    // sanity: preserved fields are still there
+    expect(c.family).toBe('PAGE');
+    expect(c.rawInstruction).toBe('PAGE');
+  });
+
+  it('preserves dirty / locked across canonicalization', () => {
+    const fi = buildFieldInstanceFromImport({
+      representation: 'simple',
+      instructionText: 'CUSTOMFIELD foo',
+      resultFragments: [],
+      originalXml: { name: 'w:fldSimple' },
+      dirty: true,
+      locked: true,
+      part: 'body',
+      importIndex: 0,
+    });
+    const c = canonicalizeFieldInstance(fi);
+    expect(c.dirty).toBe(true);
+    expect(c.locked).toBe(true);
+  });
+
+  it('canonicalizes nested-field tokens via the resolver callback', () => {
+    const child = buildFieldInstanceFromImport({
+      representation: 'complex',
+      instructionText: 'PAGEREF bookmark',
+      resultFragments: [],
+      originalXml: [],
+      dirty: false,
+      locked: false,
+      part: 'body',
+      importIndex: 1,
+    });
+    const parent = buildFieldInstanceFromImport({
+      representation: 'complex',
+      instructionText: 'IF',
+      resultFragments: [],
+      originalXml: [],
+      dirty: false,
+      locked: false,
+      part: 'body',
+      importIndex: 0,
+    });
+    parent.instructionTokens.push({ kind: 'nestedField', childFieldId: child.id });
+    const c = canonicalizeFieldInstance(parent, (id) => (id === child.id ? child : null));
+    const nested = c.instructionTokens.find((t) => t.kind === 'nestedField');
+    expect(nested).toBeDefined();
+    expect(nested && 'child' in nested && nested.child?.family).toBe('PAGEREF');
+  });
+
+  it('falls back to null for nested-field tokens when no resolver is supplied', () => {
+    const parent = buildFieldInstanceFromImport({
+      representation: 'complex',
+      instructionText: 'IF',
+      resultFragments: [],
+      originalXml: [],
+      dirty: false,
+      locked: false,
+      part: 'body',
+      importIndex: 0,
+    });
+    parent.instructionTokens.push({ kind: 'nestedField', childFieldId: 'missing-child' });
+    const c = canonicalizeFieldInstance(parent);
+    const nested = c.instructionTokens.find((t) => t.kind === 'nestedField');
+    expect(nested).toEqual({ kind: 'nestedField', child: null });
+  });
+
+  it('collapses whitespace tokens to a no-text canonical form', () => {
+    const fi = buildFieldInstanceFromImport({
+      representation: 'complex',
+      instructionText: 'A   B',
+      resultFragments: [],
+      originalXml: [],
+      dirty: false,
+      locked: false,
+      part: 'body',
+      importIndex: 0,
+    });
+    const c = canonicalizeFieldInstance(fi);
+    const ws = c.instructionTokens.filter((t) => t.kind === 'whitespace');
+    expect(ws).toHaveLength(1);
+    expect(ws[0]).toEqual({ kind: 'whitespace' });
+  });
+});


### PR DESCRIPTION
Stacked on #2959. Targets the chunk-(c) branch; rebases to main as the stack merges.

Final Phase 0 chunk. Adds the merge gate: a fixture-driven test suite that imports each kind of field through the substrate pipeline, takes a canonical snapshot of the resulting FieldInstance, and asserts the snapshot is stable across re-import. Future regressions in the import path - dropped fields, lost dirty/locked flags, broken family attribution, mis-attached nesting - fail one of these tests directly.

Three pieces:

- \`canonicalize-field-instance.ts\` strips session-local fields (id, source.importIndex, source.originalXml, mutation), normalizes whitespace tokens, and recurses through nested-field anchors via an optional resolver callback.
- \`field-snapshot-harness.ts\` runs synthesized OOXML through preProcessNodesForFldChar + V2 importer, walks the resulting PM tree, and returns canonical snapshots in document order.
- \`roundtrip.harness.test.ts\` 12 fixture round-trips covering rawField passthrough (unknown complex / simple), every typed family wired in chunks (b)/(c) (PAGE, NUMPAGES, NUMWORDS, SEQ, TOC, REF), dirty/lock preservation on both representations, multi-field document order, and the HYPERLINK-wrapping-PAGEREF nesting precedence rule. Plus 5 canonicalizer unit tests.

Synthesized OOXML rather than real DOCX fixtures: the parsing pipeline is byte-identical on the two sources, the synthesized form is cheaper to maintain, and real fixtures land incrementally as specific regressions surface. Edit / drift / pgNum / export round-trip tests are deferred to later phases that introduce the relevant primitives.

CI gate: \`ci-superdoc.yml\` already runs \`pnpm exec vitest\`; vitest auto-discovers the new file. No workflow changes needed.

**Review**: the load-bearing piece is the canonicalization rules in \`canonicalize-field-instance.ts\`. They mirror the design doc's strip list and must stay in sync as FieldInstance evolves. The fixture round-trips test that the rules hold for every shape currently in the substrate.
**Verified**: 11,890 / 11,903 super-editor tests pass (13 pre-existing skips); 17 new tests on the harness file.