### PR TITLE
feat: match word search behavior for tracked changes

### DIFF
--- a/packages/super-editor/src/editors/v1/components/toolbar/defaultItems.js
+++ b/packages/super-editor/src/editors/v1/components/toolbar/defaultItems.js
@@ -324,7 +324,7 @@ export const makeDefaultItems = ({
 
   const renderSearchDropdown = () => {
     const handleSubmit = ({ value }) => {
-      superToolbar.activeEditor.commands.search(value);
+      superToolbar.activeEditor.commands.search(value, { searchModel: 'visible' });
     };
 
     return h('div', {}, [

--- a/packages/super-editor/src/editors/v1/document-api-adapters/find-adapter.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/find-adapter.test.ts
@@ -1,7 +1,7 @@
 import type { Node as ProseMirrorNode } from 'prosemirror-model';
 import type { Editor } from '../core/Editor.js';
 import type { Query } from '@superdoc/document-api';
-import { findLegacyAdapter } from './find-adapter.js';
+import { findLegacyAdapter, sdFindAdapter } from './find-adapter.js';
 
 // ---------------------------------------------------------------------------
 // Helpers — lightweight ProseMirror-like stubs
@@ -703,6 +703,22 @@ describe('findLegacyAdapter — text selectors', () => {
     expect(capturedOptions!.maxMatches).toBe(Infinity);
   });
 
+  it('uses visible search model for text selector queries', () => {
+    let capturedOptions: Record<string, unknown> | undefined;
+    const doc = buildDoc({ typeName: 'paragraph', attrs: { sdBlockId: 'p1' }, nodeSize: 50, offset: 0 });
+    const search: SearchFn = (_pattern, options) => {
+      capturedOptions = options as Record<string, unknown>;
+      return [];
+    };
+    const editor = makeEditor(doc, search);
+    const query: Query = { select: { type: 'text', pattern: 'tracked' } };
+
+    findLegacyAdapter(editor, query);
+
+    expect(capturedOptions).toBeDefined();
+    expect(capturedOptions!.searchModel).toBe('visible');
+  });
+
   it('throws when editor has no search command', () => {
     const doc = buildDoc({ typeName: 'paragraph', attrs: { sdBlockId: 'p1' }, nodeSize: 50, offset: 0 });
     const editor = makeEditor(doc); // no search command
@@ -891,6 +907,51 @@ describe('findLegacyAdapter — text selectors', () => {
 
     expect(result.total).toBe(1);
     expect(result.items[0].address.nodeId).toBe('p1');
+  });
+});
+
+describe('sdFindAdapter — tracked changes text search defaults', () => {
+  it('uses visible model semantics for delete/add/collapsed queries', () => {
+    const doc = buildDoc('beforeDELETEafter ADD', {
+      typeName: 'paragraph',
+      attrs: { sdBlockId: 'p1' },
+      nodeSize: 50,
+      offset: 0,
+    });
+
+    const search: SearchFn = (pattern, options) => {
+      const source = pattern instanceof RegExp ? pattern.source : String(pattern);
+      const searchModel = (options as { searchModel?: string } | undefined)?.searchModel ?? 'raw';
+      const isVisible = searchModel === 'visible';
+
+      if (source === 'DELETE') {
+        return isVisible ? [] : [{ from: 7, to: 13, text: 'DELETE' }];
+      }
+      if (source === 'ADD') {
+        return [{ from: 18, to: 21, text: 'ADD' }];
+      }
+      if (source === 'beforeafter') {
+        return isVisible ? [] : [{ from: 0, to: 11, text: 'beforeafter' }];
+      }
+
+      return [];
+    };
+
+    const editor = makeEditor(doc, search);
+
+    const deletedOnly = sdFindAdapter(editor, { select: { type: 'text', pattern: 'DELETE' } });
+    const addedOnly = sdFindAdapter(editor, { select: { type: 'text', pattern: 'ADD' } });
+    const collapsed = sdFindAdapter(editor, { select: { type: 'text', pattern: 'beforeafter' } });
+
+    expect(deletedOnly.total).toBe(0);
+    expect(deletedOnly.items).toHaveLength(0);
+
+    expect(addedOnly.total).toBe(1);
+    expect(addedOnly.items).toHaveLength(1);
+    expect(addedOnly.items[0].address).toEqual({ kind: 'block', nodeType: 'paragraph', nodeId: 'p1' });
+
+    expect(collapsed.total).toBe(0);
+    expect(collapsed.items).toHaveLength(0);
   });
 });
 

--- a/packages/super-editor/src/editors/v1/document-api-adapters/find/text-strategy.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/find/text-strategy.ts
@@ -105,6 +105,7 @@ export function executeTextSelector(
     highlight: false,
     caseSensitive: selector.caseSensitive ?? false,
     maxMatches: Infinity,
+    searchModel: 'visible',
   });
 
   if (!Array.isArray(rawResult)) {

--- a/packages/super-editor/src/editors/v1/extensions/search/SearchIndex.js
+++ b/packages/super-editor/src/editors/v1/extensions/search/SearchIndex.js
@@ -24,6 +24,10 @@
 
 const BLOCK_SEPARATOR = '\n';
 const ATOM_PLACEHOLDER = '\ufffc';
+const DELETION_BARRIER = '\u0000';
+const DEFAULT_SEARCH_MODEL = 'raw';
+
+const hasTrackDeleteMark = (node) => node?.marks?.some((mark) => mark?.type?.name === 'trackDelete') ?? false;
 
 /**
  * SearchIndex provides a lazily-built, cached index for searching across
@@ -48,6 +52,9 @@ export class SearchIndex {
   /** @type {import('prosemirror-model').Node | null} */
   doc = null;
 
+  /** @type {'raw'|'visible'} */
+  searchModel = DEFAULT_SEARCH_MODEL;
+
   /**
    * Build the search index from a ProseMirror document.
    * Uses doc.textBetween for the flattened string and walks
@@ -55,22 +62,95 @@ export class SearchIndex {
    *
    * @param {import('prosemirror-model').Node} doc - The ProseMirror document
    */
-  build(doc) {
-    // Get the flattened text using ProseMirror's optimized textBetween
-    this.text = doc.textBetween(0, doc.content.size, BLOCK_SEPARATOR, ATOM_PLACEHOLDER);
+  build(doc, options = {}) {
+    const searchModel = options?.searchModel === 'visible' ? 'visible' : DEFAULT_SEARCH_MODEL;
+
+    if (searchModel === 'visible') {
+      this.#buildVisible(doc);
+    } else {
+      // Get the flattened text using ProseMirror's optimized textBetween
+      this.text = doc.textBetween(0, doc.content.size, BLOCK_SEPARATOR, ATOM_PLACEHOLDER);
+    }
+
     this.segments = [];
     this.docSize = doc.content.size;
     this.doc = doc;
+    this.searchModel = searchModel;
 
     // Walk the document to build the segment map
     // Note: doc node's content starts at position 0 (doc has no opening tag)
     let offset = 0;
-    this.#walkNodeContent(doc, 0, offset, (segment) => {
-      this.segments.push(segment);
-      offset = segment.offsetEnd;
-    });
+    const visibleContext = searchModel === 'visible' ? { deletionBarrierActive: false } : null;
+    this.#walkNodeContent(
+      doc,
+      0,
+      offset,
+      (segment) => {
+        this.segments.push(segment);
+        offset = segment.offsetEnd;
+      },
+      searchModel,
+      visibleContext,
+    );
 
     this.valid = true;
+  }
+
+  /**
+   * Build flattened text for the `visible` model, where tracked deletions
+   * are removed from searchable text and replaced with a non-searchable
+   * barrier to prevent false collapsed matches.
+   *
+   * @param {import('prosemirror-model').Node} doc
+   */
+  #buildVisible(doc) {
+    const parts = [];
+    let emittedDeletionBarrier = false;
+
+    const appendDeletionBarrier = () => {
+      if (emittedDeletionBarrier) return;
+      parts.push(DELETION_BARRIER);
+      emittedDeletionBarrier = true;
+    };
+
+    const walkNodeContent = (node) => {
+      let isFirstChild = true;
+      node.forEach((child) => {
+        if (child.isBlock && !isFirstChild) {
+          parts.push(BLOCK_SEPARATOR);
+          emittedDeletionBarrier = false;
+        }
+        walkNode(child);
+        isFirstChild = false;
+      });
+    };
+
+    const walkNode = (node) => {
+      if (node.isText) {
+        const text = node.text || '';
+        if (!text.length) return;
+
+        if (hasTrackDeleteMark(node)) {
+          appendDeletionBarrier();
+          return;
+        }
+
+        parts.push(text);
+        emittedDeletionBarrier = false;
+        return;
+      }
+
+      if (node.isLeaf) {
+        parts.push(ATOM_PLACEHOLDER);
+        emittedDeletionBarrier = false;
+        return;
+      }
+
+      walkNodeContent(node);
+    };
+
+    walkNodeContent(doc);
+    this.text = parts.join('');
   }
 
   /**
@@ -84,7 +164,7 @@ export class SearchIndex {
    * @param {(segment: Segment) => void} addSegment - Callback to add a segment
    * @returns {number} The new offset after processing this node's content
    */
-  #walkNodeContent(node, contentStart, offset, addSegment) {
+  #walkNodeContent(node, contentStart, offset, addSegment, searchModel = DEFAULT_SEARCH_MODEL, context = null) {
     let currentOffset = offset;
     let isFirstChild = true;
 
@@ -101,9 +181,12 @@ export class SearchIndex {
           kind: 'blockSep',
         });
         currentOffset += 1;
+        if (context && searchModel === 'visible') {
+          context.deletionBarrierActive = false;
+        }
       }
 
