### PR TITLE
ci(superdoc): enroll use-find-replace.js under checkJs gate (SD-2865)

### DIFF
--- a/packages/superdoc/scripts/check-jsdoc.cjs
+++ b/packages/superdoc/scripts/check-jsdoc.cjs
@@ -40,6 +40,7 @@ const { spawnSync } = require('child_process');
 
 const CHECKED_FILES = [
   'src/helpers/schema-introspection.js',
+  'src/composables/use-find-replace.js',
 ];
 
 const packageDir = path.resolve(__dirname, '..');

--- a/packages/superdoc/src/composables/use-find-replace.js
+++ b/packages/superdoc/src/composables/use-find-replace.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { ref, computed, markRaw, watch } from 'vue';
 
 /** @typedef {import('../core/types').FindReplaceConfig} FindReplaceConfig */
@@ -30,24 +31,48 @@ const DEFAULT_TEXTS = {
 };
 
 /**
+ * @typedef {Object} SearchResult The shape of `setSearchSession`,
+ *   `nextSearchMatch`, `previousSearchMatch`, `replaceSearchMatch` returns.
+ *   The Search extension lives in super-editor; this composable only consumes
+ *   the two fields below.
+ * @property {{ length: number }[]} matches
+ * @property {number} activeMatchIndex
+ */
+
+/**
+ * @typedef {Object} SearchStorage The Search extension's storage shape.
+ *   The Search extension is internal to super-editor; this composable only
+ *   needs the fields it reads to detect a live search session and resync
+ *   from external mutations.
+ * @property {unknown} [searchIndex]
+ * @property {unknown} [searchResults]
+ * @property {number} [activeMatchIndex]
+ * @property {{ length: number }[]} [matches]
+ */
+
+/**
  * Resolve the Search extension storage from the editor.
  * The storage is keyed by extension name in editor.extensionStorage;
  * we find it by looking for the object with our known storage shape.
+ * @param {import('@superdoc/super-editor').Editor | null | undefined} editor
+ * @returns {SearchStorage | null}
  */
 function getSearchStorage(editor) {
   if (!editor) return null;
 
-  // Try direct access by common name first
-  const byName = editor.extensionStorage?.Search ?? editor.storage?.Search;
+  // Try direct access by common name first. The Search extension's storage
+  // shape is internal to super-editor; cast to the local SearchStorage type
+  // so the field probes type-check.
+  const byName = /** @type {SearchStorage | undefined} */ (editor.extensionStorage?.Search ?? editor.storage?.Search);
   if (byName?.searchIndex || byName?.searchResults) return byName;
 
   // Fall back to scanning extensionStorage for the Search extension's storage
   const store = editor.extensionStorage ?? editor.storage;
   if (store) {
     for (const key of Object.keys(store)) {
-      const val = store[key];
+      const val = /** @type {Record<string, unknown>} */ (store)[key];
       if (val && typeof val === 'object' && 'searchIndex' in val && 'searchResults' in val) {
-        return val;
+        return /** @type {SearchStorage} */ (val);
       }
     }
   }
@@ -72,13 +97,17 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
 
   /** @type {import('../core/surface-manager.js').SurfaceHandle | null} */
   let currentSurfaceHandle = null;
+  /** @type {import('@superdoc/super-editor').Editor | null} */
   let currentEditor = null;
   let destroyed = false;
   let opening = false; // sync guard against double-open across the await gap
 
   const isOpen = ref(false);
 
-  /** Ref to the find input element, set by the renderer via handle.registerFocusFn. */
+  /**
+   * Ref to the find input element, set by the renderer via handle.registerFocusFn.
+   * @type {(() => void) | null}
+   */
   let focusFindInputFn = null;
 
   // ---- reactive state (owned by composable, consumed by renderers) ----------
@@ -104,7 +133,9 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
 
   // ---- timers ---------------------------------------------------------------
 
+  /** @type {ReturnType<typeof setTimeout> | null} */
   let debounceTimer = null;
+  /** @type {ReturnType<typeof setInterval> | null} */
   let syncInterval = null;
 
   // ---- search logic ---------------------------------------------------------
@@ -123,12 +154,14 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
     }
 
     try {
-      const result = currentEditor.commands.setSearchSession(findQuery.value, {
-        caseSensitive: caseSensitive.value,
-        ignoreDiacritics: ignoreDiacritics.value,
-        highlight: true,
-        searchModel: 'visible',
-      });
+      const result = /** @type {SearchResult} */ (
+        currentEditor.commands.setSearchSession(findQuery.value, {
+          caseSensitive: caseSensitive.value,
+          ignoreDiacritics: ignoreDiacritics.value,
+          highlight: true,
+          searchModel: 'visible',
+        })
+      );
       matchCount.value = result.matches.length;
       activeMatchIndex.value = result.activeMatchIndex;
     } catch {
@@ -137,7 +170,7 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
   }
 
   function debouncedSearch() {
-    clearTimeout(debounceTimer);
+    if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = setTimeout(runSearch, 150);
   }
 
