### PR TITLE
ci(superdoc): close 3 known declaration leaks and flip audit to strict (SD-2859)

### DIFF
--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -111,7 +111,7 @@
     "build:dev": "SUPERDOC_SKIP_DTS=1 vite build",
     "postbuild": "node ./scripts/ensure-types.cjs && node ./scripts/audit-bundle.cjs && node ./scripts/audit-declarations.cjs",
     "audit:declarations": "node ./scripts/audit-declarations.cjs",
-    "audit:declarations:strict": "node ./scripts/audit-declarations.cjs --strict",
+    "audit:declarations:informational": "node ./scripts/audit-declarations.cjs --informational",
     "build:es": "vite build && pnpm run postbuild",
     "watch:es": "vite build --watch",
     "build:cdn": "vite build --config vite.config.cdn.js",

--- a/packages/superdoc/scripts/audit-declarations.cjs
+++ b/packages/superdoc/scripts/audit-declarations.cjs
@@ -33,9 +33,10 @@
  *    drift is visible and the surface can be tightened over time, but its
  *    contents do not fail the audit.
  *
- * Default mode is informational: findings are printed and the script exits
- * zero. Pass `--strict` (or set `SUPERDOC_AUDIT_REQUIRED=1`) to exit non-zero
- * on any FAIL-level finding (rules 1, 2, or 3).
+ * Default mode is strict: findings exit non-zero so a regression cannot
+ * ship silently. Pass `--informational` (or set
+ * `SUPERDOC_AUDIT_INFORMATIONAL=1`) for an explicit opt-out when iterating
+ * locally on a known leak before the fix is ready.
  */
 
 const fs = require('node:fs');
@@ -43,8 +44,14 @@ const path = require('node:path');
 
 const distRoot = path.resolve(__dirname, '..', 'dist');
 
