### PR TITLE
feat(superdoc): export Config, Modules, and core/types public typedefs (SD-2880)

### DIFF
--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -23,6 +23,7 @@ import type {
   CommentAddress as SuperEditorCommentAddress,
   TrackedChangeAddress as SuperEditorTrackedChangeAddress,
   NavigableAddress as SuperEditorNavigableAddress,
+  CollaborationProvider as SuperEditorCollaborationProvider,
   FontConfig,
   FontsResolvedPayload,
   ProofingProvider,
@@ -79,24 +80,11 @@ export interface Document {
 /**
  * External collaboration provider interface. Accepts any Yjs-compatible
  * provider (HocuspocusProvider, LiveblocksYjsProvider, TiptapCollabProvider,
- * etc.).
+ * etc.). Re-exported from `@superdoc/super-editor` so `Config.modules.collaboration.provider`
+ * (typed against this) accepts values typed against the publicly-exported
+ * `CollaborationProvider` from `superdoc`.
  */
-export interface CollaborationProvider {
-  /** The Yjs awareness instance (optional, may be null). */
-  awareness?: object;
-  /** Event listener. */
-  on?: (event: string, handler: (...args: unknown[]) => unknown) => void;
-  /** Event unsubscriber. */
-  off?: (event: string, handler: (...args: unknown[]) => unknown) => void;
-  /** Disconnect from the provider. */
-  disconnect?: () => void;
-  /** Destroy the provider. */
-  destroy?: () => void;
-  /** Whether the provider has synced. */
-  synced?: boolean;
-  /** Alternative sync property (used by some providers). */
-  isSynced?: boolean;
-}
+export type CollaborationProvider = SuperEditorCollaborationProvider;
 
 /** Collaboration module configuration. */
 export interface CollaborationConfig {

--- a/packages/superdoc/src/index.js
+++ b/packages/superdoc/src/index.js
@@ -40,9 +40,10 @@ import { getSchemaIntrospection } from './helpers/schema-introspection.js';
 
 // ============================================
 // TYPE RE-EXPORTS
-// These types are defined in @superdoc/super-editor and re-exported for consumers.
-// vite-plugin-dts picks up these JSDoc @typedef imports and generates
-// corresponding `export type` declarations in the consumer-facing .d.ts.
+// These types are defined in @superdoc/super-editor and ./core/types/, and
+// re-exported for consumers. vite-plugin-dts picks up these JSDoc @typedef
+// imports and generates corresponding `export type` declarations in the
+// consumer-facing .d.ts.
 // ============================================
 
 /**
@@ -186,6 +187,47 @@ import { getSchemaIntrospection } from './helpers/schema-introspection.js';
  * @typedef {import('./core/types/index.js').CommentAddress} CommentAddress
  * @typedef {import('./core/types/index.js').TrackedChangeAddress} TrackedChangeAddress
  * @typedef {import('./core/types/index.js').NavigableAddress} NavigableAddress
+ *
+ * @typedef {import('./core/types/index.js').Config} Config
+ * @typedef {import('./core/types/index.js').Modules} Modules
+ * @typedef {import('./core/types/index.js').CollaborationConfig} CollaborationConfig
+ * @typedef {import('./core/types/index.js').UpgradeToCollaborationOptions} UpgradeToCollaborationOptions
+ * @typedef {import('./core/types/index.js').ExternalPopoverRenderContext} ExternalPopoverRenderContext
+ * @typedef {import('./core/types/index.js').IntentSurfaceRequest} IntentSurfaceRequest
+ * @typedef {import('./core/types/index.js').DirectSurfaceRequest} DirectSurfaceRequest
+ * @typedef {import('./core/types/index.js').SurfaceRequest} SurfaceRequest
+ * @typedef {import('./core/types/index.js').SurfaceResolution} SurfaceResolution
+ * @typedef {import('./core/types/index.js').SurfaceResolver} SurfaceResolver
+ * @typedef {import('./core/types/index.js').SurfaceOutcome} SurfaceOutcome
+ * @typedef {import('./core/types/index.js').SurfaceHandle} SurfaceHandle
+ * @typedef {import('./core/types/index.js').SurfaceComponentProps} SurfaceComponentProps
+ * @typedef {import('./core/types/index.js').ExternalSurfaceRenderContext} ExternalSurfaceRenderContext
+ * @typedef {import('./core/types/index.js').SurfacesModuleConfig} SurfacesModuleConfig
+ * @typedef {import('./core/types/index.js').SurfaceMode} SurfaceMode
+ * @typedef {import('./core/types/index.js').SurfaceFloatingPlacement} SurfaceFloatingPlacement
+ * @typedef {import('./core/types/index.js').ResolvedPasswordPromptTexts} ResolvedPasswordPromptTexts
+ * @typedef {import('./core/types/index.js').PasswordPromptAttemptResult} PasswordPromptAttemptResult
+ * @typedef {import('./core/types/index.js').PasswordPromptHandle} PasswordPromptHandle
+ * @typedef {import('./core/types/index.js').PasswordPromptContext} PasswordPromptContext
+ * @typedef {import('./core/types/index.js').PasswordPromptRenderContext} PasswordPromptRenderContext
+ * @typedef {import('./core/types/index.js').PasswordPromptResolution} PasswordPromptResolution
+ * @typedef {import('./core/types/index.js').PasswordPromptConfig} PasswordPromptConfig
+ * @typedef {import('./core/types/index.js').ResolvedFindReplaceTexts} ResolvedFindReplaceTexts
+ * @typedef {import('./core/types/index.js').FindReplaceHandle} FindReplaceHandle
+ * @typedef {import('./core/types/index.js').FindReplaceContext} FindReplaceContext
+ * @typedef {import('./core/types/index.js').FindReplaceRenderContext} FindReplaceRenderContext
+ * @typedef {import('./core/types/index.js').FindReplaceResolution} FindReplaceResolution
+ * @typedef {import('./core/types/index.js').FindReplaceConfig} FindReplaceConfig
+ * @typedef {import('./core/types/index.js').TrackChangesModuleConfig} TrackChangesModuleConfig
+ * @typedef {import('./core/types/index.js').ViewingVisibilityConfig} ViewingVisibilityConfig
+ * @typedef {import('./core/types/index.js').SuperDocLayoutEngineOptions} SuperDocLayoutEngineOptions
+ * @typedef {import('./core/types/index.js').EditorSurface} EditorSurface
+ * @typedef {import('./core/types/index.js').EditorUpdateEvent} EditorUpdateEvent
+ * @typedef {import('./core/types/index.js').EditorTransactionEvent} EditorTransactionEvent
+ * @typedef {import('./core/types/index.js').ExportType} ExportType
+ * @typedef {import('./core/types/index.js').CommentsType} CommentsType
+ * @typedef {import('./core/types/index.js').ExportParams} ExportParams
+ * @typedef {import('./core/types/index.js').SuperDocTelemetryConfig} SuperDocTelemetryConfig
  */
 
 // Public exports

--- a/tests/consumer-typecheck/src/all-public-types.ts
+++ b/tests/consumer-typecheck/src/all-public-types.ts
@@ -24,6 +24,7 @@ import type {
   CanObject,
   ChainableCommandObject,
   ChainedCommand,
+  CollaborationConfig,
   CollaborationProvider,
   Command,
   CommandProps,
@@ -33,11 +34,14 @@ import type {
   CommentElement,
   CommentLocationsPayload,
   CommentsPayload,
+  CommentsType,
+  Config,
   ContextMenuConfig,
   ContextMenuContext,
   ContextMenuItem,
   ContextMenuSection,
   CoreCommandMap,
+  DirectSurfaceRequest,
   DocumentApi,
   DocumentMode,
   DocumentProtectionState,
@@ -48,19 +52,32 @@ import type {
   EditorLifecycleState,
   EditorOptions,
   EditorState,
+  EditorSurface,
+  EditorTransactionEvent,
+  EditorUpdateEvent,
   EditorView,
   EntityAddress,
   ExportDocxParams,
   ExportFormat,
   ExportOptions,
+  ExportParams,
+  ExportType,
   ExtensionCommandMap,
+  ExternalPopoverRenderContext,
+  ExternalSurfaceRenderContext,
   FieldValue,
+  FindReplaceConfig,
+  FindReplaceContext,
+  FindReplaceHandle,
+  FindReplaceRenderContext,
+  FindReplaceResolution,
   FlowBlock,
   FlowMode,
   FontConfig,
   FontsResolvedPayload,
   ImageDeselectedEvent,
   ImageSelectedEvent,
+  IntentSurfaceRequest,
   Layout,
   LayoutEngineOptions,
   LayoutError,
@@ -75,6 +92,7 @@ import type {
   LinkPopoverResolver,
   ListDefinitionsPayload,
   Measure,
+  Modules,
   NavigableAddress,
   OpenOptions,
   PageMargins,
@@ -85,6 +103,12 @@ import type {
   PartChangedEvent,
   PartId,
   PartSectionId,
+  PasswordPromptAttemptResult,
+  PasswordPromptConfig,
+  PasswordPromptContext,
+  PasswordPromptHandle,
+  PasswordPromptRenderContext,
+  PasswordPromptResolution,
   PermissionParams,
   PositionHit,
   PresenceOptions,
@@ -107,6 +131,8 @@ import type {
   RemoteCursorsRenderPayload,
   RemoteUserInfo,
   ResolveRangeOutput,
+  ResolvedFindReplaceTexts,
+  ResolvedPasswordPromptTexts,
   SaveOptions,
   Schema,
   ScrollIntoViewInput,
@@ -118,18 +144,32 @@ import type {
   SelectionHandle,
   SelectionInfo,
   StoryLocator,
+  SuperDocLayoutEngineOptions,
+  SuperDocTelemetryConfig,
+  SurfaceComponentProps,
+  SurfaceFloatingPlacement,
+  SurfaceHandle,
+  SurfaceMode,
+  SurfaceOutcome,
+  SurfaceRequest,
+  SurfaceResolution,
+  SurfaceResolver,
+  SurfacesModuleConfig,
   TelemetryEvent,
   TextAddress,
   TextSegment,
   TextTarget,
+  TrackChangesModuleConfig,
   TrackedChangeAddress,
   TrackedChangesMode,
   TrackedChangesOverrides,
   Transaction,
   UnsupportedContentItem,
+  UpgradeToCollaborationOptions,
   User,
   ViewLayout,
   ViewOptions,
+  ViewingVisibilityConfig,
   VirtualizationOptions,
 } from 'superdoc';
 
@@ -149,6 +189,7 @@ const _real_BoundingRect: AssertNotAny<BoundingRect> = true;
 const _real_CanObject: AssertNotAny<CanObject> = true;
 const _real_ChainableCommandObject: AssertNotAny<ChainableCommandObject> = true;
 const _real_ChainedCommand: AssertNotAny<ChainedCommand> = true;
+const _real_CollaborationConfig: AssertNotAny<CollaborationConfig> = true;
 const _real_CollaborationProvider: AssertNotAny<CollaborationProvider> = true;
 const _real_Command: AssertNotAny<Command> = true;
 const _real_CommandProps: AssertNotAny<CommandProps> = true;
@@ -158,11 +199,14 @@ const _real_CommentConfig: AssertNotAny<CommentConfig> = true;
 const _real_CommentElement: AssertNotAny<CommentElement> = true;
 const _real_CommentLocationsPayload: AssertNotAny<CommentLocationsPayload> = true;
 const _real_CommentsPayload: AssertNotAny<CommentsPayload> = true;
+const _real_CommentsType: AssertNotAny<CommentsType> = true;
+const _real_Config: AssertNotAny<Config> = true;
 const _real_ContextMenuConfig: AssertNotAny<ContextMenuConfig> = true;
 const _real_ContextMenuContext: AssertNotAny<ContextMenuContext> = true;
 const _real_ContextMenuItem: AssertNotAny<ContextMenuItem> = true;
 const _real_ContextMenuSection: AssertNotAny<ContextMenuSection> = true;
 const _real_CoreCommandMap: AssertNotAny<CoreCommandMap> = true;
+const _real_DirectSurfaceRequest: AssertNotAny<DirectSurfaceRequest> = true;
 const _real_DocumentApi: AssertNotAny<DocumentApi> = true;
 const _real_DocumentMode: AssertNotAny<DocumentMode> = true;
 const _real_DocumentProtectionState: AssertNotAny<DocumentProtectionState> = true;
@@ -173,19 +217,32 @@ const _real_EditorExtension: AssertNotAny<EditorExtension> = true;
 const _real_EditorLifecycleState: AssertNotAny<EditorLifecycleState> = true;
 const _real_EditorOptions: AssertNotAny<EditorOptions> = true;
 const _real_EditorState: AssertNotAny<EditorState> = true;
+const _real_EditorSurface: AssertNotAny<EditorSurface> = true;
+const _real_EditorTransactionEvent: AssertNotAny<EditorTransactionEvent> = true;
+const _real_EditorUpdateEvent: AssertNotAny<EditorUpdateEvent> = true;
 const _real_EditorView: AssertNotAny<EditorView> = true;
 const _real_EntityAddress: AssertNotAny<EntityAddress> = true;
 const _real_ExportDocxParams: AssertNotAny<ExportDocxParams> = true;
 const _real_ExportFormat: AssertNotAny<ExportFormat> = true;
 const _real_ExportOptions: AssertNotAny<ExportOptions> = true;
+const _real_ExportParams: AssertNotAny<ExportParams> = true;
+const _real_ExportType: AssertNotAny<ExportType> = true;
 const _real_ExtensionCommandMap: AssertNotAny<ExtensionCommandMap> = true;
+const _real_ExternalPopoverRenderContext: AssertNotAny<ExternalPopoverRenderContext> = true;
+const _real_ExternalSurfaceRenderContext: AssertNotAny<ExternalSurfaceRenderContext> = true;
 const _real_FieldValue: AssertNotAny<FieldValue> = true;
+const _real_FindReplaceConfig: AssertNotAny<FindReplaceConfig> = true;
+const _real_FindReplaceContext: AssertNotAny<FindReplaceContext> = true;
+const _real_FindReplaceHandle: AssertNotAny<FindReplaceHandle> = true;
+const _real_FindReplaceRenderContext: AssertNotAny<FindReplaceRenderContext> = true;
+const _real_FindReplaceResolution: AssertNotAny<FindReplaceResolution> = true;
 const _real_FlowBlock: AssertNotAny<FlowBlock> = true;
 const _real_FlowMode: AssertNotAny<FlowMode> = true;
 const _real_FontConfig: AssertNotAny<FontConfig> = true;
 const _real_FontsResolvedPayload: AssertNotAny<FontsResolvedPayload> = true;
 const _real_ImageDeselectedEvent: AssertNotAny<ImageDeselectedEvent> = true;
 const _real_ImageSelectedEvent: AssertNotAny<ImageSelectedEvent> = true;
+const _real_IntentSurfaceRequest: AssertNotAny<IntentSurfaceRequest> = true;
 const _real_Layout: AssertNotAny<Layout> = true;
 const _real_LayoutEngineOptions: AssertNotAny<LayoutEngineOptions> = true;
 const _real_LayoutError: AssertNotAny<LayoutError> = true;
@@ -200,6 +257,7 @@ const _real_LinkPopoverResolution: AssertNotAny<LinkPopoverResolution> = true;
 const _real_LinkPopoverResolver: AssertNotAny<LinkPopoverResolver> = true;
 const _real_ListDefinitionsPayload: AssertNotAny<ListDefinitionsPayload> = true;
 const _real_Measure: AssertNotAny<Measure> = true;
+const _real_Modules: AssertNotAny<Modules> = true;
 const _real_NavigableAddress: AssertNotAny<NavigableAddress> = true;
 const _real_OpenOptions: AssertNotAny<OpenOptions> = true;
 const _real_PageMargins: AssertNotAny<PageMargins> = true;
@@ -210,6 +268,12 @@ const _real_PaintSnapshot: AssertNotAny<PaintSnapshot> = true;
 const _real_PartChangedEvent: AssertNotAny<PartChangedEvent> = true;
 const _real_PartId: AssertNotAny<PartId> = true;
 const _real_PartSectionId: AssertNotAny<PartSectionId> = true;
+const _real_PasswordPromptAttemptResult: AssertNotAny<PasswordPromptAttemptResult> = true;
+const _real_PasswordPromptConfig: AssertNotAny<PasswordPromptConfig> = true;
+const _real_PasswordPromptContext: AssertNotAny<PasswordPromptContext> = true;
+const _real_PasswordPromptHandle: AssertNotAny<PasswordPromptHandle> = true;
+const _real_PasswordPromptRenderContext: AssertNotAny<PasswordPromptRenderContext> = true;
+const _real_PasswordPromptResolution: AssertNotAny<PasswordPromptResolution> = true;
 const _real_PermissionParams: AssertNotAny<PermissionParams> = true;
 const _real_PositionHit: AssertNotAny<PositionHit> = true;
 const _real_PresenceOptions: AssertNotAny<PresenceOptions> = true;
@@ -232,6 +296,8 @@ const _real_RemoteCursorState: AssertNotAny<RemoteCursorState> = true;
 const _real_RemoteCursorsRenderPayload: AssertNotAny<RemoteCursorsRenderPayload> = true;
 const _real_RemoteUserInfo: AssertNotAny<RemoteUserInfo> = true;
 const _real_ResolveRangeOutput: AssertNotAny<ResolveRangeOutput> = true;
+const _real_ResolvedFindReplaceTexts: AssertNotAny<ResolvedFindReplaceTexts> = true;
+const _real_ResolvedPasswordPromptTexts: AssertNotAny<ResolvedPasswordPromptTexts> = true;
 const _real_SaveOptions: AssertNotAny<SaveOptions> = true;
 const _real_Schema: AssertNotAny<Schema> = true;
 const _real_ScrollIntoViewInput: AssertNotAny<ScrollIntoViewInput> = true;
@@ -243,16 +309,30 @@ const _real_SelectionCurrentInput: AssertNotAny<SelectionCurrentInput> = true;
 const _real_SelectionHandle: AssertNotAny<SelectionHandle> = true;
 const _real_SelectionInfo: AssertNotAny<SelectionInfo> = true;
 const _real_StoryLocator: AssertNotAny<StoryLocator> = true;
+const _real_SuperDocLayoutEngineOptions: AssertNotAny<SuperDocLayoutEngineOptions> = true;
+const _real_SuperDocTelemetryConfig: AssertNotAny<SuperDocTelemetryConfig> = true;
+const _real_SurfaceComponentProps: AssertNotAny<SurfaceComponentProps> = true;
+const _real_SurfaceFloatingPlacement: AssertNotAny<SurfaceFloatingPlacement> = true;
+const _real_SurfaceHandle: AssertNotAny<SurfaceHandle> = true;
+const _real_SurfaceMode: AssertNotAny<SurfaceMode> = true;
+const _real_SurfaceOutcome: AssertNotAny<SurfaceOutcome> = true;
+const _real_SurfaceRequest: AssertNotAny<SurfaceRequest> = true;
+const _real_SurfaceResolution: AssertNotAny<SurfaceResolution> = true;
+const _real_SurfaceResolver: AssertNotAny<SurfaceResolver> = true;
+const _real_SurfacesModuleConfig: AssertNotAny<SurfacesModuleConfig> = true;
 const _real_TelemetryEvent: AssertNotAny<TelemetryEvent> = true;
 const _real_TextAddress: AssertNotAny<TextAddress> = true;
 const _real_TextSegment: AssertNotAny<TextSegment> = true;
 const _real_TextTarget: AssertNotAny<TextTarget> = true;
+const _real_TrackChangesModuleConfig: AssertNotAny<TrackChangesModuleConfig> = true;
 const _real_TrackedChangeAddress: AssertNotAny<TrackedChangeAddress> = true;
 const _real_TrackedChangesMode: AssertNotAny<TrackedChangesMode> = true;
 const _real_TrackedChangesOverrides: AssertNotAny<TrackedChangesOverrides> = true;
 const _real_Transaction: AssertNotAny<Transaction> = true;
 const _real_UnsupportedContentItem: AssertNotAny<UnsupportedContentItem> = true;
+const _real_UpgradeToCollaborationOptions: AssertNotAny<UpgradeToCollaborationOptions> = true;
 const _real_User: AssertNotAny<User> = true;
 const _real_ViewLayout: AssertNotAny<ViewLayout> = true;
 const _real_ViewOptions: AssertNotAny<ViewOptions> = true;
+const _real_ViewingVisibilityConfig: AssertNotAny<ViewingVisibilityConfig> = true;
 const _real_VirtualizationOptions: AssertNotAny<VirtualizationOptions> = true;

--- a/tests/consumer-typecheck/src/modules-config-passthrough.ts
+++ b/tests/consumer-typecheck/src/modules-config-passthrough.ts
@@ -16,20 +16,13 @@
  *     keys forwarded to SuperToolbar via `...moduleConfig`.
  *   - SD-2869 review pass flagged `onAwarenessUpdate.states` narrowed from
  *     JSDoc `Array` (= `any[]`) to `unknown[]`.
- *
- * Note: `Config`, `Modules`, `FindReplaceConfig`, and `PasswordPromptConfig`
- * are not yet exported from the public `superdoc` surface — a separate
- * follow-up ticket. This fixture works around that by typing the config
- * literal off the SuperDoc constructor parameter, which is reachable.
  */
-import { SuperDoc } from 'superdoc';
-
-type SuperDocConfig = ConstructorParameters<typeof SuperDoc>[0];
+import type { Config } from 'superdoc';
 
 // A realistic config with the documented fields plus the pass-through extras
 // the runtime accepts. If any of these stops compiling under strict mode,
 // existing consumer code regresses.
-const config: SuperDocConfig = {
+const config: Config = {
   selector: '#editor',
 
   modules: {
@@ -146,8 +139,29 @@ const config: SuperDocConfig = {
 void config;
 
 // Whiteboard accepts the structured form too.
-const enabledWhiteboard: SuperDocConfig = {
+const enabledWhiteboard: Config = {
   selector: '#editor',
   modules: { whiteboard: { enabled: true } },
 };
 void enabledWhiteboard;
+
+// CollaborationProvider interop: a value typed as the publicly-exported
+// CollaborationProvider must be assignable to Config.modules.collaboration.provider
+// (also typed against CollaborationProvider). Pre-SD-2880 these were two
+// different shapes — super-editor's allowed `awareness: null`, core/types'
+// did not — and a strict-mode consumer setting both at once got an error.
+import type { CollaborationProvider } from 'superdoc';
+
+const provider: CollaborationProvider = {
+  awareness: null,
+  on(event, handler) {
+    void event;
+    void handler;
+  },
+};
+
+const collabConfig: Config = {
+  selector: '#editor',
+  modules: { collaboration: { provider } },
+};
+void collabConfig;


### PR DESCRIPTION
The most fundamental shapes of the SuperDoc API were defined in source but unreachable through the published \`superdoc\` entry. Consumers writing TypeScript could not type their constructor input, their \`modules\` block, or any of the surface/prompt/find-replace configs without falling back to deep paths or \`any\`. This is the most direct manifestation of SD-2828's "no TypeScript errors for end users."

Stacked on #3052 because it relies on the SD-2869 TypeScript conversion of \`core/types/index.js\` for the named typedefs to resolve cleanly. Will rebase to main once #3052 lands.

Adds 40 typedef re-exports — Config, Modules, all the surface/prompt/find-replace configs, the editor/transaction event payloads, etc. The auto-derived assertion list (SD-2860) picks them up automatically; each is now gated against \`any\` collapse via the consumer-typecheck matrix. Total assertions go from 116 → 156.

The pass-through fixture lands in #3052 used \`ConstructorParameters<typeof SuperDoc>[0]\` as a workaround. With \`Config\` exported, it now uses the direct import.

**Out of scope** (each is its own decision):

- \`User\`: a different \`User\` shape is already exported from \`@superdoc/super-editor\` (with name/email optional). The \`core/types\` \`User\` requires both. Picking one as canonical is a separate question.
- \`Document\`: collides with the DOM \`Document\` global at consumer sites. Needs a rename (e.g. \`SuperDocDocument\`).
- \`ViewLayout\`, \`ViewOptions\`, \`ProofingConfig\`, \`ProofingStatus\`, \`ProofingError\`: already re-exported from \`@superdoc/super-editor\` — kept as-is to avoid duplicate-name issues.

**Verified**: \`pnpm --filter superdoc run check:jsdoc\` passes; consumer matrix passes 29/29; declaration audit reports no FAIL findings.