### PR TITLE
refactor(superdoc): type three implicit-any locals (SD-2867 phase B)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -878,6 +878,7 @@ export class SuperDoc extends EventEmitter {
     const SYNC_TIMEOUT_MS = 10_000;
 
     return new Promise((resolve, reject) => {
+      /** @type {ReturnType<typeof setTimeout> | undefined} */
       let timer;
       let settled = false;
       let syncCleanup = () => {};
@@ -1507,6 +1508,7 @@ export class SuperDoc extends EventEmitter {
    * @returns {Array<string>} The HTML content of all editors
    */
   getHTML(options = {}) {
+    /** @type {Editor[]} */
     const editors = [];
     this.superdocStore.documents.forEach((doc) => {
       const editor = doc.getEditor();
@@ -1611,6 +1613,7 @@ export class SuperDoc extends EventEmitter {
     //    `converter.comments` (which the legacy delete path doesn't
     //    clear today; tracked separately under SD-2839). Pass
     //    whatever the store returns, including `[]`.
+    /** @type {unknown[] | undefined} */
     let comments;
     const commentsModuleConfig = this.config?.modules?.comments;
     const uiStoreHydrated = commentsModuleConfig !== false;


### PR DESCRIPTION
Adds JSDoc `@type` to three `let` declarations inside SuperDoc.js so they stop registering as implicit-any under strict TS. Closes a small contained slice of the SD-2867 phase B effort.

- `timer` inside `#waitForProviderSync` is later assigned `setTimeout(...)` and read by `clearTimeout`, so `ReturnType<typeof setTimeout> | undefined` matches both branches.
- `editors` inside `getHTML` collects `Editor` references pushed from `doc.getEditor()`. Annotating as `Editor[]` makes the downstream `.map(...)` typed end-to-end.
- `comments` inside the export path can be `undefined` (when the UI store is unhydrated and we let the engine's converter fallback fire), `[]`, or whatever `translateCommentsForExport()` returns. `unknown[] | undefined` captures that without committing to a private workspace `Comment` shape that isn't on the public surface.

No public surface change; internal-only typing.

**Verified**: `pnpm --filter superdoc check:jsdoc` clean; `pnpm --filter superdoc build:es` declaration audit clean; `node tests/consumer-typecheck/typecheck-matrix.mjs` 33 passed, 0 failed.