### PR TITLE
ci(superdoc): enroll use-password-prompt.js under checkJs gate (SD-2866)

### DIFF
--- a/packages/superdoc/scripts/check-jsdoc.cjs
+++ b/packages/superdoc/scripts/check-jsdoc.cjs
@@ -41,6 +41,7 @@ const { spawnSync } = require('child_process');
 const CHECKED_FILES = [
   'src/helpers/schema-introspection.js',
   'src/composables/use-find-replace.js',
+  'src/composables/use-password-prompt.js',
 ];
 
 const packageDir = path.resolve(__dirname, '..');

--- a/packages/superdoc/src/composables/use-password-prompt.js
+++ b/packages/superdoc/src/composables/use-password-prompt.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { shallowRef, markRaw } from 'vue';
 
 /** @typedef {import('../core/types').PasswordPromptConfig} PasswordPromptConfig */
@@ -41,7 +42,16 @@ const DEFAULT_TEXTS = {
 export function usePasswordPrompt({ getSurfaceManager, getPasswordPromptConfig, onUnhandled }) {
   // ---- internal state -------------------------------------------------------
 
-  /** @type {Array<{ doc: any, errorCode: string }>} */
+  /**
+   * Pending password-prompt request waiting for a free `activePrompt` slot.
+   * `originalException` is preserved so `onUnhandled` can re-emit the host's
+   * original exception payload verbatim if the prompt cannot render.
+   * @typedef {Object} QueueEntry
+   * @property {any} doc
+   * @property {string} errorCode
+   * @property {{ error?: Error, editor?: any }} [originalException]
+   */
+  /** @type {QueueEntry[]} */
   const queue = [];
 
   /** @type {import('vue').ShallowRef<{ doc: any, surfaceHandle: any } | null>} */
@@ -128,6 +138,7 @@ export function usePasswordPrompt({ getSurfaceManager, getPasswordPromptConfig, 
     if (queue.length === 0) return;
 
     const entry = queue.shift();
+    if (!entry) return;
     showPrompt(entry).catch((err) => {
       // Surface errors (e.g. from a consumer's resolver or invalid config)
       // as console errors rather than letting them become unhandled rejections.
@@ -233,8 +244,11 @@ export function usePasswordPrompt({ getSurfaceManager, getPasswordPromptConfig, 
     } else {
       // Built-in component — use ariaLabelledBy pointing to the component's
       // reactive heading, so the accessible name updates after a bad password
-      // (e.g. "Password Required" → "Incorrect Password").
-      const { default: PasswordPromptSurface } = await import('../components/surfaces/PasswordPromptSurface.vue');
+      // (e.g. "Password Required" → "Incorrect Password"). The `.vue` shim
+      // types the default export as `unknown`; narrow to `object` for
+      // `markRaw()`.
+      const mod = await import('../components/surfaces/PasswordPromptSurface.vue');
+      const PasswordPromptSurface = /** @type {object} */ (mod.default);
       const surfaceId = `password-prompt-${doc.id}`;
       handle = manager.open({
         id: surfaceId,


### PR DESCRIPTION
Third file under the SD-2863 ratchet. Stacked on #3048 because SD-2865 introduced the \`*.vue\` ambient shim that this PR also relies on; will rebase to main after #3048 merges.

The probe surfaced 8 errors. Closes them by:

- **Real drift**: the internal queue's element type was \`{ doc, errorCode }\`, but \`handleEncryptionError\` pushes \`{ doc, errorCode, originalException }\` and \`onUnhandled\` reads the field back out. Promoted to a named \`QueueEntry\` typedef with the third field properly declared.
- **Strict-null guard**: \`queue.shift()\` returns \`undefined\` when the queue is empty. Added an early return after the shift so the rest of \`drainQueue\` can rely on a defined entry.
- **Vue SFC import**: the lazy import of \`PasswordPromptSurface.vue\` now goes through the \`*.vue\` ambient shim and casts the default export to \`object\` before \`markRaw()\`, mirroring the SD-2865 fix.

**Verified**: \`pnpm --filter superdoc run check:jsdoc\` reports 3 gated files clean. The \`use-password-prompt\` test suite (35 tests) passes.