-      currentOffset = this.#walkNode(child, childDocPos, currentOffset, addSegment);
+      currentOffset = this.#walkNode(child, childDocPos, currentOffset, addSegment, searchModel, context);
       isFirstChild = false;
     });
 
@@ -119,11 +202,31 @@ export class SearchIndex {
    * @param {(segment: Segment) => void} addSegment - Callback to add a segment
    * @returns {number} The new offset after processing this node
    */
-  #walkNode(node, docPos, offset, addSegment) {
+  #walkNode(node, docPos, offset, addSegment, searchModel = DEFAULT_SEARCH_MODEL, context = null) {
     if (node.isText) {
+      if (searchModel === 'visible' && hasTrackDeleteMark(node)) {
+        if (context?.deletionBarrierActive) {
+          return offset;
+        }
+        addSegment({
+          offsetStart: offset,
+          offsetEnd: offset + 1,
+          docFrom: docPos,
+          docTo: docPos,
+          kind: 'atom',
+        });
+        if (context) {
+          context.deletionBarrierActive = true;
+        }
+        return offset + 1;
+      }
+
       // Text node: add a text segment
       const text = node.text || '';
       if (text.length > 0) {
+        if (context && searchModel === 'visible') {
+          context.deletionBarrierActive = false;
+        }
         addSegment({
           offsetStart: offset,
           offsetEnd: offset + text.length,
@@ -137,6 +240,9 @@ export class SearchIndex {
     }
 
     if (node.isLeaf) {
+      if (context && searchModel === 'visible') {
+        context.deletionBarrierActive = false;
+      }
       // Leaf node (atom): check if it's a hard_break or other atom
       if (node.type.name === 'hard_break') {
         addSegment({
@@ -161,7 +267,7 @@ export class SearchIndex {
 
     // For non-leaf nodes, recurse into content
     // Content starts at docPos + 1 (after opening tag)
-    return this.#walkNodeContent(node, docPos + 1, offset, addSegment);
+    return this.#walkNodeContent(node, docPos + 1, offset, addSegment, searchModel, context);
   }
 
   /**
@@ -177,8 +283,9 @@ export class SearchIndex {
    * @param {import('prosemirror-model').Node} doc - The document to check against
    * @returns {boolean} True if index is stale and needs rebuilding
    */
-  isStale(doc) {
-    return !this.valid || this.doc !== doc;
+  isStale(doc, options = {}) {
+    const searchModel = options?.searchModel === 'visible' ? 'visible' : DEFAULT_SEARCH_MODEL;
+    return !this.valid || this.doc !== doc || this.searchModel !== searchModel;
   }
 
   /**
@@ -187,9 +294,9 @@ export class SearchIndex {
    *
    * @param {import('prosemirror-model').Node} doc - The document
    */
-  ensureValid(doc) {
-    if (this.isStale(doc)) {
-      this.build(doc);
+  ensureValid(doc, options = {}) {
+    if (this.isStale(doc, options)) {
+      this.build(doc, options);
     }
   }
 

--- a/packages/super-editor/src/editors/v1/extensions/search/SearchIndex.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/search/SearchIndex.test.js
@@ -141,3 +141,113 @@ describe('SearchIndex.searchIgnoringDiacritics', () => {
     expect(matches[1].text).toBe('résumé');
   });
 });
+
+describe('SearchIndex searchModel: visible', () => {
+  function textNode(text, { deleted = false } = {}) {
+    return {
+      isText: true,
+      isLeaf: false,
+      isBlock: false,
+      text,
+      nodeSize: text.length,
+      marks: deleted ? [{ type: { name: 'trackDelete' } }] : [],
+      forEach: () => {},
+    };
+  }
+
+  function containerNode(children, { isBlock = false, textBetween = '' } = {}) {
+    return {
+      isText: false,
+      isLeaf: false,
+      isBlock,
+      nodeSize: children.reduce((sum, child) => sum + child.nodeSize, 0) + 2,
+      content: { size: children.reduce((sum, child) => sum + child.nodeSize, 0) },
+      forEach(cb) {
+        let offset = 0;
+        for (const child of children) {
+          cb(child, offset);
+          offset += child.nodeSize;
+        }
+      },
+      textBetween: () => textBetween,
+    };
+  }
+
+  function buildDocWithTrackedDeletion() {
+    const paragraph = containerNode([textNode('before'), textNode('DELETE', { deleted: true }), textNode('after')], {
+      isBlock: true,
+      textBetween: 'beforeDELETEafter',
+    });
+
+    const doc = containerNode([paragraph], {
+      isBlock: false,
+      textBetween: 'beforeDELETEafter',
+    });
+
+    return { doc };
+  }
+
+  function buildDocWithSplitTrackedDeletion() {
+    const paragraph = containerNode(
+      [textNode('before'), textNode('DEL', { deleted: true }), textNode('ETE', { deleted: true }), textNode('after')],
+      {
+        isBlock: true,
+        textBetween: 'beforeDELETEafter',
+      },
+    );
+
+    const doc = containerNode([paragraph], {
+      isBlock: false,
+      textBetween: 'beforeDELETEafter',
+    });
+
+    return { doc };
+  }
+
+  it('excludes pending tracked deletions in visible model', () => {
+    const { doc } = buildDocWithTrackedDeletion();
+    const index = new SearchIndex();
+
+    index.ensureValid(doc, { searchModel: 'visible' });
+    const matches = index.search('DELETE');
+
+    expect(matches).toHaveLength(0);
+  });
+
+  it('does not match collapsed impossible strings across deleted spans', () => {
+    const { doc } = buildDocWithTrackedDeletion();
+    const index = new SearchIndex();
+
+    index.ensureValid(doc, { searchModel: 'visible' });
+    const matches = index.search('beforeafter');
+
+    expect(matches).toHaveLength(0);
+  });
+
+  it('keeps raw model behavior unchanged by default', () => {
+    const { doc } = buildDocWithTrackedDeletion();
+    const index = new SearchIndex();
+
+    index.ensureValid(doc);
+    const matches = index.search('DELETE');
+
+    expect(matches).toHaveLength(1);
+  });
+
+  it('keeps offset mapping aligned after contiguous deleted text nodes', () => {
+    const { doc } = buildDocWithSplitTrackedDeletion();
+    const index = new SearchIndex();
+
+    index.ensureValid(doc, { searchModel: 'visible' });
+
+    expect(index.segments[index.segments.length - 1]?.offsetEnd).toBe(index.text.length);
+
+    const start = index.text.indexOf('after');
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    const ranges = index.offsetRangeToDocRanges(start, start + 'after'.length);
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0].to - ranges[0].from).toBe('after'.length);
+    expect(ranges[0]).toEqual({ from: 13, to: 18 });
+  });
+});

--- a/packages/super-editor/src/editors/v1/extensions/search/search.js
+++ b/packages/super-editor/src/editors/v1/extensions/search/search.js
@@ -2,7 +2,7 @@
 
 import { Extension } from '@core/Extension.js';
 import { PositionTracker } from '@core/PositionTracker.js';
-import { search, SearchQuery, setSearchState, getMatchHighlights } from './prosemirror-search-patched.js';
+import { search, getMatchHighlights } from './prosemirror-search-patched.js';
 import { Plugin, PluginKey, TextSelection } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
 import { Fragment, Slice } from 'prosemirror-model';
@@ -27,6 +27,9 @@ export const getCustomSearchDecorations = (state) => {
 
 const isRegExp = (value) => Object.prototype.toString.call(value) === '[object RegExp]';
 const SEARCH_POSITION_TRACKER_TYPE = 'search-match';
+const DEFAULT_SEARCH_MODEL = 'raw';
+
+const normalizeSearchModel = (value) => (value === 'visible' ? 'visible' : DEFAULT_SEARCH_MODEL);
 
 /**
  * Convert raw SearchIndex matches into SearchMatch objects with document ranges
@@ -211,6 +214,8 @@ const getPositionTracker = (editor) => {
  *   When false, matches are tracked without visual styling, useful for programmatic search without UI changes.
  * @property {number} [maxMatches=1000] - Maximum number of matches to return.
  * @property {boolean} [caseSensitive=false] - Whether the search should be case-sensitive.
+ * @property {'raw'|'visible'} [searchModel='raw'] - Internal text model selector used by search infrastructure.
+ *   `visible` excludes pending tracked deletions from the searchable model while preserving additions.
  */
 
 /**
@@ -263,6 +268,12 @@ export const Search = Extension.create({
        * Whether the current search ignores diacritics
        */
       ignoreDiacritics: false,
+      /**
+       * @private
+       * @type {'raw'|'visible'}
+       * Internal search text model for future behavior switches.
+       */
+      searchModel: DEFAULT_SEARCH_MODEL,
     };
   },
 
@@ -288,7 +299,9 @@ export const Search = Extension.create({
         // when the user edits the document to contain the search term.
         if (storage?.query) {
           // Rebuild the index against the new doc
-          storage.searchIndex.ensureValid(newState.doc);
+          storage.searchIndex.ensureValid(newState.doc, {
+            searchModel: storage.searchModel ?? DEFAULT_SEARCH_MODEL,
+          });
 
           const searchFn = storage.ignoreDiacritics
             ? (q, opts) => storage.searchIndex.searchIgnoringDiacritics(q, opts)
@@ -296,6 +309,7 @@ export const Search = Extension.create({
 
           const indexMatches = searchFn(storage.query, {
             caseSensitive: storage.caseSensitive,
+            searchModel: storage.searchModel ?? DEFAULT_SEARCH_MODEL,
           });
 
           const refreshed = mapIndexMatchesToDocMatches({
@@ -468,7 +482,7 @@ export const Search = Extension.create({
       search:
         (patternInput, options = {}) =>
         /** @returns {SearchMatch[]} */
-        ({ state, dispatch, editor }) => {
+        ({ state, editor }) => {
           // Validate options parameter - must be an object if provided
           if (options != null && (typeof options !== 'object' || Array.isArray(options))) {
             throw new TypeError('Search options must be an object');
@@ -477,19 +491,17 @@ export const Search = Extension.create({
           // Extract options
           const highlight = typeof options?.highlight === 'boolean' ? options.highlight : true;
           const maxMatches = typeof options?.maxMatches === 'number' ? options.maxMatches : 1000;
+          const searchModel = normalizeSearchModel(options?.searchModel);
 
           // Determine if this is a regex search
-          let isRegexSearch = false;
           let caseSensitive = false;
           let searchPattern = patternInput;
 
           if (isRegExp(patternInput)) {
-            isRegexSearch = true;
             caseSensitive = !patternInput.flags.includes('i');
             searchPattern = patternInput;
           } else if (typeof patternInput === 'string' && /^\/(.+)\/([gimsuy]*)$/.test(patternInput)) {
             const [, body, flags] = patternInput.match(/^\/(.+)\/([gimsuy]*)$/);
-            isRegexSearch = true;
             caseSensitive = !flags.includes('i');
             searchPattern = new RegExp(body, flags.includes('g') ? flags : flags + 'g');
           } else {
@@ -503,12 +515,14 @@ export const Search = Extension.create({
 
           // Ensure search index is valid
           const searchIndex = this.storage.searchIndex;
-          searchIndex.ensureValid(state.doc);
+          searchIndex.ensureValid(state.doc, { searchModel });
+          this.storage.searchModel = searchModel;
 
           // Search using the index
           const indexMatches = searchIndex.search(searchPattern, {
             caseSensitive,
             maxMatches,
+            searchModel,
           });
 
           // Map matches to document positions
@@ -591,6 +605,7 @@ export const Search = Extension.create({
        * @param {boolean} [options.caseSensitive=false] - Case-sensitive search
        * @param {boolean} [options.ignoreDiacritics=false] - Ignore diacritics when matching
        * @param {boolean} [options.highlight=true] - Apply visual highlighting
+       * @param {'raw'|'visible'} [options.searchModel='raw'] - Internal text model selector.
        * @returns {{ matches: SearchMatch[], activeMatchIndex: number }}
        */
       setSearchSession:
@@ -599,11 +614,13 @@ export const Search = Extension.create({
           const caseSensitive = options.caseSensitive ?? false;
           const ignoreDiacritics = options.ignoreDiacritics ?? false;
           const highlight = options.highlight ?? true;
+          const searchModel = normalizeSearchModel(options.searchModel);
 
           // Store session state
           this.storage.query = query;
           this.storage.caseSensitive = caseSensitive;
           this.storage.ignoreDiacritics = ignoreDiacritics;
+          this.storage.searchModel = searchModel;
 
           // Clear existing position trackers
           const positionTracker = getPositionTracker(editor);
@@ -618,12 +635,12 @@ export const Search = Extension.create({
 
           // Build/validate search index
           const searchIndex = this.storage.searchIndex;
-          searchIndex.ensureValid(state.doc);
+          searchIndex.ensureValid(state.doc, { searchModel });
 
           // Search with diacritic support
           const indexMatches = ignoreDiacritics
-            ? searchIndex.searchIgnoringDiacritics(query, { caseSensitive })
-            : searchIndex.search(query, { caseSensitive });
+            ? searchIndex.searchIgnoringDiacritics(query, { caseSensitive, searchModel })
+            : searchIndex.search(query, { caseSensitive, searchModel });
 
           // Map matches to document positions
           const resultMatches = mapIndexMatchesToDocMatches({
@@ -656,6 +673,7 @@ export const Search = Extension.create({
           this.storage.query = '';
           this.storage.caseSensitive = false;
           this.storage.ignoreDiacritics = false;
+          this.storage.searchModel = DEFAULT_SEARCH_MODEL;
 
           return true;
         },
@@ -667,7 +685,7 @@ export const Search = Extension.create({
        */
       nextSearchMatch:
         () =>
-        ({ state, editor }) => {
+        ({ editor }) => {
           const matches = this.storage.searchResults;
           if (!matches || matches.length === 0) {
             return { activeMatchIndex: -1, match: null };
@@ -690,7 +708,7 @@ export const Search = Extension.create({
        */
       previousSearchMatch:
         () =>
-        ({ state, editor }) => {
+        ({ editor }) => {
           const matches = this.storage.searchResults;
           if (!matches || matches.length === 0) {
             return { activeMatchIndex: -1, match: null };
@@ -715,7 +733,7 @@ export const Search = Extension.create({
        */
       replaceSearchMatch:
         (replacement) =>
-        ({ state, dispatch, editor, commands }) => {
+        ({ state, dispatch, commands }) => {
           const matches = this.storage.searchResults;
           const activeIdx = this.storage.activeMatchIndex;
 
@@ -744,6 +762,7 @@ export const Search = Extension.create({
             caseSensitive: this.storage.caseSensitive,
             ignoreDiacritics: this.storage.ignoreDiacritics,
             highlight: this.storage.highlightEnabled,
+            searchModel: this.storage.searchModel,
           });
 
           // Clamp activeMatchIndex to new match count and scroll to the

--- a/packages/super-editor/src/editors/v1/extensions/types/specialized-commands.ts
+++ b/packages/super-editor/src/editors/v1/extensions/types/specialized-commands.ts
@@ -20,6 +20,7 @@ export type SearchCommandOptions = {
   highlight?: boolean;
   maxMatches?: number;
   caseSensitive?: boolean;
+  searchModel?: 'raw' | 'visible';
 };
 
 type DocumentSectionCreateOptions = {

--- a/packages/super-editor/src/editors/v1/tests/extensions/search/search-transparent-nodes.test.js
+++ b/packages/super-editor/src/editors/v1/tests/extensions/search/search-transparent-nodes.test.js
@@ -694,5 +694,50 @@ describe('Search transparent nodes', () => {
         editor.destroy();
       }
     });
+
+    it('should exclude trackDelete and include trackInsert in visible search model', () => {
+      const editor = createDocxTestEditor();
+
+      try {
+        const { doc, paragraph, run } = editor.schema.nodes;
+        const trackDeleteMark = editor.schema.marks.trackDelete?.create?.({ id: 'del-1' });
+        const trackInsertMark = editor.schema.marks.trackInsert?.create?.({ id: 'ins-1' });
+
+        if (!trackDeleteMark || !trackInsertMark) {
+          expect(true).toBe(true);
+          return;
+        }
+
+        const testDoc = doc.create(null, [
+          paragraph.create(null, [
+            run.create(null, [editor.schema.text('before')]),
+            run.create(null, [editor.schema.text('DELETE', [trackDeleteMark])]),
+            run.create(null, [editor.schema.text('after ')]),
+            run.create(null, [editor.schema.text('ADD', [trackInsertMark])]),
+          ]),
+        ]);
+
+        const baseState = EditorState.create({
+          schema: editor.schema,
+          doc: testDoc,
+          plugins: editor.state.plugins,
+        });
+        editor.setState(baseState);
+
+        const rawDeleteMatches = editor.commands.search('DELETE');
+        expect(rawDeleteMatches).toHaveLength(1);
+
+        const visibleDeleteMatches = editor.commands.search('DELETE', { searchModel: 'visible' });
+        expect(visibleDeleteMatches).toHaveLength(0);
+
+        const visibleInsertMatches = editor.commands.search('ADD', { searchModel: 'visible' });
+        expect(visibleInsertMatches).toHaveLength(1);
+
+        const collapsedMatches = editor.commands.search('beforeafter', { searchModel: 'visible' });
+        expect(collapsedMatches).toHaveLength(0);
+      } finally {
+        editor.destroy();
+      }
+    });
   });
 });

--- a/packages/superdoc/src/composables/use-find-replace.js
+++ b/packages/superdoc/src/composables/use-find-replace.js
@@ -127,6 +127,7 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
         caseSensitive: caseSensitive.value,
         ignoreDiacritics: ignoreDiacritics.value,
         highlight: true,
+        searchModel: 'visible',
       });
       matchCount.value = result.matches.length;
       activeMatchIndex.value = result.activeMatchIndex;

--- a/packages/superdoc/src/composables/use-find-replace.test.js
+++ b/packages/superdoc/src/composables/use-find-replace.test.js
@@ -578,6 +578,18 @@ describe('useFindReplace', () => {
       findReplace.open();
       expect(focusFn).toHaveBeenCalled();
     });
+
+    it('runs search sessions with visible search model', async () => {
+      handle.findQuery.value = 'tracked';
+      await new Promise((resolve) => setTimeout(resolve, 180));
+
+      expect(editor.commands.setSearchSession).toHaveBeenCalledWith(
+        'tracked',
+        expect.objectContaining({
+          searchModel: 'visible',
+        }),
+      );
+    });
   });
 
   describe('handle reactive state', () => {

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -1410,7 +1410,7 @@ export class SuperDoc extends EventEmitter {
    * @returns {Object[]} The search results
    */
   search(text) {
-    return this.activeEditor?.commands.search(text);
+    return this.activeEditor?.commands.search(text, { searchModel: 'visible' });
   }
 
   /**

--- a/packages/superdoc/src/core/SuperDoc.test.js
+++ b/packages/superdoc/src/core/SuperDoc.test.js
@@ -409,6 +409,30 @@ describe('SuperDoc core', () => {
     expect(readySpy).toHaveBeenCalledTimes(1);
   });
 
+  it('uses visible search model in SuperDoc.search()', async () => {
+    createAppHarness();
+
+    const instance = new SuperDoc({
+      selector: '#host',
+      document: 'https://example.com/doc.docx',
+      documents: [],
+      modules: { comments: {}, toolbar: {} },
+      colors: ['red'],
+      user: { name: 'Jane', email: 'jane@example.com' },
+      onException: vi.fn(),
+    });
+    await flushMicrotasks();
+
+    const searchResult = [{ from: 1, to: 4 }];
+    const searchMock = vi.fn(() => searchResult);
+    instance.activeEditor = { commands: { search: searchMock } };
+
+    const result = instance.search('test');
+
+    expect(searchMock).toHaveBeenCalledWith('test', { searchModel: 'visible' });
+    expect(result).toBe(searchResult);
+  });
+
   it('locks superdoc via ydoc metadata and emits event', async () => {
     createAppHarness();
 


### PR DESCRIPTION
Linear: SD-2430

Align search with Word behavior when tracked changes are present.

This PR updates default search to use the document’s visible/current-state model:
- pending tracked additions are searchable,
- pending tracked deletions are not searchable,
- impossible collapsed matches across deleted spans are prevented.

The change is applied consistently across:
- core search indexing/commands,
- `editor.doc.find(...)` text selector path,
- UI search entry points (toolbar, find/replace, `SuperDoc.search`).