### PR TITLE
feat: add presetContent for template builder (SD-2548)

### DIFF
--- a/apps/docs/solutions/template-builder/api-reference.mdx
+++ b/apps/docs/solutions/template-builder/api-reference.mdx
@@ -178,6 +178,10 @@ interface FieldDefinition {
   id: string;                      // Unique identifier
   label: string;                   // Display name
   defaultValue?: string;           // Default value for new instances
+  presetContent?: {
+    html?: string;                 // Block preset as HTML
+    json?: unknown;                // Block preset as ProseMirror JSON
+  };
   metadata?: Record<string, any>;  // Custom metadata stored in the SDT tag
   mode?: "inline" | "block";       // Insertion mode (default: "inline")
   group?: string;                  // Group ID for linked fields
@@ -185,6 +189,8 @@ interface FieldDefinition {
   lockMode?: LockMode;             // Lock mode for this field (overrides defaultLockMode)
 }
 ```
+
+`presetContent` is applied only for `mode: "block"` fields. Inline fields ignore it.
 
 ### TemplateField
 

--- a/apps/docs/solutions/template-builder/configuration.mdx
+++ b/apps/docs/solutions/template-builder/configuration.mdx
@@ -100,6 +100,37 @@ Each color controls the field's border and label in the document. The sidebar ba
 
 The `fieldType` value flows through all callbacks (`onFieldInsert`, `onFieldsChange`, `onExport`, etc.) and is stored in the SDT tag metadata.
 
+### Preset block content
+
+Use `presetContent` to prefill block fields with a structure such as a table or list:
+
+```tsx
+<SuperDocTemplateBuilder
+  fields={{
+    available: [
+      {
+        id: "sample_table",
+        label: "Sample Table",
+        mode: "block",
+        fieldType: "data",
+        lockMode: "contentLocked",
+        presetContent: {
+          html: "<table style=\"border-collapse: collapse; width: 100%;\"><tr><th style=\"border: 1px solid #000;\">Column A</th><th style=\"border: 1px solid #000;\">Column B</th></tr><tr><td style=\"border: 1px solid #000;\"></td><td style=\"border: 1px solid #000;\"></td></tr></table>",
+          // or json: { ...ProseMirror JSON... }
+        },
+      },
+    ],
+  }}
+/>
+```
+
+`presetContent` is passed into the existing block insertion command. For `mode: "inline"` fields, `presetContent` is ignored.
+
+<Note>
+  - `presetContent.json` is recommended when you need the most reliable preservation of structure, semantics, and editor-compatible styling.
+  - With `presetContent.html`, include required attributes and inline styles explicitly so the HTML parser can map them into node attributes.
+</Note>
+
 ### Field creation
 
 Allow users to create new fields while building templates:

--- a/apps/docs/solutions/template-builder/quickstart.mdx
+++ b/apps/docs/solutions/template-builder/quickstart.mdx
@@ -75,6 +75,35 @@ Distinguish between owner-filled and signer-filled fields:
 
 Fields default to `'owner'` when no `fieldType` is specified.
 
+### Add preset block content
+
+If a field should insert a predefined structure (for example, a table), add `presetContent` on a block field:
+
+```jsx
+<SuperDocTemplateBuilder
+  fields={{
+    available: [
+      {
+        id: "sample_table",
+        label: "Sample Table",
+        mode: "block",
+        fieldType: "data",
+        presetContent: {
+          html: "<table style=\"border-collapse: collapse; width: 100%;\"><tr><th style=\"border: 1px solid #000;\">Column A</th><th style=\"border: 1px solid #000;\">Column B</th></tr><tr><td style=\"border: 1px solid #000;\"></td><td style=\"border: 1px solid #000;\"></td></tr></table>",
+        },
+      },
+    ],
+  }}
+/>
+```
+
+`presetContent` applies only to block fields. Inline fields ignore it.
+
+<Note>
+  - `presetContent.json` is recommended when you need the most reliable preservation of structure, semantics, and editor-compatible styling.
+  - With `presetContent.html`, include required attributes and inline styles explicitly so the HTML parser can map them into node attributes.
+</Note>
+
 ### Color-code fields in the editor
 
 Import the optional CSS to visually distinguish field types:

--- a/packages/template-builder/README.md
+++ b/packages/template-builder/README.md
@@ -25,7 +25,16 @@ function TemplateEditor() {
         available: [
           { id: '1324567890', label: 'Customer Name' },
           { id: '1324567891', label: 'Invoice Date' },
-          { id: '1324567892', label: 'Signature', mode: 'block', fieldType: 'signer' },
+          {
+            id: '1324567892',
+            label: 'Sample Table',
+            mode: 'block',
+            fieldType: 'signer',
+            presetContent: {
+              html: '<table style="border-collapse: collapse; width: 100%;"><tr><th style="border: 1px solid #000;">Column A</th><th style="border: 1px solid #000;">Column B</th></tr><tr><td style="border: 1px solid #000;"></td><td style="border: 1px solid #000;"></td></tr></table>',
+            },
+          },
+          { id: '1324567893', label: 'Signature', mode: 'block', fieldType: 'signer' },
         ],
       }}
       onFieldInsert={(field) => {
@@ -178,6 +187,32 @@ onFieldsChange={(fields) => {
   const signerFields = fields.filter(f => f.fieldType === 'signer');
 }}
 ```
+
+## Preset Block Content
+
+Block fields can include `presetContent` so insertion starts with a predefined structure (for example, a table or list).
+
+```jsx
+const availableFields = [
+  {
+    id: 'sample_table',
+    label: 'Sample Table',
+    mode: 'block',
+    fieldType: 'data',
+    lockMode: 'contentLocked',
+    presetContent: {
+      html: '<table style="border-collapse: collapse; width: 100%;"><tr><th style="border: 1px solid #000;">Column A</th><th style="border: 1px solid #000;">Column B</th></tr><tr><td style="border: 1px solid #000;"></td><td style="border: 1px solid #000;"></td></tr></table>',
+      // or json: { ...ProseMirror JSON... }
+    },
+  },
+];
+```
+
+Notes:
+- `presetContent` is used only for `mode: 'block'`.
+- Inline fields ignore `presetContent`.
+- Prefer `presetContent.json` when you need the most reliable preservation of structure, semantics, and editor-compatible styling.
+- With `presetContent.html`, include required attributes and inline styles explicitly so the HTML parser can map them into node attributes.
 
 ## Custom Field Creation
 

--- a/packages/template-builder/demo/src/App.tsx
+++ b/packages/template-builder/demo/src/App.tsx
@@ -10,6 +10,13 @@ import type {
 import 'superdoc/style.css';
 import './App.css';
 
+const cellBorders = {
+  top: { val: 'single', size: 1, color: '#000000', style: 'solid' },
+  right: { val: 'single', size: 1, color: '#000000', style: 'solid' },
+  bottom: { val: 'single', size: 1, color: '#000000', style: 'solid' },
+  left: { val: 'single', size: 1, color: '#000000', style: 'solid' },
+} as const;
+
 const availableFields: FieldDefinition[] = [
   { id: '1242142770', label: 'Agreement Date' },
   { id: '1242142771', label: 'User Name', defaultValue: 'John Doe' },
@@ -20,6 +27,77 @@ const availableFields: FieldDefinition[] = [
   { id: '1242142776', label: 'Signature', mode: 'block' },
   { id: '1242142777', label: 'Signer Name', fieldType: 'signer' },
   { id: '1242142778', label: 'Signer Table', mode: 'block', fieldType: 'signer' },
+  {
+    id: '1242142779',
+    label: 'Sample Table',
+    mode: 'block',
+    fieldType: 'signer',
+    presetContent: {
+      html: '<table style="border-collapse: collapse; width: 100%;"><tr><th style="border: 1px solid #000;">Column A</th><th style="border: 1px solid #000;">Column B</th></tr><tr><td style="border: 1px solid #000;"></td><td style="border: 1px solid #000;"></td></tr></table>',
+    },
+  },
+  {
+    id: '1242142780',
+    label: 'Sample List',
+    mode: 'block',
+    fieldType: 'signer',
+    presetContent: {
+      html: '<ul><li>First item</li><li>Second item</li><li>Third item</li></ul>',
+    },
+  },
+  {
+    id: '1242142781',
+    label: 'Sample Table (JSON)',
+    mode: 'block',
+    fieldType: 'signer',
+    presetContent: {
+      json: {
+        type: 'table',
+        content: [
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableHeader',
+                attrs: { borders: cellBorders },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'run', content: [{ type: 'text', text: 'Column A' }] }],
+                  },
+                ],
+              },
+              {
+                type: 'tableHeader',
+                attrs: { borders: cellBorders },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'run', content: [{ type: 'text', text: 'Column B' }] }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableCell',
+                attrs: { borders: cellBorders },
+                content: [{ type: 'paragraph' }],
+              },
+              {
+                type: 'tableCell',
+                attrs: { borders: cellBorders },
+                content: [{ type: 'paragraph' }],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
 ];
 
 export function App() {

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -183,7 +183,13 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
         const success = (
           mode === 'inline'
             ? editor.commands.insertStructuredContentInline?.({ attrs, text: field.defaultValue || field.alias })
-            : editor.commands.insertStructuredContentBlock?.({ attrs, text: field.defaultValue || field.alias })
+            : field.presetContent?.json || field.presetContent?.html
+              ? editor.commands.insertStructuredContentBlock?.({
+                  attrs,
+                  ...(field.presetContent.html ? { html: field.presetContent.html } : {}),
+                  ...(field.presetContent.json ? { json: field.presetContent.json } : {}),
+                })
+              : editor.commands.insertStructuredContentBlock?.({ attrs, text: field.defaultValue || field.alias })
         ) as boolean | undefined;
 
         if (success) {
@@ -531,6 +537,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
               alias: createdField.label,
               metadata: createdField.metadata,
               defaultValue: createdField.defaultValue,
+              presetContent: createdField.presetContent,
               fieldType: createdField.fieldType,
               lockMode: createdField.lockMode,
             });
@@ -543,6 +550,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
           alias: field.label,
           metadata: field.metadata,
           defaultValue: field.defaultValue,
+          presetContent: field.presetContent,
           fieldType: field.fieldType,
           lockMode: field.lockMode,
         });

