### PR TITLE
chore(superdoc): add @types/uuid to close SuperDoc.js TS7016 (SD-2867)

### DIFF
--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -169,6 +169,7 @@
     "@hocuspocus/provider": "catalog:",
     "@hocuspocus/server": "catalog:",
     "@superdoc-dev/superdoc-yjs-collaboration": "workspace:*",
+    "@types/uuid": "catalog:",
     "@superdoc/common": "workspace:*",
     "@superdoc/super-editor": "workspace:*",
     "@vitejs/plugin-vue": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ catalogs:
     '@types/react-dom':
       specifier: ^19.2.3
       version: 19.2.3
+    '@types/uuid':
+      specifier: ^9.0.8
+      version: 9.0.8
     '@typescript-eslint/eslint-plugin':
       specifier: ^8.49.0
       version: 8.57.2
@@ -3113,6 +3116,9 @@ importers:
       '@superdoc/super-editor':
         specifier: workspace:*
         version: link:../super-editor
+      '@types/uuid':
+        specifier: 'catalog:'
+        version: 9.0.8
       '@vitejs/plugin-vue':
         specifier: 'catalog:'
         version: 6.0.2(rolldown-vite@7.3.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
@@ -10786,6 +10792,9 @@ packages:
 
   '@types/urijs@1.19.26':
     resolution: {integrity: sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg==}
+
+  '@types/uuid@9.0.8':
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/vscode@1.110.0':
     resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
@@ -32748,6 +32757,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/urijs@1.19.26': {}
+
+  '@types/uuid@9.0.8': {}
 
   '@types/vscode@1.110.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,7 @@ catalog:
   '@types/node': 22.19.2
   '@types/react': ^19.2.6
   '@types/react-dom': ^19.2.3
+  '@types/uuid': ^9.0.8
   '@typescript-eslint/eslint-plugin': ^8.49.0
   '@typescript-eslint/parser': ^8.49.0
   '@vitejs/plugin-react': ^5.1.1


### PR DESCRIPTION
Adds `@types/uuid` to the workspace catalog and the `superdoc` package's devDependencies. Closes the TS7016 "Could not find a declaration file for module 'uuid'" error in `packages/superdoc/src/core/SuperDoc.js`.

**Why a `@types/X` instead of relying on uuid's own types**: confirmed `uuid@9.0.1` ships no `types`/`typings` field and no `types` condition in its `exports` map (`node_modules/.pnpm/uuid@9.0.1/node_modules/uuid/package.json` has `main`/`exports` only). The package resolves to `dist/esm-browser/index.js` under this repo's resolution path, with no sibling `.d.ts`. `@types/uuid@9.0.8` is the canonical fix and pairs version-wise with `uuid@9`.

The TS7016 errors in **`packages/super-editor`** files are out of scope for this PR — `super-editor` is a separate workspace package that would need its own `@types/uuid: catalog:` entry. Tracked separately.

**No code changes, only manifest/lockfile**:
- `pnpm-workspace.yaml`: catalog adds `@types/uuid: ^9.0.8` next to `@types/react-dom`
- `packages/superdoc/package.json`: devDependencies adds `@types/uuid: catalog:`
- `pnpm-lock.yaml`: regenerated

**Verified**:
- SuperDoc.js TS7016 closed (probed under `// @ts-check`).
- `pnpm --filter superdoc check:jsdoc` → 3 gated files clean.
- `pnpm --filter superdoc build:es` → no FAIL-level findings.
- `pnpm --filter superdoc audit:declarations` → no FAIL-level findings.
- `node tests/consumer-typecheck/typecheck-matrix.mjs` → 33 passed, 0 failed.

No emitted runtime change. No public surface change.