### PR TITLE
refactor(superdoc): type four implicit-any params (SD-2867 phase B)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -213,6 +213,10 @@ export class SuperDoc extends EventEmitter {
     this.#init(config, container);
   }
 
+  /**
+   * @param {Config} config
+   * @param {HTMLElement} container
+   */
   async #init(config, container) {
     this.config = {
       ...this.config,
@@ -383,6 +387,7 @@ export class SuperDoc extends EventEmitter {
     const cspNonce = this.config.cspNonce;
 
     const originalCreateElement = document.createElement;
+    /** @param {string} tagName */
     document.createElement = function (tagName) {
       const element = originalCreateElement.call(this, tagName);
       if (tagName.toLowerCase() === 'style') {
@@ -478,7 +483,7 @@ export class SuperDoc extends EventEmitter {
     this.commentsStore = commentsStore;
     this.highContrastModeStore = highContrastModeStore;
     if (typeof this.superdocStore.setExceptionHandler === 'function') {
-      this.superdocStore.setExceptionHandler((payload) => this.emit('exception', payload));
+      this.superdocStore.setExceptionHandler((/** @type {unknown} */ payload) => this.emit('exception', payload));
     }
     this.superdocStore.init(this.config);
     const commentsModuleConfig = this.config.modules.comments;
@@ -1048,6 +1053,7 @@ export class SuperDoc extends EventEmitter {
     this.emit('sidebar-toggle', isOpened);
   }
 
+  /** @param {unknown[]} args */
   #log(...args) {
     (console.debug ? console.debug : console.log)('🦋 🦸‍♀️ [superdoc]', ...args);
   }

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -878,6 +878,7 @@ export class SuperDoc extends EventEmitter {
     const SYNC_TIMEOUT_MS = 10_000;
 
     return new Promise((resolve, reject) => {
+      /** @type {ReturnType<typeof setTimeout> | undefined} */
       let timer;
       let settled = false;
       let syncCleanup = () => {};
@@ -1507,6 +1508,7 @@ export class SuperDoc extends EventEmitter {
    * @returns {Array<string>} The HTML content of all editors
    */
   getHTML(options = {}) {
+    /** @type {Editor[]} */
     const editors = [];
     this.superdocStore.documents.forEach((doc) => {
       const editor = doc.getEditor();
@@ -1611,6 +1613,7 @@ export class SuperDoc extends EventEmitter {
     //    `converter.comments` (which the legacy delete path doesn't
     //    clear today; tracked separately under SD-2839). Pass
     //    whatever the store returns, including `[]`.
+    /** @type {unknown[] | undefined} */
     let comments;
     const commentsModuleConfig = this.config?.modules?.comments;
     const uiStoreHydrated = commentsModuleConfig !== false;


### PR DESCRIPTION
Stacked on #3064. Adds JSDoc `@param` annotations to four implicit-any function parameters in SuperDoc.js so they stop reporting as `any` under strict TS.

- `#init(config, container)` — typed as `(Config, HTMLElement)` to match the constructor's call site (which already validates `container instanceof HTMLElement`).
- `#patchNaiveUIStyles` — the `document.createElement` override gets `@param {string} tagName` so the inner `tagName.toLowerCase()` call typechecks.
- `setExceptionHandler` callback — `payload` typed as `unknown` since the store contract isn't on the public surface; the handler just forwards to `emit('exception', payload)`.
- `#log(...args)` — `args: unknown[]` matches the underlying `console.debug/log` rest signature.

The Yjs `metaMap.observe((event) => ...)` call still has an implicit-any `event`; deferring that one because typing it cleanly requires importing `YMapEvent` and risks pulling Yjs ambient types into a separate type cascade.

No public surface change; internal-only typing.

**Verified**: `pnpm --filter superdoc check:jsdoc` clean; `pnpm --filter superdoc build:es` declaration audit clean; `node tests/consumer-typecheck/typecheck-matrix.mjs` 33 passed, 0 failed.