### PR TITLE
docs: update banner for Bring your own editor launch

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -289,7 +289,7 @@
     ]
   },
   "banner": {
-    "content": "**Introducing Document Engine.** Edit DOCX files from code, CLI, SDKs, or AI agents. [Read the announcement →](https://www.superdoc.dev/changelog/2026-03-22-document-engine)",
+    "content": "**Bring your own editor.** Use SuperDoc as the document engine behind your own editor experience. [Read the announcement →](https://www.superdoc.dev/changelog/2026-05-01-bring-your-own-editor)",
     "dismissible": true
   },
   "redirects": [

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -289,7 +289,7 @@
     ]
   },
   "banner": {
-    "content": "**Bring your own editor.** Use SuperDoc as the document engine behind your own editor experience. [Read the announcement →](https://www.superdoc.dev/changelog/2026-05-01-bring-your-own-editor)",
+    "content": "**Bring your own editor UI.** Use SuperDoc as the document engine underneath. [Read the announcement →](https://www.superdoc.dev/changelog/2026-05-01-bring-your-own-editor)",
     "dismissible": true
   },
   "redirects": [


### PR DESCRIPTION
Swap the docs banner from the Document Engine launch to the Bring your own editor launch.

**Before**:
> **Introducing Document Engine.** Edit DOCX files from code, CLI, SDKs, or AI agents. [Read the announcement →]

**After**:
> **Bring your own editor.** Use SuperDoc as the document engine behind your own editor experience. [Read the announcement →]

Link points at \`https://www.superdoc.dev/changelog/2026-05-01-bring-your-own-editor\` (same pattern as the existing changelog).

**Verified**: \`pnpm validate\` (mintlify), \`pnpm check:em-dashes\`, \`pnpm check:icons\`, \`pnpm check:imports\` all green.