### PR TITLE
refactor(superdoc): tighten @param {Object} on three callback methods (SD-2867 phase B)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -512,9 +512,11 @@ export class SuperDoc extends EventEmitter {
   }
 
   /**
-   * Initialize collaboration if configured
-   * @param {Object} config
-   * @returns {Promise<Object[]>} The processed documents with collaboration enabled
+   * Initialize collaboration if configured. Accepts the full
+   * `Config.modules` block so it can read both the collaboration
+   * subkey and the comments subkey at once.
+   * @param {Modules} [modules]
+   * @returns {Promise<Document[] | undefined>} The processed documents with collaboration enabled. Caller awaits for side effects; the return value is informational.
    */
   async #initCollaboration({ collaboration: collaborationModuleConfig, comments: commentsConfig = {} } = {}) {
     if (!collaborationModuleConfig) return this.config.documents;

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -59,6 +59,7 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
 
 /** @typedef {import('./types/index.js').User} User */
 /** @typedef {import('./types/index.js').Document} Document */
+/** @typedef {import('./types/index.js').RuntimeDocument} RuntimeDocument */
 /** @typedef {import('./types/index.js').Modules} Modules */
 /** @typedef {import('./types/index.js').Editor} Editor */
 /** @typedef {import('./types/index.js').DocumentMode} DocumentMode */
