### PR TITLE
docs(intro): broaden AI Agents card to agent workflows

### DIFF
--- a/apps/docs/getting-started/introduction.mdx
+++ b/apps/docs/getting-started/introduction.mdx
@@ -35,7 +35,7 @@ SuperDoc renders and edits DOCX files directly in the browser. Built on OOXML â€
     icon="sparkles"
     href="/getting-started/ai-agents"
   >
-    Headless mode and LLM workflows
+    Headless mode and agent workflows
   </Card>
   <Card
     title="Examples"


### PR DESCRIPTION
Second end-to-end test of the docs deploy flow. With #2989 and #2992 now on main, this PR should: trigger Mintlify's preview API via `preview-stable-docs.yml`, post a single `📖 Docs preview:` comment, and not deploy to production until promoted to `stable` and the release succeeds.