--- a/packages/template-builder/src/tests/insertFieldPresetContent.test.tsx
+++ b/packages/template-builder/src/tests/insertFieldPresetContent.test.tsx
@@ -1,0 +1,164 @@
+import { createRef } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import SuperDocTemplateBuilder from '../index';
+import type { SuperDocTemplateBuilderHandle } from '../types';
+
+const insertStructuredContentInlineMock = vi.fn(() => true);
+const insertStructuredContentBlockMock = vi.fn(() => true);
+
+vi.mock('superdoc', () => {
+  class MockSuperDoc {
+    activeEditor: any;
+    superdocStore: any;
+
+    constructor(options: { onReady?: () => void }) {
+      this.activeEditor = {
+        state: {
+          selection: { from: 0, to: 0 },
+          doc: { textBetween: () => '' },
+        },
+        view: {
+          coordsAtPos: () => ({ left: 0, top: 0, bottom: 0 }),
+          dispatch: vi.fn(),
+        },
+        commands: {
+          insertStructuredContentInline: insertStructuredContentInlineMock,
+          insertStructuredContentBlock: insertStructuredContentBlockMock,
+        },
+        helpers: {
+          structuredContentCommands: {
+            getStructuredContentTags: () => [],
+          },
+        },
+        on: vi.fn(),
+      };
+
+      this.superdocStore = {
+        documents: [{ getPresentationEditor: () => ({ coordsAtPos: () => ({ left: 0, top: 0, bottom: 0 }) }) }],
+      };
+
+      queueMicrotask(() => options.onReady?.());
+    }
+
+    destroy() {}
+
+    setDocumentMode() {}
+  }
+
+  return { SuperDoc: MockSuperDoc };
+});
+
+const renderBuilder = async () => {
+  const ref = createRef<SuperDocTemplateBuilderHandle>();
+  const onReady = vi.fn();
+
+  render(
+    <SuperDocTemplateBuilder ref={ref} document={{ mode: 'editing' }} fields={{ available: [] }} onReady={onReady} />,
+  );
+
+  await waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(ref.current).not.toBeNull());
+
+  return ref;
+};
+
+describe('SuperDocTemplateBuilder presetContent insertion', () => {
+  beforeEach(() => {
+    insertStructuredContentInlineMock.mockClear();
+    insertStructuredContentBlockMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('passes presetContent.html to block insert command', async () => {
+    const ref = await renderBuilder();
+    let result = false;
+
+    await act(async () => {
+      result = ref.current!.insertBlockField({
+        alias: 'Sample Table',
+        presetContent: { html: '<table><tr><th>Date</th></tr></table>' },
+      });
+    });
+
+    expect(result).toBe(true);
+    expect(insertStructuredContentBlockMock).toHaveBeenCalledTimes(1);
+    expect(insertStructuredContentBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: '<table><tr><th>Date</th></tr></table>',
+      }),
+    );
+    const firstBlockCallArg = (insertStructuredContentBlockMock as any).mock.calls[0]?.[0];
+    expect(firstBlockCallArg).toBeDefined();
+    expect(firstBlockCallArg).not.toHaveProperty('text');
+  });
+
+  it('passes presetContent.json to block insert command', async () => {
+    const ref = await renderBuilder();
+    const json = { type: 'paragraph', content: [{ type: 'text', text: 'Preset block' }] };
+    let result = false;
+
+    await act(async () => {
+      result = ref.current!.insertBlockField({
+        alias: 'Preset Block',
+        presetContent: { json },
+      });
+    });
+
+    expect(result).toBe(true);
+    expect(insertStructuredContentBlockMock).toHaveBeenCalledTimes(1);
+    expect(insertStructuredContentBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json,
+      }),
+    );
+    const firstBlockCallArg = (insertStructuredContentBlockMock as any).mock.calls[0]?.[0];
+    expect(firstBlockCallArg).toBeDefined();
+    expect(firstBlockCallArg).not.toHaveProperty('text');
+  });
+
+  it('keeps text fallback for block fields without presetContent', async () => {
+    const ref = await renderBuilder();
+    let result = false;
+
+    await act(async () => {
+      result = ref.current!.insertBlockField({
+        alias: 'Signature',
+        defaultValue: 'Default signature content',
+      });
+    });
+
+    expect(result).toBe(true);
+    expect(insertStructuredContentBlockMock).toHaveBeenCalledTimes(1);
+    expect(insertStructuredContentBlockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Default signature content',
+      }),
+    );
+  });
+
+  it('ignores presetContent for inline insertion', async () => {
+    const ref = await renderBuilder();
+    let result = false;
+
+    await act(async () => {
+      result = ref.current!.insertField({
+        alias: 'Inline Name',
+        defaultValue: 'Alice',
+        presetContent: { html: '<ul><li>Ignored</li></ul>' },
+      });
+    });
+
+    expect(result).toBe(true);
+    expect(insertStructuredContentInlineMock).toHaveBeenCalledTimes(1);
+    expect(insertStructuredContentInlineMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Alice',
+      }),
+    );
+    expect(insertStructuredContentBlockMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/template-builder/src/types.ts
+++ b/packages/template-builder/src/types.ts
@@ -7,6 +7,10 @@ export interface FieldDefinition {
   id: string;
   label: string;
   defaultValue?: string;
+  presetContent?: {
+    html?: string;
+    json?: unknown;
+  };
   metadata?: Record<string, any>;
   mode?: 'inline' | 'block';
   group?: string;


### PR DESCRIPTION
Cherry-pick of #2856 into stable.

Adds presetContent support to Template Builder block fields - when defined, blocks insert preset HTML/JSON instead of the text fallback. Inline fields are unaffected.

Original: https://github.com/superdoc-dev/superdoc/pull/2856 (commit 1d3d77a, clean pick).