### PR TITLE
fix(super-editor): correct SelectionSlice JSDoc insert example (SD-2921)

### DIFF
--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -259,7 +259,7 @@ export interface SelectionSlice {
    * ```ts
    * const { selectionTarget } = ui.selection.getSnapshot();
    * if (selectionTarget) {
-   *   editor.doc.insert({ target: selectionTarget, content: 'Hello' });
+   *   editor.doc.insert({ target: selectionTarget, value: 'Hello', type: 'text' });
    * }
    * ```
    *


### PR DESCRIPTION
The example in `SelectionSlice.selectionTarget` JSDoc still showed the pre-rename insert shape (`content: 'Hello'`). The doc-API takes `value` + `type`. Anyone copy-pasting it from IDE hover got a type error.

- Linear: [SD-2921](https://linear.app/superdocworkspace/issue/SD-2921)
- One line. No code changes.