### PR TITLE
test: validate merge policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @superdoc-dev/reviewers
+# test: validating merge policy (delete after)


### PR DESCRIPTION
Test PR to validate that maintainers can solo-merge after the policy changes. Safe to close without merging - the comment line is only for triggering CI.