### PR TITLE
feat(superdoc): declare SuperDoc implements SuperDocLike (SD-2917)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -73,6 +73,7 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
  * @typedef {import('./types/index.js').SurfaceHandle<T>} SurfaceHandle
  */
 /** @typedef {import('./types/index.js').NavigableAddress} NavigableAddress */
+/** @typedef {import('@superdoc/super-editor/ui').SuperDocLike} SuperDocLike */
 
 /**
  * Config callbacks are optional on the public typedef because consumers do
@@ -99,6 +100,7 @@ function asEventListener(listener) {
  *
  * @class
  * @extends EventEmitter
+ * @implements {SuperDocLike}
  */
 export class SuperDoc extends EventEmitter {
   /** @type {Array<string>} */


### PR DESCRIPTION
The browser UI controller (`createSuperDocUI`) takes the structural `SuperDocLike` shape from `superdoc/ui`. The concrete `SuperDoc` class shipped without declaring it implements that contract, so every consumer had to write a cast on the very first line:

```ts
const ui = createSuperDocUI({
  superdoc: superdoc as unknown as Parameters<typeof createSuperDocUI>[0]['superdoc'],
});
```

Adding a JSDoc `@implements` tag plus the typedef import gets the relationship into the generated `.d.ts`, and the cast goes away for every framework adapter and example.

- Linear: SD-2917
- Two lines added. No runtime change. Verified the cast can be dropped against the published `.d.ts`.

**Verified**: `pnpm --filter superdoc build` clean; minimal external TS project compiles `createSuperDocUI({ superdoc })` without a cast.