### PR TITLE
refactor(superdoc): guard nullable toolbar accesses (SD-2867 phase B)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -1189,7 +1189,11 @@ export class SuperDoc extends EventEmitter {
     this.toolbar = new SuperToolbar(config);
 
     this.toolbar.on('exception', this.config.onException);
-    this.once('editorCreate', () => this.toolbar.updateToolbarState());
+    // `this.toolbar` is typed `SuperToolbar | null` because `#addToolbar`
+    // sets it to `null` before reassigning. The closure captures the live
+    // reference, so the optional chain only fires if `destroy()` cleared
+    // the toolbar between editorCreate scheduling and emission.
+    this.once('editorCreate', () => this.toolbar?.updateToolbarState());
   }
 
   /**
@@ -1421,7 +1425,11 @@ export class SuperDoc extends EventEmitter {
   }
 
   #setModeViewing() {
-    this.toolbar.activeEditor = null;
+    // `this.toolbar` is typed `SuperToolbar | null` because `#addToolbar`
+    // briefly nulls it before reassigning. By the time mode changes run
+    // through public API the toolbar is constructed; the guard here
+    // keeps the assignment a no-op in any transient null state.
+    if (this.toolbar) this.toolbar.activeEditor = null;
 
     const commentsVisible = this.config.comments?.visible === true;
     const trackChangesVisible = this.config.trackChanges?.visible === true;

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -1189,10 +1189,13 @@ export class SuperDoc extends EventEmitter {
     this.toolbar = new SuperToolbar(config);
 
     this.toolbar.on('exception', this.config.onException);
-    // `this.toolbar` is typed `SuperToolbar | null` because `#addToolbar`
-    // sets it to `null` before reassigning. The closure captures the live
-    // reference, so the optional chain only fires if `destroy()` cleared
-    // the toolbar between editorCreate scheduling and emission.
+    // `this.toolbar` infers as `SuperToolbar | null` from the field's
+    // first assignment in `#addToolbar` (the `null` placeholder a few
+    // lines up). The closure registers after the SuperToolbar instance
+    // is in place and reads `this.toolbar` at emission time, so under
+    // normal flow it will see the live instance; the optional chain
+    // is here to satisfy TS's typedef and to no-op if a future
+    // `destroy()` ever clears the field.
     this.once('editorCreate', () => this.toolbar?.updateToolbarState());
   }
 
@@ -1425,10 +1428,13 @@ export class SuperDoc extends EventEmitter {
   }
 
   #setModeViewing() {
-    // `this.toolbar` is typed `SuperToolbar | null` because `#addToolbar`
-    // briefly nulls it before reassigning. By the time mode changes run
-    // through public API the toolbar is constructed; the guard here
-    // keeps the assignment a no-op in any transient null state.
+    // `this.toolbar` infers as `SuperToolbar | null` from the field's
+    // first assignment in `#addToolbar` (the `null` placeholder before
+    // the SuperToolbar is constructed). `#addToolbar` runs once during
+    // init and unconditionally installs the instance, so by the time
+    // mode changes are reachable the toolbar is non-null. The guard
+    // keeps TS satisfied and stays a no-op if a future destroy/teardown
+    // ever clears the field.
     if (this.toolbar) this.toolbar.activeEditor = null;
 
     const commentsVisible = this.config.comments?.visible === true;


### PR DESCRIPTION
Stacked on #3068. Closes two TS2533 errors on `this.toolbar` accesses; the field is typed `SuperToolbar | null` because `#addToolbar` writes `null` before reassigning the new instance, so every later read needs a strict-null guard.

- The `editorCreate` callback inside `#addToolbar` reads `this.toolbar` lazily, after the closure captures the live reference. Optional-chain (`this.toolbar?.updateToolbarState()`) is the natural form: at call time toolbar is the constructed instance, but if `destroy()` cleared it between scheduling and emission the chain skips instead of throwing.
- `#setModeViewing` writes `this.toolbar.activeEditor = null`, which can't be optional-chained on the LHS. Wrapped the assignment in `if (this.toolbar)` so the same null-guard semantics apply.

Both call paths run after `#init` invokes `#addToolbar`, so in practice the guards are no-ops. Inline comments call out the runtime invariant so future readers don't go looking for a missing toolbar.

**Verified**: `pnpm --filter superdoc check:jsdoc` clean; `pnpm --filter superdoc build:es` declaration audit clean; `node tests/consumer-typecheck/typecheck-matrix.mjs` 33 passed, 0 failed.