### PR TITLE
feat(ui): add observe() aliases to domain handles (SD-2919)

### DIFF
--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -912,7 +912,7 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     // snapshot — the public `ToolbarSnapshotSlice` shape is the merged
     // one, not the underlying built-ins-only shape.
     getSnapshot: () => computeState().toolbar,
-    subscribe(listener) {
+    observe(listener) {
       // Drives off the same selector substrate so subscribers receive
       // the same coalesced burst pattern as ui.select consumers.
       // Equality is set to "always different" because the headless
@@ -923,11 +923,14 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
         () => false,
       ).subscribe((snapshot) => {
         try {
-          listener({ snapshot });
+          listener(snapshot);
         } catch {
           // see scheduleNotify
         }
       });
+    },
+    subscribe(listener) {
+      return toolbar.observe((snapshot) => listener({ snapshot }));
     },
     execute: ((id: PublicToolbarItemId, payload?: unknown): boolean => {
       // Routes through the centralized `dispatchCommand` so a later
@@ -1188,14 +1191,17 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
 
   const comments: CommentsHandle = {
     getSnapshot: () => computeState().comments,
-    subscribe(listener) {
+    observe(listener) {
       return select((state) => state.comments, shallowEqual).subscribe((snapshot) => {
         try {
-          listener({ snapshot });
+          listener(snapshot);
         } catch {
           // see scheduleNotify
         }
       });
+    },
+    subscribe(listener) {
+      return comments.observe((snapshot) => listener({ snapshot }));
     },
     createFromSelection({ text }) {
       const editor = resolveRoutedEditor(superdoc);
@@ -1350,14 +1356,17 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
 
   const trackChanges: TrackChangesHandle = {
     getSnapshot: () => computeState().trackChanges,
-    subscribe(listener) {
+    observe(listener) {
       return select((state) => state.trackChanges, shallowEqual).subscribe((snapshot) => {
         try {
-          listener({ snapshot });
+          listener(snapshot);
         } catch {
           // see scheduleNotify
         }
       });
+    },
+    subscribe(listener) {
+      return trackChanges.observe((snapshot) => listener({ snapshot }));
     },
     accept(changeId) {
       const api = requireDocTrackChanges();
@@ -1542,14 +1551,17 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
   // selector substrate.
   const selection: SelectionHandle = {
     getSnapshot: () => computeState().selection,
-    subscribe(listener) {
+    observe(listener) {
       return select((state) => state.selection, shallowEqual).subscribe((snapshot) => {
         try {
-          listener({ snapshot });
+          listener(snapshot);
         } catch {
           // see scheduleNotify
         }
       });
+    },
+    subscribe(listener) {
+      return selection.observe((snapshot) => listener({ snapshot }));
     },
     capture() {
       // Capture is sugar over `getSnapshot()` plus a deep clone +
@@ -1580,14 +1592,17 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
   // backwards-compat shim once consumers migrate to ui.document).
   const document: DocumentHandle = {
     getSnapshot: () => computeState().document,
-    subscribe(listener) {
+    observe(listener) {
       return select((state) => state.document, shallowEqual).subscribe((snapshot) => {
         try {
-          listener({ snapshot });
+          listener(snapshot);
         } catch {
           // see scheduleNotify
         }
       });
+    },
+    subscribe(listener) {
+      return document.observe((snapshot) => listener({ snapshot }));
     },
     setMode(mode) {
       // Routes through the host setter; ignored when the stub omits

--- a/packages/super-editor/src/ui/observe-aliases.test.ts
+++ b/packages/super-editor/src/ui/observe-aliases.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSuperDocUI } from './create-super-doc-ui.js';
+import type { SuperDocLike } from './types.js';
+
+/**
+ * Verifies the value-shaped `observe(snapshot => ...)` aliases on
+ * every domain handle (SD-2919). The aliases sit alongside the
+ * existing `subscribe(({ snapshot }) => ...)` form and emit the same
+ * sequence with the snapshot unwrapped, matching the per-command
+ * `observe(state => ...)` shape on `ui.commands.<id>.observe`.
+ *
+ * What the tests pin:
+ * - Every domain handle exposes `observe`.
+ * - The first emit is synchronous with the current snapshot.
+ * - The unsubscribe returned by `observe` actually detaches the
+ *   listener.
+ * - The legacy `subscribe` keeps emitting with the event-wrapped
+ *   shape so existing consumers don't churn.
+ */
+function makeSuperdocStub(): SuperDocLike {
+  return {
+    activeEditor: {
+      on: vi.fn(),
+      off: vi.fn(),
+      doc: {
+        selection: {
+          current: vi.fn(() => ({ empty: true, text: undefined, target: null })),
+        },
+      },
+    },
+    config: { documentMode: 'editing' },
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+}
+
+describe('domain handle observe() aliases (SD-2919)', () => {
+  let teardown: Array<() => void> = [];
+
+  afterEach(() => {
+    teardown.forEach((fn) => fn());
+    teardown = [];
+  });
+
+  it('ui.document.observe fires synchronously with the snapshot', () => {
+    const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+    teardown.push(() => ui.destroy());
+
+    const fn = vi.fn();
+    const off = ui.document.observe(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn.mock.calls[0]![0]).toEqual(ui.document.getSnapshot());
+    off();
+  });
+
+  it('ui.selection.observe fires synchronously with the snapshot', () => {
+    const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+    teardown.push(() => ui.destroy());
+
+    const fn = vi.fn();
+    const off = ui.selection.observe(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn.mock.calls[0]![0]).toEqual(ui.selection.getSnapshot());
+    off();
+  });
+
+  it('ui.toolbar.observe fires synchronously with the snapshot', () => {
+    const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+    teardown.push(() => ui.destroy());
+
+    const fn = vi.fn();
+    const off = ui.toolbar.observe(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    // `state.toolbar` is sourced from the headless-toolbar controller,
+    // so identity equality with `getSnapshot()` is brittle. Pin the
+    // shape instead.
+    expect(fn.mock.calls[0]![0]).toMatchObject({
+      context: expect.anything(),
+      commands: expect.any(Object),
+    });
+    off();
+  });
+
+  it('ui.comments.observe fires synchronously with the snapshot', () => {
+    const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+    teardown.push(() => ui.destroy());
+
+    const fn = vi.fn();
+    const off = ui.comments.observe(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn.mock.calls[0]![0]).toEqual(ui.comments.getSnapshot());
+    off();
+  });
+
+  it('ui.trackChanges.observe fires synchronously with the snapshot', () => {
+    const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+    teardown.push(() => ui.destroy());
+
+    const fn = vi.fn();
+    const off = ui.trackChanges.observe(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn.mock.calls[0]![0]).toEqual(ui.trackChanges.getSnapshot());
+    off();
+  });
+
+  it('the unsubscribe returned by observe stops further emissions', () => {
+    const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+    teardown.push(() => ui.destroy());
+
+    const fn = vi.fn();
+    const off = ui.document.observe(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    off();
+    // No remaining listeners — destroy should not re-fire the listener.
+    ui.destroy();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribe still emits the event-wrapped shape (no churn for existing consumers)', () => {
+    const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+    teardown.push(() => ui.destroy());
+
+    const fn = vi.fn();
+    const off = ui.document.subscribe(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn.mock.calls[0]![0]).toHaveProperty('snapshot');
+    expect(fn.mock.calls[0]![0]!.snapshot).toEqual(ui.document.getSnapshot());
+    off();
+  });
+});

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -565,6 +565,16 @@ export interface DocumentHandle {
    */
   subscribe(listener: (event: { snapshot: DocumentSlice }) => void): () => void;
   /**
+   * Value-shaped alias of {@link subscribe}: listener receives the
+   * snapshot directly instead of an event wrapper. Matches the
+   * per-command `observe(state => ...)` shape on
+   * {@link CommandHandle.observe}, so a single listener style works
+   * across the whole controller surface. Same emission semantics as
+   * `subscribe`: fires once synchronously, then on shallow-equality
+   * change. Returns an unsubscribe.
+   */
+  observe(listener: (snapshot: DocumentSlice) => void): () => void;
+  /**
    * Set the document mode. Routes through `superdoc.setDocumentMode`
    * which fires the existing `document-mode-change` event and updates
    * the per-editor mode. No-op when the host stub omits the setter
@@ -609,6 +619,12 @@ export interface SelectionHandle {
    * typing-only transactions). Returns an unsubscribe.
    */
   subscribe(listener: (event: { snapshot: SelectionSlice }) => void): () => void;
+  /**
+   * Value-shaped alias of {@link subscribe}: listener receives the
+   * snapshot directly. See {@link DocumentHandle.observe} for why
+   * this exists alongside `subscribe`.
+   */
+  observe(listener: (snapshot: SelectionSlice) => void): () => void;
   /**
    * Capture the current selection as a portable handle.
    *
@@ -674,6 +690,12 @@ export interface ToolbarHandle {
    * with the latest snapshot. Returns an unsubscribe.
    */
   subscribe(listener: (event: { snapshot: ToolbarSnapshotSlice }) => void): () => void;
+  /**
+   * Value-shaped alias of {@link subscribe}: listener receives the
+   * snapshot directly. See {@link DocumentHandle.observe} for why
+   * this exists alongside `subscribe`.
+   */
+  observe(listener: (snapshot: ToolbarSnapshotSlice) => void): () => void;
   /**
    * Execute a built-in toolbar command. Type-safe payload is enforced
    * via the existing `ToolbarPayloadMap`.
@@ -934,6 +956,12 @@ export interface CommentsHandle {
    */
   subscribe(listener: (event: { snapshot: CommentsSlice }) => void): () => void;
   /**
+   * Value-shaped alias of {@link subscribe}: listener receives the
+   * snapshot directly. See {@link DocumentHandle.observe} for why
+   * this exists alongside `subscribe`.
+   */
+  observe(listener: (snapshot: CommentsSlice) => void): () => void;
+  /**
    * Create a comment anchored to the current selection. Reads the
    * routed editor's `selection.current().target` and routes through
    * `editor.doc.comments.create`. Returns the operation receipt.
@@ -1001,6 +1029,12 @@ export interface TrackChangesHandle {
    * equality. Returns an unsubscribe.
    */
   subscribe(listener: (event: { snapshot: TrackChangesSlice }) => void): () => void;
+  /**
+   * Value-shaped alias of {@link subscribe}: listener receives the
+   * snapshot directly. See {@link DocumentHandle.observe} for why
+   * this exists alongside `subscribe`.
+   */
+  observe(listener: (snapshot: TrackChangesSlice) => void): () => void;
   /** Accept a single tracked change via `trackChanges.decide`. */
   accept(changeId: string): import('@superdoc/document-api').Receipt;
   /** Reject a single tracked change via `trackChanges.decide`. */


### PR DESCRIPTION
Domain handles (\`ui.document\`, \`ui.selection\`, \`ui.toolbar\`, \`ui.comments\`, \`ui.trackChanges\`) used to emit through \`subscribe(({ snapshot }) => ...)\` while per-command handles use \`observe(state => ...)\`. Two listener shapes for the same kind of state observation. Adapter authors writing per-command and per-domain listeners in the same file kept tripping on which one wrapped the value in \`{ snapshot }\`.

This PR adds \`observe(snapshot => ...)\` alongside the existing \`subscribe(...)\` on every domain handle, matching the per-command shape. Non-breaking: \`subscribe\` stays and continues to emit the wrapped event. Internally \`subscribe\` is now a thin delegate over \`observe\` so the selector wiring isn't duplicated.

- Linear: SD-2919
- Sets up \`scope.add(handle.observe(fn))\` as the uniform pattern for the eventual SD-2918 v2 sugar (\`scope.observe(handle, fn)\`).
- 7 vitest cases pin: synchronous initial emit per handle, snapshot identity, unsubscribe detaches, and the legacy \`subscribe\` shape stays.

**Verified**: \`pnpm --filter @superdoc/super-editor test src/ui/\` passes 173/173; \`pnpm --filter superdoc build\` clean.