### PR TITLE
chore: remove CODEOWNERS to disable auto review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @superdoc-dev/reviewers


### PR DESCRIPTION
Removes `.github/CODEOWNERS` so opening a PR no longer auto-requests review from `@superdoc-dev/reviewers`.

Approval enforcement still lives in the `require-pr` ruleset (1 approval required). The `maintainers` team can bypass via PR for solo merges. Code-owner review check on the ruleset becomes a no-op without the file.