### PR TITLE
refactor(superdoc): cast doc.ydoc in setLocked (SD-2867 phase B)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -213,6 +213,10 @@ export class SuperDoc extends EventEmitter {
     this.#init(config, container);
   }
 
+  /**
+   * @param {Config} config
+   * @param {HTMLElement} container
+   */
   async #init(config, container) {
     this.config = {
       ...this.config,
@@ -383,6 +387,7 @@ export class SuperDoc extends EventEmitter {
     const cspNonce = this.config.cspNonce;
 
     const originalCreateElement = document.createElement;
+    /** @param {string} tagName */
     document.createElement = function (tagName) {
       const element = originalCreateElement.call(this, tagName);
       if (tagName.toLowerCase() === 'style') {
@@ -478,7 +483,7 @@ export class SuperDoc extends EventEmitter {
     this.commentsStore = commentsStore;
     this.highContrastModeStore = highContrastModeStore;
     if (typeof this.superdocStore.setExceptionHandler === 'function') {
-      this.superdocStore.setExceptionHandler((payload) => this.emit('exception', payload));
+      this.superdocStore.setExceptionHandler((/** @type {unknown} */ payload) => this.emit('exception', payload));
     }
     this.superdocStore.init(this.config);
     const commentsModuleConfig = this.config.modules.comments;
@@ -1048,6 +1053,7 @@ export class SuperDoc extends EventEmitter {
     this.emit('sidebar-toggle', isOpened);
   }
 
+  /** @param {unknown[]} args */
   #log(...args) {
     (console.debug ? console.debug : console.log)('🦋 🦸‍♀️ [superdoc]', ...args);
   }

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -878,6 +878,7 @@ export class SuperDoc extends EventEmitter {
     const SYNC_TIMEOUT_MS = 10_000;
 
     return new Promise((resolve, reject) => {
+      /** @type {ReturnType<typeof setTimeout> | undefined} */
       let timer;
       let settled = false;
       let syncCleanup = () => {};
@@ -1507,6 +1508,7 @@ export class SuperDoc extends EventEmitter {
    * @returns {Array<string>} The HTML content of all editors
    */
   getHTML(options = {}) {
+    /** @type {Editor[]} */
     const editors = [];
     this.superdocStore.documents.forEach((doc) => {
       const editor = doc.getEditor();
@@ -1611,6 +1613,7 @@ export class SuperDoc extends EventEmitter {
     //    `converter.comments` (which the legacy delete path doesn't
     //    clear today; tracked separately under SD-2839). Pass
     //    whatever the store returns, including `[]`.
+    /** @type {unknown[] | undefined} */
     let comments;
     const commentsModuleConfig = this.config?.modules?.comments;
     const uiStoreHydrated = commentsModuleConfig !== false;

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -1501,8 +1501,13 @@ export class SuperDoc extends EventEmitter {
    */
   setLocked(lock = true) {
     this.config.documents.forEach((doc) => {
-      const metaMap = doc.ydoc.getMap('meta');
-      doc.ydoc.transact(() => {
+      // setLocked is a collaboration-only API; the surrounding flow only
+      // calls it once each document has a Yjs doc attached. Cast away the
+      // optional shape on the public Document typedef without changing
+      // runtime behavior.
+      const ydoc = /** @type {import('yjs').Doc} */ (doc.ydoc);
+      const metaMap = ydoc.getMap('meta');
+      ydoc.transact(() => {
         metaMap.set('locked', lock);
         metaMap.set('lockedBy', this.user);
       });


### PR DESCRIPTION
Stacked on #3065. Adds a JSDoc cast to assert non-null on `doc.ydoc` inside `setLocked`, closing two TS18048 errors without changing runtime behavior.

`setLocked` is a collaboration-only entry point: it writes `locked` / `lockedBy` into the Yjs meta map. The surrounding flow only calls it once each document has a Yjs doc attached, so `doc.ydoc` is non-null at this site even though the public `Document.ydoc` typedef stays optional. A type-only cast keeps that invariant explicit at the call site without forcing every consumer to handle a non-collab path that doesn't exist.

Captured the cast into a local `ydoc` so both the `getMap` and `transact` calls go through it; preserves the prior runtime semantics exactly (`undefined.getMap` would still throw the same TypeError if invariants ever broke).

No public surface change; internal-only typing.

**Verified**: `pnpm --filter superdoc check:jsdoc` clean; `pnpm --filter superdoc build:es` declaration audit clean; `node tests/consumer-typecheck/typecheck-matrix.mjs` 33 passed, 0 failed.