### PR TITLE
test(consumer-typecheck): pack-and-install + guarded public types probe (SD-2831)

### DIFF
--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -73,12 +73,17 @@ jobs:
       - name: Typecheck
         run: pnpm run type-check
 
-      - name: Consumer typecheck
+      - name: Consumer typecheck (matrix)
+        # The matrix script owns the published-package validation path:
+        # it packs superdoc, installs the tarball into the standalone
+        # fixture (`pnpm install --ignore-workspace`), then runs every
+        # scenario under its declared resolution mode and strictness
+        # settings. Replaces the pre-SD-2831 bare `tsc --noEmit` step
+        # so the new pack-and-install scenarios are actually exercised
+        # in CI, not just locally.
         run: |
-          cd packages/superdoc && pnpm pack --pack-destination .
-          cd ../../tests/consumer-typecheck
-          npm install ../../packages/superdoc/superdoc-*.tgz --no-save
-          npx tsc --noEmit
+          cd tests/consumer-typecheck
+          node typecheck-matrix.mjs
 
   unit-tests:
     needs: build

--- a/tests/consumer-typecheck/.gitignore
+++ b/tests/consumer-typecheck/.gitignore
@@ -1,0 +1,6 @@
+# Build artifact: written per-scenario by typecheck-matrix.mjs
+tsconfig.matrix.json
+
+# pnpm install --ignore-workspace generates this; the fixture's
+# package-lock.json is the committed lockfile of record.
+pnpm-lock.yaml

--- a/tests/consumer-typecheck/src/guarded-public-types.ts
+++ b/tests/consumer-typecheck/src/guarded-public-types.ts
@@ -1,0 +1,116 @@
+/**
+ * Consumer typecheck: guarded public types must not collapse to `any`.
+ *
+ * The published superdoc types currently route some surfaces (notably the
+ * Document API, layout contracts, and a few editor primitives) through
+ * private workspace packages that get aliased to `any` in the shim file
+ * shipped under `dist/_internal-shims.d.ts`. Customers see the consequences
+ * as `any`-typed values where they expect real types.
+ *
+ * This file is the regression net. It uses the `@ts-expect-error` trick:
+ * if the imported type is real, the assignment is an error and the directive
+ * suppresses it. If the type is `any`, the assignment passes and the
+ * directive itself becomes an unused-directive error (TS2578), failing the
+ * scenario.
+ *
+ * The list below is the "guarded public types" surface referenced by the
+ * package boundary RFC (SD-2829, deliverable 4).
+ *
+ * STATE: this scenario is currently INFORMATIONAL in the matrix. Most
+ * assertions are expected to fail today because the bundling/curated-emit
+ * work in SD-2830 has not landed yet. Once SD-2830 ships and the leaks are
+ * resolved, flip the matrix entry from `mustPass: false` to `mustPass: true`
+ * so further regressions break CI.
+ */
+
+import type {
+  // Document API surface (subset reachable from `superdoc` today;
+  // `DocumentApi`, `BlocksListResult`, `BookmarkInfo` are not yet
+  // exported from `superdoc` and are tracked separately under the RFC's
+  // Decision 2 -- they belong in `@superdoc-dev/document-api` once that
+  // package ships).
+  TextSegment,
+  ResolveRangeOutput,
+  // Selection / range primitives
+  SelectionApi,
+  SelectionInfo,
+  // Editor lifecycle / options
+  EditorOptions,
+  OpenOptions,
+  SaveOptions,
+  ExportOptions,
+  // Command surface
+  CommandProps,
+  EditorCommands,
+  ChainedCommand,
+  CanObject,
+  // Layout-facing types reachable from public surface
+  Layout,
+  LayoutPage,
+  FlowBlock,
+} from 'superdoc';
+
+// --------------------------------------------------------------------------
+// Document API surface
+// --------------------------------------------------------------------------
+
+// @ts-expect-error — TextSegment is an object, not assignable from string
+const _textSegment: TextSegment = 'not a segment';
+
+// @ts-expect-error — ResolveRangeOutput is an object, not assignable from number
+const _resolveRangeOutput: ResolveRangeOutput = 0;
+
+// --------------------------------------------------------------------------
+// Selection / range primitives
+// --------------------------------------------------------------------------
+
+// @ts-expect-error — SelectionApi has methods, not assignable from string
+const _selectionApi: SelectionApi = 'not a selection api';
+
+// @ts-expect-error — SelectionInfo is an object, not assignable from number
+const _selectionInfo: SelectionInfo = 0;
+
+// --------------------------------------------------------------------------
+// Editor lifecycle / options
+// --------------------------------------------------------------------------
+
+// @ts-expect-error — EditorOptions is an object, not assignable from string
+const _editorOptions: EditorOptions = 'not options';
+
+// @ts-expect-error — OpenOptions is an object, not assignable from boolean
+const _openOptions: OpenOptions = false;
+
+// @ts-expect-error — SaveOptions is an object, not assignable from number
+const _saveOptions: SaveOptions = 1;
+
+// @ts-expect-error — ExportOptions is an object, not assignable from string
+const _exportOptions: ExportOptions = 'not export options';
+
+// --------------------------------------------------------------------------
+// Command surface
+// --------------------------------------------------------------------------
+
+// @ts-expect-error — CommandProps is an object, not assignable from string
+const _commandProps: CommandProps = 'not command props';
+
+// @ts-expect-error — EditorCommands is a record of functions, not assignable from number
+const _editorCommands: EditorCommands = 7;
+
+// @ts-expect-error — ChainedCommand is a function/object, not assignable from boolean
+const _chainedCommand: ChainedCommand = false;
+
+// @ts-expect-error — CanObject is an object, not assignable from string
+const _canObject: CanObject = 'not a can object';
+
+// --------------------------------------------------------------------------
+// Layout-facing types reachable from public surface
+// --------------------------------------------------------------------------
+
+// @ts-expect-error — Layout is an object, not assignable from string
+const _layout: Layout = 'not a layout';
+
+// @ts-expect-error — LayoutPage is an object, not assignable from number
+const _layoutPage: LayoutPage = 0;
+
+// @ts-expect-error — FlowBlock is an object, not assignable from boolean
+const _flowBlock: FlowBlock = true;

