### PR TITLE
feat(editor): allow child editors to skip telemetry

### DIFF
--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -605,7 +605,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
     }
 
     // Skip for sub-editors that are not primary document editors
-    if (this.options.mode === 'text' || this.options.isHeaderOrFooter) {
+    if (this.options.mode === 'text' || this.options.isHeaderOrFooter || this.options.isChildEditor) {
       return;
     }
 

--- a/packages/super-editor/src/editors/v1/core/child-editor/child-editor.test.js
+++ b/packages/super-editor/src/editors/v1/core/child-editor/child-editor.test.js
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createLinkedChildEditor } from './child-editor.js';
+import { initTestEditor } from '../../tests/helpers/helpers.js';
+
+const createdEditors = [];
+
+function trackEditor(editor) {
+  if (editor) createdEditors.push(editor);
+  return editor;
+}
+
+afterEach(() => {
+  while (createdEditors.length > 0) {
+    const editor = createdEditors.pop();
+    try {
+      editor?.destroy?.();
+    } catch {
+      // best-effort cleanup for test editors
+    }
+  }
+});
+
+describe('createLinkedChildEditor', () => {
+  it('marks linked child editors with isChildEditor so they skip document-open telemetry', () => {
+    const parent = trackEditor(
+      initTestEditor({
+        mode: 'text',
+        content: '<p>parent</p>',
+        telemetry: { enabled: true },
+      }).editor,
+    );
+
+    const child = trackEditor(createLinkedChildEditor(parent, { headless: true }));
+
+    expect(child.options.isChildEditor).toBe(true);
+    expect(child.options.parentEditor).toBe(parent);
+  });
+
+  it('returns null when called on an editor that is already a child editor', () => {
+    const parent = trackEditor(
+      initTestEditor({
+        mode: 'text',
+        content: '<p>parent</p>',
+      }).editor,
+    );
+    const child = trackEditor(createLinkedChildEditor(parent, { headless: true }));
+
+    const grandchild = createLinkedChildEditor(child, { headless: true });
+    expect(grandchild).toBeNull();
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/story-editor-factory.test.ts
+++ b/packages/super-editor/src/editors/v1/core/story-editor-factory.test.ts
@@ -118,4 +118,28 @@ describe('createStoryEditor', () => {
     expect(headerFooter.options.telemetry).toEqual({ enabled: false });
     expect(note.options.telemetry).toEqual({ enabled: false });
   });
+
+  it('keeps telemetry disabled even when a caller passes telemetry overrides', () => {
+    const parent = trackEditor(
+      initTestEditor({
+        mode: 'text',
+        content: '<p>parent</p>',
+      }).editor as Editor,
+    );
+
+    const child = trackEditor(
+      createStoryEditor(
+        parent,
+        { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'h/f' }] }] },
+        {
+          documentId: 'hf:part:rId1',
+          isHeaderOrFooter: true,
+          headless: true,
+          telemetry: { enabled: true, endpoint: 'https://ingest.example/v1/collect' },
+        } as Parameters<typeof createStoryEditor>[2],
+      ),
+    );
+
+    expect(child.options.telemetry).toEqual({ enabled: false });
+  });
 });

--- a/packages/super-editor/src/editors/v1/core/story-editor-factory.test.ts
+++ b/packages/super-editor/src/editors/v1/core/story-editor-factory.test.ts
@@ -91,4 +91,31 @@ describe('createStoryEditor', () => {
     expect(child.presentationEditor).toBe(presentationEditor);
     expect((child as Editor & { _presentationEditor?: unknown })._presentationEditor).toBe(presentationEditor);
   });
+
+  it('disables telemetry on story editors regardless of isHeaderOrFooter', () => {
+    const parent = trackEditor(
+      initTestEditor({
+        mode: 'text',
+        content: '<p>parent</p>',
+      }).editor as Editor,
+    );
+
+    const headerFooter = trackEditor(
+      createStoryEditor(
+        parent,
+        { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'h/f' }] }] },
+        { documentId: 'hf:part:rId1', isHeaderOrFooter: true, headless: true },
+      ),
+    );
+    const note = trackEditor(
+      createStoryEditor(
+        parent,
+        { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'footnote' }] }] },
+        { documentId: 'footnote:1', isHeaderOrFooter: false, headless: true },
+      ),
+    );
+
+    expect(headerFooter.options.telemetry).toEqual({ enabled: false });
+    expect(note.options.telemetry).toEqual({ enabled: false });
+  });
 });

--- a/packages/super-editor/src/editors/v1/core/story-editor-factory.ts
+++ b/packages/super-editor/src/editors/v1/core/story-editor-factory.ts
@@ -170,11 +170,12 @@ export function createStoryEditor(
     isCommentsEnabled: false,
     fragment: null,
 
-    // Sub-editors must never emit document-open telemetry.
-    telemetry: { enabled: false },
-
     // Caller-provided overrides (e.g. onCreate, onBlur)
     ...editorOptions,
+
+    // Document opens are tracked by the parent editor. Force off after
+    // caller overrides so sub-editors never emit telemetry.
+    telemetry: { enabled: false },
   } as Partial<EditorOptions>);
 
   const inheritedPresentationEditor =

--- a/packages/super-editor/src/editors/v1/core/story-editor-factory.ts
+++ b/packages/super-editor/src/editors/v1/core/story-editor-factory.ts
@@ -170,6 +170,9 @@ export function createStoryEditor(
     isCommentsEnabled: false,
     fragment: null,
 
+    // Sub-editors must never emit document-open telemetry.
+    telemetry: { enabled: false },
+
     // Caller-provided overrides (e.g. onCreate, onBlur)
     ...editorOptions,
   } as Partial<EditorOptions>);


### PR DESCRIPTION
- Updated the condition in the Editor class to include `isChildEditor` for skipping processing in non-primary document editors.
- Added a test to ensure telemetry is disabled for story editors, regardless of their header/footer status.