### PR TITLE
fix(superdoc): close public typedef gaps surfaced by SuperDoc.js probe (SD-2872)

### DIFF
--- a/packages/superdoc/src/core/types/index.js
+++ b/packages/superdoc/src/core/types/index.js
@@ -3,6 +3,7 @@
  * @property {string} name The user's name
  * @property {string} email The user's email
  * @property {string | null} [image] The user's photo
+ * @property {string} [color] Awareness color for collaborative cursors. Auto-assigned from the configured palette (or a default palette) when omitted, derived from a hash of the user's identity so the assignment is stable across reloads.
  */
 
 /**
@@ -15,6 +16,7 @@
  * @property {boolean} [isNewFile] Whether the document is a new file
  * @property {import('yjs').Doc} [ydoc] The Yjs document for collaboration
  * @property {import('@hocuspocus/provider').HocuspocusProvider} [provider] The provider for collaboration
+ * @property {'editor' | 'viewer' | 'suggester'} [role] Per-document role override. Inherits from the top-level `Config.role` when not set; `SuperDoc` propagates the SuperDoc-level role onto each document during initialization.
  */
 
 /**
@@ -536,6 +538,8 @@
  * @property {Object} [slashMenu] Deprecated. Use contextMenu instead.
  * @property {SurfacesModuleConfig} [surfaces] Surface system configuration
  * @property {TrackChangesModuleConfig} [trackChanges] Track changes module configuration
+ * @property {Object} [whiteboard] Whiteboard module configuration
+ * @property {boolean} [whiteboard.enabled] Whether the whiteboard overlay is enabled (default: false)
  */
 
 /**
@@ -628,6 +632,11 @@
  * @property {Object} [semanticOptions] Internal-only semantic mode tuning options.
  *   This shape is intentionally not a stable public API in v1.
  * @property {Object} [trackedChanges] Deprecated. Use `modules.trackChanges` instead. Optional override for paginated track-changes rendering (e.g., `{ mode: 'original' }` or `{ enabled: false }`).
+ * @property {Object} [virtualization] Page virtualization options for paginated layout. Defaults to `{ enabled: true, window: 5, overscan: 1 }` to render only the visible window of pages plus a small overscan buffer.
+ * @property {boolean} [virtualization.enabled] Whether virtualization is active (default: true)
+ * @property {number} [virtualization.window] Number of pages kept rendered around the active page (default: 5)
+ * @property {number} [virtualization.overscan] Extra pages rendered outside the active window for smoother scrolling (default: 1)
+ * @property {boolean} [showBookmarks] Whether bookmark indicators are shown in the rendered layout. Toggleable at runtime via `superdoc.setShowBookmarks()`.
  */
 
 /**
@@ -725,6 +734,9 @@
  * @property {string} [licenseKey] License key for organization identification
  * @property {SuperDocTelemetryConfig} [telemetry] Telemetry configuration
  * @property {ProofingConfig} [proofing] Proofing / spellcheck configuration
+ * @property {boolean} [useLayoutEngine] Opt-in toggle for the layout engine. Auto-disabled when web layout is requested without `layoutEngineOptions.flowMode === 'semantic'`; the loader logs a warning and falls back to the legacy ProseMirror render path in that case.
+ * @property {(params: { editor: Editor }) => void} [onFontsResolved] Callback fired after the editor reports `fonts-resolved`. Useful for hosts that need to wait for embedded font loading before measuring or printing.
+ * @property {import('@hocuspocus/provider').HocuspocusProviderWebsocket} [socket] Internal: the shared websocket instance created by SuperDoc when `modules.collaboration.providerType === 'hocuspocus'`. Set automatically; do not pass from outside.
  */
 
 /**

--- a/packages/superdoc/src/core/types/index.js
+++ b/packages/superdoc/src/core/types/index.js
@@ -16,7 +16,6 @@
  * @property {boolean} [isNewFile] Whether the document is a new file
  * @property {import('yjs').Doc} [ydoc] The Yjs document for collaboration
  * @property {import('@hocuspocus/provider').HocuspocusProvider} [provider] The provider for collaboration
- * @property {'editor' | 'viewer' | 'suggester'} [role] Per-document role override. Inherits from the top-level `Config.role` when not set; `SuperDoc` propagates the SuperDoc-level role onto each document during initialization.
  */
 
 /**
@@ -538,8 +537,7 @@
  * @property {Object} [slashMenu] Deprecated. Use contextMenu instead.
  * @property {SurfacesModuleConfig} [surfaces] Surface system configuration
  * @property {TrackChangesModuleConfig} [trackChanges] Track changes module configuration
- * @property {Object} [whiteboard] Whiteboard module configuration
- * @property {boolean} [whiteboard.enabled] Whether the whiteboard overlay is enabled (default: false)
+ * @property {false | { enabled?: boolean }} [whiteboard] Whiteboard module configuration. Pass `false` to disable the module entirely; pass an object to opt in (with `enabled: true`) or to keep it registered but inert (`enabled: false`, the default when no field is set).
  */
 
 /**
@@ -735,7 +733,7 @@
  * @property {SuperDocTelemetryConfig} [telemetry] Telemetry configuration
  * @property {ProofingConfig} [proofing] Proofing / spellcheck configuration
  * @property {boolean} [useLayoutEngine] Opt-in toggle for the layout engine. Auto-disabled when web layout is requested without `layoutEngineOptions.flowMode === 'semantic'`; the loader logs a warning and falls back to the legacy ProseMirror render path in that case.
- * @property {(params: { editor: Editor }) => void} [onFontsResolved] Callback fired after the editor reports `fonts-resolved`. Useful for hosts that need to wait for embedded font loading before measuring or printing.
+ * @property {(payload: import('@superdoc/super-editor').FontsResolvedPayload) => void} [onFontsResolved] Callback fired after the editor reports `fonts-resolved`. The payload contains `documentFonts` and `unsupportedFonts` arrays so hosts can fall back, warn, or block printing on unsupported faces.
  * @property {import('@hocuspocus/provider').HocuspocusProviderWebsocket} [socket] Internal: the shared websocket instance created by SuperDoc when `modules.collaboration.providerType === 'hocuspocus'`. Set automatically; do not pass from outside.
  */
 


### PR DESCRIPTION
Probing \`// @ts-check\` against \`packages/superdoc/src/core/SuperDoc.js\` (per the SD-2863 ratchet) surfaced 16 properties that the implementation reads but the public JSDoc typedefs do not declare. Each missing field is a customer-typeable property the runtime supports today but TypeScript reports as unknown for consumers.

Closes 8 distinct typedef gaps, 17 error sites:

| Typedef | Field |
|---|---|
| \`Config\` | \`useLayoutEngine\`, \`onFontsResolved\`, \`socket\` |
| \`Modules\` | \`whiteboard\` |
| \`SuperDocLayoutEngineOptions\` | \`virtualization\` (+ enabled, window, overscan), \`showBookmarks\` |
| \`User\` | \`color\` |
| \`Document\` | \`role\` |

**Verified**: enabling \`// @ts-check\` on \`SuperDoc.js\` locally drops the TS2339 errors against named typedefs from 17 to 1. The remaining error is a \`Editor | PresentationEditor\` narrowing issue at SuperDoc.js:814 — that is JS-side, not a typedef gap, and is in scope for SD-2867 (gate enrollment).

This PR ships the typedef side only. ~137 unrelated errors in SuperDoc.js (implicit-any params, loose \`Object\` typedefs, strict-null) need dedicated cleanup before SD-2867 can enroll the file under the SD-2863 gate.