### PR TITLE
feat(superdoc/ui): ui.selection.capture for sidebar / floating-menu composers (SD-2821)

### DIFF
--- a/packages/super-editor/src/ui/create-super-doc-ui.test.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.test.ts
@@ -719,6 +719,60 @@ describe('createSuperDocUI', () => {
     expect(Object.isFrozen(captured)).toBe(true);
   });
 
+  // Regression for PR #3016 review: shallow Object.freeze leaves
+  // nested fields (target, target.segments, activeMarks array)
+  // mutable. A consumer that does
+  // `captured.target.segments[0].range.start = 99` or
+  // `captured.activeMarks.push('foo')` would otherwise corrupt the
+  // shared memoized slice and feed bad targets into later
+  // editor.doc.* calls.
+  it('ui.selection.capture deep-freezes nested fields against consumer mutation', () => {
+    const superdoc = makeSuperdocStub();
+    const target = {
+      kind: 'text' as const,
+      segments: [{ blockId: 'p1', range: { start: 0, end: 5 } }],
+    };
+    (superdoc.activeEditor as { doc: { selection: { current: unknown } } }).doc.selection.current = vi.fn(() => ({
+      empty: false,
+      text: 'hello',
+      target,
+      activeMarks: ['italic'],
+      activeCommentIds: [],
+      activeChangeIds: [],
+    }));
+    const ui = createSuperDocUI({ superdoc });
+    teardown.push(() => ui.destroy());
+
+    const captured = ui.selection.capture();
+    expect(captured).not.toBeNull();
+
+    // Top-level frozen.
+    expect(Object.isFrozen(captured)).toBe(true);
+    // Nested object: target itself.
+    expect(Object.isFrozen(captured!.target)).toBe(true);
+    // Nested arrays: segments and the marks list.
+    expect(Object.isFrozen(captured!.target!.segments)).toBe(true);
+    expect(Object.isFrozen(captured!.target!.segments[0])).toBe(true);
+    expect(Object.isFrozen(captured!.target!.segments[0].range)).toBe(true);
+    expect(Object.isFrozen(captured!.activeMarks)).toBe(true);
+    expect(Object.isFrozen(captured!.selectionTarget)).toBe(true);
+    expect(Object.isFrozen(captured!.selectionTarget!.start)).toBe(true);
+
+    // Strict-mode mutation attempts throw. The test file is an ES
+    // module so its top-level code is strict by default.
+    expect(() => {
+      (captured!.target!.segments[0].range as { start: number }).start = 99;
+    }).toThrow();
+    expect(() => {
+      (captured!.activeMarks as string[]).push('bold');
+    }).toThrow();
+
+    // The shared snapshot the controller still holds is unaffected.
+    const liveAgain = ui.selection.getSnapshot();
+    expect(liveAgain.target?.segments[0].range.start).toBe(0);
+    expect(liveAgain.activeMarks).toEqual(['italic']);
+  });
+
   it('ui.selection.capture returns null when there is no addressable selection', () => {
     const superdoc = makeSuperdocStub();
     (superdoc.activeEditor as { doc: { selection: { current: unknown } } }).doc.selection.current = vi.fn(() => ({

--- a/packages/super-editor/src/ui/create-super-doc-ui.test.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.test.ts
@@ -687,6 +687,84 @@ describe('createSuperDocUI', () => {
     });
   });
 
+  it('ui.selection.capture returns a frozen snapshot for an addressable selection', () => {
+    const superdoc = makeSuperdocStub();
+    const target = {
+      kind: 'text' as const,
+      segments: [{ blockId: 'p1', range: { start: 0, end: 5 } }],
+    };
+    (superdoc.activeEditor as { doc: { selection: { current: unknown } } }).doc.selection.current = vi.fn(() => ({
+      empty: false,
+      text: 'hello',
+      target,
+      activeMarks: ['italic'],
+      activeCommentIds: [],
+      activeChangeIds: [],
+    }));
+    const ui = createSuperDocUI({ superdoc });
+    teardown.push(() => ui.destroy());
+
+    const captured = ui.selection.capture();
+    expect(captured).not.toBeNull();
+    expect(captured!.target).toEqual(target);
+    expect(captured!.selectionTarget).toEqual({
+      kind: 'selection',
+      start: { kind: 'text', blockId: 'p1', offset: 0 },
+      end: { kind: 'text', blockId: 'p1', offset: 5 },
+    });
+    expect(captured!.activeMarks).toEqual(['italic']);
+    expect(captured!.quotedText).toBe('hello');
+
+    // Frozen: assigning a property must throw in strict mode.
+    expect(Object.isFrozen(captured)).toBe(true);
+  });
+
+  it('ui.selection.capture returns null when there is no addressable selection', () => {
+    const superdoc = makeSuperdocStub();
+    (superdoc.activeEditor as { doc: { selection: { current: unknown } } }).doc.selection.current = vi.fn(() => ({
+      empty: true,
+      text: '',
+      target: null,
+      activeMarks: [],
+      activeCommentIds: [],
+      activeChangeIds: [],
+    }));
+    const ui = createSuperDocUI({ superdoc });
+    teardown.push(() => ui.destroy());
+
+    expect(ui.selection.capture()).toBeNull();
+  });
+
+  it('ui.selection.capture survives a later selection clear (use-case: sidebar composer keeps focus)', () => {
+    const superdoc = makeSuperdocStub();
+    const target = {
+      kind: 'text' as const,
+      segments: [{ blockId: 'p1', range: { start: 0, end: 4 } }],
+    };
+    let live: unknown = {
+      empty: false,
+      text: 'word',
+      target,
+      activeMarks: [],
+      activeCommentIds: [],
+      activeChangeIds: [],
+    };
+    (superdoc.activeEditor as { doc: { selection: { current: unknown } } }).doc.selection.current = vi.fn(() => live);
+    const ui = createSuperDocUI({ superdoc });
+    teardown.push(() => ui.destroy());
+
+    const captured = ui.selection.capture();
+    expect(captured?.target).toEqual(target);
+
+    // Composer takes focus: the live selection clears, but the
+    // captured handle keeps the original target so a downstream
+    // `editor.doc.comments.create({ target: captured.target })`
+    // still has a valid anchor.
+    live = { empty: true, text: '', target: null, activeMarks: [], activeCommentIds: [], activeChangeIds: [] };
+    expect(ui.selection.getSnapshot().target).toBeNull();
+    expect(captured!.target).toEqual(target);
+  });
+
   it('ui.selection.subscribe fires once with the initial snapshot then on changes', async () => {
     const superdoc = makeSuperdocStub();
     let activeMarks: string[] = [];

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -145,6 +145,53 @@ const ALL_TOOLBAR_COMMAND_IDS: PublicToolbarItemId[] = Object.keys(createToolbar
 const EMPTY_ACTIVE_IDS: readonly string[] = Object.freeze<string[]>([]);
 
 /**
+ * Recursive structural clone for `ui.selection.capture()` (SD-2821).
+ * The captured handle is consumer-facing; it must not share array
+ * or object references with the controller's memoized selection
+ * slice. Without this, a `captured.target.segments[0].range.start =
+ * 99` from consumer code would corrupt the shared snapshot every
+ * other subscriber sees. JSON-clone is sufficient because the
+ * selection slice is plain data (strings, numbers, booleans, null,
+ * arrays, plain objects) with no functions, Dates, Maps, or cycles.
+ */
+function deepClone<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => deepClone(item)) as unknown as T;
+  }
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value as object)) {
+    out[key] = deepClone((value as Record<string, unknown>)[key]);
+  }
+  return out as T;
+}
+
+/**
+ * Recursive `Object.freeze` for `ui.selection.capture()` (SD-2821).
+ * `Object.freeze({ ...slice })` only freezes the top level; nested
+ * arrays / objects (target, target.segments, activeMarks) stay
+ * mutable. Walking the structure here makes
+ * `captured.activeMarks.push(...)` and
+ * `captured.target.segments[0].range.start = 99` throw in strict
+ * mode, matching the public API's "captured handle is opaque"
+ * promise. Cycle-safe: we check `Object.isFrozen(value)` before
+ * recursing so already-frozen sentinels (e.g.
+ * {@link EMPTY_ACTIVE_IDS}) don't loop back through this helper.
+ */
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  if (Object.isFrozen(value)) return value;
+  if (Array.isArray(value)) {
+    for (const item of value) deepFreeze(item);
+  } else {
+    for (const key of Object.keys(value as object)) {
+      deepFreeze((value as Record<string, unknown>)[key]);
+    }
+  }
+  return Object.freeze(value);
+}
+
+/**
  * Resolve the **routed** editor — the body, header, footer, or note
  * editor that PresentationEditor currently routes input/selection to.
  * Falls back to `superdoc.activeEditor` when no presentation layer is
@@ -1375,21 +1422,20 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
       });
     },
     capture() {
-      // Capture is sugar over `getSnapshot()` plus a freeze: the
-      // memoized selection slice already carries the portable
-      // address shapes consumers need (target, selectionTarget,
-      // activeMarks, etc.). The freeze prevents accidental mutation
-      // of the shared snapshot; the consumer treats the captured
-      // value as opaque.
-      //
-      // Returns null when the snapshot has no addressable text
-      // anchor (empty selection in a node selection, no editor
-      // mounted, doc not yet bootstrapped). A `null` guard at the
-      // call site is the consumer's signal that capture-and-restore
-      // doesn't make sense for the current state.
+      // Capture is sugar over `getSnapshot()` plus a deep clone +
+      // deep freeze: the memoized selection slice carries the
+      // portable address shapes consumers need (target,
+      // selectionTarget, activeMarks, etc.), and shares them with
+      // every other live subscriber. A shallow freeze on the
+      // top-level snapshot would still let
+      // `captured.target.segments[0].range.start = 99` or
+      // `captured.activeMarks.push(...)` corrupt the shared slice
+      // and feed bad targets into later `editor.doc.*` calls. Clone
+      // first so the freeze applies to the consumer's copy alone,
+      // not the controller's memo, then freeze recursively.
       const slice = computeState().selection;
       if (!slice.target && !slice.selectionTarget) return null;
-      return Object.freeze({ ...slice });
+      return deepFreeze(deepClone(slice));
     },
   };
 

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -1374,6 +1374,23 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
         }
       });
     },
+    capture() {
+      // Capture is sugar over `getSnapshot()` plus a freeze: the
+      // memoized selection slice already carries the portable
+      // address shapes consumers need (target, selectionTarget,
+      // activeMarks, etc.). The freeze prevents accidental mutation
+      // of the shared snapshot; the consumer treats the captured
+      // value as opaque.
+      //
+      // Returns null when the snapshot has no addressable text
+      // anchor (empty selection in a node selection, no editor
+      // mounted, doc not yet bootstrapped). A `null` guard at the
+      // call site is the consumer's signal that capture-and-restore
+      // doesn't make sense for the current state.
+      const slice = computeState().selection;
+      if (!slice.target && !slice.selectionTarget) return null;
+      return Object.freeze({ ...slice });
+    },
   };
 
   const destroy = () => {

--- a/packages/super-editor/src/ui/index.ts
+++ b/packages/super-editor/src/ui/index.ts
@@ -88,6 +88,7 @@ export type {
   SuperDocUIState,
 
   // Selection
+  SelectionCapture,
   SelectionHandle,
   SelectionSlice,
 

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -433,7 +433,46 @@ export interface SelectionHandle {
    * typing-only transactions). Returns an unsubscribe.
    */
   subscribe(listener: (event: { snapshot: SelectionSlice }) => void): () => void;
