### PR TITLE
ci(superdoc): per-file checkJs gate for public-contract drift (SD-2863)

### DIFF
--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -113,6 +113,13 @@ jobs:
       - name: Typecheck
         run: pnpm run type-check
 
+      - name: Public-contract checkJs (SD-2863)
+        # Gated subset of public-contract files run with `// @ts-check`. The
+        # script greps tsc output for errors in the curated file list and
+        # ignores the wider 1500+ errors from the broader super-editor source
+        # tree (those are tracked under SD-2863 follow-up tickets).
+        run: pnpm --filter superdoc run check:jsdoc
+
       - name: Consumer typecheck (matrix)
         # The matrix script owns the published-package validation path:
         # it packs superdoc, installs the tarball into the standalone

--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -112,6 +112,7 @@
     "postbuild": "node ./scripts/ensure-types.cjs && node ./scripts/audit-bundle.cjs && node ./scripts/audit-declarations.cjs",
     "audit:declarations": "node ./scripts/audit-declarations.cjs",
     "audit:declarations:informational": "node ./scripts/audit-declarations.cjs --informational",
+    "check:jsdoc": "node ./scripts/check-jsdoc.cjs",
     "build:es": "vite build && pnpm run postbuild",
     "watch:es": "vite build --watch",
     "build:cdn": "vite build --config vite.config.cdn.js",

