### PR TITLE
refactor(superdoc): preserve SurfaceHandle generic in typedef alias (SD-2867 phase B)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -67,7 +67,10 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
 /** @typedef {import('./types/index.js').ExportParams} ExportParams */
 /** @typedef {import('./types/index.js').UpgradeToCollaborationOptions} UpgradeToCollaborationOptions */
 /** @typedef {import('./types/index.js').SurfaceRequest} SurfaceRequest */
-/** @typedef {import('./types/index.js').SurfaceHandle} SurfaceHandle */
+/**
+ * @template [T=unknown]
+ * @typedef {import('./types/index.js').SurfaceHandle<T>} SurfaceHandle
+ */
 /** @typedef {import('./types/index.js').NavigableAddress} NavigableAddress */
 
 /**


### PR DESCRIPTION
Closes one TS2315 error: `SurfaceHandle` is generic in `core/types/index.ts` (`SurfaceHandle<TResult = unknown>`), but the JSDoc typedef alias at the top of `SuperDoc.js` re-declared it without a `@template`, so the `@returns {SurfaceHandle<TResult>}` annotation on `openSurface` failed to apply the type parameter and TS reported "Type 'SurfaceHandle' is not generic."

Adding `@template [T=unknown]` to the typedef alias preserves the generic. The default matches the source typedef so existing call sites that don't pass a type parameter resolve to `SurfaceHandle<unknown>`, identical to before. The emitted public `.d.ts` for `openSurface` now correctly carries `SurfaceHandle<TResult>` through to consumers.

No public surface change beyond restoring the intended generic; internal-only typedef wiring fix.

**Verified**: `pnpm --filter superdoc check:jsdoc` clean; `pnpm --filter superdoc build:es` declaration audit clean; `node tests/consumer-typecheck/typecheck-matrix.mjs` 33 passed, 0 failed.