@@ -1304,8 +1305,8 @@ export class SuperDoc extends EventEmitter {
   /**
    * Set the document mode on a document's editor (PresentationEditor or Editor).
    * Tries PresentationEditor first, falls back to Editor for backward compatibility.
-   * @param {Object} doc - The document object
-   * @param {string} mode - The document mode ('editing', 'viewing', 'suggesting')
+   * @param {RuntimeDocument} doc - The document object
+   * @param {DocumentMode} mode - The document mode ('editing', 'viewing', 'suggesting')
    */
   #applyDocumentMode(doc, mode) {
     const presentationEditor = typeof doc.getPresentationEditor === 'function' ? doc.getPresentationEditor() : null;

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -960,7 +960,7 @@ export class SuperDoc extends EventEmitter {
 
   /**
    * Add a user to the shared users list
-   * @param {Object} user The user to add
+   * @param {User} user The user to add
    * @returns {void}
    */
   addSharedUser(user) {
@@ -979,9 +979,7 @@ export class SuperDoc extends EventEmitter {
 
   /**
    * Triggered when there is an error in the content
-   * @param {Object} param0
-   * @param {Error} param0.error The error that occurred
-   * @param {Editor} param0.editor The editor that caused the error
+   * @param {{ error: Error, editor: Editor }} params
    */
   onContentError({ error, editor }) {
     const { documentId } = editor.options;
@@ -1078,12 +1076,19 @@ export class SuperDoc extends EventEmitter {
    * Used by downstream consumers (toolbar, context menu, commands) to keep
    * tracked-change affordances consistent with customer overrides.
    *
-   * @param {Object} params
-   * @param {string} params.permission Permission key to evaluate
-   * @param {string} [params.role=this.config.role] Role to evaluate against
-   * @param {boolean} [params.isInternal=this.config.isInternal] Internal/external flag
-   * @param {Object|null} [params.comment] Comment object (if already resolved)
-   * @param {Object|null} [params.trackedChange] Tracked change metadata (id, attrs, etc.)
+   * `comment` and `trackedChange` carry an open index signature because
+   * the function forwards the full payload to `isAllowed()`; tracked-change
+   * payloads from the editor include `type`, `attrs`, `from`, `to`,
+   * `segments`, and the comment objects passed by consumers vary in shape.
+   * The named fields below are the ones this method reads directly.
+   *
+   * @param {{
+   *   permission?: string,
+   *   role?: string,
+   *   isInternal?: boolean,
+   *   comment?: (object & Record<string, unknown>) | null,
+   *   trackedChange?: ({ id?: string, commentId?: string, comment?: unknown } & Record<string, unknown>) | null,
+   * }} [params]
    * @returns {boolean}
    */
   canPerformPermission({
@@ -1436,7 +1441,7 @@ export class SuperDoc extends EventEmitter {
 
   /**
    * Go to the next search result
-   * @param {Object} match The match object
+   * @param {Object} match The match object (returned as-is by `superdoc.search()`; pass it through unchanged). Stays loose here because the upstream `commands.goToSearchResult` expects a private `SearchMatch` shape that is not yet on the public surface; tightening this is a separate follow-up.
    * @returns {void}
    */
   goToSearchResult(match) {

--- a/packages/superdoc/src/core/create-app.js
+++ b/packages/superdoc/src/core/create-app.js
@@ -302,11 +302,23 @@ const setPiniaDevtoolsSuppressedForApp = (app, isSuppressed) => {
 };
 
 /**
+ * Result of `createSuperdocVueApp()`. Internal-only: the shape is consumed
+ * by `SuperDoc.#initVueApp` and is not part of the public surface.
+ *
+ * @typedef {Object} SuperdocVueAppRefs
+ * @property {import('vue').App} app The Vue 3 app instance
+ * @property {import('pinia').Pinia} pinia The Pinia store instance attached to `app`
+ * @property {ReturnType<typeof useSuperdocStore>} superdocStore The SuperDoc Pinia store
+ * @property {ReturnType<typeof useCommentsStore>} commentsStore The Comments Pinia store
+ * @property {ReturnType<typeof useHighContrastMode>} highContrastModeStore The high-contrast mode composable refs (`isHighContrastMode`, `setHighContrastMode`). Named `*Store` for historical reasons; this is a plain Vue composable, not a Pinia store.
+ */
+
+/**
  * Generate the superdoc vue app
  *
  * @param {Object} [options]
  * @param {boolean} [options.disablePiniaDevtools=false] Disable Pinia devtools registration for this app instance
- * @returns {Object} An object containing the vue app, the pinia reference, and the superdoc store
+ * @returns {SuperdocVueAppRefs} An object containing the vue app, the pinia reference, the superdoc/comments Pinia stores, and the high-contrast mode composable
  */
 export const createSuperdocVueApp = ({ disablePiniaDevtools = false } = {}) => {
   const app = createApp(App);

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -17,6 +17,7 @@ import type { Ref, ComputedRef } from 'vue';
 
 import type {
   Editor as SuperEditor,
+  PresentationEditor as SuperEditorPresentationEditor,
   StoryLocator as SuperEditorStoryLocator,
   BookmarkAddress as SuperEditorBookmarkAddress,
   BlockNavigationAddress as SuperEditorBlockNavigationAddress,
@@ -85,6 +86,50 @@ export interface Document {
  * `CollaborationProvider` from `superdoc`.
  */
 export type CollaborationProvider = SuperEditorCollaborationProvider;
+
+/**
+ * Internal augmentation of `Document` for runtime-only fields that the
+ * SuperDoc instance attaches to each document during initialization. The
+ * public `Document` interface above is what consumers pass in via
+ * `Config.documents`; this type adds the fields SuperDoc itself sets and
+ * reads internally (per-document `role` propagation, the live `getEditor`
+ * and `getPresentationEditor` accessors that the surface manager and
+ * mode-switch helpers walk).
+ *
+ * Internal use only: not part of any public typedef. Consumers cannot
+ * import this through `superdoc` and should not pass any of these fields
+ * into `Config.documents` from outside.
+ */
+export interface RuntimeDocument extends Document {
+  /**
+   * Per-document role. `useDocument()` reads `params.role` from the input
+   * config and exposes it on the smart-doc object; once collaboration
+   * setup runs, SuperDoc unconditionally writes `doc.role = config.role`,
+   * silently replacing whatever was passed. SD-2872 removed this from
+   * the public `Document` interface so consumers stop trying to use it
+   * as a stable per-document override; it lives on `RuntimeDocument`
+   * only so internal SuperDoc.js callsites can type the assignment.
+   */
+  role?: 'editor' | 'viewer' | 'suggester';
+  /**
+   * Returns the body Editor for this document, when the runtime has
+   * created one. Set by the editor-create lifecycle.
+   *
+   * @deprecated Direct editor access will be removed in a future version.
+   * Use the Document API (`editor.doc`) instead. This typedef carries the
+   * deprecation marker forward from the source accessor in
+   * `packages/superdoc/src/composables/use-document.js`.
+   */
+  getEditor?: () => SuperEditor | null | undefined;
+  /**
+   * Returns the PresentationEditor for this document, when the runtime
+   * has created one. Set by the editor-create lifecycle.
+   *
+   * @deprecated Direct editor access will be removed in a future version.
+   * Use the Document API (`editor.doc`) instead.
+   */
+  getPresentationEditor?: () => SuperEditorPresentationEditor | null | undefined;
+}
 
 /** Collaboration module configuration. */
 export interface CollaborationConfig {

--- a/tests/consumer-typecheck/src/can-perform-permission-payload.ts
+++ b/tests/consumer-typecheck/src/can-perform-permission-payload.ts
@@ -1,0 +1,45 @@
+/**
+ * Consumer typecheck: SuperDoc.canPerformPermission must accept the wide
+ * payloads consumers produce (SD-2867 phase B).
+ *
+ * The method forwards `comment` and `trackedChange` to `isAllowed()`
+ * unchanged, and the editor produces tracked-change objects with `type`,
+ * `attrs`, `from`, `to`, `segments`, etc. A typedef that closes the shape
+ * to only `{ id, commentId, comment }` rejects valid payloads under
+ * strict TS even though the runtime accepts them.
+ *
+ * This fixture pins the contract: each call below must compile under
+ * strict mode. If a future change re-narrows `comment` or `trackedChange`,
+ * the line stops compiling and CI fails.
+ */
+import { SuperDoc } from 'superdoc';
+
+declare const sd: SuperDoc;
+
+// Wide trackedChange payload like the editor's permission helper produces.
+sd.canPerformPermission({
+  permission: 'edit',
+  trackedChange: {
+    id: 'tc-1',
+    type: 'insert',
+    attrs: { color: 'red' },
+    from: 0,
+    to: 5,
+    segments: [],
+    comment: { id: 'c-1', body: 'note' },
+  },
+});
+
+// Wide comment payload (consumer-defined comment shapes).
+sd.canPerformPermission({
+  permission: 'edit',
+  comment: { id: 'c-1', body: 'note', author: { name: 'A' } },
+});
+
+// No-args / empty payload — function defaults `= {}` and bails on missing
+// permission via `if (!permission) return false`.
+sd.canPerformPermission();
+sd.canPerformPermission({});
+
+// Common minimal payload.
+sd.canPerformPermission({ permission: 'comment' });

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -425,6 +425,30 @@ const scenarios = [
     files: ['src/internal-fields-stripped.ts'],
     mustPass: true,
   },
+  // SD-2867 phase B: SuperDoc.canPerformPermission forwards `comment` and
+  // `trackedChange` to isAllowed() unchanged, so the public contract must
+  // accept the wide payloads the editor's permission helper produces
+  // (tracked-change `type`, `attrs`, `from`, `to`, `segments`, etc.). The
+  // fixture pins this so a future PR cannot re-narrow the typedef into a
+  // closed shape that rejects valid runtime payloads.
+  {
+    name: 'bundler / canPerformPermission wide payloads (SD-2867)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: true,
+    strict: true,
+    files: ['src/can-perform-permission-payload.ts'],
+    mustPass: true,
+  },
+  {
+    name: 'node16 / canPerformPermission wide payloads (SD-2867)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: true,
+    strict: true,
+    files: ['src/can-perform-permission-payload.ts'],
+    mustPass: true,
+  },
 ];
 
 const tscPath = join(__dirname, 'node_modules', '.bin', 'tsc');


### PR DESCRIPTION
Three callback methods on SuperDoc had \`@param {Object}\` JSDoc that masked their actual contract:

- \`addSharedUser(user)\` typed as \`Object\`. Actually expects \`User\` (the function reads \`u.email\`).
- \`onContentError({ error, editor })\` typed as \`Object\`. Actually expects an \`{ error: Error, editor: Editor }\` payload forwarded to \`config.onContentError\`.
- \`canPerformPermission({ permission, role, isInternal, comment, trackedChange })\` typed as \`Object\`. Promoted to a structural typedef with all fields optional (the function defaults \`= {}\` and treats missing \`permission\` as a no-op via the early \`if (!permission) return false\` guard).

Stacked on #3060 because all three sites are typedef-tightening on private/public methods of \`SuperDoc.js\`.

**Skipped \`goToSearchResult\`**: the upstream \`commands.goToSearchResult\` expects a private \`SearchMatch\` shape (\`{ id, from, to, text }\`) that is not on the public surface yet. Tightening that requires either exporting \`SearchMatch\` publicly or asserting at the call site; deferring to a separate follow-up. Left a comment on the JSDoc documenting the deferral.

This is groundwork for SD-2867 phase B's gate enrollment of \`SuperDoc.js\`. Each subsequent PR closes one cluster.

**Verified**: \`pnpm --filter superdoc run check:jsdoc\` passes (3 gated files clean); consumer matrix passes 31/31; declaration audit reports no FAIL findings; published \`.d.ts\` surface unchanged.