### PR TITLE
feat(ui): pass routed editor to custom-command execute (SD-2844)

### DIFF
--- a/demos/build-your-own-ui/src/components/InsertClauseButton.tsx
+++ b/demos/build-your-own-ui/src/components/InsertClauseButton.tsx
@@ -92,7 +92,7 @@ export function InsertClauseButton() {
           state.documentMode === 'viewing' ||
           state.selection.target === null,
       }),
-      execute: ({ payload, superdoc }) => {
+      execute: ({ payload, editor }) => {
         if (!payload) return false;
         const clause = CLAUSES.find((c) => c.id === payload.clauseId);
         if (!clause) return false;
@@ -101,20 +101,10 @@ export function InsertClauseButton() {
         // already exposes the cursor in BOTH shapes the doc-api
         // consumes: `target` (TextTarget, for comments / format.apply)
         // and `selectionTarget` (SelectionTarget, for insert /
-        // replace). No inline lift, no adapter-helper import; pass
-        // `selectionTarget` straight through.
+        // replace). Pass `selectionTarget` straight through.
         const selectionTarget = ui.selection.getSnapshot().selectionTarget;
         if (!selectionTarget) return false;
-        const host = superdoc as {
-          activeEditor?: {
-            doc?: {
-              insert(input: { value: string; type: 'text'; target: typeof selectionTarget }): {
-                success: boolean;
-              };
-            };
-          };
-        };
-        const receipt = host.activeEditor?.doc?.insert({
+        const receipt = editor?.doc?.insert?.({
           value: clause.body,
           type: 'text',
           target: selectionTarget,

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -942,6 +942,10 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
   // built-ins. Built-in collisions are refused without `override: true`.
   const customCommandsRegistry = createCustomCommandsRegistry({
     superdoc,
+    // Late-bound so `execute` sees whichever story editor is active at
+    // the time the command runs (matches the routing every other
+    // `ui.*` mutation uses).
+    getEditor: () => resolveRoutedEditor(superdoc),
     isBuiltIn: (id) => BUILT_IN_COMMAND_ID_SET.has(id),
     scheduleNotify,
     buildSubscribable: (id) => select((state) => state.toolbar.commands?.[id], shallowEqual),

--- a/packages/super-editor/src/ui/custom-commands.test.ts
+++ b/packages/super-editor/src/ui/custom-commands.test.ts
@@ -105,7 +105,35 @@ describe('ui.commands.register', () => {
     expect(execute).toHaveBeenCalledWith({
       payload: { prompt: 'fix tone' },
       superdoc,
+      editor: superdoc.activeEditor,
     });
+
+    ui.destroy();
+  });
+
+  it('execute receives the routed editor late-bound (story swap between register and execute)', () => {
+    const { superdoc, editor } = makeStubs();
+    const ui = createSuperDocUI({ superdoc });
+
+    const execute = vi.fn(() => true);
+    const reg = ui.commands.register({ id: 'company.aiRewrite', execute });
+
+    // Plant a child story editor that PresentationEditor would route
+    // to (header focus, footer focus, etc). The custom-command runtime
+    // re-resolves on each execute, so the edit-time editor must be the
+    // routed one — not whichever was active at register-time.
+    const childEditor = { tag: 'header-editor' };
+    (
+      editor as unknown as {
+        presentationEditor?: { getActiveEditor?: () => unknown };
+      }
+    ).presentationEditor = { getActiveEditor: () => childEditor };
+
+    reg.handle.execute();
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    const args = execute.mock.calls[0]?.[0] as { editor: unknown };
+    expect(args.editor).toBe(childEditor);
 
     ui.destroy();
   });
@@ -645,6 +673,7 @@ describe('ui.commands.get', () => {
     expect(execute).toHaveBeenCalledWith({
       payload: { prompt: 'fix tone' },
       superdoc,
+      editor: superdoc.activeEditor,
     });
 
     ui.destroy();

--- a/packages/super-editor/src/ui/custom-commands.ts
+++ b/packages/super-editor/src/ui/custom-commands.ts
@@ -3,6 +3,7 @@ import type {
   CustomCommandRegistrationResult,
   CustomCommandHandle,
   CustomCommandHandleState,
+  SuperDocEditorLike,
   SuperDocLike,
   SuperDocUIState,
   Subscribable,
@@ -80,6 +81,15 @@ interface CustomCommandsRegistryDeps {
   isBuiltIn(id: string): boolean;
   /** Host superdoc passed to custom `execute` callbacks. */
   superdoc: SuperDocLike;
+  /**
+   * Resolve the routed editor at execute-time. Passed to custom
+   * `execute` callbacks alongside `superdoc` so registrations can
+   * reach `editor.doc.*` without a structural cast. Late-bound (a
+   * function, not a captured value) so the registry sees whichever
+   * story editor is active when the command runs, matching the
+   * routing the rest of `ui.*` uses.
+   */
+  getEditor(): SuperDocEditorLike | null;
   /**
    * Re-emit the controller snapshot. Called whenever the registry
    * changes (register / unregister / invalidate) so subscribers see the
@@ -353,9 +363,16 @@ export function createCustomCommandsRegistry(deps: CustomCommandsRegistryDeps): 
         // `register<TPayload>(...)` signature carries the consumer's
         // payload type to the captured handle, but the runtime registry
         // stores entries with the default `void` payload. Cast to bridge.
-        const result = (entry.execute as (args: { payload?: unknown; superdoc: SuperDocLike }) => unknown)({
+        const result = (
+          entry.execute as (args: {
+            payload?: unknown;
+            superdoc: SuperDocLike;
+            editor: SuperDocEditorLike | null;
+          }) => unknown
+        )({
           payload,
           superdoc: deps.superdoc,
+          editor: deps.getEditor(),
         });
         if (result instanceof Promise) {
           return result.then(

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -112,6 +112,18 @@ export interface SuperDocEditorLike {
       list?(query?: unknown): unknown;
       decide?(input: unknown, options?: unknown): unknown;
     };
+    /**
+     * Insert content at a positional target. Surfaces the typed
+     * doc-API signature so custom commands can call
+     * `editor.doc.insert(...)` without a structural cast. The control
+     * surface needs `editor.doc.insert` for the BYO-UI custom-command
+     * pattern (Insert clause, AI-generated text); other doc-API
+     * mutation methods stay loose unless a similar use case lands.
+     */
+    insert?(
+      input: import('@superdoc/document-api').InsertInput,
+      options?: unknown,
+    ): import('@superdoc/document-api').SDMutationReceipt;
   };
   /**
    * PresentationEditor handle. Browser-only. The controller calls
@@ -814,12 +826,23 @@ export type CustomCommandRegistration<TPayload = void, TValue = unknown> = {
    */
   id: string;
   /**
-   * Execute the command. Receives `payload` (typed per registration)
-   * and the host `superdoc` instance. Return value is normalized to
-   * `boolean` for the synchronous result; async commands return a
-   * Promise that the runtime awaits internally.
+   * Execute the command. Receives:
+   *
+   * - `payload` (typed per registration),
+   * - the host `superdoc` instance, and
+   * - the routed `editor` — the same editor `ui.commands.*` mutations
+   *   target. Use `editor.doc.*` for direct Document API access without
+   *   reaching `superdoc.activeEditor`. `editor` is `null` before the
+   *   editor has reported ready, so guard early.
+   *
+   * Return value is normalized to `boolean` for the synchronous result;
+   * async commands return a Promise the runtime awaits internally.
    */
-  execute: (args: { payload?: TPayload; superdoc: SuperDocLike }) => boolean | void | Promise<boolean | void>;
+  execute: (args: {
+    payload?: TPayload;
+    superdoc: SuperDocLike;
+    editor: SuperDocEditorLike | null;
+  }) => boolean | void | Promise<boolean | void>;
   /**
    * Optional state deriver. Runs on every snapshot rebuild. If omitted,
    * the command's state stays static at `{ active: false, disabled: false, value: undefined }`.


### PR DESCRIPTION
Custom commands previously reached the Document API through a structural cast on \`superdoc.activeEditor\`. The \`execute\` callback now receives a third argument:

\`\`\`ts
execute: ({ payload, superdoc, editor }) => {
  if (!editor) return false;
  return editor.doc?.insert?.({ ... })?.success === true;
}
\`\`\`

\`editor\` is typed as \`SuperDocEditorLike | null\` and resolved late-bound at execute time, so it tracks header/footer focus the same way every other \`ui.*\` mutation does.

- \`SuperDocEditorLike.doc\` widens to include a typed \`insert(input: InsertInput, options?: unknown): SDMutationReceipt\` signature, matching the doc-api shape. Other doc-API mutation methods stay loose (\`unknown\` in / \`unknown\` out) unless a comparable BYO-UI pattern lands.
- Demo's \`InsertClauseButton\` drops the structural cast.
- New test asserts the routed editor is passed: planted child story editor flows through to \`execute\` instead of whichever was active at register time.
- Existing tests update to assert \`{ payload, superdoc, editor }\` shape.

**Review**: backwards-compatibility — \`execute\` callbacks that destructure \`{ payload, superdoc }\` ignore \`editor\`, so this is additive. Worth confirming the \`SDMutationReceipt\` choice (\`Receipt\` would also fit; the doc-api uses \`SDMutationReceipt\` for \`insert\` specifically).
**Verified**: 158/158 super-editor UI tests; superdoc + @superdoc-dev/react builds clean; BYO-UI demo builds clean.

Once merged, the BYO-UI docs PR (#3034) drops the structural-cast snippet on \`custom-commands.mdx\` in favor of \`editor.doc?.insert?.(...)\`.