### PR TITLE
feat(ui): add ui.comments.reply for thread replies (SD-2817)

### DIFF
--- a/demos/build-your-own-ui/src/components/ActivitySidebar.tsx
+++ b/demos/build-your-own-ui/src/components/ActivitySidebar.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { SuperDoc } from 'superdoc';
 import type { CommentsListResult, TrackChangeInfo } from 'superdoc/ui';
 import {
   useSuperDocComments,
-  useSuperDocHost,
   useSuperDocSelection,
   useSuperDocTrackChanges,
   useSuperDocUI,
@@ -271,7 +269,6 @@ function CommentBody({
   replies?: ActivityItem[];
   ui: NonNullable<ReturnType<typeof useSuperDocUI>>;
 }) {
-  const host = useSuperDocHost() as SuperDoc | null;
   const [replyOpen, setReplyOpen] = useState(false);
   const [replyText, setReplyText] = useState('');
   const [replying, setReplying] = useState(false);
@@ -294,17 +291,15 @@ function CommentBody({
   };
 
   const postReply = () => {
-    const editor = host?.activeEditor;
-    const commentsApi = editor?.doc?.comments;
-    if (!commentsApi || typeof commentsApi.create !== 'function' || !replyText.trim()) return;
+    if (!replyText.trim()) return;
     setReplying(true);
     try {
-      // Reply uses the doc-api `create({ parentCommentId, text })`
-      // path. `ui.comments` doesn't yet expose a typed `reply()`
-      // method (filed as a follow-up under SD-2817); the `host`
-      // surface is the documented escape hatch until then.
-      commentsApi.create({ parentCommentId: comment.id, text: replyText.trim() });
-      cancelReply();
+      const receipt = ui.comments.reply(comment.id, { text: replyText.trim() });
+      if (receipt.success) {
+        cancelReply();
+      } else {
+        console.error('[ActivitySidebar] reply rejected', receipt);
+      }
     } catch (err) {
       console.error('[ActivitySidebar] reply failed', err);
     } finally {
@@ -359,7 +354,7 @@ function CommentBody({
             <button onClick={cancelReply}>Cancel</button>
             <button
               className="primary"
-              disabled={!host || replying || !replyText.trim()}
+              disabled={replying || !replyText.trim()}
               onClick={postReply}
             >
               {replying ? 'Posting…' : 'Reply'}
@@ -376,9 +371,7 @@ function CommentBody({
           <>
             <button onClick={() => ui.comments.resolve(comment.id)}>Resolve</button>
             {!replyOpen && (
-              <button disabled={!host} onClick={openReply}>
-                Reply
-              </button>
+              <button onClick={openReply}>Reply</button>
             )}
           </>
         )}

--- a/packages/super-editor/src/ui/comments.test.ts
+++ b/packages/super-editor/src/ui/comments.test.ts
@@ -379,6 +379,77 @@ describe('ui.comments — actions route through editor.doc.*', () => {
     ui.destroy();
   });
 
+  it('reply forwards to comments.create with parentCommentId set and no target', () => {
+    const { superdoc, mocks } = makeStubs();
+    const ui = createSuperDocUI({ superdoc });
+
+    const receipt = ui.comments.reply('c-parent', { text: 'thanks!' });
+
+    expect(receipt.success).toBe(true);
+    expect(mocks.create).toHaveBeenCalledWith({ parentCommentId: 'c-parent', text: 'thanks!' });
+    // Reply must NOT carry a `target` — the doc-api adapter resolves
+    // the parent's anchor itself. Sending one would either be ignored
+    // or, worse, override the inherited address.
+    expect(mocks.create.mock.calls[0]?.[0]).not.toHaveProperty('target');
+
+    ui.destroy();
+  });
+
+  it('reply returns a NO_OP receipt when text is empty or whitespace-only', () => {
+    const { superdoc, mocks } = makeStubs();
+    const ui = createSuperDocUI({ superdoc });
+
+    const empty = ui.comments.reply('c-parent', { text: '' });
+    expect(empty.success).toBe(false);
+
+    const whitespace = ui.comments.reply('c-parent', { text: '   \n\t' });
+    expect(whitespace.success).toBe(false);
+
+    expect(mocks.create).not.toHaveBeenCalled();
+
+    ui.destroy();
+  });
+
+  it('reply refreshes the comments snapshot synchronously after the post', async () => {
+    const { superdoc } = makeStubs({
+      comments: [{ id: 'c-parent', commentId: 'c-parent', text: 'parent' }],
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.comments.getSnapshot().items).toHaveLength(1);
+
+    // Stub mutates list as if a reply was just persisted.
+    superdoc.setComments([
+      { id: 'c-parent', commentId: 'c-parent', text: 'parent' },
+      { id: 'c-reply', commentId: 'c-reply', text: 'thanks', parentCommentId: 'c-parent' },
+    ]);
+    ui.comments.reply('c-parent', { text: 'thanks' });
+
+    // refreshAndNotify should already have re-read the cache.
+    expect(ui.comments.getSnapshot().items.map((i) => i.id)).toEqual(['c-parent', 'c-reply']);
+
+    ui.destroy();
+  });
+
+  it('reply routes through the routed editor (header / footer focus stays scoped)', () => {
+    // Same posture as createFromSelection / createFromCapture: replies
+    // go through `resolveRoutedEditor` so a header-focused composer
+    // posts in the header story, not the body. Mirrors the doc-api
+    // contract: `comments.create` is story-scoped on the routed editor.
+    const { superdoc, mocks } = makeStubs();
+    const ui = createSuperDocUI({ superdoc });
+
+    ui.comments.reply('c-parent', { text: 'in scope' });
+
+    expect(mocks.create).toHaveBeenCalledTimes(1);
+    expect(mocks.create.mock.calls[0]?.[0]).toMatchObject({
+      parentCommentId: 'c-parent',
+      text: 'in scope',
+    });
+
+    ui.destroy();
+  });
+
   it('resolve forwards to comments.patch({ commentId, status: "resolved" })', () => {
     const { superdoc, mocks } = makeStubs();
     const ui = createSuperDocUI({ superdoc });

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -1171,6 +1171,27 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
       refreshAndNotify();
       return receipt;
     },
+    reply(parentCommentId, { text }) {
+      // Reply uses the same `create` operation as a top-level comment;
+      // discrimination is `parentCommentId` set vs absent. Replies
+      // inherit the parent's anchor, so callers don't pass a target —
+      // the doc-api adapter resolves the parent's positional address
+      // and stamps it on the new comment.
+      const trimmed = typeof text === 'string' ? text.trim() : '';
+      if (!trimmed) {
+        return {
+          success: false,
+          failure: { code: 'NO_OP', message: 'ui.comments.reply: text is empty.' },
+        };
+      }
+      const api = requireDocComments();
+      const receipt = (api.create as (input: unknown, options?: unknown) => Receipt).call(api, {
+        parentCommentId,
+        text,
+      });
+      refreshAndNotify();
+      return receipt;
+    },
     resolve(commentId) {
       const api = requireDocComments();
       const receipt = (api.patch as (input: unknown, options?: unknown) => Receipt).call(api, {

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -912,6 +912,21 @@ export interface CommentsHandle {
    * lacks a positional target.
    */
   createFromCapture(capture: SelectionCapture, input: { text: string }): import('@superdoc/document-api').Receipt;
+  /**
+   * Post a reply to an existing thread. Routes through
+   * `editor.doc.comments.create({ parentCommentId, text })`; the
+   * reply inherits the parent's anchor, so callers don't pass a
+   * target. The next `useSuperDocComments()` snapshot includes the
+   * reply with `parentCommentId` set, which sidebars can group under
+   * the thread root.
+   *
+   * Returns a `NO_OP` receipt when `text` is empty or whitespace-only,
+   * matching the doc-api's text-required contract for top-level
+   * comments. Returns a failure receipt when the parent id has been
+   * deleted between the time the user opened the reply composer and
+   * pressed Send.
+   */
+  reply(parentCommentId: string, input: { text: string }): import('@superdoc/document-api').Receipt;
   /** Resolve a comment via `editor.doc.comments.patch`. */
   resolve(commentId: string): import('@superdoc/document-api').Receipt;
   /**


### PR DESCRIPTION
Closes the last \`useSuperDocHost()\` reach in the comments surface. Posting a reply now goes through a typed \`ui.comments.reply(parentCommentId, { text })\` call that mirrors \`editor.doc.comments.create({ parentCommentId, text })\`. Replies inherit the parent's anchor; the adapter resolves it.

- New method on \`CommentsHandle\`. NO_OP receipt on empty/whitespace text.
- Routes through the routed editor so header/footer-focused composers post in the right story.
- Demo's \`ActivitySidebar\` swaps the host reach for \`ui.comments.reply()\` and drops \`useSuperDocHost\` / the \`SuperDoc\` type import.
- Tests: forwards with parentCommentId and no \`target\`; NO_OP on empty/whitespace; refreshes the snapshot synchronously after the post; routes through the routed editor.

**Review**: the only judgment call is the empty-text guard. Top-level comments fail at the doc-api layer with \`INVALID_INPUT\`; replies short-circuit here with \`NO_OP\` instead of hitting the API. That keeps the receipt shape predictable for sidebar UIs that disable the Send button on empty input but call \`reply()\` defensively.
**Verified**: 157/157 super-editor UI tests; superdoc + @superdoc-dev/react builds clean; BYO-UI demo \`tsc -b && vite build\` clean.

Once merged, the BYO-UI docs PR (#3034) drops the \`useSuperDocHost()\` reply snippet on \`comments.mdx\` in favor of the typed call.