### PR TITLE
ci(docs): trigger preview workflow on docs PRs to main

### DIFF
--- a/.github/workflows/preview-stable-docs.yml
+++ b/.github/workflows/preview-stable-docs.yml
@@ -1,13 +1,22 @@
-# Triggers a Mintlify preview deployment for any PR targeting `stable`.
-# Promote-stable PRs target this branch, so reviewers see the docs that will
-# go live the moment the release succeeds.
-name: 👀 Preview docs for stable PRs
+# Triggers a Mintlify preview deployment for docs-touching PRs targeting
+# `main` or `stable`. The `stable` case covers promote-stable PRs so reviewers
+# see the docs that will go live the moment the release succeeds. The `main`
+# case gives doc authors a hosted preview during normal development, since
+# Mintlify's automatic previews only fire on PRs targeting the deployment
+# branch (`docs-stable`). Path filter keeps the 5 req/min Mintlify API quota
+# from being spent on unrelated code PRs.
+name: 👀 Preview docs for main and stable PRs
 
 on:
   pull_request:
     types: [opened, reopened, synchronize]
     branches:
+      - main
       - stable
+    paths:
+      - 'apps/docs/**'
+      - 'packages/document-api/src/contract/**'
+      - 'scripts/generate-all.mjs'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Doc authors who PR against \`main\` currently get no hosted preview. Mintlify's automatic previews only fire on PRs targeting the deployment branch (\`docs-stable\` since #2989), and the preview workflow added in #2989 only fires on PRs targeting \`stable\`. They'd only see a preview when their change reached the promote-stable PR, which can be days later.

This adds \`main\` as a trigger branch and gates the workflow with a path filter so it only fires when something docs-relevant changed. The 5 req/min Mintlify API quota stays comfortably out of reach.

The path filter also now applies to \`stable\` PRs. Promote-stable PRs always touch docs so they still get previews; code-only stable hotfixes don't need one.

Caught while testing the new flow on #2991.