--- a/packages/superdoc/scripts/check-jsdoc.cjs
+++ b/packages/superdoc/scripts/check-jsdoc.cjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * SD-2863: per-file checkJs gate for the public-contract surface.
+ *
+ * Why this exists in this shape (and not as a plain `tsc -p tsconfig.checkjs.json`):
+ *
+ * The codebase uses `customConditions: ["source"]`, which makes TypeScript
+ * resolve `import { Editor } from '@superdoc/super-editor'` to the source
+ * `.js`/`.ts` files of the workspace package. With `// @ts-check` enabled on
+ * any file in this package, TS follows those imports and type-checks the
+ * super-editor source too — about 6500 errors. Those errors are real (they
+ * are the broader SD-2863 work) but they are not what this PR is trying to
+ * gate. The gate here is "files in CHECKED_FILES must stay clean."
+ *
+ * The script:
+ *
+ *   1. Runs `tsc --noEmit -p packages/superdoc/tsconfig.json`. Because each
+ *      file in CHECKED_FILES has `// @ts-check`, TS reports errors on those
+ *      files even though the project-wide `checkJs` is `false`.
+ *   2. Filters the tsc output to errors whose path matches an entry in
+ *      CHECKED_FILES.
+ *   3. Exits non-zero if any matched the filter; exits zero if not.
+ *
+ * Adding a new file to the gate:
+ *
+ *   1. Add `// @ts-check` as the first line of the file.
+ *   2. Add the file's path (relative to `packages/superdoc/`) to
+ *      CHECKED_FILES below.
+ *   3. Run `node packages/superdoc/scripts/check-jsdoc.cjs` and fix what
+ *      surfaces.
+ *
+ * The intent is for CHECKED_FILES to grow over time as the team ratchets
+ * checkJs across the public-contract surface. SD-2863 lands the pattern;
+ * follow-up tickets land the additional files.
+ */
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const CHECKED_FILES = [
+  'src/helpers/schema-introspection.js',
+];
+
+const packageDir = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(packageDir, '..', '..');
+
+const tscBin = path.join(repoRoot, 'node_modules', '.bin', 'tsc');
+const tsconfigPath = path.join(packageDir, 'tsconfig.json');
+
+const result = spawnSync(tscBin, ['--noEmit', '-p', tsconfigPath], {
+  encoding: 'utf8',
+  cwd: repoRoot,
+});
+
+const output = `${result.stdout || ''}${result.stderr || ''}`;
+
+// Match each `path/to/file(line,col): error TSxxxx: ...` row. tsc emits
+// paths relative to the cwd we ran from (repoRoot).
+const allErrors = output
+  .split('\n')
+  .filter((line) => /\.[jt]sx?\(\d+,\d+\):\s+error\s+TS\d+:/.test(line));
+
+const checkedAbsolute = CHECKED_FILES.map((rel) => path.join(packageDir, rel));
+
+const isCheckedError = (line) => {
+  const match = line.match(/^([^(]+)\(\d+,\d+\):/);
+  if (!match) return false;
+  const filePath = path.resolve(repoRoot, match[1]);
+  return checkedAbsolute.includes(filePath);
+};
+
+const checkedErrors = allErrors.filter(isCheckedError);
+
+console.log('[check-jsdoc] SD-2863 public-contract checkJs gate');
+console.log('='.repeat(72));
+console.log(`Files under gate: ${CHECKED_FILES.length}`);
+for (const f of CHECKED_FILES) {
+  console.log(`  - ${f}`);
+}
+console.log();
+
+if (checkedErrors.length === 0) {
+  console.log(`OK    ${CHECKED_FILES.length} gated file${CHECKED_FILES.length === 1 ? '' : 's'} clean.`);
+  console.log(`      (${allErrors.length} non-gated error${allErrors.length === 1 ? '' : 's'} in the wider tsc run, ignored — see SD-2863 follow-up tickets.)`);
+  process.exit(0);
+}
+
+console.log(`FAIL  ${checkedErrors.length} error${checkedErrors.length === 1 ? '' : 's'} in gated files:`);
+for (const line of checkedErrors) {
+  console.log(`        ${line}`);
+}
+console.log();
+console.log('Each error means a public-contract JSDoc has drifted from the implementation.');
+console.log('Fix the type or the code so they match. Adding `// @ts-ignore` is not the answer.');
+process.exit(1);

--- a/packages/superdoc/scripts/check-jsdoc.cjs
+++ b/packages/superdoc/scripts/check-jsdoc.cjs
@@ -34,6 +34,7 @@
  * follow-up tickets land the additional files.
  */
 
+const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
@@ -47,17 +48,62 @@ const repoRoot = path.resolve(packageDir, '..', '..');
 const tscBin = path.join(repoRoot, 'node_modules', '.bin', 'tsc');
 const tsconfigPath = path.join(packageDir, 'tsconfig.json');
 
+// Pre-flight: every file in CHECKED_FILES must opt into `// @ts-check`.
+// The project's tsconfig sets `checkJs: false`, so a JS file without the
+// directive is not type-checked at all. Without this guard, removing or
+// forgetting the directive on a listed file makes the gate silently stop
+// covering it — the script keeps reporting OK even though the file has
+// drifted.
+const missingDirective = [];
+const missingFiles = [];
+for (const rel of CHECKED_FILES) {
+  const abs = path.join(packageDir, rel);
+  if (!fs.existsSync(abs)) {
+    missingFiles.push(rel);
+    continue;
+  }
+  // The directive only takes effect when it precedes any non-comment
+  // statement, so it lives near the top. 4 KiB is plenty of margin for
+  // a leading license/doc block.
+  const head = fs.readFileSync(abs, 'utf8').slice(0, 4096);
+  if (!/^\s*\/\/\s*@ts-check\b/m.test(head)) {
+    missingDirective.push(rel);
+  }
+}
+
+if (missingFiles.length > 0) {
+  console.error('[check-jsdoc] gated files do not exist:');
+  for (const f of missingFiles) console.error(`  - ${f}`);
+  process.exit(1);
+}
+if (missingDirective.length > 0) {
+  console.error('[check-jsdoc] gated files are missing the `// @ts-check` directive:');
+  for (const f of missingDirective) console.error(`  - ${f}`);
+  console.error('Each gated file must opt into checkJs explicitly.');
+  console.error('Add `// @ts-check` as the first non-blank line, then re-run.');
+  process.exit(1);
+}
+
 const result = spawnSync(tscBin, ['--noEmit', '-p', tsconfigPath], {
   encoding: 'utf8',
   cwd: repoRoot,
 });
 
-// Fail fast if tsc itself could not run (ENOENT on the binary, signal,
-// permission denied, etc.). Without this guard, a missing `tsc` returns
+// Fail fast if tsc itself could not be spawned (ENOENT on the binary,
+// EACCES, etc.). Without this guard, a missing `tsc` leaves
 // `result.error` set, empty stdout/stderr, and the rest of the script
 // would happily report "OK" because it found zero parseable errors.
 if (result.error) {
   console.error(`[check-jsdoc] failed to invoke tsc at ${tscBin}: ${result.error.message}`);
+  process.exit(1);
+}
+
+// Killed by a signal (SIGKILL/OOM/SIGTERM) mid-run. spawnSync sets
+// `result.status` to null in that case and may leave partial output
+// containing parseable diagnostics, which would otherwise sneak past
+// the structural-failure check below.
+if (result.signal !== null) {
+  console.error(`[check-jsdoc] tsc was killed by signal: ${result.signal}`);
   process.exit(1);
 }
 
@@ -69,10 +115,10 @@ const allErrors = output
   .split('\n')
   .filter((line) => /\.[jt]sx?\(\d+,\d+\):\s+error\s+TS\d+:/.test(line));
 
-// Catch the second silent-pass mode: tsc exited non-zero but produced no
-// parseable diagnostics. That means the failure is structural (config
-// error, internal compiler crash, etc.) rather than a normal type-check
-// fail, and the gate cannot reason about it.
+// Catch the structural-failure mode: tsc exited non-zero but produced no
+// parseable diagnostics. That means the failure is something like a
+// missing tsconfig, an internal compiler crash, or a config error,
+// rather than a normal type-check fail; the gate cannot reason about it.
 if (result.status !== 0 && allErrors.length === 0) {
   console.error('[check-jsdoc] tsc exited with a non-zero status but produced no parseable diagnostics.');
   console.error(`Status: ${result.status}`);

--- a/packages/superdoc/scripts/check-jsdoc.cjs
+++ b/packages/superdoc/scripts/check-jsdoc.cjs
@@ -52,6 +52,15 @@ const result = spawnSync(tscBin, ['--noEmit', '-p', tsconfigPath], {
   cwd: repoRoot,
 });
 
+// Fail fast if tsc itself could not run (ENOENT on the binary, signal,
+// permission denied, etc.). Without this guard, a missing `tsc` returns
+// `result.error` set, empty stdout/stderr, and the rest of the script
+// would happily report "OK" because it found zero parseable errors.
+if (result.error) {
+  console.error(`[check-jsdoc] failed to invoke tsc at ${tscBin}: ${result.error.message}`);
+  process.exit(1);
+}
+
 const output = `${result.stdout || ''}${result.stderr || ''}`;
 
 // Match each `path/to/file(line,col): error TSxxxx: ...` row. tsc emits
@@ -59,6 +68,17 @@ const output = `${result.stdout || ''}${result.stderr || ''}`;
 const allErrors = output
   .split('\n')
   .filter((line) => /\.[jt]sx?\(\d+,\d+\):\s+error\s+TS\d+:/.test(line));
+
+// Catch the second silent-pass mode: tsc exited non-zero but produced no
+// parseable diagnostics. That means the failure is structural (config
+// error, internal compiler crash, etc.) rather than a normal type-check
+// fail, and the gate cannot reason about it.
+if (result.status !== 0 && allErrors.length === 0) {
+  console.error('[check-jsdoc] tsc exited with a non-zero status but produced no parseable diagnostics.');
+  console.error(`Status: ${result.status}`);
+  console.error(`Output:\n${output || '(empty)'}`);
+  process.exit(1);
+}
 
 const checkedAbsolute = CHECKED_FILES.map((rel) => path.join(packageDir, rel));
 

--- a/packages/superdoc/src/helpers/schema-introspection.js
+++ b/packages/superdoc/src/helpers/schema-introspection.js
@@ -1,9 +1,10 @@
+// @ts-check
 import { Editor, getRichTextExtensions, getStarterExtensions } from '@superdoc/super-editor';
 
 /**
  * @typedef {Object} SchemaIntrospectionOptions
  * @property {import('@superdoc/super-editor').Editor} [editor] - Existing Editor instance to introspect.
- * @property {Array} [extensions] - Extension list to build a schema from.
+ * @property {NonNullable<import('@superdoc/super-editor').EditorOptions['extensions']>} [extensions] - Extension list to build a schema from.
  * @property {'docx' | 'text' | 'html'} [mode] - Editor mode when building a schema. Defaults to 'docx'.
  */
 


### PR DESCRIPTION
The audit gates we have today all check the published artifact (declarations, consumer matrix, public-type assertion list). None of them catches the case where a JSDoc typedef on a public-contract file drifts from the implementation that consumes it — the IT-300 / IT-338 / SD-2514 class.

Project-wide `checkJs: true` is not viable here. `customConditions: ["source"]` resolves workspace imports to source files, so a single \`// @ts-check\` cascades into ~6500 errors across 439 files. That is the broader SD-2863 work; this PR is the gate, not the migration.

Lands the per-file pattern: a curated list (`CHECKED_FILES` in `scripts/check-jsdoc.cjs`) of files with \`// @ts-check\`. The script runs `tsc --noEmit` against the existing project tsconfig and filters output to the curated list. Regressions on gated files fail CI; everything else is ignored and tracked under follow-up tickets. Adding a file: \`// @ts-check\` on line 1, append the path to `CHECKED_FILES`, fix what surfaces.

First file under the gate: `packages/superdoc/src/helpers/schema-introspection.js`. The probe immediately found one real drift — the `extensions` parameter was typed `Array` (no argument), which collapses to `Array<any>` for consumers. Replaced with `NonNullable<EditorOptions['extensions']>`.

**Verified**: `pnpm --filter superdoc run check:jsdoc` passes locally. Reverting the JSDoc fix to `Array` makes the gate fail with the expected error pointing back at the file. The wider tsc run still reports 1500+ pre-existing errors; they are ignored by design.

Follow-up tickets:

- SD-2865 checkJs gate: `use-find-replace.js` (probe found a real `closeOnEscape` drift)
- SD-2866 checkJs gate: `use-password-prompt.js`
- SD-2867 checkJs gate: `SuperDoc.js` (Config consumer; highest value)
- SD-2868 export `EditorExtension` publicly
- SD-2869 convert `core/types/index.js` to TypeScript
- SD-2870 fix `closeOnEscape` drift in `IntentSurfaceRequest.floating`