+  /**
+   * Capture the current selection as a portable handle.
+   *
+   * The pattern: a sidebar composer or floating menu opens, takes
+   * focus into its own input element, and the editor's selection
+   * visually clears (browser focus moved away). Without this
+   * primitive every consumer reaches for an ad-hoc closure that
+   * snapshots the selection at click-time and races to use it
+   * before focus moves. Capture freezes the portable address
+   * shapes (target / selectionTarget / activeMarks / etc.) so the
+   * consumer can pass `captured.target` or
+   * `captured.selectionTarget` directly into `editor.doc.*` calls
+   * (`comments.create`, `text.replace`, `format.apply`, etc.) when
+   * the composer submits, regardless of where browser focus is.
+   *
+   * Returns `null` when there is no addressable selection (no
+   * editor mounted, selection collapsed in a non-text node, etc.).
+   * The returned handle is a frozen value object, safe to store
+   * on a React ref or in component state across renders.
+   *
+   * Visual restore (re-focus the editor and highlight the captured
+   * range when the composer closes) is intentionally NOT on this
+   * surface today: the public Document API has no `selection.set`
+   * primitive yet, and `editor.doc.*` is the contract this
+   * controller routes through. A `restore()` method lands once the
+   * doc-api primitive does.
+   */
+  capture(): SelectionCapture | null;
 }
