### PR TITLE
feat(superdoc/ui): official React provider and hooks (SD-2813)

### DIFF
--- a/packages/super-editor/package.json
+++ b/packages/super-editor/package.json
@@ -34,6 +34,11 @@
       "types": "./dist/src/ui/index.d.ts",
       "import": "./dist/ui.es.js"
     },
+    "./ui/react": {
+      "source": "./src/ui/react/index.ts",
+      "types": "./dist/src/ui/react/index.d.ts",
+      "import": "./dist/ui-react.es.js"
+    },
     "./parts-runtime": {
       "source": "./src/editors/v1/core/parts/init-parts-runtime.ts",
       "types": "./dist/src/editors/v1/core/parts/init-parts-runtime.d.ts"
@@ -166,8 +171,10 @@
   },
   "devDependencies": {
     "@floating-ui/dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/mdast": "catalog:",
     "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
     "@vue/test-utils": "catalog:",
     "canvas": "catalog:",
@@ -176,6 +183,7 @@
     "postcss-nested-import": "catalog:",
     "prosemirror-test-builder": "catalog:",
     "react": "catalog:",
+    "react-dom": "catalog:",
     "tippy.js": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/packages/super-editor/src/ui/react/hooks.test.tsx
+++ b/packages/super-editor/src/ui/react/hooks.test.tsx
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { SuperDocUIProvider, useSetSuperDoc } from './provider.js';
+import {
+  useSuperDocCommand,
+  useSuperDocComments,
+  useSuperDocReview,
+  useSuperDocSelection,
+  useSuperDocToolbar,
+} from './hooks.js';
+
+function makeSuperdocStub(overrides: { selectionInfo?: unknown } = {}) {
+  const editorListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const superdocListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  const editor = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!editorListeners.has(event)) editorListeners.set(event, new Set());
+      editorListeners.get(event)!.add(handler);
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      editorListeners.get(event)?.delete(handler);
+    }),
+    state: { selection: { empty: true, from: 0, to: 0 } },
+    options: { documentId: 'doc-1', isHeaderOrFooter: false },
+    commands: {},
+    isEditable: true,
+    doc: {
+      selection: {
+        current: vi.fn(
+          () =>
+            overrides.selectionInfo ?? {
+              empty: true,
+              target: null,
+              activeMarks: [],
+              activeCommentIds: [],
+              activeChangeIds: [],
+            },
+        ),
+      },
+    },
+  };
+
+  return {
+    activeEditor: editor,
+    config: { documentMode: 'editing' as const },
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!superdocListeners.has(event)) superdocListeners.set(event, new Set());
+      superdocListeners.get(event)!.add(handler);
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      superdocListeners.get(event)?.delete(handler);
+    }),
+  };
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+describe('domain hooks', () => {
+  it('useSuperDocSelection returns the empty default before ready, then the live slice', () => {
+    let selection: ReturnType<typeof useSuperDocSelection> | undefined;
+    let setSuperDoc: ReturnType<typeof useSetSuperDoc> | undefined;
+
+    function Probe() {
+      selection = useSuperDocSelection();
+      setSuperDoc = useSetSuperDoc();
+      return null;
+    }
+
+    render(
+      <SuperDocUIProvider>
+        <Probe />
+      </SuperDocUIProvider>,
+    );
+
+    expect(selection).toEqual({
+      empty: true,
+      target: null,
+      selectionTarget: null,
+      activeMarks: [],
+      activeCommentIds: [],
+      activeChangeIds: [],
+      quotedText: '',
+    });
+
+    act(() => {
+      setSuperDoc!(
+        makeSuperdocStub({
+          selectionInfo: {
+            empty: false,
+            text: 'hello',
+            target: {
+              kind: 'text',
+              segments: [{ blockId: 'p1', range: { start: 0, end: 5 } }],
+            },
+            activeMarks: ['bold'],
+            activeCommentIds: ['c1'],
+            activeChangeIds: [],
+          },
+        }),
+      );
+    });
+
+    expect(selection?.empty).toBe(false);
+    expect(selection?.target?.segments[0]).toEqual({ blockId: 'p1', range: { start: 0, end: 5 } });
+    // SD-2812: selectionTarget mirrors the TextTarget for downstream
+    // doc-api point/range operations.
+    expect(selection?.selectionTarget).toEqual({
+      kind: 'selection',
+      start: { kind: 'text', blockId: 'p1', offset: 0 },
+      end: { kind: 'text', blockId: 'p1', offset: 5 },
+    });
+    expect(selection?.activeMarks).toEqual(['bold']);
+    expect(selection?.activeCommentIds).toEqual(['c1']);
+  });
+
+  it('useSuperDocComments / useSuperDocReview / useSuperDocToolbar return initial empties before ready', () => {
+    let comments: ReturnType<typeof useSuperDocComments> | undefined;
+    let review: ReturnType<typeof useSuperDocReview> | undefined;
+    let toolbar: ReturnType<typeof useSuperDocToolbar> | undefined;
+
+    function Probe() {
+      comments = useSuperDocComments();
+      review = useSuperDocReview();
+      toolbar = useSuperDocToolbar();
+      return null;
+    }
+
+    render(
+      <SuperDocUIProvider>
+        <Probe />
+      </SuperDocUIProvider>,
+    );
+
+    expect(comments).toEqual({ items: [], activeIds: [], total: 0 });
+    expect(review).toEqual({ items: [], openCount: 0, activeId: null });
+    expect(toolbar).toEqual({ context: null, commands: {} });
+  });
+
+  it('useSuperDocCommand returns the disabled fallback for unknown ids', () => {
+    let cmd: ReturnType<typeof useSuperDocCommand> | undefined;
+    let setSuperDoc: ReturnType<typeof useSetSuperDoc> | undefined;
+
+    function Probe() {
+      cmd = useSuperDocCommand('not-a-real-command');
+      setSuperDoc = useSetSuperDoc();
+      return null;
+    }
+
+    render(
+      <SuperDocUIProvider>
+        <Probe />
+      </SuperDocUIProvider>,
+    );
+
+    // Pre-ready: fallback.
+    expect(cmd).toEqual({ active: false, disabled: true, value: undefined, source: 'built-in' });
+
+    act(() => {
+      setSuperDoc!(makeSuperdocStub());
+    });
+
+    // Post-ready, unknown id: still the fallback.
+    expect(cmd).toEqual({ active: false, disabled: true, value: undefined, source: 'built-in' });
+  });
+
+  it('useSuperDocCommand returns the live snapshot for built-in ids', () => {
+    let cmd: ReturnType<typeof useSuperDocCommand> | undefined;
+    let setSuperDoc: ReturnType<typeof useSetSuperDoc> | undefined;
+
+    function Probe() {
+      cmd = useSuperDocCommand('bold');
+      setSuperDoc = useSetSuperDoc();
+      return null;
+    }
+
+    render(
+      <SuperDocUIProvider>
+        <Probe />
+      </SuperDocUIProvider>,
+    );
+
+    act(() => {
+      setSuperDoc!(makeSuperdocStub());
+    });
+
+    // The stub doesn't populate per-command state, so bold lands on the
+    // built-in snapshot's default disabled posture (no editor context).
+    expect(cmd?.source).toBe('built-in');
+    expect(typeof cmd?.disabled).toBe('boolean');
+  });
+});

