### PR TITLE
refactor(superdoc): type optional event callback registration

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -75,6 +75,20 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
 /** @typedef {import('./types/index.js').NavigableAddress} NavigableAddress */
 
 /**
+ * Config callbacks are optional on the public typedef because consumers do
+ * not need to pass them. The default config installs no-op functions before
+ * listener registration; keep the cast local so EventEmitter's runtime
+ * behavior stays unchanged if that invariant is ever broken.
+ *
+ * @template {(...args: any[]) => void} T
+ * @param {T | undefined} listener
+ * @returns {(...args: any[]) => void}
+ */
+function asEventListener(listener) {
+  return /** @type {(...args: any[]) => void} */ (listener);
+}
+
+/**
  * SuperDoc class
  * Expects a config object
  *
@@ -558,21 +572,21 @@ export class SuperDoc extends EventEmitter {
   }
 
   #initListeners() {
-    this.on('editorBeforeCreate', this.config.onEditorBeforeCreate);
-    this.on('editorCreate', this.config.onEditorCreate);
-    this.on('editorDestroy', this.config.onEditorDestroy);
-    this.on('ready', this.config.onReady);
-    this.on('comments-update', this.config.onCommentsUpdate);
-    this.on('awareness-update', this.config.onAwarenessUpdate);
-    this.on('locked', this.config.onLocked);
-    this.on('pdf:document-ready', this.config.onPdfDocumentReady);
-    this.on('sidebar-toggle', this.config.onSidebarToggle);
-    this.on('collaboration-ready', this.config.onCollaborationReady);
-    this.on('editor-update', this.config.onEditorUpdate);
+    this.on('editorBeforeCreate', asEventListener(this.config.onEditorBeforeCreate));
+    this.on('editorCreate', asEventListener(this.config.onEditorCreate));
+    this.on('editorDestroy', asEventListener(this.config.onEditorDestroy));
+    this.on('ready', asEventListener(this.config.onReady));
+    this.on('comments-update', asEventListener(this.config.onCommentsUpdate));
+    this.on('awareness-update', asEventListener(this.config.onAwarenessUpdate));
+    this.on('locked', asEventListener(this.config.onLocked));
+    this.on('pdf:document-ready', asEventListener(this.config.onPdfDocumentReady));
+    this.on('sidebar-toggle', asEventListener(this.config.onSidebarToggle));
+    this.on('collaboration-ready', asEventListener(this.config.onCollaborationReady));
+    this.on('editor-update', asEventListener(this.config.onEditorUpdate));
     this.on('content-error', this.onContentError);
-    this.on('exception', this.config.onException);
-    this.on('list-definitions-change', this.config.onListDefinitionsChange);
-    this.on('pagination-update', this.config.onPaginationUpdate);
+    this.on('exception', asEventListener(this.config.onException));
+    this.on('list-definitions-change', asEventListener(this.config.onListDefinitionsChange));
+    this.on('pagination-update', asEventListener(this.config.onPaginationUpdate));
 
     if (this.config.onFontsResolved) {
       this.on('fonts-resolved', this.config.onFontsResolved);
@@ -1248,7 +1262,7 @@ export class SuperDoc extends EventEmitter {
 
     this.toolbar = new SuperToolbar(config);
 
-    this.toolbar.on('exception', this.config.onException);
+    this.toolbar.on('exception', asEventListener(this.config.onException));
     // `this.toolbar` infers as `SuperToolbar | null` from the field's
     // first assignment in `#addToolbar` (the `null` placeholder a few
     // lines up). The closure registers after the SuperToolbar instance

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -123,12 +123,14 @@ export class SuperDoc extends EventEmitter {
   colors = [];
 
   /**
-   * Pinia stores and Vue runtime references. All four fields are populated
-   * by `#initVueApp`, which runs synchronously inside `#init` before any
-   * public method becomes reachable. Declared without initializers because
-   * the constructed instances are not available at field-init time;
-   * downstream code reads them post-`#init` and the runtime invariant is
-   * that they are non-null by then.
+   * Pinia stores and Vue runtime references. Populated by `#initVueApp`
+   * inside the async `#init`, which runs *after* `await #initCollaboration`,
+   * so these fields are briefly `undefined` between `new SuperDoc(config)`
+   * returning and the `ready` event firing. The non-null JSDoc here matches
+   * the existing pattern used for `users` / `version` / `whiteboard` and
+   * assumes consumers wait for `ready` before dereferencing. SD-2916 tracks
+   * the systematic soundness fix across all of these fields (declaring them
+   * `T | undefined` and casting at internal post-init access sites).
    *
    * @type {ReturnType<typeof import('../stores/superdoc-store.js').useSuperdocStore>}
    */

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -76,12 +76,17 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
 
 /**
  * Config callbacks are optional on the public typedef because consumers do
- * not need to pass them. The default config installs no-op functions before
- * listener registration; keep the cast local so EventEmitter's runtime
- * behavior stays unchanged if that invariant is ever broken.
+ * not need to pass them. The fields wrapped by this helper (every callback
+ * registered in `#initListeners` plus the toolbar `exception` listener)
+ * default to `() => null` in the class-field initializer, so EventEmitter
+ * receives a function in normal use. This helper is a runtime identity
+ * cast: behavior is unchanged if that invariant is ever broken (e.g. a
+ * consumer explicitly passes `undefined`), and EventEmitter sees the same
+ * value it would have without the wrapper. Sites with a `null` default
+ * (`onFontsResolved`, `onTrackedChangeBubbleAccept`, `onTrackedChangeBubbleReject`)
+ * use a separate `if`-guard pattern instead of this helper.
  *
- * @template {(...args: any[]) => void} T
- * @param {T | undefined} listener
+ * @param {((...args: any[]) => void) | undefined} listener
  * @returns {(...args: any[]) => void}
  */
 function asEventListener(listener) {

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -64,6 +64,7 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
 /** @typedef {import('./types/index.js').Editor} Editor */
 /** @typedef {import('./types/index.js').DocumentMode} DocumentMode */
 /** @typedef {import('./types/index.js').Config} Config */
+/** @typedef {import('./types/index.js').InternalConfig} InternalConfig */
 /** @typedef {import('./types/index.js').ExportParams} ExportParams */
 /** @typedef {import('./types/index.js').UpgradeToCollaborationOptions} UpgradeToCollaborationOptions */
 /** @typedef {import('./types/index.js').SurfaceRequest} SurfaceRequest */
@@ -120,6 +121,36 @@ export class SuperDoc extends EventEmitter {
    * @type {string[]}
    */
   colors = [];
+
+  /**
+   * Pinia stores and Vue runtime references. All four fields are populated
+   * by `#initVueApp`, which runs synchronously inside `#init` before any
+   * public method becomes reachable. Declared without initializers because
+   * the constructed instances are not available at field-init time;
+   * downstream code reads them post-`#init` and the runtime invariant is
+   * that they are non-null by then.
+   *
+   * @type {ReturnType<typeof import('../stores/superdoc-store.js').useSuperdocStore>}
+   */
+  superdocStore;
+
+  /** @type {ReturnType<typeof import('../stores/comments-store.js').useCommentsStore>} */
+  commentsStore;
+
+  /** @type {ReturnType<typeof import('../composables/use-high-contrast-mode.js').useHighContrastMode>} */
+  highContrastModeStore;
+
+  /** @type {import('vue').App} */
+  app;
+
+  /** @type {import('pinia').Pinia} */
+  pinia;
+
+  /** @type {number} Count of editors that have signaled `editorCreate`. */
+  readyEditors = 0;
+
+  /** @type {number} Outstanding async saves waiting for collaboration ack. */
+  pendingCollaborationSaves = 0;
 
   /** @type {Config} */
   config = {
@@ -239,6 +270,12 @@ export class SuperDoc extends EventEmitter {
       this.config.comments.visible = false;
     }
     normalizeTrackChangesConfig(this.config);
+
+    // Default `layoutEngineOptions` to an empty object so downstream
+    // assignments (`flowMode`, `virtualization`, `trackedChanges`) don't
+    // need to null-check the parent on every access. Consumers rarely
+    // pass this; SuperDoc owns the runtime shape.
+    this.config.layoutEngineOptions = this.config.layoutEngineOptions || {};
 
     // Web layout behavior:
     // - Backward compatible default: web layout still uses PM rendering.
@@ -503,7 +540,7 @@ export class SuperDoc extends EventEmitter {
       this.superdocStore.setExceptionHandler((/** @type {unknown} */ payload) => this.emit('exception', payload));
     }
     this.superdocStore.init(this.config);
-    const commentsModuleConfig = this.config.modules.comments;
+    const commentsModuleConfig = /** @type {InternalConfig} */ (this.config).modules.comments;
     // `commentsModuleConfig` is `false | object | undefined`. A truthy
     // check already rules out both `false` and `undefined`, so an
     // explicit `!== false` afterwards is redundant.
@@ -629,7 +666,7 @@ export class SuperDoc extends EventEmitter {
     this.#assignUserColor();
     this._cleanupAwareness = setupAwarenessHandler(provider, this, this.config.user);
 
-    this.config.documents.forEach((doc) => {
+    /** @type {InternalConfig} */ (this.config).documents.forEach((doc) => {
       doc.ydoc = ydoc;
       doc.provider = provider;
       doc.role = this.config.role;
@@ -652,9 +689,10 @@ export class SuperDoc extends EventEmitter {
     this._commentsCollabInitialized = false;
     this.ydoc = undefined;
     this.provider = undefined;
-    delete this.config.modules.collaboration;
+    const cfg = /** @type {InternalConfig} */ (this.config);
+    delete cfg.modules.collaboration;
 
-    this.config.documents.forEach((doc) => {
+    cfg.documents.forEach((doc) => {
       delete doc.ydoc;
       delete doc.provider;
     });
@@ -722,7 +760,7 @@ export class SuperDoc extends EventEmitter {
       overwriteRoomLockState(ydoc, { isLocked: this.isLocked, lockedBy: this.lockedBy });
 
       // --- Attach collaboration config (awareness, flags, config.documents) ---
-      this.config.modules.collaboration = { ydoc, provider };
+      /** @type {InternalConfig} */ (this.config).modules.collaboration = { ydoc, provider };
       this.#attachExternalCollaboration(ydoc, provider);
 
       // --- Update live store documents in place (no Vue unmount) ---
@@ -967,14 +1005,15 @@ export class SuperDoc extends EventEmitter {
       throw new Error('SuperDoc: upgradeToCollaboration() requires both ydoc and provider');
     }
 
-    const docxDocs = this.config.documents.filter((d) => d.type === DOCX);
+    const cfg = /** @type {InternalConfig} */ (this.config);
+    const docxDocs = cfg.documents.filter((d) => d.type === DOCX);
     if (docxDocs.length === 0) {
       throw new Error('SuperDoc: no DOCX document found for upgrade');
     }
     if (docxDocs.length > 1) {
       throw new Error('SuperDoc: upgradeToCollaboration() only supports a single DOCX document');
     }
-    if (this.config.documents.length !== docxDocs.length) {
+    if (cfg.documents.length !== docxDocs.length) {
       throw new Error('SuperDoc: upgradeToCollaboration() only supports single-DOCX instances');
     }
   }
@@ -986,7 +1025,12 @@ export class SuperDoc extends EventEmitter {
    * @throws {Error} If the editor is not yet created
    */
   #resolveSourceEditor() {
-    const docxDoc = this.config.documents.find((d) => d.type === DOCX);
+    // Upstream `#assertCanUpgrade` already verified at least one DOCX
+    // document exists; cast the find result to assert non-null without
+    // changing runtime behavior.
+    const docxDoc = /** @type {Document} */ (
+      /** @type {InternalConfig} */ (this.config).documents.find((d) => d.type === DOCX)
+    );
     const storeDoc = this.superdocStore.documents.find((d) => d.id === docxDoc.id);
     const editor = storeDoc?.getEditor?.();
 
@@ -1021,7 +1065,10 @@ export class SuperDoc extends EventEmitter {
    */
   onContentError({ error, editor }) {
     const { documentId } = editor.options;
-    const doc = this.superdocStore.documents.find((d) => d.id === documentId);
+    // The errored editor came from `superdocStore.documents`, so the find
+    // by its `documentId` is expected to hit. Cast the find result to a
+    // RuntimeDocument to assert non-null at the consumer callback.
+    const doc = /** @type {RuntimeDocument} */ (this.superdocStore.documents.find((d) => d.id === documentId));
     // `onContentError` is typed as optional on the public Config typedef
     // because consumers don't have to wire a handler. The class field
     // initializer installs a `() => null` default, but `#init` spreads
@@ -1549,7 +1596,7 @@ export class SuperDoc extends EventEmitter {
    * @param {boolean} lock
    */
   setLocked(lock = true) {
-    this.config.documents.forEach((doc) => {
+    /** @type {InternalConfig} */ (this.config).documents.forEach((doc) => {
       // setLocked is a collaboration-only API; the surrounding flow only
       // calls it once each document has a Yjs doc attached. Cast away the
       // optional shape on the public Document typedef without changing
@@ -1777,15 +1824,16 @@ export class SuperDoc extends EventEmitter {
       this._cleanupAwareness = null;
     }
 
-    this.config.socket?.cancelWebsocketRetry();
-    this.config.socket?.disconnect();
-    this.config.socket?.destroy();
+    const cfg = /** @type {InternalConfig} */ (this.config);
+    cfg.socket?.cancelWebsocketRetry();
+    cfg.socket?.disconnect();
+    cfg.socket?.destroy();
 
     this.ydoc?.destroy();
     this.provider?.disconnect();
     this.provider?.destroy();
 
-    this.config.documents.forEach((doc) => {
+    cfg.documents.forEach((doc) => {
       doc.provider?.disconnect();
       doc.provider?.destroy();
       doc.ydoc?.destroy();

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -271,10 +271,14 @@ export class SuperDoc extends EventEmitter {
     }
     normalizeTrackChangesConfig(this.config);
 
-    // Default `layoutEngineOptions` to an empty object so downstream
-    // assignments (`flowMode`, `virtualization`, `trackedChanges`) don't
-    // need to null-check the parent on every access. Consumers rarely
-    // pass this; SuperDoc owns the runtime shape.
+    // Defensive defaults so the `InternalConfig` runtime invariants hold
+    // for every reachable code path. The class-field initializer seeds
+    // both `documents: []` and `layoutEngineOptions` is filled in by
+    // `normalizeTrackChangesConfig` above, but a consumer that explicitly
+    // passes `{ documents: undefined }` or omits `layoutEngineOptions`
+    // when track-changes hasn't initialized it yet would otherwise leave
+    // these undefined and break later non-null casts.
+    this.config.documents = this.config.documents || [];
     this.config.layoutEngineOptions = this.config.layoutEngineOptions || {};
 
     // Web layout behavior:

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -1377,13 +1377,13 @@ export interface InternalConfig extends Config {
    * not part of the public Config surface.
    */
   socket?: HocuspocusProviderWebsocket;
-  /** Always populated by `#init` (default-initialized to `[]` if absent). */
+  /** Normalized to `[]` by `#init` if the consumer passes nothing or `undefined`. */
   documents: Document[];
-  /** Always populated by `#init` (default-initialized to `{}` if absent). */
+  /** Normalized to `{}` by `#init` if the consumer passes nothing or `undefined`. */
   modules: Modules;
-  /** Always populated by `#init` (DEFAULT_USER spread over consumer input). */
+  /** Spread of `DEFAULT_USER` over consumer input by `#init`; `name` always present. */
   user: User;
-  /** Always populated by `#init` (default-initialized to `{}` if absent). */
+  /** Normalized to `{}` by `#init` if the consumer passes nothing or `undefined`. */
   layoutEngineOptions: SuperDocLayoutEngineOptions;
 }
 

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -1356,11 +1356,16 @@ export interface Config {
 }
 
 /**
- * Internal augmentation of `Config` for runtime-only fields that must not
- * appear on the published consumer surface. The `Config` interface above is
- * the public contract; this type adds the fields SuperDoc sets/reads
- * internally so the implementation can be type-checked without leaking the
- * fields into customer IDE autocomplete.
+ * Internal augmentation of `Config` for runtime-only fields and tightened
+ * invariants that must not appear on the published consumer surface. The
+ * `Config` interface above is the public contract; this type adds the
+ * fields SuperDoc sets/reads internally so the implementation can be
+ * type-checked without leaking the fields into customer IDE autocomplete.
+ *
+ * The four overrides below mark fields that `Config` exposes as optional
+ * but `SuperDoc.#init` always normalizes to a populated shape. Internal
+ * call sites cast `this.config` to this type so they can access these
+ * invariants without per-site null guards.
  *
  * Use this from internal SuperDoc.js callsites that need the augmented shape
  * (e.g. `/** @type {InternalConfig} *\/ (this.config).socket = ...`).
@@ -1372,6 +1377,14 @@ export interface InternalConfig extends Config {
    * not part of the public Config surface.
    */
   socket?: HocuspocusProviderWebsocket;
+  /** Always populated by `#init` (default-initialized to `[]` if absent). */
+  documents: Document[];
+  /** Always populated by `#init` (default-initialized to `{}` if absent). */
+  modules: Modules;
+  /** Always populated by `#init` (DEFAULT_USER spread over consumer input). */
+  user: User;
+  /** Always populated by `#init` (default-initialized to `{}` if absent). */
+  layoutEngineOptions: SuperDocLayoutEngineOptions;
 }
 
 /**


### PR DESCRIPTION
SD-2867 Cluster C only: type-only fix for the EventEmitter registration sites in `SuperDoc.js` where `Config.on*` callbacks are typed as optional but the public `Config` makes them so.

- Casts optional config callbacks at EventEmitter registration sites only — `#initListeners` (14 sites) and `#addToolbar`'s `toolbar.on('exception', ...)` (1 site).
- The cast is a module-private `asEventListener<T>` identity helper; runtime returns the exact same value EventEmitter would have received before, so there is no defaulting or guard behavior change. If a consumer ever passes `undefined` explicitly, EventEmitter sees the same `undefined` it would have without the wrapper.
- Does not touch the runtime-default mismatches in Clusters A and B (initializer `null` vs typedef `undefined`, `User` typedef vs `DEFAULT_USER` shape) or the heterogeneous Cluster D fixes (provider widening, `SearchMatch` shape, `DocumentMode` literal, etc.). Those each have consumer-observable trade-offs and need a separate audit.

**Boundary check (matters for SD-2828 / SD-2867 separation)**:
The `asEventListener` helper is declared at module scope inside `SuperDoc.js`, not on the class. `grep -E "asEventListener|EventListener" packages/superdoc/dist/superdoc/src/core/SuperDoc.d.ts` returns no matches — the helper does not appear in the emitted public declarations.

**Verified**:
- `pnpm --filter superdoc check:jsdoc` → 3 gated files clean
- `pnpm --filter superdoc build:es` → no FAIL-level findings
- `node tests/consumer-typecheck/typecheck-matrix.mjs` → 33 passed, 0 failed
- Closes 15 of the 44 TS2345/TS2322 sites in SuperDoc.js (exact cluster match).