### PR TITLE
chore(ci): drop merge_group trigger from optional workflows

### DIFF
--- a/.github/workflows/ci-demos.yml
+++ b/.github/workflows/ci-demos.yml
@@ -10,7 +10,6 @@ on:
       - 'packages/layout-engine/**'
       - 'shared/**'
       - 'package.json'
-  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -10,7 +10,6 @@ on:
       - 'packages/document-api/scripts/**'
       - 'scripts/generate-all.mjs'
       - 'package.json'
-  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-document-api.yml
+++ b/.github/workflows/ci-document-api.yml
@@ -10,7 +10,6 @@ on:
       - 'apps/docs/document-api/**'
       - 'package.json'
       - '.github/workflows/ci-document-api.yml'
-  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-esign.yml
+++ b/.github/workflows/ci-esign.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     paths:
       - 'packages/esign/**'
-  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -11,7 +11,6 @@ on:
       - 'packages/sdk/**'
       - 'packages/layout-engine/**'
       - 'shared/**'
-  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     paths:
       - 'apps/mcp/**'
-  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-react.yml
+++ b/.github/workflows/ci-react.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     paths:
       - 'packages/react/**'
-  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-sdk.yml
+++ b/.github/workflows/ci-sdk.yml
@@ -13,7 +13,6 @@ on:
       - 'scripts/generate-all.mjs'
       - 'package.json'
       - '.github/workflows/ci-sdk.yml'
-  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-template-builder.yml
+++ b/.github/workflows/ci-template-builder.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     paths:
       - 'packages/template-builder/**'
-  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-vscode-ext.yml
+++ b/.github/workflows/ci-vscode-ext.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - 'apps/vscode-ext/**'
       - 'packages/superdoc/src/**'
-  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -16,7 +16,6 @@ on:
       - 'tests/visual/**'
       - 'shared/**'
       - '!**/*.md'
-  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Only ci-superdoc.yml and ci-behavior.yml are required checks. The other 11 workflows in .github/workflows/ci-*.yml plus visual-test.yml are optional and gate themselves on pull_request via path filters, but path filters don't apply to merge_group events. Today merge queue isn't enabled so this is harmless, but the moment it gets turned on every queue entry would fire all 11 regardless of changed paths.

- Required workflows (ci-superdoc, ci-behavior) keep merge_group; they need to validate the merge candidate
- Optional workflows continue to run on PR only, gated by their existing paths filters
- Pre-work for any future merge queue pilot