### PR TITLE
refactor(superdoc): drop redundant === false checks (SD-2867 phase B)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -487,7 +487,10 @@ export class SuperDoc extends EventEmitter {
     }
     this.superdocStore.init(this.config);
     const commentsModuleConfig = this.config.modules.comments;
-    this.commentsStore.init(commentsModuleConfig && commentsModuleConfig !== false ? commentsModuleConfig : {});
+    // `commentsModuleConfig` is `false | object | undefined`. A truthy
+    // check already rules out both `false` and `undefined`, so an
+    // explicit `!== false` afterwards is redundant.
+    this.commentsStore.init(commentsModuleConfig || {});
     if (this.isCollaborative) {
       initCollaborationComments(this);
     }
@@ -1201,7 +1204,10 @@ export class SuperDoc extends EventEmitter {
    */
   scrollToComment(commentId, options = {}) {
     const commentsConfig = this.config?.modules?.comments;
-    if (!commentsConfig || commentsConfig === false) return false;
+    // `commentsConfig` can be `false | object | undefined`; `!commentsConfig`
+    // already covers both `false` and `undefined`, so the secondary
+    // `=== false` check below is redundant.
+    if (!commentsConfig) return false;
     if (!commentId || typeof commentId !== 'string') return false;
 
     const root = this.element || document;

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -213,6 +213,10 @@ export class SuperDoc extends EventEmitter {
     this.#init(config, container);
   }
 
+  /**
+   * @param {Config} config
+   * @param {HTMLElement} container
+   */
   async #init(config, container) {
     this.config = {
       ...this.config,
@@ -383,6 +387,7 @@ export class SuperDoc extends EventEmitter {
     const cspNonce = this.config.cspNonce;
 
     const originalCreateElement = document.createElement;
+    /** @param {string} tagName */
     document.createElement = function (tagName) {
       const element = originalCreateElement.call(this, tagName);
       if (tagName.toLowerCase() === 'style') {
@@ -478,7 +483,7 @@ export class SuperDoc extends EventEmitter {
     this.commentsStore = commentsStore;
     this.highContrastModeStore = highContrastModeStore;
     if (typeof this.superdocStore.setExceptionHandler === 'function') {
-      this.superdocStore.setExceptionHandler((payload) => this.emit('exception', payload));
+      this.superdocStore.setExceptionHandler((/** @type {unknown} */ payload) => this.emit('exception', payload));
     }
     this.superdocStore.init(this.config);
     const commentsModuleConfig = this.config.modules.comments;
@@ -1048,6 +1053,7 @@ export class SuperDoc extends EventEmitter {
     this.emit('sidebar-toggle', isOpened);
   }
 
+  /** @param {unknown[]} args */
   #log(...args) {
     (console.debug ? console.debug : console.log)('🦋 🦸‍♀️ [superdoc]', ...args);
   }

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -878,6 +878,7 @@ export class SuperDoc extends EventEmitter {
     const SYNC_TIMEOUT_MS = 10_000;
 
     return new Promise((resolve, reject) => {
+      /** @type {ReturnType<typeof setTimeout> | undefined} */
       let timer;
       let settled = false;
       let syncCleanup = () => {};
@@ -1507,6 +1508,7 @@ export class SuperDoc extends EventEmitter {
    * @returns {Array<string>} The HTML content of all editors
    */
   getHTML(options = {}) {
+    /** @type {Editor[]} */
     const editors = [];
     this.superdocStore.documents.forEach((doc) => {
       const editor = doc.getEditor();
@@ -1611,6 +1613,7 @@ export class SuperDoc extends EventEmitter {
     //    `converter.comments` (which the legacy delete path doesn't
     //    clear today; tracked separately under SD-2839). Pass
     //    whatever the store returns, including `[]`.
+    /** @type {unknown[] | undefined} */
     let comments;
     const commentsModuleConfig = this.config?.modules?.comments;
     const uiStoreHydrated = commentsModuleConfig !== false;

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -1501,8 +1501,13 @@ export class SuperDoc extends EventEmitter {
    */
   setLocked(lock = true) {
     this.config.documents.forEach((doc) => {
-      const metaMap = doc.ydoc.getMap('meta');
-      doc.ydoc.transact(() => {
+      // setLocked is a collaboration-only API; the surrounding flow only
+      // calls it once each document has a Yjs doc attached. Cast away the
+      // optional shape on the public Document typedef without changing
+      // runtime behavior.
+      const ydoc = /** @type {import('yjs').Doc} */ (doc.ydoc);
+      const metaMap = ydoc.getMap('meta');
+      ydoc.transact(() => {
         metaMap.set('locked', lock);
         metaMap.set('lockedBy', this.user);
       });


### PR DESCRIPTION
Stacked on #3066. Closes two TS2367 errors by removing comparisons that are dead under the existing truthy/falsy guards.

`Modules.comments` is typed as `false | object | undefined`. Both call sites already test the value with the truthy/falsy operator, which rules out `false` and `undefined` together — so the explicit `!== false` and `=== false` afterwards are redundant. TS2367 fires because after the truthy narrowing, the remaining type has no overlap with `boolean`, which is the engine telling us the comparison is dead.

- `#initVueApp` simplified from `commentsModuleConfig && commentsModuleConfig !== false ? commentsModuleConfig : {}` to `commentsModuleConfig || {}` (same semantics for every value of the union).
- `scrollToComment` simplified from `if (!commentsConfig || commentsConfig === false) return false;` to `if (!commentsConfig) return false;` (same behavior).

Behavior is preserved for every value the union can take. Added short comments at each site so future readers see why the simpler form is sufficient under the typedef.

**Verified**: `pnpm --filter superdoc check:jsdoc` clean; `pnpm --filter superdoc build:es` declaration audit clean; `node tests/consumer-typecheck/typecheck-matrix.mjs` 33 passed, 0 failed.