### PR TITLE
refactor(superdoc): close remaining any-leaks on SuperDoc instance (SD-2828)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -286,6 +286,7 @@ export class SuperDoc extends EventEmitter {
     }
 
     this.config.colors = shuffleArray(this.config.colors);
+    /** @type {Map<unknown, unknown>} */
     this.userColorMap = new Map();
     this.colorIndex = 0;
 
@@ -293,6 +294,7 @@ export class SuperDoc extends EventEmitter {
     this.version = __APP_VERSION__;
     this.#log('🦋 [superdoc] Using SuperDoc version:', this.version);
 
+    /** @type {string} */
     this.superdocId = config.superdocId || uuidv4();
     // Default to an empty palette when no colors are configured so downstream
     // assignment logic doesn't have to null-check on every access.


### PR DESCRIPTION
SD-2828 public-surface closeout. Tightens the last two `any` leaks on the `SuperDoc` class itself.

Before this slice, the emitted public `.d.ts` had:

```
superdocId: any;
userColorMap: Map<any, any> | undefined;
```

After:

```
superdocId: string | undefined;
userColorMap: Map<unknown, unknown> | undefined;
```

`superdocId` was typed `any` because `uuid` ships without a declaration file, so `config.superdocId || uuidv4()` resolved to `any`. The runtime always assigns a string; `@type {string}` makes that explicit. `userColorMap` is initialized with an empty `Map()` and never written elsewhere, so it inferred as `Map<any, any>`. Tightening to `Map<unknown, unknown>` matches the actual contract and forces consumers to narrow before use.

After this PR the `SuperDoc` class declaration has no remaining `any` fields. The deep `any`s under `superdocStore` / `commentsStore` come from the Pinia store source files, not SuperDoc.js, and are tracked separately as part of the bundled-declarations work.

This is the SD-2828 closeout. Per-error checkJs slicing on SuperDoc.js stops here. Remaining SuperDoc.js checkJs errors are internal TS satisfaction (strict-null guards, narrowing) that don't move the public surface; they land in a separate ticket grouped by error category, not as 2-line stacked PRs.

**Verified**:
- `pnpm --filter superdoc check:jsdoc` → 3 gated files clean
- `pnpm --filter superdoc build:es` → no FAIL-level findings
- `pnpm --filter superdoc audit:declarations` → no FAIL-level findings
- `node tests/consumer-typecheck/typecheck-matrix.mjs` → 33 passed, 0 failed

**Must stay the same**: `superdocId` is still `string | undefined` at runtime (uuid fallback unchanged); `userColorMap` is still constructed empty and never written.

**Review**: confirm the `.d.ts` for `SuperDoc` no longer carries `any` on these two fields.