@@ -161,7 +194,7 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
   function goNext() {
     if (!hasMatches.value || !currentEditor) return;
     try {
-      const result = currentEditor.commands.nextSearchMatch();
+      const result = /** @type {SearchResult} */ (currentEditor.commands.nextSearchMatch());
       activeMatchIndex.value = result.activeMatchIndex;
     } catch {
       /* destroyed */
@@ -171,7 +204,7 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
   function goPrev() {
     if (!hasMatches.value || !currentEditor) return;
     try {
-      const result = currentEditor.commands.previousSearchMatch();
+      const result = /** @type {SearchResult} */ (currentEditor.commands.previousSearchMatch());
       activeMatchIndex.value = result.activeMatchIndex;
     } catch {
       /* destroyed */
@@ -182,7 +215,7 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
     if (!currentReplaceEnabled) return;
     if (!hasMatches.value || !currentEditor) return;
     try {
-      const result = currentEditor.commands.replaceSearchMatch(replaceText.value);
+      const result = /** @type {SearchResult} */ (currentEditor.commands.replaceSearchMatch(replaceText.value));
       matchCount.value = result.matches.length;
       activeMatchIndex.value = result.activeMatchIndex;
     } catch {
@@ -222,9 +255,9 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
   }
 
   function stopPolling() {
-    clearTimeout(debounceTimer);
+    if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = null;
-    clearInterval(syncInterval);
+    if (syncInterval) clearInterval(syncInterval);
     syncInterval = null;
   }
 
@@ -368,6 +401,7 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
   /**
    * Wrap a FindReplaceHandle for external (non-Vue) renderers.
    * Converts Vue refs to JavaScript getter/setter properties.
+   * @param {FindReplaceHandle} handle
    */
   function wrapHandleForExternal(handle) {
     return {
@@ -429,6 +463,7 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
   /**
    * Clear the search session on the given editor, swallowing errors
    * (the editor may already be destroyed).
+   * @param {import('@superdoc/super-editor').Editor | null | undefined} editor
    */
   function clearEditorSession(editor) {
     if (!editor) return;
@@ -520,6 +555,7 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
       focusFindInputFn = null;
 
       // Late-wired close — the handle is created before the surface opens
+      /** @type {(reason?: unknown) => void} */
       let lateCloseFn = () => {};
 
       const handle = createHandle(config, (reason) => lateCloseFn(reason));
@@ -555,10 +591,14 @@ export function useFindReplace({ getSurfaceManager, getActiveEditor, activeEdito
             }),
         });
       } else {
-        // Built-in — lazy import
+        // Built-in — lazy import. The `.vue` shim types the default export as
+        // `unknown`; narrow to `object` for `markRaw()` since the Vue compiler
+        // guarantees the SFC default export is a component definition object.
+        /** @type {object | undefined} */
         let FindReplaceSurface;
         try {
-          ({ default: FindReplaceSurface } = await import('../components/surfaces/FindReplaceSurface.vue'));
+          const mod = await import('../components/surfaces/FindReplaceSurface.vue');
+          FindReplaceSurface = /** @type {object} */ (mod.default);
         } catch {
           opening = false;
           return;

--- a/packages/superdoc/src/composables/use-find-replace.test.js
+++ b/packages/superdoc/src/composables/use-find-replace.test.js
@@ -317,6 +317,53 @@ describe('useFindReplace', () => {
     });
   });
 
+  describe('getSearchStorage fallback', () => {
+    // `getSearchStorage` first tries `extensionStorage.Search` and
+    // `storage.Search`. When neither carries a live session, it falls back
+    // to scanning every key for an object with `searchIndex` and
+    // `searchResults`. The fallback is what catches non-default extension
+    // names; without an explicit test the polling path silently skips it.
+    it('finds storage under a non-Search key via the fallback scan', async () => {
+      // Editor with the Search extension registered under a custom key. The
+      // direct `extensionStorage.Search` and `storage.Search` lookups miss;
+      // the fallback iterates keys and matches on the structural probe.
+      const customEditor = {
+        commands: editor.commands,
+        extensionStorage: {
+          CustomFinder: {
+            searchIndex: [{ from: 0, to: 1 }],
+            searchResults: [
+              { from: 0, to: 1 },
+              { from: 5, to: 6 },
+            ],
+            activeMatchIndex: 1,
+          },
+        },
+      };
+      const customFindReplace = useFindReplace({
+        getSurfaceManager: () => manager,
+        getActiveEditor: () => customEditor,
+        activeEditorRef: ref(customEditor),
+        getFindReplaceConfig: () => true,
+      });
+
+      await customFindReplace.open();
+      await vi.dynamicImportSettled();
+
+      // The handle exposed to the surface component carries the live state
+      // refs that polling syncs into.
+      const findReplaceHandle = manager.open.mock.calls.at(-1)[0].props.findReplace;
+
+      // Wait one polling tick (200 ms interval) so syncFromEditorStorage runs.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      expect(findReplaceHandle.matchCount.value).toBe(2);
+      expect(findReplaceHandle.activeMatchIndex.value).toBe(1);
+
+      customFindReplace.close();
+    });
+  });
+
   describe('surface close cleanup', () => {
     it('clears search session when surface settles as closed', async () => {
       await findReplace.open();

--- a/packages/superdoc/src/shims-vue.d.ts
+++ b/packages/superdoc/src/shims-vue.d.ts
@@ -1,0 +1,14 @@
+// Ambient declaration for Vue SFC modules (`*.vue`).
+//
+// Vite handles `.vue` resolution at build time; tsc has no resolver for them
+// without the official Vue TS plugin. The composables in this package import
+// SFCs lazily (e.g. `await import('../components/surfaces/FindReplaceSurface.vue')`)
+// and only ever use them as opaque tokens passed to `markRaw()`.
+//
+// Declared as a type-only ambient module so the `// @ts-check`-gated files
+// can import `.vue` modules without resorting to per-import suppression.
+// The shape is intentionally opaque; the build keeps the real Vue component.
+declare module '*.vue' {
+  const component: unknown;
+  export default component;
+}


### PR DESCRIPTION
Second file under the SD-2863 ratchet. The find/replace composable is the most public-typedef-heavy file in \`packages/superdoc/src/composables/\` — it consumes \`FindReplaceConfig\`, \`FindReplaceHandle\`, \`FindReplaceContext\`, \`FindReplaceResolution\`, and \`ResolvedFindReplaceTexts\`. With the gate skipping it, the JSDoc and the implementation could drift indefinitely.

The probe surfaced 23 errors. Closes them by:

- Annotating the in-scope mutable state (\`currentEditor\`, \`focusFindInputFn\`, \`lateCloseFn\`, \`debounceTimer\`, \`syncInterval\`).
- Annotating function parameters (\`getSearchStorage\`, \`wrapHandleForExternal\`, \`clearEditorSession\`) with the public \`Editor\` and \`FindReplaceHandle\` types.
- Casting \`editor.commands.{set,next,previous,replace}SearchSession\` results to a local \`SearchResult\` typedef. The Search extension lives in super-editor and its command return types are not surfaced through the public command-map yet; the cast names what this composable actually consumes.
- Null-guarding \`clearTimeout\` / \`clearInterval\` so the timer fields can be \`Timer | null\`.
- Adding an ambient \`*.vue\` shim under \`packages/superdoc/src/\` so tsc resolves the lazy SFC import. The Vue compiler still owns the runtime shape; this is type-only resolution.

The \`closeOnEscape\` drift the original probe found shipped separately as SD-2870 and is no longer in scope.

**Verified**: \`pnpm --filter superdoc run check:jsdoc\` reports 2 gated files clean. The \`use-find-replace\` test suite (54 tests) passes.