### PR TITLE
refactor(superdoc): type two implicit-any instance members (SD-2867 phase B)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -67,7 +67,10 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
 /** @typedef {import('./types/index.js').ExportParams} ExportParams */
 /** @typedef {import('./types/index.js').UpgradeToCollaborationOptions} UpgradeToCollaborationOptions */
 /** @typedef {import('./types/index.js').SurfaceRequest} SurfaceRequest */
-/** @typedef {import('./types/index.js').SurfaceHandle} SurfaceHandle */
+/**
+ * @template [T=unknown]
+ * @typedef {import('./types/index.js').SurfaceHandle<T>} SurfaceHandle
+ */
 /** @typedef {import('./types/index.js').NavigableAddress} NavigableAddress */
 
 /**

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -322,11 +322,13 @@ export class SuperDoc extends EventEmitter {
     // --- One-time shell setup (survives upgrade) ---
     this.user = this.config.user;
     this.users = this.config.users || [];
+    /** @type {unknown} */
     this.socket = null;
     this.isDev = this.config.isDev || false;
 
     /** @type {Editor | null | undefined} */
     this.activeEditor = null;
+    /** @type {unknown[]} */
     this.comments = [];
 
     this.isLocked = this.config.isLocked || false;


### PR DESCRIPTION
Stacked on #3073. Closes two TS7008 errors and replaces two `any` leaks on the public `.d.ts` surface (SD-2828's "must not collapse public types to any" rule).

`this.socket` and `this.comments` are assigned once during `#init` and never read inside `SuperDoc.js`. Without explicit types, TS infers them from the literal-only assignment (`null` and `[]`), which the JSDoc emitter widens to `any` and `any[]` in the public declaration. The previous public surface was:

```
socket: any
comments: any[] | undefined
```

After this slice:

```
socket: unknown
comments: unknown[] | undefined
```

Picked `unknown` rather than a more specific shape because the fields have no read sites in this file and no clear consumer contract; `unknown` accurately reflects "we know it's there, we don't claim what's in it" and forces consumers to narrow before use, which is the correct downstream behavior.

No runtime change, only annotation. Removing the fields entirely would be cleaner but is a public-surface deletion and out of scope for a typing-only slice.

**Verified**: `pnpm --filter superdoc check:jsdoc` clean; `pnpm --filter superdoc build:es` declaration audit clean; `node tests/consumer-typecheck/typecheck-matrix.mjs` 33 passed, 0 failed.