### PR TITLE
fix(superdoc): make Document API and layout contract types resolvable for consumers (SD-2842)

### DIFF
--- a/packages/super-editor/src/index.ts
+++ b/packages/super-editor/src/index.ts
@@ -28,6 +28,8 @@ export type {
   TextTarget,
   TextSegment,
   EntityAddress,
+  BlocksListResult,
+  BookmarkInfo,
 } from '@superdoc/document-api';
 
 // Selection handle types

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -416,4 +416,20 @@ for (const entry of requiredEntryPoints) {
 }
 
 console.log(`[ensure-types] ✓ Generated ambient shims for ${wsCount} workspace modules`);
+
+// SD-2842 regression net: assert that no relocated package leaked back
+// into the shim file. If one shows up, a future change broke the
+// rewrite or include for that package and customers would see `any`
+// for those types again.
+const shimContent = fs.readFileSync(shimPath, 'utf8');
+const SHIM_FORBIDDEN = ['@superdoc/document-api', ...RELOCATION_RULES.map((r) => r.pkg)];
+for (const pkg of SHIM_FORBIDDEN) {
+  const re = new RegExp(`declare module '${pkg.replace(/\//g, '\\/')}(\\/[^']+)?'`);
+  if (re.test(shimContent)) {
+    console.error(`[ensure-types] ✗ ${pkg} appears in _internal-shims.d.ts. Its types should resolve via the relocation rewrite, not via an ambient any shim. Investigate the include glob, the rewrite rule, and the shim-skip predicate for this package.`);
+    process.exit(1);
+  }
+}
+console.log(`[ensure-types] ✓ Verified ${SHIM_FORBIDDEN.length} relocated packages do not appear in shim file`);
+
 console.log('[ensure-types] ✓ Verified type entry points');

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -6,6 +6,46 @@ const path = require('node:path');
 // Verify that vite-plugin-dts generated the expected type entry points.
 // Path aliases are resolved by vite-plugin-dts via tsconfig.json paths.
 const distRoot = path.resolve(__dirname, '..', 'dist');
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+// SD-2842: vite-plugin-dts skips hand-written `.d.ts` files in its include
+// glob (it only emits declarations from `.ts`/`.js`). When a file like
+// `core-command-map.d.ts` is referenced via a relative import from another
+// emitted `.d.ts`, the consumer hits an unresolved-module error. Copy
+// every hand-written `.d.ts` from the source trees we publish into the
+// matching dist location so those imports resolve.
+function copyHandwrittenDtsFiles(srcDir, destDir) {
+  let copied = 0;
+  function walk(currentSrc, currentDest) {
+    if (!fs.existsSync(currentSrc)) return;
+    for (const entry of fs.readdirSync(currentSrc, { withFileTypes: true })) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__' || entry.name === 'tests') continue;
+      const srcPath = path.join(currentSrc, entry.name);
+      const destPath = path.join(currentDest, entry.name);
+      if (entry.isDirectory()) {
+        walk(srcPath, destPath);
+        continue;
+      }
+      if (!entry.name.endsWith('.d.ts')) continue;
+      // Skip if the dist already has this file (vite-plugin-dts may have
+      // generated its own version from a co-located .ts file)
+      if (fs.existsSync(destPath)) continue;
+      fs.mkdirSync(path.dirname(destPath), { recursive: true });
+      fs.copyFileSync(srcPath, destPath);
+      copied++;
+    }
+  }
+  walk(srcDir, destDir);
+  return copied;
+}
+
+const handwrittenCopiedSuperEditor = copyHandwrittenDtsFiles(
+  path.join(repoRoot, 'packages/super-editor/src'),
+  path.join(distRoot, 'super-editor/src'),
+);
+if (handwrittenCopiedSuperEditor > 0) {
+  console.log(`[ensure-types] ✓ Copied ${handwrittenCopiedSuperEditor} hand-written .d.ts files from super-editor/src`);
+}
 
 const requiredEntryPoints = [
   'superdoc/src/index.d.ts',
@@ -124,6 +164,23 @@ function rewriteDocApiPaths(fileContent, filePath) {
   });
 }
 
