### PR TITLE
refactor(superdoc): use narrowed doc local in #initDocuments (SD-2867 phase B)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -67,7 +67,10 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
 /** @typedef {import('./types/index.js').ExportParams} ExportParams */
 /** @typedef {import('./types/index.js').UpgradeToCollaborationOptions} UpgradeToCollaborationOptions */
 /** @typedef {import('./types/index.js').SurfaceRequest} SurfaceRequest */
-/** @typedef {import('./types/index.js').SurfaceHandle} SurfaceHandle */
+/**
+ * @template [T=unknown]
+ * @typedef {import('./types/index.js').SurfaceHandle<T>} SurfaceHandle
+ */
 /** @typedef {import('./types/index.js').NavigableAddress} NavigableAddress */
 
 /**

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -322,11 +322,13 @@ export class SuperDoc extends EventEmitter {
     // --- One-time shell setup (survives upgrade) ---
     this.user = this.config.user;
     this.users = this.config.users || [];
+    /** @type {unknown} */
     this.socket = null;
     this.isDev = this.config.isDev || false;
 
     /** @type {Editor | null | undefined} */
     this.activeEditor = null;
+    /** @type {unknown[]} */
     this.comments = [];
 
     this.isLocked = this.config.isLocked || false;

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -414,7 +414,10 @@ export class SuperDoc extends EventEmitter {
 
   #initDocuments() {
     const doc = this.config.document;
-    const hasDocumentConfig = !!doc && typeof doc === 'object' && Object.keys(this.config.document)?.length;
+    // Pass the narrowed `doc` to `Object.keys` so the `!!doc && typeof doc === 'object'`
+    // gate carries through; refetching `this.config.document` would re-widen to
+    // `string | object | File | Blob | undefined` and trip noImplicitAny.
+    const hasDocumentConfig = !!doc && typeof doc === 'object' && Object.keys(doc)?.length;
     const hasDocumentUrl = !!doc && typeof doc === 'string' && doc.length > 0;
     const hasDocumentFile = !!doc && typeof File === 'function' && doc instanceof File;
     const hasDocumentBlob = !!doc && doc instanceof Blob && !(doc instanceof File);


### PR DESCRIPTION
Stacked on #3074. Closes one TS2769 error in `#initDocuments`.

`Config.document` is typed `string | object | File | Blob | undefined`. The function captures it as `const doc = this.config.document` and then guards with `!!doc && typeof doc === 'object'` before calling `Object.keys`. The original code passed `this.config.document` (refetched) into `Object.keys`, which TS re-widens to the full union and rejects against the `Object.keys` overloads (none accept `undefined`).

Switching the argument to the narrowed local `doc` carries the guard through: at that point in the expression `doc` is `object`, which `Object.keys` accepts. Behavior is identical because both reads return the same field value within a single synchronous expression.

No public surface change; internal-only typing.

**Verified**: `pnpm --filter superdoc check:jsdoc` clean; `pnpm --filter superdoc build:es` declaration audit clean; `node tests/consumer-typecheck/typecheck-matrix.mjs` 33 passed, 0 failed.