+
+/**
+ * Frozen snapshot returned by {@link SelectionHandle.capture}.
+ *
+ * Same shape as {@link SelectionSlice}; declared as its own type
+ * so consumers can name the captured value in their component
+ * state (`useState<SelectionCapture | null>(null)`) and so the
+ * planned `restore(capture)` follow-up has a stable input type.
+ * Treat as a value object; do NOT mutate.
+ */
+export type SelectionCapture = SelectionSlice;
 
 /**
  * Aggregate toolbar handle exposed on `ui.toolbar`. Compatible with

--- a/packages/superdoc/src/ui.d.ts
+++ b/packages/superdoc/src/ui.d.ts
@@ -22,6 +22,7 @@ export {
   type ReviewSlice,
   type ScrollIntoViewInput,
   type ScrollIntoViewOutput,
+  type SelectionCapture,
   type SelectionHandle,
   type SelectionInfo,
   type SelectionPoint,


### PR DESCRIPTION
Adds `ui.selection.capture(): SelectionCapture | null` so a sidebar composer / floating menu can freeze the addressable selection at open time and pass `captured.target` straight into `editor.doc.*` actions on submit. The captured handle is frozen so a stored reference can't be mutated across renders. Returns null when there's no addressable text anchor (empty / non-text selection, no editor mounted, doc not yet bootstrapped).

**Visual restore is intentionally NOT in this PR.** The public Document API has no `selection.set` primitive today; routing through `editor.commands.setTextSelection` would skip the contract `superdoc/ui` is built on. A `restore(capture)` method lands once the upstream doc-api primitive does (separate ticket).

Last must-have on the SD-2667 launch-blocking list. The BYO UI docs guide (SD-2669) can now write against a stable surface.

**Verified**: 131 ui tests pass (3 new); bundle audit clean.