-const isStrict =
-  process.argv.includes('--strict') || process.env.SUPERDOC_AUDIT_REQUIRED === '1';
+// SD-2859: strict is the default. The audit fails the build on any
+// FAIL-level finding so a regression in the published declaration
+// surface cannot ship silently. Pass `--informational` (or set
+// `SUPERDOC_AUDIT_INFORMATIONAL=1`) for an explicit opt-out — useful
+// when iterating locally on a known leak before the fix is ready.
+const isInformational =
+  process.argv.includes('--informational') || process.env.SUPERDOC_AUDIT_INFORMATIONAL === '1';
+const isStrict = !isInformational;
 
 if (!fs.existsSync(distRoot)) {
   console.error(`[audit-declarations] dist/ not found at ${distRoot}; run the build first.`);
@@ -221,12 +228,12 @@ console.log(`FAIL findings: ${violations.join(', ')}`);
 console.log();
 
 if (isStrict) {
-  console.log('Strict mode is on; exiting non-zero.');
+  console.log('Exiting non-zero (strict mode is the default since SD-2859).');
   console.log('See docs/architecture/package-boundaries.md for what each rule means.');
+  console.log('Pass --informational (or SUPERDOC_AUDIT_INFORMATIONAL=1) to opt out for local iteration on a known leak.');
   process.exit(1);
 }
 
-console.log('Strict mode is off; exiting zero (informational).');
-console.log('Pass --strict (or SUPERDOC_AUDIT_REQUIRED=1) to fail on FAIL-level findings.');
+console.log('Exiting zero (informational mode).');
 console.log('See docs/architecture/package-boundaries.md for what each rule means.');
 process.exit(0);

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -14,6 +14,19 @@ const repoRoot = path.resolve(__dirname, '..', '..', '..');
 // emitted `.d.ts`, the consumer hits an unresolved-module error. Copy
 // every hand-written `.d.ts` from the source trees we publish into the
 // matching dist location so those imports resolve.
+// Hand-written `.d.ts` files we know are internal-only and must NOT ship
+// in `superdoc`'s published dist. The copy step is opt-in via filename
+// blocklist (rather than e.g. a per-file directive) so future hand-written
+// declarations land in dist by default and the cost of skipping one is one
+// line here. Each entry should have a comment explaining why.
+const HANDWRITTEN_DTS_BLOCKLIST = new Set([
+  // Ambient module declarations for internal `@superdoc/super-editor/converter/internal/...`
+  // subpaths. Nothing in `superdoc`'s shipped surface actually imports those subpaths,
+  // so the declarations would only leak the bare specifiers into published d.ts.
+  // Keep the file in source for super-editor's own typecheck; just don't ship it. (SD-2859)
+  'converter-internal.d.ts',
+]);
+
 function copyHandwrittenDtsFiles(srcDir, destDir) {
   let copied = 0;
   function walk(currentSrc, currentDest) {
@@ -27,6 +40,8 @@ function copyHandwrittenDtsFiles(srcDir, destDir) {
         continue;
       }
       if (!entry.name.endsWith('.d.ts')) continue;
+      // Skip blocklisted files (see HANDWRITTEN_DTS_BLOCKLIST above).
+      if (HANDWRITTEN_DTS_BLOCKLIST.has(entry.name)) continue;
       // Skip if the dist already has this file (vite-plugin-dts may have
       // generated its own version from a co-located .ts file)
       if (fs.existsSync(destPath)) continue;
@@ -72,7 +87,12 @@ if (!hasSuperDocExport) {
 }
 
 // Fix workspace package imports that aren't resolvable by consumers.
-// @superdoc/common is a private workspace package — inline its types.
+// @superdoc/common is a private workspace package — inline its types in
+// the main entry. Other reachable d.ts files that import from
+// @superdoc/common fall through to the ambient shim block below; those
+// imports surface internal types (Comment, CommentContent, CommentJSON)
+// that are not on the public surface, so collapsing them to `any` via
+// the shim is correct.
 const hadWorkspaceImport = content.includes('@superdoc/common');
 if (hadWorkspaceImport) {
   // Replace the @superdoc/common import with inline declarations
@@ -325,7 +345,7 @@ for (const filePath of dtsFiles) {
     const mod = m[2];
 
     // Skip relative imports and already-handled packages
-    if (mod.startsWith('.') || mod.startsWith('@superdoc/common') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || RELOCATION_RULES.some((r) => mod === r.pkg || mod.startsWith(r.pkg + '/'))) continue;
+    if (mod.startsWith('.') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || RELOCATION_RULES.some((r) => mod === r.pkg || mod.startsWith(r.pkg + '/'))) continue;
 
     if (mod.startsWith('@superdoc/')) {
       if (!workspaceImports.has(mod)) workspaceImports.set(mod, new Set());
@@ -338,7 +358,7 @@ for (const filePath of dtsFiles) {
   const dynamicImports = fileContent.matchAll(/import\(['"]([^'"]+)['"]\)\.(\w+)/g);
   for (const m of dynamicImports) {
     const mod = m[1];
-    if (mod.startsWith('.') || mod.startsWith('@superdoc/common') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || RELOCATION_RULES.some((r) => mod === r.pkg || mod.startsWith(r.pkg + '/'))) continue;
+    if (mod.startsWith('.') || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || RELOCATION_RULES.some((r) => mod === r.pkg || mod.startsWith(r.pkg + '/'))) continue;
 
     if (mod.startsWith('@superdoc/')) {
       if (!workspaceImports.has(mod)) workspaceImports.set(mod, new Set());
@@ -350,10 +370,15 @@ for (const filePath of dtsFiles) {
   const bareRefs = fileContent.matchAll(/['"](@superdoc\/[^'"]+)['"]/g);
   for (const m of bareRefs) {
     const mod = m[1];
-    // Skip @superdoc/super-editor (consumer-facing, not internal)
-    // Skip @superdoc/common root module (inlined separately), but allow subpath
-    // imports like @superdoc/common/components/BasicUpload.vue to be shimmed
-    if (mod === '@superdoc/common' || mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || RELOCATION_RULES.some((r) => mod === r.pkg || mod.startsWith(r.pkg + '/'))) continue;
+    // Skip @superdoc/super-editor (consumer-facing, not internal). All
+    // other @superdoc/* references (including @superdoc/common root and
+    // its subpaths) fall through to shim generation. The strip-and-inline
+    // step above handles `superdoc/src/index.d.ts`'s @superdoc/common
+    // import explicitly; other files importing from @superdoc/common
+    // resolve through the shim and collapse internal-only types
+    // (Comment, CommentContent, CommentJSON) to `any`. None of those
+    // appear on superdoc's public surface, so the collapse is safe.
+    if (mod.startsWith('@superdoc/super-editor') || mod.startsWith('@superdoc/document-api') || RELOCATION_RULES.some((r) => mod === r.pkg || mod.startsWith(r.pkg + '/'))) continue;
     if (!workspaceImports.has(mod)) workspaceImports.set(mod, new Set());
   }
 }
@@ -391,8 +416,20 @@ if (workspaceImports.size > 0) {
   for (const [mod, names] of [...workspaceImports.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
     wsCount++;
     const sortedNames = [...names].sort();
-    const exportLines = sortedNames
-      .map(n => `  export type ${n} = any;`);
+    const exportLines = [];
+    for (const n of sortedNames) {
+      // `default` is a reserved word and cannot appear in `export type
+      // default = any;`. When a file imports the default export of a
+      // private module (e.g. `import { default as Foo } from '@superdoc/common/components/Foo.vue'`),
+      // the named-imports collector picks up `default` as a name; emit
+      // a proper `export default` declaration instead.
+      if (n === 'default') {
+        exportLines.push('  const _default: any;');
+        exportLines.push('  export default _default;');
+      } else {
+        exportLines.push(`  export type ${n} = any;`);
+      }
+    }
     if (exportLines.length > 0) {
       shimLines.push(`declare module '${mod}' {\n${exportLines.join('\n')}\n}`);
     } else {


### PR DESCRIPTION
The declaration audit (SD-2832, merged into main via #3017) was running in informational mode because three pre-existing leaks the narrowed audit had surfaced were still open. Closes all three so strict mode is the default; from this PR forward, a new private-specifier leak in published declarations fails CI rather than warns.

**Leak 1 (closed):** Unused ambient declaration file `super-editor/src/editors/v1/types/converter-internal.d.ts` shipped to superdoc's dist via the SD-2842 hand-written-d.ts copy step. The file declares two `@superdoc/super-editor/converter/internal/v3/handlers/w/{pPr,rpr}/index.js` modules that no shipped code imports. Added a `HANDWRITTEN_DTS_BLOCKLIST` so internal-only ambient files like this stay in source for super-editor's own typecheck but do not ship.

**Leak 2 (closed):** `@superdoc/common` (root) leaked from three reachable d.ts files (`commentsExporter.d.ts`, `node-translator.d.ts`, `CommentsLayer/types.d.ts`). The existing strip-and-inline logic only handled `superdoc/src/index.d.ts`. Removed the `@superdoc/common` special-cases from the shim-skip predicates so the bare specifier in those files routes through the standard shim generator. The internal types it carries (`Comment`, `CommentContent`, `CommentJSON`) are not on the public surface, so collapsing them to `any` via the shim is safe; the strip-and-inline still runs for the main entry where the real `DOCX` / `PDF` / `HTML` constants are needed.

**Leak 3 (uncovered while fixing leak 2):** once `@superdoc/common/components/BasicUpload.vue` started flowing through the shim generator's named-import path, the file's `import { default as BasicUpload }` triggered the generator to emit `export type default = any;`, which is invalid TypeScript because `default` is a reserved word. Updated the generator to emit a proper `export default` declaration when `default` appears in the collected names.

**Default flipped to strict:** the audit script's default is now non-zero exit on FAIL findings. `--informational` (or `SUPERDOC_AUDIT_INFORMATIONAL=1`) is the explicit opt-out for local iteration on a known leak before the fix is ready. Replaced the redundant `audit:declarations:strict` npm script with `audit:declarations:informational`.

**Verified locally:**
- Build: ✓ exit 0 (postbuild's audit step now actually fails on findings; passing means clean).
- Audit: 0 FAIL findings; 9 modules remain in `_internal-shims.d.ts` (informational), all internal-only types not on the public surface.
- Consumer matrix: 17/17 required pass.
- Repo type-check: ✓.
- superdoc unit tests: 60 files / 943 tests pass.
- super-editor unit tests: previously verified green on the same source.
- React type-check: ✓.
- Template-builder build: ✓.