--- a/packages/super-editor/src/ui/react/hooks.test.tsx
+++ b/packages/super-editor/src/ui/react/hooks.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render } from '@testing-library/react';
-import { SuperDocUIProvider, useSetSuperDoc } from './provider.js';
+import { SuperDocUIProvider, useSetSuperDoc, useSuperDocUI } from './provider.js';
 import {
   useSuperDocCommand,
   useSuperDocComments,
@@ -194,5 +194,81 @@ describe('domain hooks', () => {
     // built-in snapshot's default disabled posture (no editor context).
     expect(cmd?.source).toBe('built-in');
     expect(typeof cmd?.disabled).toBe('boolean');
+  });
+
+  // Regression for PR #3011 review comment: useSuperDocCommand must
+  // resubscribe when the id prop changes while the same controller
+  // stays mounted. A toolbar that maps over a config array of command
+  // ids and reuses one component instance per slot would otherwise
+  // observe the wrong command when the id changes.
+  it('useSuperDocCommand resubscribes when the id changes', async () => {
+    let setSuperDoc: ReturnType<typeof useSetSuperDoc> | undefined;
+    const captured: Array<{ id: string; source: string; value: unknown }> = [];
+
+    function Probe({ id }: { id: string }) {
+      const cmd = useSuperDocCommand(id);
+      setSuperDoc = useSetSuperDoc();
+      captured.push({ id, source: cmd.source, value: cmd.value });
+      return <span>{id}</span>;
+    }
+
+    const { rerender } = render(
+      <SuperDocUIProvider>
+        <Probe id='ai.first' />
+      </SuperDocUIProvider>,
+    );
+
+    // Stub a controller, then register two distinct custom commands so
+    // each id has a state distinguishable in the snapshot.
+    const stub = makeSuperdocStub();
+    act(() => {
+      setSuperDoc!(stub);
+    });
+
+    // Reach into the controller via context to register custom commands
+    // with distinct values per id. Use the public ui.commands.register
+    // surface.
+    let registered = false;
+    function Register() {
+      const ui = useSuperDocUI();
+      if (ui && !registered) {
+        registered = true;
+        ui.commands.register({ id: 'ai.first', execute: () => true, getState: () => ({ value: 'A' }) });
+        ui.commands.register({ id: 'ai.second', execute: () => true, getState: () => ({ value: 'B' }) });
+      }
+      return null;
+    }
+    rerender(
+      <SuperDocUIProvider>
+        <Probe id='ai.first' />
+        <Register />
+      </SuperDocUIProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Probe with id='ai.second' now. If the hook fails to resubscribe,
+    // the captured value will keep showing 'A' (stale).
+    rerender(
+      <SuperDocUIProvider>
+        <Probe id='ai.second' />
+        <Register />
+      </SuperDocUIProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The most recent capture for id='ai.second' must reflect the
+    // ai.second command's value, not ai.first's.
+    const lastForSecond = [...captured].reverse().find((c) => c.id === 'ai.second');
+    expect(lastForSecond).toBeDefined();
+    expect(lastForSecond!.value).toBe('B');
+    expect(lastForSecond!.source).toBe('custom');
   });
 });

--- a/packages/super-editor/src/ui/react/hooks.ts
+++ b/packages/super-editor/src/ui/react/hooks.ts
@@ -1,0 +1,82 @@
+import { shallowEqual } from '../equality.js';
+import type {
+  CommentsSlice,
+  ReviewSlice,
+  SelectionSlice,
+  ToolbarSnapshotSlice,
+  UIToolbarCommandState,
+} from '../types.js';
+import { useSuperDocSlice } from './provider.js';
+
+const EMPTY_SELECTION: SelectionSlice = {
+  empty: true,
+  target: null,
+  selectionTarget: null,
+  activeMarks: [],
+  activeCommentIds: [],
+  activeChangeIds: [],
+  quotedText: '',
+};
+
+const EMPTY_COMMENTS: CommentsSlice = { items: [], activeIds: [], total: 0 };
+
+const EMPTY_REVIEW: ReviewSlice = { items: [], openCount: 0, activeId: null };
+
+const EMPTY_TOOLBAR: ToolbarSnapshotSlice = { context: null, commands: {} };
+
+/**
+ * Subscribe to the current selection slice.
+ *
+ * Returns the full {@link SelectionSlice} — empty/target/selectionTarget
+ * (SD-2812)/activeMarks/activeCommentIds/activeChangeIds/quotedText.
+ * Use the returned `target` for `editor.doc.comments.create({ target })`
+ * and the `selectionTarget` for `editor.doc.insert({ target })`.
+ */
+export function useSuperDocSelection(): SelectionSlice {
+  return useSuperDocSlice((ui) => ui.select((state) => state.selection, shallowEqual), EMPTY_SELECTION);
+}
+
+/** Subscribe to the comments slice (items, activeIds, total). */
+export function useSuperDocComments(): CommentsSlice {
+  return useSuperDocSlice((ui) => ui.select((state) => state.comments, shallowEqual), EMPTY_COMMENTS);
+}
+
+/** Subscribe to the merged review feed (comments + tracked changes). */
+export function useSuperDocReview(): ReviewSlice {
+  return useSuperDocSlice((ui) => ui.select((state) => state.review, shallowEqual), EMPTY_REVIEW);
+}
+
+/** Subscribe to the full toolbar snapshot (context + per-command states). */
+export function useSuperDocToolbar(): ToolbarSnapshotSlice {
+  return useSuperDocSlice((ui) => ui.select((state) => state.toolbar, shallowEqual), EMPTY_TOOLBAR);
+}
+
+const FALLBACK_COMMAND_STATE: UIToolbarCommandState = {
+  active: false,
+  disabled: true,
+  value: undefined,
+  source: 'built-in',
+};
+
+/**
+ * Subscribe to a single command's state by id.
+ *
+ * Works for both built-in command ids (`'bold'`, `'italic'`, …) and
+ * custom command ids registered via `ui.commands.register(...)`. The
+ * returned object includes `active`, `disabled`, `value`, and the
+ * `source` discriminator (`'built-in' | 'custom'`).
+ *
+ * Returns the fallback disabled state until the editor is ready or
+ * while the id isn't registered.
+ *
+ * ```tsx
+ * const bold = useSuperDocCommand('bold');
+ * <button data-active={bold.active} disabled={bold.disabled}>B</button>
+ * ```
+ */
+export function useSuperDocCommand(id: string): UIToolbarCommandState {
+  return useSuperDocSlice(
+    (ui) => ui.select((state) => state.toolbar.commands?.[id] ?? FALLBACK_COMMAND_STATE, shallowEqual),
+    FALLBACK_COMMAND_STATE,
+  );
+}

--- a/packages/super-editor/src/ui/react/hooks.ts
+++ b/packages/super-editor/src/ui/react/hooks.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { shallowEqual } from '../equality.js';
 import type {
   CommentsSlice,
@@ -6,7 +7,7 @@ import type {
   ToolbarSnapshotSlice,
   UIToolbarCommandState,
 } from '../types.js';
-import { useSuperDocSlice } from './provider.js';
+import { useSuperDocSlice, useSuperDocUI } from './provider.js';
 
 const EMPTY_SELECTION: SelectionSlice = {
   empty: true,
@@ -73,10 +74,27 @@ const FALLBACK_COMMAND_STATE: UIToolbarCommandState = {
  * const bold = useSuperDocCommand('bold');
  * <button data-active={bold.active} disabled={bold.disabled}>B</button>
  * ```
+ *
+ * Implementation note: this hook bypasses {@link useSuperDocSlice}
+ * because the selector closes over `id`. `useSuperDocSlice`'s
+ * subscription effect re-runs only when the controller swaps, so a
+ * toolbar component reused with a different command id under the
+ * same provider would otherwise keep emitting state for the prior
+ * id. Subscribing here with `[ui, id]` deps fixes the resubscription
+ * the substrate alone can't see.
  */
 export function useSuperDocCommand(id: string): UIToolbarCommandState {
-  return useSuperDocSlice(
-    (ui) => ui.select((state) => state.toolbar.commands?.[id] ?? FALLBACK_COMMAND_STATE, shallowEqual),
-    FALLBACK_COMMAND_STATE,
-  );
+  const ui = useSuperDocUI();
+  const [value, setValue] = useState<UIToolbarCommandState>(FALLBACK_COMMAND_STATE);
+
+  useEffect(() => {
+    if (!ui) {
+      setValue(FALLBACK_COMMAND_STATE);
+      return;
+    }
+    const sub = ui.select((state) => state.toolbar.commands?.[id] ?? FALLBACK_COMMAND_STATE, shallowEqual);
+    return sub.subscribe((next) => setValue(next));
+  }, [ui, id]);
+
+  return value;
 }

--- a/packages/super-editor/src/ui/react/index.ts
+++ b/packages/super-editor/src/ui/react/index.ts
@@ -1,0 +1,39 @@
+/**
+ * `superdoc/ui/react` — official React bindings for the
+ * `createSuperDocUI` controller.
+ *
+ * Ships the provider, the lifecycle-correct context, and a typed
+ * subscription helper. Domain-specific convenience hooks (selection,
+ * comments, review, toolbar, per-command) are sugar on top of
+ * `useSuperDocSlice` so consumers don't repeat the same `useEffect +
+ * setState + cleanup` boilerplate per slice.
+ *
+ * ```tsx
+ * import {
+ *   SuperDocUIProvider,
+ *   useSuperDocUI,
+ *   useSuperDocSelection,
+ *   useSuperDocComments,
+ *   useSuperDocReview,
+ *   useSuperDocToolbar,
+ *   useSuperDocCommand,
+ * } from 'superdoc/ui/react';
+ * ```
+ */
+
+export {
+  SuperDocUIProvider,
+  useSuperDocUI,
+  useSuperDocHost,
+  useSetSuperDoc,
+  useSuperDocSlice,
+  type SuperDocHost,
+} from './provider.js';
+
+export {
+  useSuperDocSelection,
+  useSuperDocComments,
+  useSuperDocReview,
+  useSuperDocToolbar,
+  useSuperDocCommand,
+} from './hooks.js';

--- a/packages/super-editor/src/ui/react/provider.test.tsx
+++ b/packages/super-editor/src/ui/react/provider.test.tsx
@@ -1,10 +1,13 @@
+import { StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
 import { SuperDocUIProvider, useSetSuperDoc, useSuperDocHost, useSuperDocSlice, useSuperDocUI } from './provider.js';
 import { shallowEqual } from '../equality.js';
 
 // Stub mirroring the controller test stubs — just enough surface for
-// `createSuperDocUI({ superdoc })` to succeed.
+// `createSuperDocUI({ superdoc })` to succeed. Tracks subscription
+// counts so the StrictMode regression below can assert that the
+// provider only attaches one set of listeners per setSuperDoc call.
 function makeSuperdocStub() {
   const editorListeners = new Map<string, Set<(...args: unknown[]) => void>>();
   const superdocListeners = new Map<string, Set<(...args: unknown[]) => void>>();
@@ -39,6 +42,13 @@ function makeSuperdocStub() {
       superdocListeners.get(event)?.delete(handler);
     }),
     export: vi.fn(async () => ({ ok: true })),
+    // Test-only window into how many editor handlers are currently
+    // attached for a given event. Lets the StrictMode regression
+    // below assert "exactly one set of subscriptions" without leaking
+    // the listener Maps into production typing.
+    __activeEditorListeners(event: string): number {
+      return editorListeners.get(event)?.size ?? 0;
+    },
   };
 
   return superdoc;
@@ -181,6 +191,65 @@ describe('<SuperDocUIProvider> + core hooks', () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(() => render(<Probe />)).toThrow(/inside <SuperDocUIProvider>/);
     errSpy.mockRestore();
+  });
+
+  // Regression for PR #3011 review comment: React StrictMode
+  // (development behavior) invokes state-updater functions twice for
+  // purity-checking. If `createSuperDocUI` is called inside a
+  // `setUI((prev) => ...)` updater, the second invocation builds a
+  // second controller that React then discards but whose
+  // subscriptions stay attached to the SuperDoc / editor instance.
+  // The fix moves controller construction out of the updater into the
+  // callback body. This test asserts that one setSuperDoc call under
+  // StrictMode produces exactly one controller's worth of editor
+  // subscriptions, not two.
+  it('does not leak a controller when setSuperDoc runs under StrictMode', () => {
+    // First, measure how many editor.on calls a single controller
+    // registers in the no-StrictMode case. The number depends on
+    // headless-toolbar + EDITOR_EVENTS + LIST_REFRESH_EVENTS internal
+    // wiring; capturing it here keeps the assertion stable against
+    // future event-list changes.
+    let baselineSetSuperDoc: ReturnType<typeof useSetSuperDoc> | undefined;
+    function BaselineProbe() {
+      baselineSetSuperDoc = useSetSuperDoc();
+      return null;
+    }
+    const { unmount: unmountBaseline } = render(
+      <SuperDocUIProvider>
+        <BaselineProbe />
+      </SuperDocUIProvider>,
+    );
+    const baselineStub = makeSuperdocStub();
+    act(() => {
+      baselineSetSuperDoc!(baselineStub);
+    });
+    const perControllerOnCalls = (baselineStub.activeEditor.on as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(perControllerOnCalls).toBeGreaterThan(0);
+    unmountBaseline();
+
+    // Now mount the same provider inside StrictMode. If the bug were
+    // present (controller created inside `setUI((prev) => ...)`),
+    // React's purity-check would build a second controller and we'd
+    // see 2x the per-controller call count.
+    let setSuperDoc: ReturnType<typeof useSetSuperDoc> | undefined;
+    function Probe() {
+      setSuperDoc = useSetSuperDoc();
+      return null;
+    }
+    render(
+      <StrictMode>
+        <SuperDocUIProvider>
+          <Probe />
+        </SuperDocUIProvider>
+      </StrictMode>,
+    );
+    const stub = makeSuperdocStub();
+    act(() => {
+      setSuperDoc!(stub);
+    });
+
+    const onCallsUnderStrictMode = (stub.activeEditor.on as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(onCallsUnderStrictMode).toBe(perControllerOnCalls);
   });
 
   it('useSuperDocSlice returns the initial value before setSuperDoc, then live values after', async () => {

--- a/packages/super-editor/src/ui/react/provider.test.tsx
+++ b/packages/super-editor/src/ui/react/provider.test.tsx
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { SuperDocUIProvider, useSetSuperDoc, useSuperDocHost, useSuperDocSlice, useSuperDocUI } from './provider.js';
+import { shallowEqual } from '../equality.js';
+
+// Stub mirroring the controller test stubs — just enough surface for
+// `createSuperDocUI({ superdoc })` to succeed.
+function makeSuperdocStub() {
+  const editorListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const superdocListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  const editor = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!editorListeners.has(event)) editorListeners.set(event, new Set());
+      editorListeners.get(event)!.add(handler);
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      editorListeners.get(event)?.delete(handler);
+    }),
+    state: { selection: { empty: true, from: 0, to: 0 } },
+    options: { documentId: 'doc-1', isHeaderOrFooter: false },
+    commands: {},
+    isEditable: true,
+    doc: {
+      selection: {
+        current: vi.fn(() => ({ empty: true, target: null, activeMarks: [] })),
+      },
+    },
+  };
+
+  const superdoc = {
+    activeEditor: editor,
+    config: { documentMode: 'editing' as const },
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!superdocListeners.has(event)) superdocListeners.set(event, new Set());
+      superdocListeners.get(event)!.add(handler);
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      superdocListeners.get(event)?.delete(handler);
+    }),
+    export: vi.fn(async () => ({ ok: true })),
+  };
+
+  return superdoc;
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+describe('<SuperDocUIProvider> + core hooks', () => {
+  it('useSuperDocUI returns null until setSuperDoc is called, then returns the controller', () => {
+    let captured: ReturnType<typeof useSuperDocUI> | undefined;
+    let setSuperDoc: ReturnType<typeof useSetSuperDoc> | undefined;
+
+    function Probe() {
+      captured = useSuperDocUI();
+      setSuperDoc = useSetSuperDoc();
+      return null;
+    }
+
+    render(
+      <SuperDocUIProvider>
+        <Probe />
+      </SuperDocUIProvider>,
+    );
+
+    expect(captured).toBeNull();
+    expect(typeof setSuperDoc).toBe('function');
+
+    const superdoc = makeSuperdocStub();
+    act(() => {
+      setSuperDoc!(superdoc);
+    });
+
+    expect(captured).not.toBeNull();
+    expect(typeof captured?.select).toBe('function');
+  });
+
+  it('useSuperDocHost returns the host instance once setSuperDoc is called', () => {
+    let host: ReturnType<typeof useSuperDocHost> | undefined;
+    let setSuperDoc: ReturnType<typeof useSetSuperDoc> | undefined;
+
+    function Probe() {
+      host = useSuperDocHost();
+      setSuperDoc = useSetSuperDoc();
+      return null;
+    }
+
+    render(
+      <SuperDocUIProvider>
+        <Probe />
+      </SuperDocUIProvider>,
+    );
+
+    expect(host).toBeNull();
+
+    const superdoc = makeSuperdocStub();
+    act(() => {
+      setSuperDoc!(superdoc);
+    });
+
+    expect(host).toBe(superdoc);
+    // The host's export method is reachable — same shape consumers use
+    // for the Export DOCX button.
+    expect(typeof host?.export).toBe('function');
+  });
+
+  it('destroys the controller on provider unmount', () => {
+    let setSuperDoc: ReturnType<typeof useSetSuperDoc> | undefined;
+    let captured: ReturnType<typeof useSuperDocUI> | undefined;
+
+    function Probe() {
+      captured = useSuperDocUI();
+      setSuperDoc = useSetSuperDoc();
+      return null;
+    }
+
+    const { unmount } = render(
+      <SuperDocUIProvider>
+        <Probe />
+      </SuperDocUIProvider>,
+    );
+
+    const superdoc = makeSuperdocStub();
+    act(() => {
+      setSuperDoc!(superdoc);
+    });
+
+    const ui = captured!;
+    expect(ui).not.toBeNull();
+    const destroySpy = vi.spyOn(ui!, 'destroy');
+
+    unmount();
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('replacing the SuperDoc instance destroys the prior controller before creating a new one', () => {
+    let setSuperDoc: ReturnType<typeof useSetSuperDoc> | undefined;
+    let captured: ReturnType<typeof useSuperDocUI> | undefined;
+
+    function Probe() {
+      captured = useSuperDocUI();
+      setSuperDoc = useSetSuperDoc();
+      return null;
+    }
+
+    render(
+      <SuperDocUIProvider>
+        <Probe />
+      </SuperDocUIProvider>,
+    );
+
+    act(() => {
+      setSuperDoc!(makeSuperdocStub());
+    });
+    const first = captured!;
+    const firstDestroy = vi.spyOn(first!, 'destroy');
+
+    act(() => {
+      setSuperDoc!(makeSuperdocStub());
+    });
+    const second = captured!;
+
+    expect(firstDestroy).toHaveBeenCalledTimes(1);
+    expect(second).not.toBe(first);
+  });
+
+  it('useSuperDocUI throws outside the provider', () => {
+    function Probe() {
+      useSuperDocUI();
+      return null;
+    }
+    // Suppress React's expected-error log for this test.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<Probe />)).toThrow(/inside <SuperDocUIProvider>/);
+    errSpy.mockRestore();
+  });
+
+  it('useSuperDocSlice returns the initial value before setSuperDoc, then live values after', async () => {
+    let slice: { empty: boolean } | undefined;
+    let setSuperDoc: ReturnType<typeof useSetSuperDoc> | undefined;
+
+    function Probe() {
+      slice = useSuperDocSlice<{ empty: boolean }>(
+        (ui) => ui.select((state) => ({ empty: state.selection.empty }), shallowEqual),
+        { empty: true },
+      );
+      setSuperDoc = useSetSuperDoc();
+      return <span data-testid='empty'>{String(slice.empty)}</span>;
+    }
+
+    render(
+      <SuperDocUIProvider>
+        <Probe />
+      </SuperDocUIProvider>,
+    );
+
+    // Pre-onReady: hook returns the initial value.
+    expect(screen.getByTestId('empty').textContent).toBe('true');
+    expect(slice).toEqual({ empty: true });
+
+    act(() => {
+      setSuperDoc!(makeSuperdocStub());
+    });
+
+    expect(slice).toEqual({ empty: true });
+  });
+});

--- a/packages/super-editor/src/ui/react/provider.tsx
+++ b/packages/super-editor/src/ui/react/provider.tsx
@@ -62,18 +62,27 @@ export function SuperDocUIProvider({ children }: { children: ReactNode }) {
   const [ui, setUI] = useState<SuperDocUI | null>(null);
   const [host, setHost] = useState<SuperDocHost | null>(null);
 
+  // Tracks the latest controller for the unmount cleanup effect and
+  // for prior-controller teardown on re-init. Maintained imperatively
+  // by `setSuperDoc`, never assigned during render: a render-time
+  // assignment would run twice under React StrictMode and could mask
+  // the controller that was actually live at unmount time.
   const uiRef = useRef<SuperDocUI | null>(null);
-  uiRef.current = ui;
 
   const setSuperDoc = useCallback((instance: unknown) => {
-    setUI((prev) => {
-      // SuperDoc emits `onReady` once per mount. If it ever fires
-      // twice for the same instance (re-init, dev StrictMode, etc.),
-      // drop the prior controller before creating the new one so
-      // subscriptions don't accumulate.
-      prev?.destroy();
-      return createSuperDocUI({ superdoc: instance as never });
-    });
+    // Construct (and tear down the prior) controller in the callback
+    // body, NOT inside a `setUI((prev) => ...)` updater. React's
+    // StrictMode invokes state-updater functions twice in development
+    // to find non-pure updaters: a second invocation here would call
+    // `createSuperDocUI` again, producing a controller React then
+    // discards but whose subscriptions stay attached to the SuperDoc
+    // / editor instance. The body of `setSuperDoc` runs once per call
+    // so the side effects (destroy + create) stay in lockstep with
+    // the value React records as the new state.
+    uiRef.current?.destroy();
+    const next = createSuperDocUI({ superdoc: instance as never });
+    uiRef.current = next;
+    setUI(next);
     setHost(instance as SuperDocHost);
   }, []);
 

--- a/packages/super-editor/src/ui/react/provider.tsx
+++ b/packages/super-editor/src/ui/react/provider.tsx
@@ -1,0 +1,168 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import { createSuperDocUI } from '../create-super-doc-ui.js';
+import type { Subscribable, SuperDocUI } from '../types.js';
+
+/**
+ * Minimal structural type for the host SuperDoc instance — exposed
+ * through {@link useSuperDocHost} so components can call methods that
+ * aren't on the controller surface (currently: `export({...})`).
+ *
+ * Most components should never reach for the host; prefer
+ * {@link useSuperDocUI} and the domain hooks. The host is only here
+ * for the small set of operations the controller doesn't yet bridge.
+ */
+export interface SuperDocHost {
+  export(options: {
+    exportType: string[];
+    commentsType?: 'internal' | 'external';
+    triggerDownload?: boolean;
+  }): Promise<unknown>;
+}
+
+interface SuperDocUIContextValue {
+  /** The controller, or null until the editor reports ready. */
+  ui: SuperDocUI | null;
+  /** The host SuperDoc instance, or null until the editor reports ready. */
+  host: SuperDocHost | null;
+  /**
+   * Setter the editor mount calls from the React wrapper's `onReady`
+   * callback. Most components never use this directly.
+   */
+  setSuperDoc(instance: unknown): void;
+}
+
+const SuperDocUIContext = createContext<SuperDocUIContextValue | null>(null);
+
+/**
+ * React context wrapping the `superdoc/ui` browser controller.
+ *
+ * Construction is deferred until SuperDoc reports ready — the editor
+ * mount path calls `setSuperDoc(instance)` once the wrapper dispatches
+ * `onReady`, and this provider creates exactly one
+ * `createSuperDocUI({ superdoc })` and stores it in state. Re-renders
+ * never recreate the controller; unmount calls `ui.destroy()` so every
+ * subscriber is torn down deterministically.
+ *
+ * ```tsx
+ * <SuperDocUIProvider>
+ *   <Toolbar />
+ *   <SuperDocEditor onReady={({ superdoc }) => setSuperDoc(superdoc)} />
+ *   <ActivitySidebar />
+ * </SuperDocUIProvider>
+ * ```
+ *
+ * Implementation note: the unmount cleanup uses a ref to the latest
+ * controller. Doing the obvious `useEffect(() => () => ui?.destroy(),
+ * [])` would capture the initial null value (controllers are created
+ * on `onReady`, after the first render), and changing the deps to
+ * `[ui]` would destroy the controller every time it's created. The
+ * ref sidesteps both pitfalls.
+ */
+export function SuperDocUIProvider({ children }: { children: ReactNode }) {
+  const [ui, setUI] = useState<SuperDocUI | null>(null);
+  const [host, setHost] = useState<SuperDocHost | null>(null);
+
+  const uiRef = useRef<SuperDocUI | null>(null);
+  uiRef.current = ui;
+
+  const setSuperDoc = useCallback((instance: unknown) => {
+    setUI((prev) => {
+      // SuperDoc emits `onReady` once per mount. If it ever fires
+      // twice for the same instance (re-init, dev StrictMode, etc.),
+      // drop the prior controller before creating the new one so
+      // subscriptions don't accumulate.
+      prev?.destroy();
+      return createSuperDocUI({ superdoc: instance as never });
+    });
+    setHost(instance as SuperDocHost);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      uiRef.current?.destroy();
+      uiRef.current = null;
+    };
+  }, []);
+
+  return <SuperDocUIContext.Provider value={{ ui, host, setSuperDoc }}>{children}</SuperDocUIContext.Provider>;
+}
+
+/**
+ * Read the controller from context. Returns `null` until the editor
+ * reports ready — components either wait for non-null or render a
+ * pending state.
+ */
+export function useSuperDocUI(): SuperDocUI | null {
+  const ctx = useContext(SuperDocUIContext);
+  if (!ctx) {
+    throw new Error('useSuperDocUI must be used inside <SuperDocUIProvider>.');
+  }
+  return ctx.ui;
+}
+
+/**
+ * Read the host SuperDoc instance from context. Reach for
+ * {@link useSuperDocUI} first — host access is reserved for
+ * operations that aren't on the controller surface today
+ * (e.g. `export()`).
+ */
+export function useSuperDocHost(): SuperDocHost | null {
+  const ctx = useContext(SuperDocUIContext);
+  if (!ctx) {
+    throw new Error('useSuperDocHost must be used inside <SuperDocUIProvider>.');
+  }
+  return ctx.host;
+}
+
+/**
+ * Setter exposed for the editor mount component that owns the React
+ * wrapper's `onReady` callback. Most components do NOT need this —
+ * use {@link useSuperDocUI} to read the controller instead.
+ */
+export function useSetSuperDoc() {
+  const ctx = useContext(SuperDocUIContext);
+  if (!ctx) {
+    throw new Error('useSetSuperDoc must be used inside <SuperDocUIProvider>.');
+  }
+  return ctx.setSuperDoc;
+}
+
+/**
+ * Bind a React component to a slice of controller state.
+ *
+ * ```tsx
+ * const toolbar = useSuperDocSlice(
+ *   (ui) => ui.select((state) => state.toolbar, shallowEqual),
+ *   { context: null, commands: {} },
+ * );
+ * ```
+ *
+ * The selector returns a `Subscribable<T>`; pass anything from
+ * `ui.select(...)` (the canonical substrate) or any other API on the
+ * controller that exposes the same shape.
+ *
+ * Domain handles (`ui.toolbar.subscribe`, `ui.comments.subscribe`,
+ * etc.) emit a `{ snapshot }` event instead of the raw value — prefer
+ * `ui.select(...)` when you need a single field, or use the typed
+ * domain hooks (`useSuperDocSelection`, `useSuperDocComments`,
+ * `useSuperDocReview`).
+ *
+ * The hook re-emits the most recent value on every change. While the
+ * controller is null (before the editor reports ready), the hook
+ * returns the `initial` value so the first render is coherent.
+ */
+export function useSuperDocSlice<T>(pickSubscribable: (ui: SuperDocUI) => Subscribable<T>, initial: T): T {
+  const ui = useSuperDocUI();
+  const [value, setValue] = useState<T>(() => initial);
+
+  // `pickSubscribable` is treated as stable — pass a function that
+  // closes only over `ui` (e.g. `(ui) => ui.select(...)`) so a new
+  // function reference per render does not retrigger the effect.
+  useEffect(() => {
+    if (!ui) return;
+    const sub = pickSubscribable(ui);
+    return sub.subscribe((next) => setValue(next));
+  }, [ui]);
+
+  return value;
+}

--- a/packages/super-editor/tsconfig.json
+++ b/packages/super-editor/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "dist",
+    "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
       "@": ["./src/*"],

--- a/packages/super-editor/vite.config.js
+++ b/packages/super-editor/vite.config.js
@@ -122,6 +122,7 @@ export default defineConfig(({ mode }) => {
           'headless-toolbar-vue': 'src/headless-toolbar/vue.ts',
           'super-editor': 'src/index.ts',
           'ui': 'src/ui/index.ts',
+          'ui-react': 'src/ui/react/index.ts',
           'types': 'src/types.ts',
           'editor': '@core/Editor',
           'converter': '@core/super-converter/SuperConverter',

--- a/packages/super-editor/vite.config.js
+++ b/packages/super-editor/vite.config.js
@@ -113,6 +113,17 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         external: [
           'react',
+          // Externalize the JSX runtime so the ui-react entry (the
+          // only TSX in this build) does not inline React 19's
+          // jsx-runtime bytes. The published `superdoc/ui/react`
+          // bundle resolves @superdoc/super-editor from source via
+          // aliases, so end users hit superdoc's externalization,
+          // not this dist directly. Externalizing here keeps the
+          // intermediate bundle compatible if it's ever consumed
+          // through pnpm-link / examples that use the dist path,
+          // which would otherwise feed React-17/18 hosts a runtime
+          // their renderer can't read.
+          'react/jsx-runtime',
           'vue',
           'yjs',
           'y-protocols',

--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -81,6 +81,9 @@
       "ui": [
         "./dist/superdoc/src/ui.d.ts"
       ],
+      "ui/react": [
+        "./dist/superdoc/src/ui-react.d.ts"
+      ],
       "headless-toolbar/react": [
         "./dist/superdoc/src/headless-toolbar-react.d.ts"
       ],

--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -52,6 +52,11 @@
       "source": "./src/ui.js",
       "import": "./dist/ui.es.js"
     },
+    "./ui/react": {
+      "types": "./dist/superdoc/src/ui-react.d.ts",
+      "source": "./src/ui-react.js",
+      "import": "./dist/ui-react.es.js"
+    },
     "./headless-toolbar/react": {
       "types": "./dist/superdoc/src/headless-toolbar-react.d.ts",
       "source": "./src/headless-toolbar-react.js",

--- a/packages/superdoc/src/ui-react.d.ts
+++ b/packages/superdoc/src/ui-react.d.ts
@@ -1,0 +1,13 @@
+export {
+  SuperDocUIProvider,
+  useSuperDocUI,
+  useSuperDocHost,
+  useSetSuperDoc,
+  useSuperDocSlice,
+  useSuperDocSelection,
+  useSuperDocComments,
+  useSuperDocReview,
+  useSuperDocToolbar,
+  useSuperDocCommand,
+  type SuperDocHost,
+} from '@superdoc/super-editor/ui/react';

--- a/packages/superdoc/src/ui-react.js
+++ b/packages/superdoc/src/ui-react.js
@@ -1,0 +1,19 @@
+/**
+ * Public sub-entry: `superdoc/ui/react`
+ *
+ * Official React bindings for the `createSuperDocUI` controller —
+ * provider, lifecycle-correct context, and typed subscription helper
+ * plus per-domain hooks. See `packages/super-editor/src/ui/react/`.
+ */
+export {
+  SuperDocUIProvider,
+  useSuperDocUI,
+  useSuperDocHost,
+  useSetSuperDoc,
+  useSuperDocSlice,
+  useSuperDocSelection,
+  useSuperDocComments,
+  useSuperDocReview,
+  useSuperDocToolbar,
+  useSuperDocCommand,
+} from '@superdoc/super-editor/ui/react';

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -85,6 +85,10 @@ export const getAliases = (_isDev) => {
     { find: '@superdoc/super-editor/headless-toolbar/react', replacement: path.resolve(__dirname, '../super-editor/src/headless-toolbar/react.ts') },
     { find: '@superdoc/super-editor/headless-toolbar/vue', replacement: path.resolve(__dirname, '../super-editor/src/headless-toolbar/vue.ts') },
     { find: '@superdoc/super-editor/presentation-editor', replacement: path.resolve(__dirname, '../super-editor/src/index.ts') },
+    // The longer `/ui/react` alias must come before `/ui` so the
+    // prefix match resolves it first; otherwise `/ui` would swallow
+    // `/ui/react` and the React entry would resolve to the controller.
+    { find: '@superdoc/super-editor/ui/react', replacement: path.resolve(__dirname, '../super-editor/src/ui/react/index.ts') },
     { find: '@superdoc/super-editor/ui', replacement: path.resolve(__dirname, '../super-editor/src/ui/index.ts') },
     { find: '@superdoc/super-editor', replacement: path.resolve(__dirname, '../super-editor/src/index.ts') },
 
@@ -205,6 +209,7 @@ export default defineConfig(({ mode, command }) => {
           'headless-toolbar-react': 'src/headless-toolbar-react.js',
           'headless-toolbar-vue': 'src/headless-toolbar-vue.js',
           'ui': 'src/ui.js',
+          'ui-react': 'src/ui-react.js',
           'super-editor': 'src/super-editor.js',
           'types': 'src/types.ts',
           'super-editor/docx-zipper': '@core/DocxZipper',
@@ -219,6 +224,7 @@ export default defineConfig(({ mode, command }) => {
           'pdfjs-dist/legacy/build/pdf.mjs',
           'pdfjs-dist/web/pdf_viewer.mjs',
           'react',
+          'react/jsx-runtime',
           'vue',
         ],
         output: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2396,7 +2396,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/esign:
     devDependencies:
@@ -2964,12 +2964,18 @@ importers:
       '@floating-ui/dom':
         specifier: 'catalog:'
         version: 1.7.6
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/mdast':
         specifier: 'catalog:'
         version: 4.0.4
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-vue':
         specifier: 'catalog:'
         version: 6.0.2(rolldown-vite@7.3.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
@@ -2994,6 +3000,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.4
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.4(react@19.2.4)
       tippy.js:
         specifier: 'catalog:'
         version: 6.3.7
@@ -6461,6 +6470,7 @@ packages:
   '@microsoft/teamsapp-cli@3.0.2':
     resolution: {integrity: sha512-AowuJwrrUxeF9Bq/frxuy9YZjK/ECk3pi0UBXl3CQLZ4XNWfgWatiFi/UWpyHDLccFs+0Za3nNYATFvgsxEFwQ==}
     engines: {node: '>=12'}
+    deprecated: This package is deprecated and supported Node.js version is 18-22. Please use @microsoft/m365agentstoolkit-cli instead.
     hasBin: true
 
   '@microsoft/teamsfx-api@0.23.1':


### PR DESCRIPTION
**Stacked on PR #3010 (SD-2812).** Will rebase to main once #3010 merges.

The build-your-own-ui example (PR #3008) had to write four pieces of glue from scratch: a context provider that creates one controller per app, a hook to read it, a hook that subscribes a component to a slice of controller state, and the unmount lifecycle that destroys the controller. The unmount in particular has a stale-closure bug — `useEffect(() => () => ui?.destroy(), [])` captures the initial null and silently leaks subscriptions. Every React consumer would re-discover the same patterns and ship their own provider, often with that bug.

This PR ships the bindings officially:

```tsx
import {
  SuperDocUIProvider,
  useSuperDocUI,
  useSuperDocHost,
  useSetSuperDoc,
  useSuperDocSlice,
  useSuperDocSelection,
  useSuperDocComments,
  useSuperDocReview,
  useSuperDocToolbar,
  useSuperDocCommand,
} from 'superdoc/ui/react';
```

**What ships**
- `<SuperDocUIProvider>` — context provider with ref-tracked unmount cleanup, replaces the prior controller cleanly when re-`setSuperDoc` fires
- Core hooks: `useSuperDocUI` / `useSuperDocHost` / `useSetSuperDoc` / `useSuperDocSlice`
- Domain sugar: `useSuperDocSelection` / `useSuperDocComments` / `useSuperDocReview` / `useSuperDocToolbar` / `useSuperDocCommand`

**Plumbing**
- New `./ui/react` exports entry on `@superdoc/super-editor`
- Vite build input emits `dist/ui-react.es.js`
- Public `superdoc/ui/react` sub-entry with Vite alias ordered before `/ui` so longer paths win
- `react` + `react/jsx-runtime` externalized in rollup
- `"jsx": "react-jsx"` in super-editor's tsconfig
- `@testing-library/react`, `react-dom`, `@types/react-dom` added as devDeps

**Verified**
- `pnpm --filter @superdoc/super-editor run test:ui` → 114 pass (104 prior + 10 new)
- `pnpm exec tsc -b tsconfig.references.json` → clean
- `pnpm --filter superdoc run build:es` → emits `dist/ui-react.es.js`, bundle audit clean

Closes SD-2813.