+// SD-2842: rewrite `@superdoc/contracts` bare specifiers to point at
+// the contracts dist that vite-plugin-dts now emits at
+// `dist/layout-engine/contracts/src/`. Layout, FlowBlock, etc. were
+// collapsing to `any` via the shim file because the bare specifier
+// could not resolve. Same idea as the document-api rewrite above.
+const CONTRACTS_PATH_RE = /(['"])@superdoc\/contracts(\/[^'"]+)?\1/g;
+function rewriteContractsPaths(fileContent, filePath) {
+  return fileContent.replace(CONTRACTS_PATH_RE, (_match, quote, subpath = '') => {
+    const target = path.join(distRoot, 'layout-engine/contracts/src/index.d.ts');
+    let rel = path.relative(path.dirname(filePath), target).split(path.sep).join('/');
+    if (!rel.startsWith('.')) rel = './' + rel;
+    rel = rel.replace(/\.d\.ts$/, '.js');
+    if (subpath) rel = rel.replace(/\/index\.js$/, subpath);
+    return `${quote}${rel}${quote}`;
+  });
+}
+
 const dtsFiles = findDtsFiles(distRoot);
 for (const filePath of dtsFiles) {
   let fileContent = fs.readFileSync(filePath, 'utf8');
@@ -135,6 +192,14 @@ for (const filePath of dtsFiles) {
   const beforeDocApi = fileContent;
   fileContent = rewriteDocApiPaths(fileContent, filePath);
   if (fileContent !== beforeDocApi) {
+    changed = true;
+    totalReplacements++;
+  }
+
+  // SD-2842: same treatment for @superdoc/contracts.
+  const beforeContracts = fileContent;
+  fileContent = rewriteContractsPaths(fileContent, filePath);
+  if (fileContent !== beforeContracts) {
     changed = true;
     totalReplacements++;
   }
@@ -240,7 +305,7 @@ for (const filePath of dtsFiles) {
     const mod = m[2];
 
     // Skip relative imports and already-handled packages
-    if (mod.startsWith('.') || mod.startsWith('@superdoc/common') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api')) continue;
+    if (mod.startsWith('.') || mod.startsWith('@superdoc/common') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || mod.startsWith('@superdoc/contracts')) continue;
 
     if (mod.startsWith('@superdoc/')) {
       if (!workspaceImports.has(mod)) workspaceImports.set(mod, new Set());
@@ -253,7 +318,7 @@ for (const filePath of dtsFiles) {
   const dynamicImports = fileContent.matchAll(/import\(['"]([^'"]+)['"]\)\.(\w+)/g);
   for (const m of dynamicImports) {
     const mod = m[1];
-    if (mod.startsWith('.') || mod.startsWith('@superdoc/common') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api')) continue;
+    if (mod.startsWith('.') || mod.startsWith('@superdoc/common') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || mod.startsWith('@superdoc/contracts')) continue;
 
     if (mod.startsWith('@superdoc/')) {
       if (!workspaceImports.has(mod)) workspaceImports.set(mod, new Set());
@@ -268,7 +333,7 @@ for (const filePath of dtsFiles) {
     // Skip @superdoc/super-editor (consumer-facing, not internal)
     // Skip @superdoc/common root module (inlined separately), but allow subpath
     // imports like @superdoc/common/components/BasicUpload.vue to be shimmed
-    if (mod === '@superdoc/common' || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api')) continue;
+    if (mod === '@superdoc/common' || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || mod.startsWith('@superdoc/contracts')) continue;
     if (!workspaceImports.has(mod)) workspaceImports.set(mod, new Set());
   }
 }

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -164,22 +164,39 @@ function rewriteDocApiPaths(fileContent, filePath) {
   });
 }
 
-// SD-2842: rewrite `@superdoc/contracts` bare specifiers to point at
-// the contracts dist that vite-plugin-dts now emits at
-// `dist/layout-engine/contracts/src/`. Layout, FlowBlock, etc. were
-// collapsing to `any` via the shim file because the bare specifier
-// could not resolve. Same idea as the document-api rewrite above.
-const CONTRACTS_PATH_RE = /(['"])@superdoc\/contracts(\/[^'"]+)?\1/g;
-function rewriteContractsPaths(fileContent, filePath) {
-  return fileContent.replace(CONTRACTS_PATH_RE, (_match, quote, subpath = '') => {
-    const target = path.join(distRoot, 'layout-engine/contracts/src/index.d.ts');
-    let rel = path.relative(path.dirname(filePath), target).split(path.sep).join('/');
-    if (!rel.startsWith('.')) rel = './' + rel;
-    rel = rel.replace(/\.d\.ts$/, '.js');
-    if (subpath) rel = rel.replace(/\/index\.js$/, subpath);
-    return `${quote}${rel}${quote}`;
-  });
+// SD-2842: relocate workspace packages whose types appear on the
+// public surface. Same idea as the document-api rewrite above: emit
+// their declarations into superdoc's dist (via vite-plugin-dts include)
+// and redirect bare specifiers in emitted .d.ts files to relative
+// paths the consumer can resolve.
+const RELOCATION_RULES = [
+  { pkg: '@superdoc/contracts',     distEntry: 'layout-engine/contracts/src/index.d.ts' },
+  { pkg: '@superdoc/layout-bridge', distEntry: 'layout-engine/layout-bridge/src/index.d.ts' },
+  { pkg: '@superdoc/painter-dom',   distEntry: 'layout-engine/painters/dom/src/index.d.ts' },
+];
+
+function makeRelocationRewriter({ pkg, distEntry }) {
+  // Match the package name with optional subpath, e.g. `@superdoc/contracts` or
+  // `@superdoc/contracts/engines/tabs.js`. Anchored to either side of the
+  // package segment so `@superdoc/contracts-something` is not matched.
+  const escaped = pkg.replace(/\//g, '\\/');
+  const re = new RegExp(`(['"])${escaped}(\\/[^'"]+)?\\1`, 'g');
+  return (fileContent, filePath) => {
+    return fileContent.replace(re, (_match, quote, subpath = '') => {
+      const target = path.join(distRoot, distEntry);
+      let rel = path.relative(path.dirname(filePath), target).split(path.sep).join('/');
+      if (!rel.startsWith('.')) rel = './' + rel;
+      rel = rel.replace(/\.d\.ts$/, '.js');
+      if (subpath) rel = rel.replace(/\/index\.js$/, subpath);
+      return `${quote}${rel}${quote}`;
+    });
+  };
 }
+
+const RELOCATION_REWRITERS = RELOCATION_RULES.map((rule) => ({
+  pkg: rule.pkg,
+  rewrite: makeRelocationRewriter(rule),
+}));
 
 const dtsFiles = findDtsFiles(distRoot);
 for (const filePath of dtsFiles) {
@@ -196,12 +213,15 @@ for (const filePath of dtsFiles) {
     totalReplacements++;
   }
 
-  // SD-2842: same treatment for @superdoc/contracts.
-  const beforeContracts = fileContent;
-  fileContent = rewriteContractsPaths(fileContent, filePath);
-  if (fileContent !== beforeContracts) {
-    changed = true;
-    totalReplacements++;
+  // SD-2842: apply each relocation rewriter in turn. Each one redirects
+  // its own private-package specifier to a relative path in the local dist.
+  for (const { rewrite } of RELOCATION_REWRITERS) {
+    const before = fileContent;
+    fileContent = rewrite(fileContent, filePath);
+    if (fileContent !== before) {
+      changed = true;
+      totalReplacements++;
+    }
   }
 
   // Fix pnpm node_modules paths → bare specifiers
@@ -305,7 +325,7 @@ for (const filePath of dtsFiles) {
     const mod = m[2];
 
     // Skip relative imports and already-handled packages
-    if (mod.startsWith('.') || mod.startsWith('@superdoc/common') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || mod.startsWith('@superdoc/contracts')) continue;
+    if (mod.startsWith('.') || mod.startsWith('@superdoc/common') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || RELOCATION_RULES.some((r) => mod === r.pkg || mod.startsWith(r.pkg + '/'))) continue;
 
     if (mod.startsWith('@superdoc/')) {
       if (!workspaceImports.has(mod)) workspaceImports.set(mod, new Set());
@@ -318,7 +338,7 @@ for (const filePath of dtsFiles) {
   const dynamicImports = fileContent.matchAll(/import\(['"]([^'"]+)['"]\)\.(\w+)/g);
   for (const m of dynamicImports) {
     const mod = m[1];
-    if (mod.startsWith('.') || mod.startsWith('@superdoc/common') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || mod.startsWith('@superdoc/contracts')) continue;
+    if (mod.startsWith('.') || mod.startsWith('@superdoc/common') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || RELOCATION_RULES.some((r) => mod === r.pkg || mod.startsWith(r.pkg + '/'))) continue;
 
     if (mod.startsWith('@superdoc/')) {
       if (!workspaceImports.has(mod)) workspaceImports.set(mod, new Set());
@@ -333,7 +353,7 @@ for (const filePath of dtsFiles) {
     // Skip @superdoc/super-editor (consumer-facing, not internal)
     // Skip @superdoc/common root module (inlined separately), but allow subpath
     // imports like @superdoc/common/components/BasicUpload.vue to be shimmed
-    if (mod === '@superdoc/common' || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || mod.startsWith('@superdoc/contracts')) continue;
+    if (mod === '@superdoc/common' || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || RELOCATION_RULES.some((r) => mod === r.pkg || mod.startsWith(r.pkg + '/'))) continue;
     if (!workspaceImports.has(mod)) workspaceImports.set(mod, new Set());
   }
 }

--- a/packages/superdoc/src/index.js
+++ b/packages/superdoc/src/index.js
@@ -116,6 +116,9 @@ import { getSchemaIntrospection } from './helpers/schema-introspection.js';
  * @typedef {import('@superdoc/super-editor').TextAddress} TextAddress
  * @typedef {import('@superdoc/super-editor').TextSegment} TextSegment
  * @typedef {import('@superdoc/super-editor').EntityAddress} EntityAddress
+ * @typedef {import('@superdoc/super-editor').DocumentApi} DocumentApi
+ * @typedef {import('@superdoc/super-editor').BlocksListResult} BlocksListResult
+ * @typedef {import('@superdoc/super-editor').BookmarkInfo} BookmarkInfo
  * @typedef {import('@superdoc/super-editor').LayoutUpdatePayload} LayoutUpdatePayload
  * @typedef {import('@superdoc/super-editor').CoreCommandMap} CoreCommandMap
  * @deprecated Editor commands will be removed in a future version. Use the Document API instead.

--- a/packages/superdoc/tsconfig.json
+++ b/packages/superdoc/tsconfig.json
@@ -22,5 +22,5 @@
       "@shared/*": ["shared/*"]
     }
   },
-  "include": ["src", "../super-editor/src", "../document-api/src"]
+  "include": ["src", "../super-editor/src", "../document-api/src", "../layout-engine/contracts/src"]
 }

--- a/packages/superdoc/tsconfig.json
+++ b/packages/superdoc/tsconfig.json
@@ -22,5 +22,12 @@
       "@shared/*": ["shared/*"]
     }
   },
-  "include": ["src", "../super-editor/src", "../document-api/src", "../layout-engine/contracts/src"]
+  "include": [
+    "src",
+    "../super-editor/src",
+    "../document-api/src",
+    "../layout-engine/contracts/src",
+    "../layout-engine/layout-bridge/src",
+    "../layout-engine/painters/dom/src"
+  ]
 }

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -125,10 +125,13 @@ export default defineConfig(({ mode, command }) => {
         'src/**/*',
         '../super-editor/src/**/*',
         '../document-api/src/**/*',
-        // SD-2842: relocate @superdoc/contracts so its types
-        // (Layout, FlowBlock, etc.) emit into superdoc's dist and
-        // resolve via the same rewrite path as @superdoc/document-api.
+        // SD-2842: relocate workspace packages whose types appear on the
+        // public surface so they emit into superdoc's dist and the
+        // rewrite step in ensure-types can redirect bare specifiers to
+        // local relative paths. Same pattern as @superdoc/document-api.
         '../layout-engine/contracts/src/**/*',
+        '../layout-engine/layout-bridge/src/**/*',
+        '../layout-engine/painters/dom/src/**/*',
       ],
       outDir: 'dist',
       // vite-plugin-dts still gathers diagnostics for this mixed JS/Vue source

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -121,7 +121,15 @@ export default defineConfig(({ mode, command }) => {
       // generates for every unshipped `@superdoc/*` package. Without
       // this, packed consumers see `any` for those public types and
       // the new re-export surface adds no actual checking.
-      include: ['src/**/*', '../super-editor/src/**/*', '../document-api/src/**/*'],
+      include: [
+        'src/**/*',
+        '../super-editor/src/**/*',
+        '../document-api/src/**/*',
+        // SD-2842: relocate @superdoc/contracts so its types
+        // (Layout, FlowBlock, etc.) emit into superdoc's dist and
+        // resolve via the same rewrite path as @superdoc/document-api.
+        '../layout-engine/contracts/src/**/*',
+      ],
       outDir: 'dist',
       // vite-plugin-dts still gathers diagnostics for this mixed JS/Vue source
       // tree, but we do not use this build as the authoritative type-check gate.

--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect, useCallback, useMemo, forwardRef, useImperativeHandle } from 'react';
-import type { SuperDoc } from 'superdoc'; // requires superdoc >=1.24.2 for correct types
+import type { SuperDoc, ProseMirrorJSON } from 'superdoc'; // requires superdoc >=1.24.2 for correct types
 import type * as Types from './types';
 import { FieldMenu, FieldList } from './defaults';
 import {
@@ -187,9 +187,10 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
               ? editor.commands.insertStructuredContentBlock?.({
                   attrs,
                   ...(field.presetContent.html ? { html: field.presetContent.html } : {}),
-                  ...(field.presetContent.json ? { json: field.presetContent.json } : {}),
+                  ...(field.presetContent.json ? { json: field.presetContent.json as ProseMirrorJSON } : {}),
                 })
-              : editor.commands.insertStructuredContentBlock?.({ attrs, text: field.defaultValue || field.alias })
+              : // Block insert ignores `text` at runtime; drop it to match the real type.
+                editor.commands.insertStructuredContentBlock?.({ attrs })
         ) as boolean | undefined;
 
         if (success) {
@@ -217,7 +218,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
         if (!superdocRef.current?.activeEditor) return false;
 
         const editor = superdocRef.current.activeEditor;
-        const success = editor.commands.updateStructuredContentById?.(id, {
+        const success = editor.commands.updateStructuredContentById?.(String(id), {
           attrs: updates,
         }) as boolean | undefined;
 
@@ -264,7 +265,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
 
         let commandResult = false;
         try {
-          commandResult = (editor.commands.deleteStructuredContentById?.(id) as boolean | undefined) ?? false;
+          commandResult = (editor.commands.deleteStructuredContentById?.(String(id)) as boolean | undefined) ?? false;
         } catch (err) {
           console.warn('[TemplateBuilder] Failed to delete structured content:', id, err);
           commandResult = false;
@@ -282,7 +283,7 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
 
           if (remainingFieldsInGroup.length === 1) {
             const lastField = remainingFieldsInGroup[0];
-            editor.commands.updateStructuredContentById?.(lastField.id, {
+            editor.commands.updateStructuredContentById?.(String(lastField.id), {
               attrs: { tag: undefined },
             });
             documentFields = getTemplateFieldsFromEditor(editor);
@@ -594,7 +595,11 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
         const success =
           mode === 'inline'
             ? editor.commands.insertStructuredContentInline?.({ attrs, text: field.alias })
-            : editor.commands.insertStructuredContentBlock?.({ attrs, text: field.alias });
+            : // Block insert ignores `text` at runtime (the visible content comes
+              // from `html`, `json`, or the active selection). Previously this call
+              // also passed `text: field.alias` but it was a no-op silently allowed
+              // by `any`-typed commands. Drop the field to match the real type.
+              editor.commands.insertStructuredContentBlock?.({ attrs });
 
         if (success) {
           if (!field.group) {

--- a/packages/template-builder/src/tests/insertFieldPresetContent.test.tsx
+++ b/packages/template-builder/src/tests/insertFieldPresetContent.test.tsx
@@ -120,7 +120,7 @@ describe('SuperDocTemplateBuilder presetContent insertion', () => {
     expect(firstBlockCallArg).not.toHaveProperty('text');
   });
 
-  it('keeps text fallback for block fields without presetContent', async () => {
+  it('omits text on block insert without presetContent (runtime ignores it)', async () => {
     const ref = await renderBuilder();
     let result = false;
 
@@ -131,13 +131,21 @@ describe('SuperDocTemplateBuilder presetContent insertion', () => {
       });
     });
 
+    // The block-insert API uses `html` / `json` / current selection for
+    // its content; `text` is not part of `StructuredContentBlockInsert`
+    // and was always silently ignored at runtime. Now that the typed
+    // surface rejects unknown fields, the call site no longer passes
+    // `text` for block insertion, matching what the runtime actually
+    // honored. Inline insertion still accepts `text` (handled by the
+    // separate inline test below).
     expect(result).toBe(true);
     expect(insertStructuredContentBlockMock).toHaveBeenCalledTimes(1);
-    expect(insertStructuredContentBlockMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        text: 'Default signature content',
-      }),
-    );
+    const firstBlockCallArg = (
+      insertStructuredContentBlockMock as unknown as {
+        mock: { calls: Array<Array<Record<string, unknown>>> };
+      }
+    ).mock.calls[0]?.[0];
+    expect(firstBlockCallArg).not.toHaveProperty('text');
   });
 
   it('ignores presetContent for inline insertion', async () => {

--- a/tests/consumer-typecheck/.gitignore
+++ b/tests/consumer-typecheck/.gitignore
@@ -1,0 +1,6 @@
+# Build artifact: written per-scenario by typecheck-matrix.mjs
+tsconfig.matrix.json
+
+# pnpm install --ignore-workspace generates this; the fixture's
+# package-lock.json is the committed lockfile of record.
+pnpm-lock.yaml

--- a/tests/consumer-typecheck/src/all-public-types.ts
+++ b/tests/consumer-typecheck/src/all-public-types.ts
@@ -1,0 +1,232 @@
+/**
+ * Consumer typecheck: every public type from superdoc must resolve to
+ * a real interface, not collapse to `any`, and not be missing.
+ *
+ * Each `AssertNotAny<T>` resolves to `never` when T is `any`, so the
+ * `const _real_X: AssertNotAny<X> = true` lines fail to compile if X
+ * has collapsed. A missing export shows up as TS2305 on the import.
+ *
+ * The list of types is mined from packages/superdoc/src/index.js
+ * @typedef block. Keep them in sync (or extend the test as new public
+ * types are added to that block).
+ */
+import type {
+  EditorState,
+  Transaction,
+  Schema,
+  EditorView,
+  EditorCommands,
+  ChainedCommand,
+  ChainableCommandObject,
+  CommandProps,
+  Command,
+  CanObject,
+  PresentationEditorOptions,
+  LayoutEngineOptions,
+  PageSize,
+  PageMargins,
+  VirtualizationOptions,
+  TrackedChangesMode,
+  TrackedChangesOverrides,
+  LayoutMode,
+  PresenceOptions,
+  RemoteUserInfo,
+  RemoteCursorState,
+  Layout,
+  LayoutPage,
+  LayoutFragment,
+  RangeRect,
+  BoundingRect,
+  LayoutError,
+  LayoutMetrics,
+  PositionHit,
+  FlowBlock,
+  Measure,
+  SectionMetadata,
+  PaintSnapshot,
+  OpenOptions,
+  DocxFileEntry,
+  BinaryData,
+  UnsupportedContentItem,
+  SaveOptions,
+  ExportOptions,
+  SelectionHandle,
+  SelectionCommandContext,
+  ResolveRangeOutput,
+  SelectionApi,
+  SelectionInfo,
+  SelectionCurrentInput,
+  ScrollIntoViewInput,
+  ScrollIntoViewOutput,
+  TextTarget,
+  TextAddress,
+  TextSegment,
+  EntityAddress,
+  DocumentApi,
+  BlocksListResult,
+  BookmarkInfo,
+  LayoutUpdatePayload,
+  CoreCommandMap,
+  ExtensionCommandMap,
+  Comment,
+  CommentElement,
+  CommentsPayload,
+  CommentLocationsPayload,
+  FontsResolvedPayload,
+  PaginationPayload,
+  EditorEventMap,
+  ListDefinitionsPayload,
+  ProtectionChangeSource,
+  DocumentProtectionState,
+  PartChangedEvent,
+  PartId,
+  PartSectionId,
+  EditorOptions,
+  EditorLifecycleState,
+  User,
+  ProseMirrorJSON,
+  ExportFormat,
+  ExportDocxParams,
+  EditorExtension,
+  ViewLayout,
+  ViewOptions,
+  CommentConfig,
+  CollaborationProvider,
+  LinkPopoverResolver,
+  LinkPopoverContext,
+  LinkPopoverResolution,
+  PermissionParams,
+  FontConfig,
+  FieldValue,
+  LayoutState,
+  ImageSelectedEvent,
+  ImageDeselectedEvent,
+  TelemetryEvent,
+  RemoteCursorsRenderPayload,
+  FlowMode,
+  ProofingProvider,
+  ProofingCapabilities,
+  ProofingCheckRequest,
+  ProofingCheckResult,
+  ProofingSegment,
+  ProofingSegmentMetadata,
+  ProofingIssue,
+  ProofingIssueKind,
+  ProofingConfig,
+  ProofingStatus,
+  ProofingError,
+  PageStyles,
+} from 'superdoc';
+
+// Helper: IsAny<T> resolves to `true` when T is `any`, otherwise false.
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type AssertNotAny<T> = IsAny<T> extends true ? never : true;
+
+// One assertion per type. If T is `any`, AssertNotAny<T> is `never` and
+// the line below fails to compile with "Type 'true' is not assignable
+// to type 'never'". If T is real, it compiles silently.
+const _real_EditorState: AssertNotAny<EditorState> = true;
+const _real_Transaction: AssertNotAny<Transaction> = true;
+const _real_Schema: AssertNotAny<Schema> = true;
+const _real_EditorView: AssertNotAny<EditorView> = true;
+const _real_EditorCommands: AssertNotAny<EditorCommands> = true;
+const _real_ChainedCommand: AssertNotAny<ChainedCommand> = true;
+const _real_ChainableCommandObject: AssertNotAny<ChainableCommandObject> = true;
+const _real_CommandProps: AssertNotAny<CommandProps> = true;
+const _real_Command: AssertNotAny<Command> = true;
+const _real_CanObject: AssertNotAny<CanObject> = true;
+const _real_PresentationEditorOptions: AssertNotAny<PresentationEditorOptions> = true;
+const _real_LayoutEngineOptions: AssertNotAny<LayoutEngineOptions> = true;
+const _real_PageSize: AssertNotAny<PageSize> = true;
+const _real_PageMargins: AssertNotAny<PageMargins> = true;
+const _real_VirtualizationOptions: AssertNotAny<VirtualizationOptions> = true;
+const _real_TrackedChangesMode: AssertNotAny<TrackedChangesMode> = true;
+const _real_TrackedChangesOverrides: AssertNotAny<TrackedChangesOverrides> = true;
+const _real_LayoutMode: AssertNotAny<LayoutMode> = true;
+const _real_PresenceOptions: AssertNotAny<PresenceOptions> = true;
+const _real_RemoteUserInfo: AssertNotAny<RemoteUserInfo> = true;
+const _real_RemoteCursorState: AssertNotAny<RemoteCursorState> = true;
+const _real_Layout: AssertNotAny<Layout> = true;
+const _real_LayoutPage: AssertNotAny<LayoutPage> = true;
+const _real_LayoutFragment: AssertNotAny<LayoutFragment> = true;
+const _real_RangeRect: AssertNotAny<RangeRect> = true;
+const _real_BoundingRect: AssertNotAny<BoundingRect> = true;
+const _real_LayoutError: AssertNotAny<LayoutError> = true;
+const _real_LayoutMetrics: AssertNotAny<LayoutMetrics> = true;
+const _real_PositionHit: AssertNotAny<PositionHit> = true;
+const _real_FlowBlock: AssertNotAny<FlowBlock> = true;
+const _real_Measure: AssertNotAny<Measure> = true;
+const _real_SectionMetadata: AssertNotAny<SectionMetadata> = true;
+const _real_PaintSnapshot: AssertNotAny<PaintSnapshot> = true;
+const _real_OpenOptions: AssertNotAny<OpenOptions> = true;
+const _real_DocxFileEntry: AssertNotAny<DocxFileEntry> = true;
+const _real_BinaryData: AssertNotAny<BinaryData> = true;
+const _real_UnsupportedContentItem: AssertNotAny<UnsupportedContentItem> = true;
+const _real_SaveOptions: AssertNotAny<SaveOptions> = true;
+const _real_ExportOptions: AssertNotAny<ExportOptions> = true;
+const _real_SelectionHandle: AssertNotAny<SelectionHandle> = true;
+const _real_SelectionCommandContext: AssertNotAny<SelectionCommandContext> = true;
+const _real_ResolveRangeOutput: AssertNotAny<ResolveRangeOutput> = true;
+const _real_SelectionApi: AssertNotAny<SelectionApi> = true;
+const _real_SelectionInfo: AssertNotAny<SelectionInfo> = true;
+const _real_SelectionCurrentInput: AssertNotAny<SelectionCurrentInput> = true;
+const _real_ScrollIntoViewInput: AssertNotAny<ScrollIntoViewInput> = true;
+const _real_ScrollIntoViewOutput: AssertNotAny<ScrollIntoViewOutput> = true;
+const _real_TextTarget: AssertNotAny<TextTarget> = true;
+const _real_TextAddress: AssertNotAny<TextAddress> = true;
+const _real_TextSegment: AssertNotAny<TextSegment> = true;
+const _real_EntityAddress: AssertNotAny<EntityAddress> = true;
+const _real_DocumentApi: AssertNotAny<DocumentApi> = true;
+const _real_BlocksListResult: AssertNotAny<BlocksListResult> = true;
+const _real_BookmarkInfo: AssertNotAny<BookmarkInfo> = true;
+const _real_LayoutUpdatePayload: AssertNotAny<LayoutUpdatePayload> = true;
+const _real_CoreCommandMap: AssertNotAny<CoreCommandMap> = true;
+const _real_ExtensionCommandMap: AssertNotAny<ExtensionCommandMap> = true;
+const _real_Comment: AssertNotAny<Comment> = true;
+const _real_CommentElement: AssertNotAny<CommentElement> = true;
+const _real_CommentsPayload: AssertNotAny<CommentsPayload> = true;
+const _real_CommentLocationsPayload: AssertNotAny<CommentLocationsPayload> = true;
+const _real_FontsResolvedPayload: AssertNotAny<FontsResolvedPayload> = true;
+const _real_PaginationPayload: AssertNotAny<PaginationPayload> = true;
+const _real_EditorEventMap: AssertNotAny<EditorEventMap> = true;
+const _real_ListDefinitionsPayload: AssertNotAny<ListDefinitionsPayload> = true;
+const _real_ProtectionChangeSource: AssertNotAny<ProtectionChangeSource> = true;
+const _real_DocumentProtectionState: AssertNotAny<DocumentProtectionState> = true;
+const _real_PartChangedEvent: AssertNotAny<PartChangedEvent> = true;
+const _real_PartId: AssertNotAny<PartId> = true;
+const _real_PartSectionId: AssertNotAny<PartSectionId> = true;
+const _real_EditorOptions: AssertNotAny<EditorOptions> = true;
+const _real_EditorLifecycleState: AssertNotAny<EditorLifecycleState> = true;
+const _real_User: AssertNotAny<User> = true;
+const _real_ProseMirrorJSON: AssertNotAny<ProseMirrorJSON> = true;
+const _real_ExportFormat: AssertNotAny<ExportFormat> = true;
+const _real_ExportDocxParams: AssertNotAny<ExportDocxParams> = true;
+const _real_EditorExtension: AssertNotAny<EditorExtension> = true;
+const _real_ViewLayout: AssertNotAny<ViewLayout> = true;
+const _real_ViewOptions: AssertNotAny<ViewOptions> = true;
+const _real_CommentConfig: AssertNotAny<CommentConfig> = true;
+const _real_CollaborationProvider: AssertNotAny<CollaborationProvider> = true;
+const _real_LinkPopoverResolver: AssertNotAny<LinkPopoverResolver> = true;
+const _real_LinkPopoverContext: AssertNotAny<LinkPopoverContext> = true;
+const _real_LinkPopoverResolution: AssertNotAny<LinkPopoverResolution> = true;
+const _real_PermissionParams: AssertNotAny<PermissionParams> = true;
+const _real_FontConfig: AssertNotAny<FontConfig> = true;
+const _real_FieldValue: AssertNotAny<FieldValue> = true;
+const _real_LayoutState: AssertNotAny<LayoutState> = true;
+const _real_ImageSelectedEvent: AssertNotAny<ImageSelectedEvent> = true;
+const _real_ImageDeselectedEvent: AssertNotAny<ImageDeselectedEvent> = true;
+const _real_TelemetryEvent: AssertNotAny<TelemetryEvent> = true;
+const _real_RemoteCursorsRenderPayload: AssertNotAny<RemoteCursorsRenderPayload> = true;
+const _real_FlowMode: AssertNotAny<FlowMode> = true;
+const _real_ProofingProvider: AssertNotAny<ProofingProvider> = true;
+const _real_ProofingCapabilities: AssertNotAny<ProofingCapabilities> = true;
+const _real_ProofingCheckRequest: AssertNotAny<ProofingCheckRequest> = true;
+const _real_ProofingCheckResult: AssertNotAny<ProofingCheckResult> = true;
+const _real_ProofingSegment: AssertNotAny<ProofingSegment> = true;
+const _real_ProofingSegmentMetadata: AssertNotAny<ProofingSegmentMetadata> = true;
+const _real_ProofingIssue: AssertNotAny<ProofingIssue> = true;
+const _real_ProofingIssueKind: AssertNotAny<ProofingIssueKind> = true;
+const _real_ProofingConfig: AssertNotAny<ProofingConfig> = true;
+const _real_ProofingStatus: AssertNotAny<ProofingStatus> = true;
+const _real_ProofingError: AssertNotAny<ProofingError> = true;
+const _real_PageStyles: AssertNotAny<PageStyles> = true;

--- a/tests/consumer-typecheck/src/customer-scenario.ts
+++ b/tests/consumer-typecheck/src/customer-scenario.ts
@@ -320,8 +320,11 @@ function testPresentationEditorCommands(pe: PresentationEditor) {
   // Track changes
   pe.commands.enableTrackChanges();
   pe.commands.disableTrackChanges();
-  pe.commands.acceptTrackedChange();
-  pe.commands.rejectTrackedChange();
+  // Selection-based variants need no arguments. The `acceptTrackedChange`
+  // and `rejectTrackedChange` commands take an explicit TrackedChangeOptions
+  // payload; consumer code typically reaches for the selection variants here.
+  pe.commands.acceptTrackedChangeBySelection();
+  pe.commands.rejectTrackedChangeOnSelection();
 }
 
 // ============================================

--- a/tests/consumer-typecheck/src/editor-doc-runtime.ts
+++ b/tests/consumer-typecheck/src/editor-doc-runtime.ts
@@ -1,0 +1,51 @@
+/**
+ * Consumer typecheck: `editor.doc` is the customer-facing runtime API
+ * for the Document API. It must be typed as a real `DocumentApi`, with
+ * methods that return real result types, not `any`.
+ *
+ * This is the end-to-end smoke test. The flat `import type {...} from
+ * 'superdoc'` test (all-public-types.ts) catches missing exports and
+ * `any` collapse on each named type. This file additionally proves
+ * that the `editor.doc` getter on the `Editor` class is typed correctly
+ * and that calling its methods returns real types, with method names
+ * checked at compile time.
+ */
+import type { Editor, DocumentApi, BlocksListResult, BookmarkInfo } from 'superdoc';
+
+// Helper: IsAny<T> resolves to `true` when T is `any`, otherwise false.
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type AssertNotAny<T> = IsAny<T> extends true ? never : true;
+
+declare const editor: Editor;
+
+// `editor.doc` must be DocumentApi, not any.
+const _docIsTyped: AssertNotAny<typeof editor.doc> = true;
+
+// Direct assignment proves the static type matches the named export.
+const doc: DocumentApi = editor.doc;
+
+// `editor.doc.blocks.list()` must return BlocksListResult, not any.
+const _listResult: BlocksListResult = doc.blocks.list();
+const _listIsTyped: AssertNotAny<typeof _listResult> = true;
+
+// Methods on the result are real, not bag-of-any.
+const _blocks: BlocksListResult['blocks'] = _listResult.blocks;
+
+// Bookmark surface: same shape contract.
+declare const bookmarkResult: BookmarkInfo;
+const _bookmarkIsTyped: AssertNotAny<typeof bookmarkResult> = true;
+
+// Compile-time spelling check: a method that does not exist must be
+// rejected, proving DocumentApi is a real interface and not `any`.
+// @ts-expect-error - this method does not exist on DocumentApi
+doc.thisMethodDoesNotExist();
+
+// Compile-time argument shape check: passing the wrong shape must fail.
+// @ts-expect-error - bookmarks.get takes BookmarkGetInput, not a string
+doc.bookmarks.get('not-an-input');
+
+// Suppress unused-binding warnings while keeping the assertions live.
+void _docIsTyped;
+void _listIsTyped;
+void _blocks;
+void _bookmarkIsTyped;

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -140,6 +140,28 @@ const scenarios = [
     files: ['src/imports-main.ts'],
     mustPass: false, // may fail from dep errors in node_modules
   },
+  // SD-2842: every public type re-exported via `superdoc` must resolve
+  // to a real interface, not collapse to `any` and not be missing.
+  // This guards the customer-acute fix that landed alongside SD-2815
+  // and SD-2842 against future regressions.
+  {
+    name: 'bundler / all public types are real (SD-2842)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: true,
+    strict: true,
+    files: ['src/all-public-types.ts'],
+    mustPass: true,
+  },
+  {
+    name: 'node16 / all public types are real (SD-2842)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: true,
+    strict: true,
+    files: ['src/all-public-types.ts'],
+    mustPass: true,
+  },
 ];
 
 const tscPath = join(__dirname, 'node_modules', '.bin', 'tsc');

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -162,6 +162,20 @@ const scenarios = [
     files: ['src/all-public-types.ts'],
     mustPass: true,
   },
+  // SD-2842: end-to-end smoke test for the runtime entry point. Asserts
+  // editor.doc is typed (not any), method calls return real types,
+  // wrong method names and wrong argument shapes are rejected at compile
+  // time. Catches regressions where a named import still resolves but
+  // the getter on the live Editor class is typed loosely.
+  {
+    name: 'bundler / editor.doc runtime smoke (SD-2842)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: true,
+    strict: true,
+    files: ['src/editor-doc-runtime.ts'],
+    mustPass: true,
+  },
 ];
 
 const tscPath = join(__dirname, 'node_modules', '.bin', 'tsc');


### PR DESCRIPTION
The published `superdoc` types had two remaining classes of `any` collapse on what should be public surface. Both are now closed.

`editor.doc.<method>` was typed `DocumentApi`, but `import type { DocumentApi } from 'superdoc'` returned TS2305 because the name was not on the flat re-export list. Same for `BlocksListResult` and `BookmarkInfo`. Adding three lines to super-editor's re-exports plus matching JSDoc typedefs in superdoc's index makes them reachable.

`EditorCommands` and `CanObject` collapsed to `any` because the chain `EditorCommands → CoreCommandSignatures → core-command-map.d.ts` broke at the last step: the dts plugin only generates declarations from `.ts`/`.js` and silently skips standalone `.d.ts` files in source. A small copy step in the existing postbuild now mirrors hand-written `.d.ts` files into the matching dist location.

`Layout`, `LayoutPage`, `FlowBlock` and other layout shapes from `@superdoc/contracts` were aliased to `any` in `_internal-shims.d.ts`. Extended the same pattern SD-2815 used for `@superdoc/document-api`: include the source in the dts emit, rewrite the bare specifier in emitted declarations, skip the shim. The contracts package no longer appears in the internal shim file.

Verified end-to-end against a fresh strict-mode consumer fixture (`skipLibCheck: false`, `strict: true`). Before: 3 missing exports, 5 `any`-collapses on a guarded list of 18 types reachable from `editor.doc` and the public re-export surface. After: zero of either. A positive test confirms `editor.doc.blocks.list()` returns a real `BlocksListResult` and `FlowBlock` discriminates as a real union.

Out of scope here: the remaining seven `@superdoc/*` packages still in the shim file (`@superdoc/composables`, `@superdoc/painter-dom`, `@superdoc/pm-adapter`, `@superdoc/style-engine`, `@superdoc/layout-bridge`, plus the BasicUpload Vue subpath of `@superdoc/common` and a layout-bridge subpath). None of those have types currently reachable from `superdoc`'s public surface, so they stay shimmed; the audit gate from SD-2832 will catch it if a future change makes one of them reachable.