### PR TITLE
test(consumer-typecheck): auto-derive public-type assertion list (SD-2860)

### DIFF
--- a/tests/consumer-typecheck/check-public-types.mjs
+++ b/tests/consumer-typecheck/check-public-types.mjs
@@ -81,7 +81,13 @@ console.log();
 
 if (missingFromTest.length === 0 && extraInTest.length === 0) {
   console.log('OK    Test list matches the public-type surface.');
-  process.exit(0);
+  // In `--write` mode, fall through to the regeneration block. The file may
+  // be in semantic sync (every typedef has an assertion) but stale on
+  // formatting or comments; `--write` is the explicit "force regenerate"
+  // path, not "regenerate only when names diverged."
+  if (mode !== 'write') {
+    process.exit(0);
+  }
 }
 
 if (missingFromTest.length > 0) {
@@ -121,8 +127,9 @@ const header = `/**
  *
  * THIS FILE IS GENERATED from the JSDoc @typedef block in
  * packages/superdoc/src/index.js. Edit the typedef block (or run
- *   pnpm --filter consumer-typecheck run check:types -- --write
- * to regenerate this file) and commit both. SD-2860's check script enforces
+ *   node tests/consumer-typecheck/check-public-types.mjs --write
+ * from the repo root, or \`npm run check:types:write\` from inside
+ * tests/consumer-typecheck) and commit both. SD-2860's check script enforces
  * that the two stay in sync; a missing assertion fails CI with a message
  * pointing at this script.
  */

--- a/tests/consumer-typecheck/check-public-types.mjs
+++ b/tests/consumer-typecheck/check-public-types.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * SD-2860: keep `tests/consumer-typecheck/src/all-public-types.ts` in sync with
+ * the public type surface that `superdoc` actually exports.
+ *
+ * Without this, a developer can add a new `@typedef` line to
+ * `packages/superdoc/src/index.js` (or land a new public export some other
+ * way that flows through the typedef block) and the regression net does not
+ * cover the new type. The matrix passes, the type collapses to `any` for
+ * customers, and we find out from a customer report.
+ *
+ * The source of truth is the JSDoc `@typedef {import('...').<Name>} <Name>`
+ * block in `packages/superdoc/src/index.js`. Each line declares one public
+ * type. The script reads that block, reads the assertion list in
+ * `all-public-types.ts`, and:
+ *
+ *   - default mode (`--check`): exits non-zero if the two lists differ, with
+ *     a clear message listing what is missing or extra and how to fix it.
+ *   - `--write`: regenerates the test file from the source list. Fast path
+ *     for a developer who added a new public export and just wants to wire
+ *     up the assertion.
+ *
+ * The script is intentionally low-tech (regex on the source), not a TS
+ * compiler API call. The typedef block has a stable shape and adding more
+ * sources of truth (direct `export type` constructs, etc.) is a follow-up
+ * if/when they appear.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+const SOURCE_FILE = path.join(repoRoot, 'packages/superdoc/src/index.js');
+const TEST_FILE = path.join(__dirname, 'src/all-public-types.ts');
+
+const args = process.argv.slice(2);
+const mode = args.includes('--write') ? 'write' : 'check';
+
+if (!fs.existsSync(SOURCE_FILE)) {
+  console.error(`[check-public-types] source file not found: ${SOURCE_FILE}`);
+  process.exit(1);
+}
+if (!fs.existsSync(TEST_FILE)) {
+  console.error(`[check-public-types] test file not found: ${TEST_FILE}`);
+  process.exit(1);
+}
+
+// Parse the @typedef block. Each line looks like:
+//   * @typedef {import('@superdoc/super-editor').EditorState} EditorState
+// We capture the trailing identifier (the typedef name).
+const sourceContent = fs.readFileSync(SOURCE_FILE, 'utf8');
+const TYPEDEF_RE = /@typedef\s+\{import\(['"][^'"]+['"]\)\.[A-Za-z0-9_]+\}\s+([A-Za-z0-9_]+)/g;
+const sourceTypes = new Set();
+for (const match of sourceContent.matchAll(TYPEDEF_RE)) {
+  sourceTypes.add(match[1]);
+}
+
+// Parse the test file. Anchor on `const _real_` so doc-comment placeholders
+// like the literal `_real_X` reference inside the leading comment block do
+// not contaminate the list.
+const testContent = fs.readFileSync(TEST_FILE, 'utf8');
+const ASSERTION_RE = /^const\s+_real_[A-Za-z0-9_]+:\s*AssertNotAny<([A-Za-z0-9_]+)>/gm;
+const testTypes = new Set();
+for (const match of testContent.matchAll(ASSERTION_RE)) {
+  testTypes.add(match[1]);
+}
+
+const missingFromTest = [...sourceTypes].filter((t) => !testTypes.has(t)).sort();
+const extraInTest = [...testTypes].filter((t) => !sourceTypes.has(t)).sort();
+
+console.log('[check-public-types] superdoc public-type surface');
+console.log('='.repeat(72));
+console.log(`Source: ${path.relative(repoRoot, SOURCE_FILE)}`);
+console.log(`        ${sourceTypes.size} typedef${sourceTypes.size === 1 ? '' : 's'}`);
+console.log(`Test:   ${path.relative(repoRoot, TEST_FILE)}`);
+console.log(`        ${testTypes.size} assertion${testTypes.size === 1 ? '' : 's'}`);
+console.log();
+
+if (missingFromTest.length === 0 && extraInTest.length === 0) {
+  console.log('OK    Test list matches the public-type surface.');
+  process.exit(0);
+}
+
+if (missingFromTest.length > 0) {
+  console.log(`FAIL  ${missingFromTest.length} public type${missingFromTest.length === 1 ? '' : 's'} missing from the test:`);
+  for (const name of missingFromTest) {
+    console.log(`        ${name}`);
+  }
+}
+if (extraInTest.length > 0) {
+  if (missingFromTest.length > 0) console.log();
+  console.log(`FAIL  ${extraInTest.length} type${extraInTest.length === 1 ? '' : 's'} in the test but not in the source typedef block:`);
+  for (const name of extraInTest) {
+    console.log(`        ${name}`);
+  }
+  console.log('      Either add the missing @typedef line, or remove the assertion.');
+}
+
+if (mode !== 'write') {
+  console.log();
+  console.log('Run with --write to regenerate the test file from the typedef block,');
+  console.log('or add the missing assertions manually. See the script header for details.');
+  process.exit(1);
+}
+
+// `--write` mode: regenerate the test file from the source list.
+const sortedNames = [...sourceTypes].sort();
+
+// Preserve the file header and the IsAny / AssertNotAny helpers; rewrite the
+// import block and the assertion list. Anchor on the existing structure.
+const header = `/**
+ * Consumer typecheck: every public type from superdoc must resolve to
+ * a real interface, not collapse to \`any\`, and not be missing.
+ *
+ * Each \`AssertNotAny<T>\` resolves to \`never\` when T is \`any\`, so the
+ * \`const _real_X: AssertNotAny<X> = true\` lines fail to compile if X
+ * has collapsed. A missing export shows up as TS2305 on the import.
+ *
+ * THIS FILE IS GENERATED from the JSDoc @typedef block in
+ * packages/superdoc/src/index.js. Edit the typedef block (or run
+ *   pnpm --filter consumer-typecheck run check:types -- --write
+ * to regenerate this file) and commit both. SD-2860's check script enforces
+ * that the two stay in sync; a missing assertion fails CI with a message
+ * pointing at this script.
+ */
+import type {
+${sortedNames.map((n) => `  ${n},`).join('\n')}
+} from 'superdoc';
+
+// Helper: IsAny<T> resolves to \`true\` when T is \`any\`, otherwise false.
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type AssertNotAny<T> = IsAny<T> extends true ? never : true;
+
+// One assertion per type. If T is \`any\`, AssertNotAny<T> is \`never\` and
+// the line below fails to compile with "Type 'true' is not assignable
+// to type 'never'". If T is real, it compiles silently.
+${sortedNames.map((n) => `const _real_${n}: AssertNotAny<${n}> = true;`).join('\n')}
+`;
+
+fs.writeFileSync(TEST_FILE, header);
+console.log();
+console.log(`Wrote ${sortedNames.length} assertions to ${path.relative(repoRoot, TEST_FILE)}.`);
+process.exit(0);

--- a/tests/consumer-typecheck/package.json
+++ b/tests/consumer-typecheck/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "typecheck:matrix": "node typecheck-matrix.mjs"
+    "typecheck:matrix": "node typecheck-matrix.mjs",
+    "check:types": "node check-public-types.mjs",
+    "check:types:write": "node check-public-types.mjs --write"
   },
   "dependencies": {
     "superdoc": "file:../../packages/superdoc/superdoc.tgz"

--- a/tests/consumer-typecheck/src/all-public-types.ts
+++ b/tests/consumer-typecheck/src/all-public-types.ts
@@ -8,8 +8,9 @@
  *
  * THIS FILE IS GENERATED from the JSDoc @typedef block in
  * packages/superdoc/src/index.js. Edit the typedef block (or run
- *   pnpm --filter consumer-typecheck run check:types -- --write
- * to regenerate this file) and commit both. SD-2860's check script enforces
+ *   node tests/consumer-typecheck/check-public-types.mjs --write
+ * from the repo root, or `npm run check:types:write` from inside
+ * tests/consumer-typecheck) and commit both. SD-2860's check script enforces
  * that the two stay in sync; a missing assertion fails CI with a message
  * pointing at this script.
  */

--- a/tests/consumer-typecheck/src/all-public-types.ts
+++ b/tests/consumer-typecheck/src/all-public-types.ts
@@ -6,116 +6,130 @@
  * `const _real_X: AssertNotAny<X> = true` lines fail to compile if X
  * has collapsed. A missing export shows up as TS2305 on the import.
  *
- * The list of types is mined from packages/superdoc/src/index.js
- * @typedef block. Keep them in sync (or extend the test as new public
- * types are added to that block).
+ * THIS FILE IS GENERATED from the JSDoc @typedef block in
+ * packages/superdoc/src/index.js. Edit the typedef block (or run
+ *   pnpm --filter consumer-typecheck run check:types -- --write
+ * to regenerate this file) and commit both. SD-2860's check script enforces
+ * that the two stay in sync; a missing assertion fails CI with a message
+ * pointing at this script.
  */
 import type {
-  EditorState,
-  Transaction,
-  Schema,
-  EditorView,
-  EditorCommands,
-  ChainedCommand,
-  ChainableCommandObject,
-  CommandProps,
-  Command,
-  CanObject,
-  PresentationEditorOptions,
-  LayoutEngineOptions,
-  PageSize,
-  PageMargins,
-  VirtualizationOptions,
-  TrackedChangesMode,
-  TrackedChangesOverrides,
-  LayoutMode,
-  PresenceOptions,
-  RemoteUserInfo,
-  RemoteCursorState,
-  Layout,
-  LayoutPage,
-  LayoutFragment,
-  RangeRect,
-  BoundingRect,
-  LayoutError,
-  LayoutMetrics,
-  PositionHit,
-  FlowBlock,
-  Measure,
-  SectionMetadata,
-  PaintSnapshot,
-  OpenOptions,
-  DocxFileEntry,
   BinaryData,
-  UnsupportedContentItem,
-  SaveOptions,
-  ExportOptions,
-  SelectionHandle,
-  SelectionCommandContext,
-  ResolveRangeOutput,
-  SelectionApi,
-  SelectionInfo,
-  SelectionCurrentInput,
-  ScrollIntoViewInput,
-  ScrollIntoViewOutput,
-  TextTarget,
-  TextAddress,
-  TextSegment,
-  EntityAddress,
-  DocumentApi,
+  BlockNavigationAddress,
   BlocksListResult,
+  BookmarkAddress,
   BookmarkInfo,
-  LayoutUpdatePayload,
-  CoreCommandMap,
-  ExtensionCommandMap,
+  BoundingRect,
+  CanObject,
+  ChainableCommandObject,
+  ChainedCommand,
+  CollaborationProvider,
+  Command,
+  CommandProps,
   Comment,
+  CommentAddress,
+  CommentConfig,
   CommentElement,
-  CommentsPayload,
   CommentLocationsPayload,
-  FontsResolvedPayload,
-  PaginationPayload,
-  EditorEventMap,
-  ListDefinitionsPayload,
-  ProtectionChangeSource,
+  CommentsPayload,
+  ContextMenuConfig,
+  ContextMenuContext,
+  ContextMenuItem,
+  ContextMenuSection,
+  CoreCommandMap,
+  DocumentApi,
+  DocumentMode,
   DocumentProtectionState,
+  DocxFileEntry,
+  EditorCommands,
+  EditorEventMap,
+  EditorExtension,
+  EditorLifecycleState,
+  EditorOptions,
+  EditorState,
+  EditorView,
+  EntityAddress,
+  ExportDocxParams,
+  ExportFormat,
+  ExportOptions,
+  ExtensionCommandMap,
+  FieldValue,
+  FlowBlock,
+  FlowMode,
+  FontConfig,
+  FontsResolvedPayload,
+  ImageDeselectedEvent,
+  ImageSelectedEvent,
+  Layout,
+  LayoutEngineOptions,
+  LayoutError,
+  LayoutFragment,
+  LayoutMetrics,
+  LayoutMode,
+  LayoutPage,
+  LayoutState,
+  LayoutUpdatePayload,
+  LinkPopoverContext,
+  LinkPopoverResolution,
+  LinkPopoverResolver,
+  ListDefinitionsPayload,
+  Measure,
+  NavigableAddress,
+  OpenOptions,
+  PageMargins,
+  PageSize,
+  PageStyles,
+  PaginationPayload,
+  PaintSnapshot,
   PartChangedEvent,
   PartId,
   PartSectionId,
-  EditorOptions,
-  EditorLifecycleState,
-  User,
-  ProseMirrorJSON,
-  ExportFormat,
-  ExportDocxParams,
-  EditorExtension,
-  ViewLayout,
-  ViewOptions,
-  CommentConfig,
-  CollaborationProvider,
-  LinkPopoverResolver,
-  LinkPopoverContext,
-  LinkPopoverResolution,
   PermissionParams,
-  FontConfig,
-  FieldValue,
-  LayoutState,
-  ImageSelectedEvent,
-  ImageDeselectedEvent,
-  TelemetryEvent,
-  RemoteCursorsRenderPayload,
-  FlowMode,
-  ProofingProvider,
+  PositionHit,
+  PresenceOptions,
+  PresentationEditorOptions,
   ProofingCapabilities,
   ProofingCheckRequest,
   ProofingCheckResult,
-  ProofingSegment,
-  ProofingSegmentMetadata,
+  ProofingConfig,
+  ProofingError,
   ProofingIssue,
   ProofingIssueKind,
-  ProofingConfig,
+  ProofingProvider,
+  ProofingSegment,
+  ProofingSegmentMetadata,
   ProofingStatus,
-  ProofingError,
-  PageStyles,
+  ProseMirrorJSON,
+  ProtectionChangeSource,
+  RangeRect,
+  RemoteCursorState,
+  RemoteCursorsRenderPayload,
+  RemoteUserInfo,
+  ResolveRangeOutput,
+  SaveOptions,
+  Schema,
+  ScrollIntoViewInput,
+  ScrollIntoViewOutput,
+  SectionMetadata,
+  SelectionApi,
+  SelectionCommandContext,
+  SelectionCurrentInput,
+  SelectionHandle,
+  SelectionInfo,
+  StoryLocator,
+  TelemetryEvent,
+  TextAddress,
+  TextSegment,
+  TextTarget,
+  TrackedChangeAddress,
+  TrackedChangesMode,
+  TrackedChangesOverrides,
+  Transaction,
+  UnsupportedContentItem,
+  User,
+  ViewLayout,
+  ViewOptions,
+  VirtualizationOptions,
 } from 'superdoc';
 
 // Helper: IsAny<T> resolves to `true` when T is `any`, otherwise false.
@@ -125,108 +139,119 @@ type AssertNotAny<T> = IsAny<T> extends true ? never : true;
 // One assertion per type. If T is `any`, AssertNotAny<T> is `never` and
 // the line below fails to compile with "Type 'true' is not assignable
 // to type 'never'". If T is real, it compiles silently.
-const _real_EditorState: AssertNotAny<EditorState> = true;
-const _real_Transaction: AssertNotAny<Transaction> = true;
-const _real_Schema: AssertNotAny<Schema> = true;
-const _real_EditorView: AssertNotAny<EditorView> = true;
-const _real_EditorCommands: AssertNotAny<EditorCommands> = true;
-const _real_ChainedCommand: AssertNotAny<ChainedCommand> = true;
-const _real_ChainableCommandObject: AssertNotAny<ChainableCommandObject> = true;
-const _real_CommandProps: AssertNotAny<CommandProps> = true;
-const _real_Command: AssertNotAny<Command> = true;
-const _real_CanObject: AssertNotAny<CanObject> = true;
-const _real_PresentationEditorOptions: AssertNotAny<PresentationEditorOptions> = true;
-const _real_LayoutEngineOptions: AssertNotAny<LayoutEngineOptions> = true;
-const _real_PageSize: AssertNotAny<PageSize> = true;
-const _real_PageMargins: AssertNotAny<PageMargins> = true;
-const _real_VirtualizationOptions: AssertNotAny<VirtualizationOptions> = true;
-const _real_TrackedChangesMode: AssertNotAny<TrackedChangesMode> = true;
-const _real_TrackedChangesOverrides: AssertNotAny<TrackedChangesOverrides> = true;
-const _real_LayoutMode: AssertNotAny<LayoutMode> = true;
-const _real_PresenceOptions: AssertNotAny<PresenceOptions> = true;
-const _real_RemoteUserInfo: AssertNotAny<RemoteUserInfo> = true;
-const _real_RemoteCursorState: AssertNotAny<RemoteCursorState> = true;
-const _real_Layout: AssertNotAny<Layout> = true;
-const _real_LayoutPage: AssertNotAny<LayoutPage> = true;
-const _real_LayoutFragment: AssertNotAny<LayoutFragment> = true;
-const _real_RangeRect: AssertNotAny<RangeRect> = true;
-const _real_BoundingRect: AssertNotAny<BoundingRect> = true;
-const _real_LayoutError: AssertNotAny<LayoutError> = true;
-const _real_LayoutMetrics: AssertNotAny<LayoutMetrics> = true;
-const _real_PositionHit: AssertNotAny<PositionHit> = true;
-const _real_FlowBlock: AssertNotAny<FlowBlock> = true;
-const _real_Measure: AssertNotAny<Measure> = true;
-const _real_SectionMetadata: AssertNotAny<SectionMetadata> = true;
-const _real_PaintSnapshot: AssertNotAny<PaintSnapshot> = true;
-const _real_OpenOptions: AssertNotAny<OpenOptions> = true;
-const _real_DocxFileEntry: AssertNotAny<DocxFileEntry> = true;
 const _real_BinaryData: AssertNotAny<BinaryData> = true;
-const _real_UnsupportedContentItem: AssertNotAny<UnsupportedContentItem> = true;
-const _real_SaveOptions: AssertNotAny<SaveOptions> = true;
-const _real_ExportOptions: AssertNotAny<ExportOptions> = true;
-const _real_SelectionHandle: AssertNotAny<SelectionHandle> = true;
-const _real_SelectionCommandContext: AssertNotAny<SelectionCommandContext> = true;
-const _real_ResolveRangeOutput: AssertNotAny<ResolveRangeOutput> = true;
-const _real_SelectionApi: AssertNotAny<SelectionApi> = true;
-const _real_SelectionInfo: AssertNotAny<SelectionInfo> = true;
-const _real_SelectionCurrentInput: AssertNotAny<SelectionCurrentInput> = true;
-const _real_ScrollIntoViewInput: AssertNotAny<ScrollIntoViewInput> = true;
-const _real_ScrollIntoViewOutput: AssertNotAny<ScrollIntoViewOutput> = true;
-const _real_TextTarget: AssertNotAny<TextTarget> = true;
-const _real_TextAddress: AssertNotAny<TextAddress> = true;
-const _real_TextSegment: AssertNotAny<TextSegment> = true;
-const _real_EntityAddress: AssertNotAny<EntityAddress> = true;
-const _real_DocumentApi: AssertNotAny<DocumentApi> = true;
+const _real_BlockNavigationAddress: AssertNotAny<BlockNavigationAddress> = true;
 const _real_BlocksListResult: AssertNotAny<BlocksListResult> = true;
+const _real_BookmarkAddress: AssertNotAny<BookmarkAddress> = true;
 const _real_BookmarkInfo: AssertNotAny<BookmarkInfo> = true;
-const _real_LayoutUpdatePayload: AssertNotAny<LayoutUpdatePayload> = true;
-const _real_CoreCommandMap: AssertNotAny<CoreCommandMap> = true;
-const _real_ExtensionCommandMap: AssertNotAny<ExtensionCommandMap> = true;
+const _real_BoundingRect: AssertNotAny<BoundingRect> = true;
+const _real_CanObject: AssertNotAny<CanObject> = true;
+const _real_ChainableCommandObject: AssertNotAny<ChainableCommandObject> = true;
+const _real_ChainedCommand: AssertNotAny<ChainedCommand> = true;
+const _real_CollaborationProvider: AssertNotAny<CollaborationProvider> = true;
+const _real_Command: AssertNotAny<Command> = true;
+const _real_CommandProps: AssertNotAny<CommandProps> = true;
 const _real_Comment: AssertNotAny<Comment> = true;
+const _real_CommentAddress: AssertNotAny<CommentAddress> = true;
+const _real_CommentConfig: AssertNotAny<CommentConfig> = true;
 const _real_CommentElement: AssertNotAny<CommentElement> = true;
-const _real_CommentsPayload: AssertNotAny<CommentsPayload> = true;
 const _real_CommentLocationsPayload: AssertNotAny<CommentLocationsPayload> = true;
-const _real_FontsResolvedPayload: AssertNotAny<FontsResolvedPayload> = true;
-const _real_PaginationPayload: AssertNotAny<PaginationPayload> = true;
-const _real_EditorEventMap: AssertNotAny<EditorEventMap> = true;
-const _real_ListDefinitionsPayload: AssertNotAny<ListDefinitionsPayload> = true;
-const _real_ProtectionChangeSource: AssertNotAny<ProtectionChangeSource> = true;
+const _real_CommentsPayload: AssertNotAny<CommentsPayload> = true;
+const _real_ContextMenuConfig: AssertNotAny<ContextMenuConfig> = true;
+const _real_ContextMenuContext: AssertNotAny<ContextMenuContext> = true;
+const _real_ContextMenuItem: AssertNotAny<ContextMenuItem> = true;
+const _real_ContextMenuSection: AssertNotAny<ContextMenuSection> = true;
+const _real_CoreCommandMap: AssertNotAny<CoreCommandMap> = true;
+const _real_DocumentApi: AssertNotAny<DocumentApi> = true;
+const _real_DocumentMode: AssertNotAny<DocumentMode> = true;
 const _real_DocumentProtectionState: AssertNotAny<DocumentProtectionState> = true;
+const _real_DocxFileEntry: AssertNotAny<DocxFileEntry> = true;
+const _real_EditorCommands: AssertNotAny<EditorCommands> = true;
+const _real_EditorEventMap: AssertNotAny<EditorEventMap> = true;
+const _real_EditorExtension: AssertNotAny<EditorExtension> = true;
+const _real_EditorLifecycleState: AssertNotAny<EditorLifecycleState> = true;
+const _real_EditorOptions: AssertNotAny<EditorOptions> = true;
+const _real_EditorState: AssertNotAny<EditorState> = true;
+const _real_EditorView: AssertNotAny<EditorView> = true;
+const _real_EntityAddress: AssertNotAny<EntityAddress> = true;
+const _real_ExportDocxParams: AssertNotAny<ExportDocxParams> = true;
+const _real_ExportFormat: AssertNotAny<ExportFormat> = true;
+const _real_ExportOptions: AssertNotAny<ExportOptions> = true;
+const _real_ExtensionCommandMap: AssertNotAny<ExtensionCommandMap> = true;
+const _real_FieldValue: AssertNotAny<FieldValue> = true;
+const _real_FlowBlock: AssertNotAny<FlowBlock> = true;
+const _real_FlowMode: AssertNotAny<FlowMode> = true;
+const _real_FontConfig: AssertNotAny<FontConfig> = true;
+const _real_FontsResolvedPayload: AssertNotAny<FontsResolvedPayload> = true;
+const _real_ImageDeselectedEvent: AssertNotAny<ImageDeselectedEvent> = true;
+const _real_ImageSelectedEvent: AssertNotAny<ImageSelectedEvent> = true;
+const _real_Layout: AssertNotAny<Layout> = true;
+const _real_LayoutEngineOptions: AssertNotAny<LayoutEngineOptions> = true;
+const _real_LayoutError: AssertNotAny<LayoutError> = true;
+const _real_LayoutFragment: AssertNotAny<LayoutFragment> = true;
+const _real_LayoutMetrics: AssertNotAny<LayoutMetrics> = true;
+const _real_LayoutMode: AssertNotAny<LayoutMode> = true;
+const _real_LayoutPage: AssertNotAny<LayoutPage> = true;
+const _real_LayoutState: AssertNotAny<LayoutState> = true;
+const _real_LayoutUpdatePayload: AssertNotAny<LayoutUpdatePayload> = true;
+const _real_LinkPopoverContext: AssertNotAny<LinkPopoverContext> = true;
+const _real_LinkPopoverResolution: AssertNotAny<LinkPopoverResolution> = true;
+const _real_LinkPopoverResolver: AssertNotAny<LinkPopoverResolver> = true;
+const _real_ListDefinitionsPayload: AssertNotAny<ListDefinitionsPayload> = true;
+const _real_Measure: AssertNotAny<Measure> = true;
+const _real_NavigableAddress: AssertNotAny<NavigableAddress> = true;
+const _real_OpenOptions: AssertNotAny<OpenOptions> = true;
+const _real_PageMargins: AssertNotAny<PageMargins> = true;
+const _real_PageSize: AssertNotAny<PageSize> = true;
+const _real_PageStyles: AssertNotAny<PageStyles> = true;
+const _real_PaginationPayload: AssertNotAny<PaginationPayload> = true;
+const _real_PaintSnapshot: AssertNotAny<PaintSnapshot> = true;
 const _real_PartChangedEvent: AssertNotAny<PartChangedEvent> = true;
 const _real_PartId: AssertNotAny<PartId> = true;
 const _real_PartSectionId: AssertNotAny<PartSectionId> = true;
-const _real_EditorOptions: AssertNotAny<EditorOptions> = true;
-const _real_EditorLifecycleState: AssertNotAny<EditorLifecycleState> = true;
-const _real_User: AssertNotAny<User> = true;
-const _real_ProseMirrorJSON: AssertNotAny<ProseMirrorJSON> = true;
-const _real_ExportFormat: AssertNotAny<ExportFormat> = true;
-const _real_ExportDocxParams: AssertNotAny<ExportDocxParams> = true;
-const _real_EditorExtension: AssertNotAny<EditorExtension> = true;
-const _real_ViewLayout: AssertNotAny<ViewLayout> = true;
-const _real_ViewOptions: AssertNotAny<ViewOptions> = true;
-const _real_CommentConfig: AssertNotAny<CommentConfig> = true;
-const _real_CollaborationProvider: AssertNotAny<CollaborationProvider> = true;
-const _real_LinkPopoverResolver: AssertNotAny<LinkPopoverResolver> = true;
-const _real_LinkPopoverContext: AssertNotAny<LinkPopoverContext> = true;
-const _real_LinkPopoverResolution: AssertNotAny<LinkPopoverResolution> = true;
 const _real_PermissionParams: AssertNotAny<PermissionParams> = true;
-const _real_FontConfig: AssertNotAny<FontConfig> = true;
-const _real_FieldValue: AssertNotAny<FieldValue> = true;
-const _real_LayoutState: AssertNotAny<LayoutState> = true;
-const _real_ImageSelectedEvent: AssertNotAny<ImageSelectedEvent> = true;
-const _real_ImageDeselectedEvent: AssertNotAny<ImageDeselectedEvent> = true;
-const _real_TelemetryEvent: AssertNotAny<TelemetryEvent> = true;
-const _real_RemoteCursorsRenderPayload: AssertNotAny<RemoteCursorsRenderPayload> = true;
-const _real_FlowMode: AssertNotAny<FlowMode> = true;
-const _real_ProofingProvider: AssertNotAny<ProofingProvider> = true;
+const _real_PositionHit: AssertNotAny<PositionHit> = true;
+const _real_PresenceOptions: AssertNotAny<PresenceOptions> = true;
+const _real_PresentationEditorOptions: AssertNotAny<PresentationEditorOptions> = true;
 const _real_ProofingCapabilities: AssertNotAny<ProofingCapabilities> = true;
 const _real_ProofingCheckRequest: AssertNotAny<ProofingCheckRequest> = true;
 const _real_ProofingCheckResult: AssertNotAny<ProofingCheckResult> = true;
-const _real_ProofingSegment: AssertNotAny<ProofingSegment> = true;
-const _real_ProofingSegmentMetadata: AssertNotAny<ProofingSegmentMetadata> = true;
+const _real_ProofingConfig: AssertNotAny<ProofingConfig> = true;
+const _real_ProofingError: AssertNotAny<ProofingError> = true;
 const _real_ProofingIssue: AssertNotAny<ProofingIssue> = true;
 const _real_ProofingIssueKind: AssertNotAny<ProofingIssueKind> = true;
-const _real_ProofingConfig: AssertNotAny<ProofingConfig> = true;
+const _real_ProofingProvider: AssertNotAny<ProofingProvider> = true;
+const _real_ProofingSegment: AssertNotAny<ProofingSegment> = true;
+const _real_ProofingSegmentMetadata: AssertNotAny<ProofingSegmentMetadata> = true;
 const _real_ProofingStatus: AssertNotAny<ProofingStatus> = true;
-const _real_ProofingError: AssertNotAny<ProofingError> = true;
-const _real_PageStyles: AssertNotAny<PageStyles> = true;
+const _real_ProseMirrorJSON: AssertNotAny<ProseMirrorJSON> = true;
+const _real_ProtectionChangeSource: AssertNotAny<ProtectionChangeSource> = true;
+const _real_RangeRect: AssertNotAny<RangeRect> = true;
+const _real_RemoteCursorState: AssertNotAny<RemoteCursorState> = true;
+const _real_RemoteCursorsRenderPayload: AssertNotAny<RemoteCursorsRenderPayload> = true;
+const _real_RemoteUserInfo: AssertNotAny<RemoteUserInfo> = true;
+const _real_ResolveRangeOutput: AssertNotAny<ResolveRangeOutput> = true;
+const _real_SaveOptions: AssertNotAny<SaveOptions> = true;
+const _real_Schema: AssertNotAny<Schema> = true;
+const _real_ScrollIntoViewInput: AssertNotAny<ScrollIntoViewInput> = true;
+const _real_ScrollIntoViewOutput: AssertNotAny<ScrollIntoViewOutput> = true;
+const _real_SectionMetadata: AssertNotAny<SectionMetadata> = true;
+const _real_SelectionApi: AssertNotAny<SelectionApi> = true;
+const _real_SelectionCommandContext: AssertNotAny<SelectionCommandContext> = true;
+const _real_SelectionCurrentInput: AssertNotAny<SelectionCurrentInput> = true;
+const _real_SelectionHandle: AssertNotAny<SelectionHandle> = true;
+const _real_SelectionInfo: AssertNotAny<SelectionInfo> = true;
+const _real_StoryLocator: AssertNotAny<StoryLocator> = true;
+const _real_TelemetryEvent: AssertNotAny<TelemetryEvent> = true;
+const _real_TextAddress: AssertNotAny<TextAddress> = true;
+const _real_TextSegment: AssertNotAny<TextSegment> = true;
+const _real_TextTarget: AssertNotAny<TextTarget> = true;
+const _real_TrackedChangeAddress: AssertNotAny<TrackedChangeAddress> = true;
+const _real_TrackedChangesMode: AssertNotAny<TrackedChangesMode> = true;
+const _real_TrackedChangesOverrides: AssertNotAny<TrackedChangesOverrides> = true;
+const _real_Transaction: AssertNotAny<Transaction> = true;
+const _real_UnsupportedContentItem: AssertNotAny<UnsupportedContentItem> = true;
+const _real_User: AssertNotAny<User> = true;
+const _real_ViewLayout: AssertNotAny<ViewLayout> = true;
+const _real_ViewOptions: AssertNotAny<ViewOptions> = true;
+const _real_VirtualizationOptions: AssertNotAny<VirtualizationOptions> = true;

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -30,6 +30,26 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..', '..');
 
 const skipPack = process.argv.includes('--skip-pack');
+const skipTypeCheck = process.argv.includes('--skip-public-types-check');
+
+// SD-2860: before doing any of the matrix work, fail fast if the public-type
+// surface drifted from the assertion list. Otherwise a developer who added a
+// new public typedef can ship past every other gate without an assertion for
+// the new type.
+if (!skipTypeCheck) {
+  console.log('Checking public-type surface against the assertion list...');
+  try {
+    execSync('node check-public-types.mjs', {
+      cwd: __dirname,
+      stdio: 'inherit',
+    });
+  } catch (e) {
+    console.error('\nPublic-type surface check failed (see message above).');
+    console.error('Run `pnpm --filter consumer-typecheck run check:types:write` locally to regenerate the assertion list, then commit the result.');
+    process.exit(1);
+  }
+  console.log();
+}
 
 if (!skipPack) {
   console.log('Packing superdoc and reinstalling fixture...');

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -45,7 +45,8 @@ if (!skipTypeCheck) {
     });
   } catch (e) {
     console.error('\nPublic-type surface check failed (see message above).');
-    console.error('Run `pnpm --filter consumer-typecheck run check:types:write` locally to regenerate the assertion list, then commit the result.');
+    console.error('Run `node tests/consumer-typecheck/check-public-types.mjs --write` from the repo root (or `npm run check:types:write` from inside `tests/consumer-typecheck/`) to regenerate the assertion list, then commit the result.');
+    console.error('(`tests/consumer-typecheck` is intentionally outside the pnpm workspace, so `pnpm --filter` cannot reach it.)');
     process.exit(1);
   }
   console.log();


### PR DESCRIPTION
The `all-public-types.ts` test was a hand-maintained list mined from the JSDoc `@typedef` block in `packages/superdoc/src/index.js`. A new public type added to that block could ship without an assertion, leaving the new export unprotected — exactly the regression class the test exists to prevent.

The list had already drifted. Eleven types added since the test was committed had no coverage:

- `BlockNavigationAddress`
- `BookmarkAddress`
- `CommentAddress`
- `ContextMenuConfig`
- `ContextMenuContext`
- `ContextMenuItem`
- `ContextMenuSection`
- `DocumentMode`
- `NavigableAddress`
- `StoryLocator`
- `TrackedChangeAddress`

This PR adds `tests/consumer-typecheck/check-public-types.mjs` which reads the typedef block, reads the assertion list, and exits non-zero if they differ. The matrix runs it as a pre-check so a drifted list fails CI before any scenarios run, with a clear message pointing at the npm script that regenerates the file:

```
$ pnpm --filter consumer-typecheck run check:types:write
```

Verified locally by injecting a fake `FakeNewType` typedef in `packages/superdoc/src/index.js` and watching the matrix bail before running scenarios with `FAIL  1 public type missing from the test:        FakeNewType`.

`all-public-types.ts` is now regenerated to reflect the current surface (116 typedefs, 116 assertions). Future drift fails CI; the fix path is one command.

Verified: matrix 17/17 required pass; the new pre-check passes when source and test are in sync, fails when they drift.