### PR TITLE
fix(ui): document useSuperDocTrackChanges return shape

### DIFF
--- a/packages/super-editor/src/ui/react/hooks.ts
+++ b/packages/super-editor/src/ui/react/hooks.ts
@@ -42,7 +42,7 @@ export function useSuperDocComments(): CommentsSlice {
   return useSuperDocSlice((ui) => ui.select((state) => state.comments, shallowEqual), EMPTY_COMMENTS);
 }
 
-/** Subscribe to the tracked-changes feed. */
+/** Subscribe to the tracked-changes slice (items, total, activeId). */
 export function useSuperDocTrackChanges(): TrackChangesSlice {
   return useSuperDocSlice((ui) => ui.select((state) => state.trackChanges, shallowEqual), EMPTY_TRACK_CHANGES);
 }


### PR DESCRIPTION
The new hook's JSDoc only said \"tracked-changes feed\". Match the companion `useSuperDocComments` JSDoc style and spell out the slice fields so consumers know what comes back without diving into the type.

The motivation is also to land #3030's `ui.review` → `ui.trackChanges` rename in a published version. The rename was a `refactor:` commit, which the release pipeline correctly classifies as no-release. This `fix:` rides along so the rename ships in the next patch.

Cherry-pick onto `main` once merged.