--- a/tests/consumer-typecheck/src/informational/guarded-public-types.ts
+++ b/tests/consumer-typecheck/src/informational/guarded-public-types.ts
@@ -30,8 +30,9 @@ import type {
   // Document API surface (subset reachable from `superdoc` today;
   // `DocumentApi`, `BlocksListResult`, `BookmarkInfo` are not yet
   // exported from `superdoc` and are tracked separately under the RFC's
-  // Decision 2 -- they belong in `@superdoc-dev/document-api` once that
-  // package ships).
+  // Decision 2 -- once Document API is published as a real public package,
+  // those types come from there. The team picks between the fast-path name
+  // `@superdoc/document-api` and the taxonomy-clean `@superdoc-dev/document-api`).
   TextSegment,
   ResolveRangeOutput,
   // Selection / range primitives

--- a/tests/consumer-typecheck/src/informational/guarded-public-types.ts
+++ b/tests/consumer-typecheck/src/informational/guarded-public-types.ts
@@ -16,11 +16,14 @@
  * The list below is the "guarded public types" surface referenced by the
  * package boundary RFC (SD-2829, deliverable 4).
  *
- * STATE: this scenario is currently INFORMATIONAL in the matrix. Most
- * assertions are expected to fail today because the bundling/curated-emit
- * work in SD-2830 has not landed yet. Once SD-2830 ships and the leaks are
- * resolved, flip the matrix entry from `mustPass: false` to `mustPass: true`
- * so further regressions break CI.
+ * STATE: this file lives under `src/informational/` and is excluded from
+ * the base `tsconfig.json` so a bare `tsc --noEmit` does not compile it.
+ * It is reached only through the matrix, which compiles it with a per-
+ * scenario tsconfig under `mustPass: false`. Most assertions are expected
+ * to fail today because the bundling / curated-emit work in SD-2830 has
+ * not landed yet. Once SD-2830 ships and the leaks are resolved, flip the
+ * matrix entry from `mustPass: false` to `mustPass: true` and consider
+ * moving this file out of `informational/` so it joins the required set.
  */
 
 import type {

--- a/tests/consumer-typecheck/tsconfig.json
+++ b/tests/consumer-typecheck/tsconfig.json
@@ -9,5 +9,6 @@
     "noEmit": true,
     "esModuleInterop": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/informational/**"]
 }

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -8,16 +8,60 @@
  *   - strict: true and false
  *   - Import paths: "superdoc", "superdoc/super-editor"
  *   - Node.js headless usage (Buffer return types)
+ *   - Guarded public types must not collapse to `any` (SD-2831)
+ *
+ * The fixture installs superdoc from the packed tarball at
+ * ../../packages/superdoc/superdoc.tgz, so the matrix tests the
+ * customer-visible surface, not the source repo.
  *
  * Run: npm run typecheck:matrix
+ *
+ * By default, the matrix re-packs superdoc and reinstalls the fixture so
+ * results reflect the current source. Pass --skip-pack to use whatever
+ * tarball is already installed (faster local iteration; risky in CI).
  */
 
 import { execSync } from 'child_process';
-import { writeFileSync, mkdirSync } from 'fs';
+import { writeFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..');
+
+const skipPack = process.argv.includes('--skip-pack');
+
+if (!skipPack) {
+  console.log('Packing superdoc and reinstalling fixture...');
+  const tarballPath = join(repoRoot, 'packages', 'superdoc', 'superdoc.tgz');
+  try {
+    execSync('pnpm --filter superdoc run pack:es', {
+      cwd: repoRoot,
+      stdio: 'inherit',
+    });
+  } catch (e) {
+    console.error('Failed to pack superdoc. Run with --skip-pack to use the existing tarball.');
+    process.exit(1);
+  }
+  if (!existsSync(tarballPath)) {
+    console.error(`Expected tarball at ${tarballPath} but it is missing.`);
+    process.exit(1);
+  }
+  // The fixture is intentionally outside the pnpm workspace so it exercises
+  // the published tarball's contract, not workspace symlinks. Running plain
+  // `pnpm install` here would walk up to the workspace root; --ignore-workspace
+  // forces a standalone install so node_modules lands inside the fixture.
+  try {
+    execSync('pnpm install --ignore-workspace --no-frozen-lockfile --silent', {
+      cwd: __dirname,
+      stdio: 'inherit',
+    });
+  } catch (e) {
+    console.error('Failed to install fixture from tarball.');
+    process.exit(1);
+  }
+  console.log('Fresh tarball installed.\n');
+}
 
 const scenarios = [
   // Core scenarios — must all pass
@@ -140,6 +184,28 @@ const scenarios = [
     files: ['src/imports-main.ts'],
     mustPass: false, // may fail from dep errors in node_modules
   },
+  // SD-2831: guarded public types must not collapse to `any`.
+  // INFORMATIONAL today — most assertions fail until SD-2830 (bundling /
+  // curated emit) lands. Flip mustPass to true once the leak class is fixed
+  // so future regressions break CI.
+  {
+    name: 'bundler / guarded public types not any (SD-2831)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: true,
+    strict: true,
+    files: ['src/guarded-public-types.ts'],
+    mustPass: false,
+  },
+  {
+    name: 'node16 / guarded public types not any (SD-2831)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: true,
+    strict: true,
+    files: ['src/guarded-public-types.ts'],
+    mustPass: false,
+  },
 ];
 
 const tscPath = join(__dirname, 'node_modules', '.bin', 'tsc');
@@ -194,21 +260,26 @@ for (const scenario of scenarios) {
     icon = '⚠';
     status = `DEPS (nm:${nmErrors})`;
     warnings++;
+  } else if (!scenario.mustPass) {
+    // Scenario is informational. Src-level errors are the regression target,
+    // not a CI failure today; report as a warning so the matrix can run green
+    // until the implementation work flips the scenario to mustPass: true.
+    icon = '⚠';
+    status = `INFO (src:${srcErrors} nm:${nmErrors})`;
+    warnings++;
   } else {
     icon = '✗';
     status = `FAIL (src:${srcErrors} nm:${nmErrors})`;
     failed++;
-    if (scenario.mustPass) {
-      console.log(`  ${icon} ${scenario.name}: ${status}`);
-      console.log(
-        output
-          .split('\n')
-          .filter((l) => l.startsWith('src/'))
-          .map((l) => `    ${l}`)
-          .join('\n'),
-      );
-      continue;
-    }
+    console.log(`  ${icon} ${scenario.name}: ${status}`);
+    console.log(
+      output
+        .split('\n')
+        .filter((l) => l.startsWith('src/'))
+        .map((l) => `    ${l}`)
+        .join('\n'),
+    );
+    continue;
   }
 
   console.log(`  ${icon} ${scenario.name}: ${status}`);

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -194,7 +194,7 @@ const scenarios = [
     moduleResolution: 'bundler',
     skipLibCheck: true,
     strict: true,
-    files: ['src/guarded-public-types.ts'],
+    files: ['src/informational/guarded-public-types.ts'],
     mustPass: false,
   },
   {
@@ -203,7 +203,7 @@ const scenarios = [
     moduleResolution: 'node16',
     skipLibCheck: true,
     strict: true,
-    files: ['src/guarded-public-types.ts'],
+    files: ['src/informational/guarded-public-types.ts'],
     mustPass: false,
   },
 ];


### PR DESCRIPTION
First cut of the consumer typecheck matrix as a real CI gate. Stacked on top of #3017 (SD-2829 RFC) so it rebases cleanly when that lands.

The fixture already installs superdoc from a packed tarball, but the matrix relied on the operator remembering to pack first. The matrix now packs superdoc and reinstalls the fixture before running, with a `--skip-pack` flag for fast local iteration. `pnpm install --ignore-workspace` is required so the fixture installs standalone instead of walking up to the workspace root.

Adds an informational scenario that imports a guarded list of public types and asserts they are not `any`, using the `@ts-expect-error` trick the existing prosemirror-coexistence test already uses. Today nine of fifteen probed types collapse to `any`; the scenario stays `mustPass: false` until the recommended D2 fix lands (publish Document API; tracked under SD-2830 with the parked D1 alternative). At that point this scenario flips to required so future regressions break CI.

Three Document API types (`DocumentApi`, `BlocksListResult`, `BookmarkInfo`) are not exported from `superdoc` at all today and are intentionally left out of this probe. Their visibility depends on the RFC's Decision 2: the team picks between the fast path (publish as `@superdoc/document-api`) and the taxonomy-clean rename (`@superdoc-dev/document-api`). Once Document API is published under either name, the probe expands to cover those types.

The matrix script now treats `mustPass: false` consistently across deps-only and src-error failures, so informational scenarios do not break CI while the underlying class of bugs is being fixed.

The probe lives under `tests/consumer-typecheck/src/informational/` and that subdirectory is excluded from the base tsconfig, so a bare `tsc --noEmit` (the default `typecheck` script) does not compile the probe under required rules. The matrix reaches it via per-scenario tsconfigs.

Local result on the SD-2831 worktree: 12 required scenarios pass, 3 informational warnings (the existing `skipLibCheck=false` plus the two new guarded-public-types scenarios).

Follow-up scope (separate PR): Angular fixture, Tiptap coexistence beyond the existing prosemirror file, Yjs coexistence, the flip from `mustPass: false` to `mustPass: true` once the D2 Document API delivery lands.