### PR TITLE
docs(intro): tighten installation card copy

### DIFF
--- a/apps/docs/getting-started/introduction.mdx
+++ b/apps/docs/getting-started/introduction.mdx
@@ -28,7 +28,7 @@ SuperDoc renders and edits DOCX files directly in the browser. Built on OOXML â€
     icon="download"
     href="/getting-started/installation"
   >
-    Get started in minutes
+    Get started in seconds
   </Card>
   <Card
     title="AI Agents"


### PR DESCRIPTION
Small copy change on the introduction page to use as a live test of the new docs deploy flow merged in #2989.

This PR targets `main` to verify that, with Mintlify now pointing at `docs-stable`, a docs change landing on `main` does NOT auto-deploy to production. After merging this and observing the (lack of) production deploy, I'll open a follow-up PR targeting `stable` to verify the preview workflow fires and the eventual release promotes the change to `docs-stable`.