### PR TITLE
fix(superdoc): hoist closeOnEscape to request top level (SD-2870)

### DIFF
--- a/packages/superdoc/src/composables/use-find-replace.js
+++ b/packages/superdoc/src/composables/use-find-replace.js
@@ -531,7 +531,8 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
         surfaceHandle = manager.open({
           mode: 'floating',
           ariaLabel: config.texts.findAriaLabel,
-          floating: { placement: 'top-right', closeOnEscape: true, autoFocus: true },
+          closeOnEscape: true,
+          floating: { placement: 'top-right', autoFocus: true },
           component: markRaw(resolution.component),
           props: { ...resolution.props, findReplace: handle },
         });
@@ -541,7 +542,8 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
         surfaceHandle = manager.open({
           mode: 'floating',
           ariaLabel: config.texts.findAriaLabel,
-          floating: { placement: 'top-right', closeOnEscape: true, autoFocus: true },
+          closeOnEscape: true,
+          floating: { placement: 'top-right', autoFocus: true },
           render: (ctx) =>
             userRender({
               container: ctx.container,
@@ -579,7 +581,8 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
           mode: 'floating',
           ariaLabel: config.texts.findAriaLabel,
           component: markRaw(FindReplaceSurface),
-          floating: { placement: 'top-right', closeOnEscape: true, autoFocus: true },
+          closeOnEscape: true,
+          floating: { placement: 'top-right', autoFocus: true },
           props: { findReplace: handle },
         });
       }

--- a/packages/superdoc/src/composables/use-find-replace.test.js
+++ b/packages/superdoc/src/composables/use-find-replace.test.js
@@ -93,7 +93,11 @@ describe('useFindReplace', () => {
       const call = manager.open.mock.calls[0][0];
       expect(call.mode).toBe('floating');
       expect(call.floating.placement).toBe('top-right');
-      expect(call.floating.closeOnEscape).toBe(true);
+      // closeOnEscape lives at the request top level — surface-manager
+      // only reads `request.closeOnEscape`, not `request.floating.closeOnEscape`.
+      // Asserting the nested location (as this test did before SD-2870) was
+      // verifying the call shape but not the runtime effect.
+      expect(call.closeOnEscape).toBe(true);
     });
 
     it('does not create second surface when already open', async () => {

--- a/packages/superdoc/src/core/types/index.js
+++ b/packages/superdoc/src/core/types/index.js
@@ -171,7 +171,7 @@
  * @property {string} [title] Optional title rendered in the surface chrome
  * @property {string} [ariaLabel] Accessible name for the surface when no visible title is provided. Used as aria-label fallback when neither title nor ariaLabelledBy is set.
  * @property {string} [ariaLabelledBy] ID of the element that labels the surface. Takes precedence over ariaLabel. Use this when the content component renders its own heading that should serve as the accessible name.
- * @property {boolean} [closeOnEscape] Whether Escape closes the surface (default: true)
+ * @property {boolean} [closeOnEscape] Whether Escape closes the surface (default: true). Set at the request top level — the runtime does not read `floating.closeOnEscape` on a per-request basis.
  * @property {boolean} [closeOnBackdrop] Whether backdrop click closes a dialog (default: true)
  * @property {{ maxWidth?: string | number }} [dialog] Dialog-specific overrides
  * @property {Object} [floating] Floating-specific overrides
@@ -196,7 +196,7 @@
  * @property {string} [title] Optional title rendered in the surface chrome
  * @property {string} [ariaLabel] Accessible name for the surface when no visible title is provided. Used as aria-label fallback when neither title nor ariaLabelledBy is set.
  * @property {string} [ariaLabelledBy] ID of the element that labels the surface. Takes precedence over ariaLabel. Use this when the content component renders its own heading that should serve as the accessible name.
- * @property {boolean} [closeOnEscape] Whether Escape closes the surface (default: true)
+ * @property {boolean} [closeOnEscape] Whether Escape closes the surface (default: true). Set at the request top level — the runtime does not read `floating.closeOnEscape` on a per-request basis.
  * @property {boolean} [closeOnBackdrop] Whether backdrop click closes a dialog (default: true)
  * @property {{ maxWidth?: string | number }} [dialog] Dialog-specific overrides
  * @property {Object} [floating] Floating-specific overrides


### PR DESCRIPTION
The find/replace composable opened its floating surface with \`floating: { closeOnEscape: true, ... }\`, but the surface manager only reads \`request.closeOnEscape\` (\`surface-manager.js:315\`). The nested field was preserved on the request and never consulted, so the explicit intent was a silent no-op.

Escape-closes-surface still worked because the top-level default is \`true\` — but a user override on \`moduleConfig.floating.closeOnEscape\` would have silently won over the find/replace request.

Hoists the field to its real top-level position in all three open() call sites, tightens the existing unit test to assert the top-level shape (the previous assertion verified the call shape but not the runtime path), and adds a one-line clarification to the typedef so future contributors do not re-nest the field.

Surfaced while probing checkJs against \`use-find-replace.js\` for SD-2863.

**Verified**: 938/938 superdoc unit tests pass locally; the \`use-find-replace\` test suite (54 tests) now asserts the top-level shape.