### PR TITLE
chore(test): merge queue smoke

### DIFF
--- a/tests/behavior/README.md
+++ b/tests/behavior/README.md
@@ -1,5 +1,7 @@
 # Behavior Tests
 
+<!-- merge-queue smoke test: this comment is a no-op to be reverted after queue mechanics are validated. -->
+
 Playwright tests that run against a real SuperDoc instance in the browser (Chromium, Firefox, WebKit).
 
 ## Setup


### PR DESCRIPTION
Single-line comment in tests/behavior/README.md to trigger ci-behavior and ci-superdoc on the new merge queue config. Not for landing - will close after queue mechanics are verified.

Test plan:
- As maintainer with no approval, observe whether the merge UI offers Merge when ready (queue accepts) or only Bypass and merge (queue refuses bypass actors without approval)
- If queue accepts, watch https://github.com/superdoc-dev/superdoc/queue/main and confirm merge_group fires both required workflows on the merge candidate