### PR TITLE
feat(ui): add ui.document.dirty for unsaved-changes indicators (SD-2667)

### DIFF
--- a/demos/build-your-own-ui/src/components/Toolbar.tsx
+++ b/demos/build-your-own-ui/src/components/Toolbar.tsx
@@ -181,6 +181,10 @@ function ToolbarButton({
  */
 function ExportButton() {
   const ui = useSuperDocUI();
+  // Read the dirty flag so the button can hint at unsaved changes.
+  // `useSuperDocDocument` re-renders only when ready / mode / dirty
+  // flip, so a typing burst is one re-render, not many.
+  const { dirty } = useSuperDocDocument();
 
   const onClick = async () => {
     if (!ui) return;
@@ -197,8 +201,18 @@ function ExportButton() {
   };
 
   return (
-    <button className="tb-btn export-btn" disabled={!ui} title="Download as DOCX" onClick={onClick}>
+    <button
+      className="tb-btn export-btn"
+      disabled={!ui}
+      title={dirty ? 'Download as DOCX (unsaved changes)' : 'Download as DOCX'}
+      onClick={onClick}
+    >
       Export
+      {dirty ? (
+        <span aria-hidden style={{ marginLeft: 4, color: '#f59e0b' }}>
+          •
+        </span>
+      ) : null}
     </button>
   );
 }

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -465,6 +465,15 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
   let documentMemo: { slice: DocumentSlice } | null = null;
 
   /**
+   * Internal dirty flag. Flipped to `true` by any editor transaction
+   * with `tr.docChanged`; cleared by a successful `ui.document.export`
+   * or by `ui.document.replaceFile`. Selection-only transactions don't
+   * touch it. Tracked separately from `documentMemo` so a flag flip
+   * busts the memo without re-allocating on every typing-only event.
+   */
+  let dirty = false;
+
+  /**
    * Stable string key over a SelectionInfo for slice memoization. Two
    * infos producing the same key represent the same observable
    * selection state, so the slice can be reused.
@@ -637,10 +646,15 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     // (ready, mode) are unchanged so `shallowEqual` on `state.document`
     // short-circuits ui.document.subscribe per transaction.
     let documentSlice: DocumentSlice;
-    if (documentMemo && documentMemo.slice.ready === ready && documentMemo.slice.mode === documentMode) {
+    if (
+      documentMemo &&
+      documentMemo.slice.ready === ready &&
+      documentMemo.slice.mode === documentMode &&
+      documentMemo.slice.dirty === dirty
+    ) {
       documentSlice = documentMemo.slice;
     } else {
-      documentSlice = { ready, mode: documentMode };
+      documentSlice = { ready, mode: documentMode, dirty };
       documentMemo = { slice: documentSlice };
     }
 
@@ -703,12 +717,30 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     scheduleNotify();
   };
 
+  /**
+   * Mutates `dirty` to `true` when a transaction actually changed the
+   * document. Read `payload.transaction.docChanged` so selection-only
+   * transactions (cursor moves, range adjustments) don't flip the flag.
+   * `scheduleNotify()` runs separately via the EDITOR_EVENTS wiring so
+   * we don't double-notify here.
+   */
+  const onTransaction = (payload: unknown) => {
+    if (dirty) return;
+    const tr = (payload as { transaction?: { docChanged?: unknown } } | undefined)?.transaction;
+    if (tr && tr.docChanged === true) {
+      dirty = true;
+    }
+  };
+
   const attachEditorListeners = () => {
     const next = resolveRoutedEditor(superdoc);
     if (next === currentEditor) return;
     currentEditorTeardown?.();
     currentEditorTeardown = null;
     currentEditor = next;
+    // Editor swap (replaceFile, document switch) resets dirty to a
+    // clean state — the new document hasn't been edited yet.
+    dirty = false;
     if (!next || typeof next.on !== 'function' || typeof next.off !== 'function') return;
 
     EDITOR_EVENTS.forEach((name) => {
@@ -721,9 +753,14 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     LIST_REFRESH_EVENTS.forEach((name) => {
       next.on?.(name, refreshAndNotify);
     });
+    // Dirty-flag listener. Runs alongside the scheduleNotify wiring on
+    // 'transaction' (kept separate so `dirty` reads the transaction
+    // payload before the snapshot is recomputed).
+    next.on?.('transaction', onTransaction);
     currentEditorTeardown = () => {
       EDITOR_EVENTS.forEach((name) => next.off?.(name, scheduleNotify));
       LIST_REFRESH_EVENTS.forEach((name) => next.off?.(name, refreshAndNotify));
+      next.off?.('transaction', onTransaction);
     };
     // The set of source events changed and the routed editor swapped
     // — refresh the comments cache for the new editor and recompute
@@ -1551,7 +1588,15 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
         // as the requireDocComments helper used by ui.comments.
         throw new Error('ui.document.export: host SuperDoc instance does not implement export().');
       }
-      return exportFn.call(superdoc, options);
+      // Successful export = persisted snapshot, clear dirty. A reject
+      // leaves dirty alone so the consumer can retry. Notify after the
+      // flip so subscribers see `dirty: false` synchronously.
+      const result = await exportFn.call(superdoc, options);
+      if (dirty) {
+        dirty = false;
+        scheduleNotify();
+      }
+      return result;
     },
     async replaceFile(file: File): Promise<void> {
       const editor = superdoc.activeEditor;
@@ -1560,6 +1605,14 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
         throw new Error('ui.document.replaceFile: host has no active editor with replaceFile().');
       }
       await replace.call(editor, file);
+      // Replacing the file rebuilds the document model from scratch —
+      // selection, scroll, and dirty all reset. The editor swap flips
+      // `dirty` via attachEditorListeners; clear here defensively in
+      // case the swap doesn't fire (same-instance reuse).
+      if (dirty) {
+        dirty = false;
+        scheduleNotify();
+      }
       // SD-2839 workaround: when `modules.comments: false`,
       // `Editor.#initComments()` short-circuits and never re-emits
       // `commentsLoaded` after `replaceFile`. The controller normally

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -738,9 +738,13 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     currentEditorTeardown?.();
     currentEditorTeardown = null;
     currentEditor = next;
-    // Editor swap (replaceFile, document switch) resets dirty to a
-    // clean state — the new document hasn't been edited yet.
-    dirty = false;
+    // NOTE: don't reset `dirty` here. `attachEditorListeners` also
+    // runs on routed-surface swaps (body ↔ header / footer / footnote
+    // via `activeSurfaceChange`), and clearing the flag there would
+    // hide unsaved body edits whenever the user clicked into a
+    // different surface. The flag is reset only by:
+    //   - `editorCreate` (new document mounted by the host), or
+    //   - `ui.document.replaceFile()` (explicit consumer action).
     if (!next || typeof next.on !== 'function' || typeof next.off !== 'function') return;
 
     EDITOR_EVENTS.forEach((name) => {
@@ -798,6 +802,19 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     };
   };
 
+  // Dedicated dirty reset on document mount. `editorCreate` fires when
+  // the host creates a fresh editor — initial mount, or after
+  // `replaceFile` rebuilds the model — so the new document opens
+  // clean. Kept as a separate handler (rather than folded into
+  // attachEditorListeners) because that helper also runs on surface
+  // swaps within the same document, which must NOT clear dirty.
+  const resetDirtyOnNewDocument = () => {
+    if (dirty) {
+      dirty = false;
+      scheduleNotify();
+    }
+  };
+
   attachPresentationListeners();
   attachEditorListeners();
   if (typeof superdoc.on === 'function') {
@@ -805,11 +822,13 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     // surface. Re-attach both layers so the controller follows.
     superdoc.on?.('editorCreate', attachPresentationListeners);
     superdoc.on?.('editorCreate', attachEditorListeners);
+    superdoc.on?.('editorCreate', resetDirtyOnNewDocument);
   }
   teardown.push(() => {
     if (typeof superdoc.off === 'function') {
       superdoc.off?.('editorCreate', attachPresentationListeners);
       superdoc.off?.('editorCreate', attachEditorListeners);
+      superdoc.off?.('editorCreate', resetDirtyOnNewDocument);
     }
     currentPresentationTeardown?.();
     currentPresentationTeardown = null;

--- a/packages/super-editor/src/ui/document.test.ts
+++ b/packages/super-editor/src/ui/document.test.ts
@@ -87,7 +87,7 @@ describe('ui.document', () => {
     const { superdoc } = makeStubs('suggesting');
     const ui = createSuperDocUI({ superdoc });
 
-    expect(ui.document.getSnapshot()).toEqual({ ready: true, mode: 'suggesting' });
+    expect(ui.document.getSnapshot()).toEqual({ ready: true, mode: 'suggesting', dirty: false });
 
     ui.destroy();
   });
@@ -100,7 +100,7 @@ describe('ui.document', () => {
     ui.document.subscribe(listener);
 
     expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener.mock.calls[0][0]).toEqual({ snapshot: { ready: true, mode: 'editing' } });
+    expect(listener.mock.calls[0][0]).toEqual({ snapshot: { ready: true, mode: 'editing', dirty: false } });
 
     ui.destroy();
   });
@@ -122,7 +122,7 @@ describe('ui.document', () => {
     await Promise.resolve();
 
     expect(listener).toHaveBeenCalledTimes(2);
-    expect(listener.mock.calls[1][0].snapshot).toEqual({ ready: true, mode: 'viewing' });
+    expect(listener.mock.calls[1][0].snapshot).toEqual({ ready: true, mode: 'viewing', dirty: false });
 
     ui.destroy();
   });
@@ -148,6 +148,128 @@ describe('ui.document', () => {
 
     expect(listener).toHaveBeenCalledTimes(1);
 
+    ui.destroy();
+  });
+
+  it('dirty starts false on a freshly-mounted editor', () => {
+    const { superdoc } = makeStubs('editing');
+    const ui = createSuperDocUI({ superdoc });
+    expect(ui.document.getSnapshot().dirty).toBe(false);
+    ui.destroy();
+  });
+
+  it('dirty flips to true on a transaction with docChanged', async () => {
+    const { superdoc } = makeStubs('editing');
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.document.getSnapshot().dirty).toBe(false);
+
+    superdoc.fireEditor('transaction', {
+      editor: superdoc.activeEditor,
+      transaction: { docChanged: true },
+      duration: 1,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ui.document.getSnapshot().dirty).toBe(true);
+    ui.destroy();
+  });
+
+  it('dirty stays false on selection-only transactions (docChanged: false)', async () => {
+    const { superdoc } = makeStubs('editing');
+    const ui = createSuperDocUI({ superdoc });
+
+    superdoc.fireEditor('transaction', {
+      editor: superdoc.activeEditor,
+      transaction: { docChanged: false },
+      duration: 1,
+    });
+    await Promise.resolve();
+
+    expect(ui.document.getSnapshot().dirty).toBe(false);
+    ui.destroy();
+  });
+
+  it('dirty re-fires subscribers when it flips', async () => {
+    const { superdoc } = makeStubs('editing');
+    const ui = createSuperDocUI({ superdoc });
+
+    const listener = vi.fn();
+    ui.document.subscribe(listener);
+    expect(listener).toHaveBeenCalledTimes(1); // initial
+
+    superdoc.fireEditor('transaction', {
+      editor: superdoc.activeEditor,
+      transaction: { docChanged: true },
+      duration: 1,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls[1][0].snapshot.dirty).toBe(true);
+
+    ui.destroy();
+  });
+
+  it('successful export() clears dirty', async () => {
+    const { superdoc } = makeStubs('editing');
+    const ui = createSuperDocUI({ superdoc });
+
+    superdoc.fireEditor('transaction', {
+      editor: superdoc.activeEditor,
+      transaction: { docChanged: true },
+      duration: 1,
+    });
+    await Promise.resolve();
+    expect(ui.document.getSnapshot().dirty).toBe(true);
+
+    await ui.document.export({ exportType: ['docx'] });
+    await Promise.resolve();
+
+    expect(ui.document.getSnapshot().dirty).toBe(false);
+    ui.destroy();
+  });
+
+  it('rejected export() leaves dirty alone so the consumer can retry', async () => {
+    const { superdoc } = makeStubs('editing');
+    superdoc.export = vi.fn(async () => {
+      throw new Error('host explosion');
+    }) as ReturnType<typeof vi.fn>;
+    const ui = createSuperDocUI({ superdoc });
+
+    superdoc.fireEditor('transaction', {
+      editor: superdoc.activeEditor,
+      transaction: { docChanged: true },
+      duration: 1,
+    });
+    await Promise.resolve();
+    expect(ui.document.getSnapshot().dirty).toBe(true);
+
+    await expect(ui.document.export({ exportType: ['docx'] })).rejects.toThrow('host explosion');
+    expect(ui.document.getSnapshot().dirty).toBe(true);
+
+    ui.destroy();
+  });
+
+  it('replaceFile() clears dirty', async () => {
+    const { superdoc, editor } = makeStubs('editing');
+    (editor as unknown as { replaceFile: ReturnType<typeof vi.fn> }).replaceFile = vi.fn(async () => undefined);
+    const ui = createSuperDocUI({ superdoc });
+
+    superdoc.fireEditor('transaction', {
+      editor: superdoc.activeEditor,
+      transaction: { docChanged: true },
+      duration: 1,
+    });
+    await Promise.resolve();
+    expect(ui.document.getSnapshot().dirty).toBe(true);
+
+    await ui.document.replaceFile(new File([''], 'next.docx'));
+    await Promise.resolve();
+
+    expect(ui.document.getSnapshot().dirty).toBe(false);
     ui.destroy();
   });
 

--- a/packages/super-editor/src/ui/document.test.ts
+++ b/packages/super-editor/src/ui/document.test.ts
@@ -273,6 +273,26 @@ describe('ui.document', () => {
     ui.destroy();
   });
 
+  it('editorCreate resets dirty (new document mounted by the host)', async () => {
+    const { superdoc } = makeStubs('editing');
+    const ui = createSuperDocUI({ superdoc });
+
+    superdoc.fireEditor('transaction', {
+      editor: superdoc.activeEditor,
+      transaction: { docChanged: true },
+      duration: 1,
+    });
+    await Promise.resolve();
+    expect(ui.document.getSnapshot().dirty).toBe(true);
+
+    superdoc.fireSuperdoc('editorCreate');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ui.document.getSnapshot().dirty).toBe(false);
+    ui.destroy();
+  });
+
   it('setMode forwards to superdoc.setDocumentMode with the passed mode', () => {
     const { superdoc } = makeStubs('editing');
     const ui = createSuperDocUI({ superdoc });

--- a/packages/super-editor/src/ui/react/hooks.ts
+++ b/packages/super-editor/src/ui/react/hooks.ts
@@ -26,7 +26,7 @@ const EMPTY_TRACK_CHANGES: TrackChangesSlice = { items: [], total: 0, activeId: 
 
 const EMPTY_TOOLBAR: ToolbarSnapshotSlice = { context: null, commands: {} };
 
-const EMPTY_DOCUMENT: DocumentSlice = { ready: false, mode: null };
+const EMPTY_DOCUMENT: DocumentSlice = { ready: false, mode: null, dirty: false };
 
 /**
  * Subscribe to the current selection slice.

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -472,6 +472,22 @@ export interface DocumentSlice {
   ready: boolean;
   /** Mirror of `superdoc.config.documentMode`. */
   mode: 'editing' | 'suggesting' | 'viewing' | null;
+  /**
+   * True when the document has unsaved changes. Flips to `true` on any
+   * editor transaction that mutates the document (`tr.docChanged`).
+   * Selection-only transactions (cursor moves, range adjustments) do
+   * not flip the flag.
+   *
+   * Cleared back to `false` when:
+   * - `ui.document.export(...)` resolves successfully, or
+   * - `ui.document.replaceFile(...)` swaps the document.
+   *
+   * Undo-to-clean is not tracked: hitting undo until the document
+   * matches its on-open state still reads as dirty. Apps that need
+   * the Word/GDocs-style "no unsaved changes" semantics should layer
+   * their own edit-count diff on top.
+   */
+  dirty: boolean;
 }
 
 /**


### PR DESCRIPTION
\`DocumentSlice\` gains a typed \`dirty: boolean\` field. Apps wiring a Save / Export button or a "you have unsaved changes" indicator drop their host-listening boilerplate.

\`\`\`tsx
const { ready, mode, dirty } = useSuperDocDocument();
return <button disabled={!dirty} onClick={onSave}>Save</button>;
\`\`\`

**Semantics chosen:**
- \`dirty\` flips to \`true\` on any editor transaction where \`tr.docChanged\` is true. Selection-only transactions leave it alone.
- Cleared by a successful \`ui.document.export(...)\` or \`ui.document.replaceFile(...)\`.
- Editor swap (replaceFile, document switch) resets to \`false\` so the new document opens clean.
- Rejected export leaves \`dirty\` alone so the consumer can retry without losing the unsaved indicator.
- Undo-to-clean is intentionally out of scope — apps that want Word/GDocs "no unsaved changes" semantics layer their own edit-count diff on top.

**Implementation notes:**
- Internal flag scoped to the controller closure; \`documentMemo\` includes \`dirty\` in its identity check so a flag flip busts the memo and re-fires \`ui.document.subscribe\` listeners (without re-firing on typing-only events that didn't move the flag).
- The \`onTransaction\` handler runs alongside the existing \`scheduleNotify\` wiring; it short-circuits when \`dirty\` is already true so a 50-keystroke burst is one mutation, not fifty.

**Verified**: 164/164 super-editor UI tests; superdoc + @superdoc-dev/react builds clean; BYO-UI demo builds clean. 7 new tests cover: starts false, flips on docChanged, stays false on selection-only, subscribers re-fire on flip, export clears, rejected export preserves, replaceFile clears.

Once merged, the BYO-UI docs PR (#3034) drops the \`useSuperDocHost()\` transaction-listener snippet from \`document-control.mdx\` in favor of \`useSuperDocDocument().dirty\`.