### PR TITLE
refactor(superdoc): add RuntimeDocument typedef for runtime doc shape (SD-2867 phase B)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -59,6 +59,7 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
 
 /** @typedef {import('./types/index.js').User} User */
 /** @typedef {import('./types/index.js').Document} Document */
+/** @typedef {import('./types/index.js').RuntimeDocument} RuntimeDocument */
 /** @typedef {import('./types/index.js').Modules} Modules */
 /** @typedef {import('./types/index.js').Editor} Editor */
 /** @typedef {import('./types/index.js').DocumentMode} DocumentMode */
@@ -1304,8 +1305,8 @@ export class SuperDoc extends EventEmitter {
   /**
    * Set the document mode on a document's editor (PresentationEditor or Editor).
    * Tries PresentationEditor first, falls back to Editor for backward compatibility.
-   * @param {Object} doc - The document object
-   * @param {string} mode - The document mode ('editing', 'viewing', 'suggesting')
+   * @param {RuntimeDocument} doc - The document object
+   * @param {DocumentMode} mode - The document mode ('editing', 'viewing', 'suggesting')
    */
   #applyDocumentMode(doc, mode) {
     const presentationEditor = typeof doc.getPresentationEditor === 'function' ? doc.getPresentationEditor() : null;

--- a/packages/superdoc/src/core/create-app.js
+++ b/packages/superdoc/src/core/create-app.js
@@ -302,11 +302,23 @@ const setPiniaDevtoolsSuppressedForApp = (app, isSuppressed) => {
 };
 
 /**
+ * Result of `createSuperdocVueApp()`. Internal-only: the shape is consumed
+ * by `SuperDoc.#initVueApp` and is not part of the public surface.
+ *
+ * @typedef {Object} SuperdocVueAppRefs
+ * @property {import('vue').App} app The Vue 3 app instance
+ * @property {import('pinia').Pinia} pinia The Pinia store instance attached to `app`
+ * @property {ReturnType<typeof useSuperdocStore>} superdocStore The SuperDoc Pinia store
+ * @property {ReturnType<typeof useCommentsStore>} commentsStore The Comments Pinia store
+ * @property {ReturnType<typeof useHighContrastMode>} highContrastModeStore The high-contrast mode composable refs (`isHighContrastMode`, `setHighContrastMode`). Named `*Store` for historical reasons; this is a plain Vue composable, not a Pinia store.
+ */
+
+/**
  * Generate the superdoc vue app
  *
  * @param {Object} [options]
  * @param {boolean} [options.disablePiniaDevtools=false] Disable Pinia devtools registration for this app instance
- * @returns {Object} An object containing the vue app, the pinia reference, and the superdoc store
+ * @returns {SuperdocVueAppRefs} An object containing the vue app, the pinia reference, the superdoc/comments Pinia stores, and the high-contrast mode composable
  */
 export const createSuperdocVueApp = ({ disablePiniaDevtools = false } = {}) => {
   const app = createApp(App);

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -17,6 +17,7 @@ import type { Ref, ComputedRef } from 'vue';
 
 import type {
   Editor as SuperEditor,
+  PresentationEditor as SuperEditorPresentationEditor,
   StoryLocator as SuperEditorStoryLocator,
   BookmarkAddress as SuperEditorBookmarkAddress,
   BlockNavigationAddress as SuperEditorBlockNavigationAddress,
@@ -85,6 +86,50 @@ export interface Document {
  * `CollaborationProvider` from `superdoc`.
  */
 export type CollaborationProvider = SuperEditorCollaborationProvider;
+
+/**
+ * Internal augmentation of `Document` for runtime-only fields that the
+ * SuperDoc instance attaches to each document during initialization. The
+ * public `Document` interface above is what consumers pass in via
+ * `Config.documents`; this type adds the fields SuperDoc itself sets and
+ * reads internally (per-document `role` propagation, the live `getEditor`
+ * and `getPresentationEditor` accessors that the surface manager and
+ * mode-switch helpers walk).
+ *
+ * Internal use only: not part of any public typedef. Consumers cannot
+ * import this through `superdoc` and should not pass any of these fields
+ * into `Config.documents` from outside.
+ */
+export interface RuntimeDocument extends Document {
+  /**
+   * Per-document role. `useDocument()` reads `params.role` from the input
+   * config and exposes it on the smart-doc object; once collaboration
+   * setup runs, SuperDoc unconditionally writes `doc.role = config.role`,
+   * silently replacing whatever was passed. SD-2872 removed this from
+   * the public `Document` interface so consumers stop trying to use it
+   * as a stable per-document override; it lives on `RuntimeDocument`
+   * only so internal SuperDoc.js callsites can type the assignment.
+   */
+  role?: 'editor' | 'viewer' | 'suggester';
+  /**
+   * Returns the body Editor for this document, when the runtime has
+   * created one. Set by the editor-create lifecycle.
+   *
+   * @deprecated Direct editor access will be removed in a future version.
+   * Use the Document API (`editor.doc`) instead. This typedef carries the
+   * deprecation marker forward from the source accessor in
+   * `packages/superdoc/src/composables/use-document.js`.
+   */
+  getEditor?: () => SuperEditor | null | undefined;
+  /**
+   * Returns the PresentationEditor for this document, when the runtime
+   * has created one. Set by the editor-create lifecycle.
+   *
+   * @deprecated Direct editor access will be removed in a future version.
+   * Use the Document API (`editor.doc`) instead.
+   */
+  getPresentationEditor?: () => SuperEditorPresentationEditor | null | undefined;
+}
 
 /** Collaboration module configuration. */
 export interface CollaborationConfig {


### PR DESCRIPTION
The internal \`doc\` parameter in SuperDoc.js's private methods (\`#applyDocumentMode\`, \`#attachExternalCollaboration\`, etc.) is shaped differently from the public \`Document\` interface: SuperDoc attaches a runtime \`role\`, \`getEditor()\`, and \`getPresentationEditor()\` to each entry during init. Today those methods are typed \`@param {Object} doc\`, so any attempt to enable \`// @ts-check\` on SuperDoc.js fails with TS2339 errors at every \`doc.getEditor()\` / \`doc.getPresentationEditor()\` / \`doc.role\` access (~10 sites).

Adds a \`RuntimeDocument\` typedef in \`core/types/index.ts\` that extends the public \`Document\` with the runtime-attached fields. Updates \`#applyDocumentMode\`'s \`@param {Object} doc\` to \`@param {RuntimeDocument} doc\` as the first callsite to migrate.

The typedef is internal-only and not on the public superdoc surface (not in the public typedef block of \`packages/superdoc/src/index.js\`), so consumers cannot import or pass these fields from outside.

Stacked on #3057 because both PRs add internal typedefs in the same area; will rebase to main if #3057 lands first.

This is groundwork: subsequent SD-2867 phase B PRs will migrate the remaining \`@param {Object} doc\` sites and then enable \`@ts-check\` on the methods involved.

**Verified**: \`pnpm --filter superdoc run check:jsdoc\` passes (3 gated files clean); consumer matrix passes 31/31; declaration audit reports no FAIL findings; published \`.d.ts\` surface unchanged (\`RuntimeDocument\` is not re-exported from the public superdoc entry).