### PR TITLE
fix(super-editor/ui): cast TextTarget through unknown for story lookup

### DIFF
--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -479,7 +479,7 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     // doc-api `StoryLocator` shape: `body` carries no extra id;
     // `headerFooterSlot` discriminates by section + kind + variant;
     // `headerFooterPart` by `refId`; `footnote` / `endnote` by `noteId`.
-    const story = target ? (target as { story?: Record<string, unknown> }).story : undefined;
+    const story = target ? (target as unknown as { story?: Record<string, unknown> }).story : undefined;
     let storyKey = '';
     if (story) {
       const storyType = typeof story.storyType === 'string' ? story.storyType : '';


### PR DESCRIPTION
The release build's type-check fails with TS2352 because `TextTarget` doesn't sufficiently overlap with `{ story?: Record<string, unknown> }`. Casting through `unknown` first satisfies the compiler without changing runtime behavior.

Failing job: https://github.com/superdoc-dev/superdoc/actions/runs/25137297898/job/73678726322

**Verified**: `pnpm run type-check` → exit 0