### PR TITLE
refactor(superdoc): type createSuperdocVueApp return shape (SD-2867 phase B)

### DIFF
--- a/packages/superdoc/src/core/create-app.js
+++ b/packages/superdoc/src/core/create-app.js
@@ -302,11 +302,23 @@ const setPiniaDevtoolsSuppressedForApp = (app, isSuppressed) => {
 };
 
 /**
+ * Result of `createSuperdocVueApp()`. Internal-only: the shape is consumed
+ * by `SuperDoc.#initVueApp` and is not part of the public surface.
+ *
+ * @typedef {Object} SuperdocVueAppRefs
+ * @property {import('vue').App} app The Vue 3 app instance
+ * @property {import('pinia').Pinia} pinia The Pinia store instance attached to `app`
+ * @property {ReturnType<typeof useSuperdocStore>} superdocStore The SuperDoc Pinia store
+ * @property {ReturnType<typeof useCommentsStore>} commentsStore The Comments Pinia store
+ * @property {ReturnType<typeof useHighContrastMode>} highContrastModeStore The high-contrast mode composable refs (`isHighContrastMode`, `setHighContrastMode`). Named `*Store` for historical reasons; this is a plain Vue composable, not a Pinia store.
+ */
+
+/**
  * Generate the superdoc vue app
  *
  * @param {Object} [options]
  * @param {boolean} [options.disablePiniaDevtools=false] Disable Pinia devtools registration for this app instance
- * @returns {Object} An object containing the vue app, the pinia reference, and the superdoc store
+ * @returns {SuperdocVueAppRefs} An object containing the vue app, the pinia reference, the superdoc/comments Pinia stores, and the high-contrast mode composable
  */
 export const createSuperdocVueApp = ({ disablePiniaDevtools = false } = {}) => {
   const app = createApp(App);


### PR DESCRIPTION
\`createSuperdocVueApp()\` returned \`Object\` per its JSDoc, so the five fields \`SuperDoc.js\` destructures from the call (\`app\`, \`pinia\`, \`superdocStore\`, \`commentsStore\`, \`highContrastModeStore\`) all resolved to \`Object\` for any consumer enabling \`// @ts-check\`. Five TS2339 errors at \`SuperDoc.js:464\` — and inside the SD-2867 ratchet that turns each into a gate failure.

Promotes the return type to a named \`SuperdocVueAppRefs\` typedef that imports \`vue.App\`, \`pinia.Pinia\`, and the store types via \`ReturnType<typeof useSuperdocStore>\` etc. The shape is internal-only (this typedef is not on the public \`Modules\` / \`Config\` surface), so adding it here doesn't widen the customer-visible surface.

This is groundwork for SD-2867 phase B: closing each cluster of \`SuperDoc.js\` TS errors so the file can eventually enroll in \`CHECKED_FILES\`. Five errors closed; ~133 remain across implicit-any params, strict-null guards, and other type-not-assignable callsites. Each cluster will land as its own focused commit so the strictness ratchet stays reviewable.

**Verified**: \`pnpm --filter superdoc run check:jsdoc\` passes (3 gated files clean); consumer matrix passes 31/31; declaration audit reports no FAIL findings; \`pnpm --filter superdoc test\` passes 944/944.

**Related**: SD-2892 (skipLibCheck:false promotion) and SD-2893 (drain \`_internal-shims.d.ts\`) — the other two named gaps from the SD-2828 audit, filed in parallel.