### PR TITLE
feat(ui): export BUILT_IN_COMMAND_IDS, add commands.has and commands.require (SD-2920)

### DIFF
--- a/packages/super-editor/src/headless-toolbar/index.ts
+++ b/packages/super-editor/src/headless-toolbar/index.ts
@@ -3,6 +3,7 @@ import { getFileOpener, processAndInsertImageFile } from '../editors/v1/extensio
 
 export { createHeadlessToolbar } from './create-headless-toolbar.js';
 export { headlessToolbarConstants } from './constants.js';
+export { BUILT_IN_COMMAND_IDS } from './types.js';
 
 export const headlessToolbarHelpers = {
   // linked-style helpers

--- a/packages/super-editor/src/headless-toolbar/types.ts
+++ b/packages/super-editor/src/headless-toolbar/types.ts
@@ -11,45 +11,59 @@ import type { DocumentApi } from '@superdoc/document-api';
  */
 export type HeadlessToolbarSurface = 'body' | 'header' | 'footer' | 'note' | 'endnote';
 
-export type PublicToolbarItemId =
-  | 'bold'
-  | 'italic'
-  | 'underline'
-  | 'strikethrough'
-  | 'font-size'
-  | 'font-family'
-  | 'text-color'
-  | 'highlight-color'
-  | 'link'
-  | 'text-align'
-  | 'line-height'
-  | 'linked-style'
-  | 'bullet-list'
-  | 'numbered-list'
-  | 'indent-increase'
-  | 'indent-decrease'
-  | 'undo'
-  | 'redo'
-  | 'ruler'
-  | 'zoom'
-  | 'document-mode'
-  | 'clear-formatting'
-  | 'copy-format'
-  | 'track-changes-accept-selection'
-  | 'track-changes-reject-selection'
-  | 'image'
-  | 'table-insert'
-  | 'table-add-row-before'
-  | 'table-add-row-after'
-  | 'table-delete-row'
-  | 'table-add-column-before'
-  | 'table-add-column-after'
-  | 'table-delete-column'
-  | 'table-delete'
-  | 'table-merge-cells'
-  | 'table-split-cell'
-  | 'table-remove-borders'
-  | 'table-fix';
+/**
+ * Runtime list of every built-in toolbar command id, single source of
+ * truth for both the public {@link PublicToolbarItemId} union and any
+ * consumer-side validation. Exported so config-driven toolbars can
+ * verify their id arrays against the canonical set without invoking
+ * the controller.
+ *
+ * Order is the historical declaration order; consumers that depend on
+ * iteration order (e.g. building a toolbar that mirrors the union)
+ * should not assume it is stable across versions.
+ */
+export const BUILT_IN_COMMAND_IDS = [
+  'bold',
+  'italic',
+  'underline',
+  'strikethrough',
+  'font-size',
+  'font-family',
+  'text-color',
+  'highlight-color',
+  'link',
+  'text-align',
+  'line-height',
+  'linked-style',
+  'bullet-list',
+  'numbered-list',
+  'indent-increase',
+  'indent-decrease',
+  'undo',
+  'redo',
+  'ruler',
+  'zoom',
+  'document-mode',
+  'clear-formatting',
+  'copy-format',
+  'track-changes-accept-selection',
+  'track-changes-reject-selection',
+  'image',
+  'table-insert',
+  'table-add-row-before',
+  'table-add-row-after',
+  'table-delete-row',
+  'table-add-column-before',
+  'table-add-column-after',
+  'table-delete-column',
+  'table-delete',
+  'table-merge-cells',
+  'table-split-cell',
+  'table-remove-borders',
+  'table-fix',
+] as const satisfies readonly string[];
+
+export type PublicToolbarItemId = (typeof BUILT_IN_COMMAND_IDS)[number];
 
 /**
  * Maps each command ID to its execute() payload type.

--- a/packages/super-editor/src/ui/command-discovery.test.ts
+++ b/packages/super-editor/src/ui/command-discovery.test.ts
@@ -10,8 +10,8 @@ import type { SuperDocLike } from './types.js';
  * - `BUILT_IN_COMMAND_IDS` runtime list (and its parity with the actual
  *   toolbar registry, so the static const cannot drift from the
  *   dynamic source of truth).
- * - `ui.commands.has(id)` — true for built-ins and registered customs.
- * - `ui.commands.require(id)` — throws when the id is unknown.
+ * - `ui.commands.has(id)`: true for built-ins and registered customs.
+ * - `ui.commands.require(id)`: throws when the id is unknown.
  */
 function makeSuperdocStub(): SuperDocLike {
   return {
@@ -80,6 +80,30 @@ describe('command discovery (SD-2920)', () => {
 
       reg.unregister();
       expect(ui.commands.has('company.aiRewrite')).toBe(false);
+    });
+  });
+
+  describe('reserved Proxy property names', () => {
+    it('refuses registration for ids that shadow Proxy methods', () => {
+      const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+      teardown.push(() => ui.destroy());
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      for (const id of ['register', 'get', 'has', 'require'] as const) {
+        const result = ui.commands.register({ id, execute: () => true });
+        // Returns a no-op result so callers don't crash on
+        // `result.handle.execute(...)`.
+        expect(typeof result.handle.execute).toBe('function');
+        // The registration was refused: `has` reports false because
+        // these ids are neither built-ins nor live custom commands.
+        expect(ui.commands.has(id)).toBe(false);
+        // Index access still returns the Proxy helper, never the
+        // refused handle.
+        expect(typeof (ui.commands as unknown as Record<string, unknown>)[id]).toBe('function');
+      }
+
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
     });
   });
 

--- a/packages/super-editor/src/ui/command-discovery.test.ts
+++ b/packages/super-editor/src/ui/command-discovery.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSuperDocUI } from './create-super-doc-ui.js';
+import { BUILT_IN_COMMAND_IDS } from '../headless-toolbar/types.js';
+import { createToolbarRegistry } from '../headless-toolbar/toolbar-registry.js';
+import type { SuperDocLike } from './types.js';
+
+/**
+ * Tests for SD-2920 command discovery helpers:
+ * - `BUILT_IN_COMMAND_IDS` runtime list (and its parity with the actual
+ *   toolbar registry, so the static const cannot drift from the
+ *   dynamic source of truth).
+ * - `ui.commands.has(id)` — true for built-ins and registered customs.
+ * - `ui.commands.require(id)` — throws when the id is unknown.
+ */
+function makeSuperdocStub(): SuperDocLike {
+  return {
+    activeEditor: {
+      on: vi.fn(),
+      off: vi.fn(),
+      doc: {
+        selection: {
+          current: vi.fn(() => ({ empty: true, text: undefined, target: null })),
+        },
+      },
+    },
+    config: { documentMode: 'editing' },
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+}
+
+describe('command discovery (SD-2920)', () => {
+  let teardown: Array<() => void> = [];
+
+  afterEach(() => {
+    teardown.forEach((fn) => fn());
+    teardown = [];
+  });
+
+  describe('BUILT_IN_COMMAND_IDS', () => {
+    it('matches the runtime toolbar registry', () => {
+      const runtimeIds = Object.keys(createToolbarRegistry()).sort();
+      const constIds = [...BUILT_IN_COMMAND_IDS].sort();
+      expect(constIds).toEqual(runtimeIds);
+    });
+
+    it('contains canonical commands', () => {
+      expect(BUILT_IN_COMMAND_IDS).toContain('bold');
+      expect(BUILT_IN_COMMAND_IDS).toContain('undo');
+      expect(BUILT_IN_COMMAND_IDS).toContain('table-insert');
+    });
+  });
+
+  describe('ui.commands.has(id)', () => {
+    it('returns true for every built-in id', () => {
+      const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+      teardown.push(() => ui.destroy());
+
+      for (const id of BUILT_IN_COMMAND_IDS) {
+        expect(ui.commands.has(id)).toBe(true);
+      }
+    });
+
+    it('returns false for unknown ids', () => {
+      const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+      teardown.push(() => ui.destroy());
+
+      expect(ui.commands.has('blod')).toBe(false);
+      expect(ui.commands.has('')).toBe(false);
+      expect(ui.commands.has('company.notRegistered')).toBe(false);
+    });
+
+    it('returns true after a custom command registers, false after unregister', () => {
+      const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+      teardown.push(() => ui.destroy());
+
+      const reg = ui.commands.register({ id: 'company.aiRewrite', execute: () => true });
+      expect(ui.commands.has('company.aiRewrite')).toBe(true);
+
+      reg.unregister();
+      expect(ui.commands.has('company.aiRewrite')).toBe(false);
+    });
+  });
+
+  describe('ui.commands.require(id)', () => {
+    it('returns a handle for built-ins', () => {
+      const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+      teardown.push(() => ui.destroy());
+
+      const handle = ui.commands.require('bold');
+      expect(handle).toBeDefined();
+      expect(typeof handle.execute).toBe('function');
+      expect(typeof handle.observe).toBe('function');
+    });
+
+    it('returns a handle for registered customs', () => {
+      const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+      teardown.push(() => ui.destroy());
+
+      ui.commands.register({ id: 'company.test', execute: () => true });
+      const handle = ui.commands.require('company.test');
+      expect(handle).toBeDefined();
+    });
+
+    it('throws for unknown ids', () => {
+      const ui = createSuperDocUI({ superdoc: makeSuperdocStub() });
+      teardown.push(() => ui.destroy());
+
+      expect(() => ui.commands.require('blod')).toThrow(/unknown command id "blod"/);
+      expect(() => ui.commands.require('')).toThrow(/unknown command id/);
+    });
+  });
+});

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -1140,6 +1140,25 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
       if (prop === 'get') {
         return getDynamicHandle;
       }
+      // `has(id)` and `require(id)` (SD-2920): explicit validation
+      // helpers for config-driven toolbars and trusted dispatch sites.
+      // Both use the same registry lookup as `get(id)`; the difference
+      // is only what they return when the id is unknown.
+      if (prop === 'has') {
+        return (id: string): boolean => {
+          if (typeof id !== 'string' || id.length === 0) return false;
+          return BUILT_IN_COMMAND_ID_SET.has(id) || customCommandsRegistry.has(id);
+        };
+      }
+      if (prop === 'require') {
+        return (id: string): DynamicCommandHandle => {
+          const handle = getDynamicHandle(id);
+          if (!handle) {
+            throw new Error(`[superdoc/ui] commands.require: unknown command id "${id}".`);
+          }
+          return handle;
+        };
+      }
       // Custom-registered ids surface a typed handle from the registry.
       // Built-in ids fall through to the existing per-id cache so they
       // keep the same observe/execute shape they had before SD-2802.

--- a/packages/super-editor/src/ui/custom-commands.ts
+++ b/packages/super-editor/src/ui/custom-commands.ts
@@ -17,6 +17,24 @@ const DEFAULT_REPLACEMENT_MESSAGE = (id: string) =>
   `[superdoc/ui] ui.commands.register(): id '${id}' was already registered. Replacing prior registration.`;
 
 /**
+ * Property names the `ui.commands` Proxy intercepts before the
+ * registry lookup. A custom command registered with one of these ids
+ * would still be reachable through `ui.commands.get(id)` /
+ * `ui.commands.require(id)`, but indexing `ui.commands[id]` would
+ * return the surface helper instead of the consumer's handle. To keep
+ * the surface consistent, we refuse these ids at registration time.
+ *
+ * `override: true` does not bypass this list. Index access on a Proxy
+ * is not something registration semantics can route around; the only
+ * fix is to choose a different id (a namespaced one like
+ * `'company.has'` is the canonical workaround).
+ */
+const RESERVED_PROXY_PROPERTY_NAMES: ReadonlySet<string> = new Set(['register', 'get', 'has', 'require']);
+
+const DEFAULT_RESERVED_NAME_MESSAGE = (id: string) =>
+  `[superdoc/ui] ui.commands.register(): id '${id}' shadows a Proxy method on ui.commands and would be unreachable through index access. Use a namespaced id (e.g. 'company.${id}') instead. Registration refused.`;
+
+/**
  * Static fallback state for a custom command when:
  *  - the registration omits `getState`
  *  - `getState` returns `undefined` / `void`
@@ -232,6 +250,24 @@ export function createCustomCommandsRegistry(deps: CustomCommandsRegistryDeps): 
       registration: CustomCommandRegistration<TPayload, TValue>,
     ): CustomCommandRegistrationResult<TPayload, TValue> {
       const { id, execute, getState, override = false } = registration;
+
+      // Reserved Proxy property names refuse unconditionally. Even
+      // `override: true` cannot route around index access on the
+      // `ui.commands` Proxy; the surface helper always wins. Returning
+      // a no-op result here keeps the call site safe (handle.execute
+      // still callable) and warns once.
+      if (RESERVED_PROXY_PROPERTY_NAMES.has(id)) {
+        console.warn(DEFAULT_RESERVED_NAME_MESSAGE(id));
+        return {
+          handle: buildNoOpHandle<TPayload, TValue>(id),
+          invalidate() {
+            // refused registration: nothing to invalidate
+          },
+          unregister() {
+            // refused registration: nothing to remove
+          },
+        };
+      }
 
       // Built-in collision: refuse without `override: true`. We return a
       // no-op registration object so the consumer's call site doesn't

--- a/packages/super-editor/src/ui/index.ts
+++ b/packages/super-editor/src/ui/index.ts
@@ -18,6 +18,7 @@
 
 export { createSuperDocUI } from './create-super-doc-ui.js';
 export { shallowEqual } from './equality.js';
+export { BUILT_IN_COMMAND_IDS } from '../headless-toolbar/types.js';
 
 // Re-export the document-side shapes the controller surfaces so
 // consumers can type their components without reaching into the

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -797,6 +797,26 @@ export type CommandsHandle = {
    * uniformly without branching on the id.
    */
   get(id: string): DynamicCommandHandle | undefined;
+
+  /**
+   * Returns `true` when `id` is currently registered: a built-in
+   * (member of `BUILT_IN_COMMAND_IDS`) or a custom registered via
+   * {@link CommandsHandle.register}. Returns `false` for unknown
+   * strings, including custom ids that have been unregistered.
+   *
+   * Use to validate config-driven toolbars at startup. The runtime
+   * lookup `ui.commands.get(id)` returns `undefined` for unknown ids
+   * silently; `has` makes the check explicit and short.
+   */
+  has(id: string): boolean;
+
+  /**
+   * Like {@link CommandsHandle.get} but throws when `id` is not
+   * registered. Use at trusted dispatch sites where an unknown id
+   * indicates a bug, not a user error: keyboard shortcut routers,
+   * tests, internal command pipelines.
+   */
+  require(id: string): DynamicCommandHandle;
 };
 
 /**

--- a/packages/superdoc/src/ui.d.ts
+++ b/packages/superdoc/src/ui.d.ts
@@ -1,4 +1,5 @@
 export {
+  BUILT_IN_COMMAND_IDS,
   createSuperDocUI,
   shallowEqual,
   type CommandHandle,

--- a/packages/superdoc/src/ui.js
+++ b/packages/superdoc/src/ui.js
@@ -10,4 +10,4 @@
  *
  * Source: `packages/super-editor/src/ui/`
  */
-export { createSuperDocUI, shallowEqual } from '@superdoc/super-editor/ui';
+export { BUILT_IN_COMMAND_IDS, createSuperDocUI, shallowEqual } from '@superdoc/super-editor/ui';

--- a/tests/consumer-typecheck/src/customer-scenario.ts
+++ b/tests/consumer-typecheck/src/customer-scenario.ts
@@ -852,6 +852,7 @@ function testVueComponents() {
  * monorepo and a broken re-export could ship undetected.
  */
 import {
+  BUILT_IN_COMMAND_IDS,
   createSuperDocUI,
   shallowEqual,
   type CommentAddress as UICommentAddress,
@@ -1008,6 +1009,26 @@ function testSuperDocUISubEntry() {
     return c.commentId;
   }
   void readCommentId;
+
+  // SD-2920: command discovery helpers exposed at the consumer surface.
+  // BUILT_IN_COMMAND_IDS is a runtime-readable list; has() / require()
+  // give configurable toolbars and trusted dispatch sites a typed way
+  // to validate id strings without indexing the proxy.
+  function exerciseCommandDiscovery(ui: SuperDocUI): void {
+    const ids: readonly string[] = BUILT_IN_COMMAND_IDS;
+    void ids;
+
+    const present: boolean = ui.commands.has('bold');
+    const missing: boolean = ui.commands.has('blod');
+    void present;
+    void missing;
+
+    const handle = ui.commands.require('bold');
+    handle.observe((_state) => {});
+    const result: boolean | Promise<boolean> = handle.execute();
+    void result;
+  }
+  void exerciseCommandDiscovery;
 }
 
 export {


### PR DESCRIPTION
Config-driven toolbars had no way to validate their command id arrays. \`ui.commands.get(id)\` returns undefined silently for unknown ids, so typos surfaced as buttons that rendered disabled with no warning at startup, in the type checker, or in the dev console.

This PR exposes three small helpers on the public \`superdoc/ui\` surface:

- \`BUILT_IN_COMMAND_IDS\` — readonly array of canonical built-in command ids. \`PublicToolbarItemId\` is now derived from this const, so the type and runtime list cannot drift from each other.
- \`ui.commands.has(id)\` — boolean check, true for built-ins and currently registered customs.
- \`ui.commands.require(id)\` — throwing variant for trusted dispatch sites (keyboard routers, tests, internal pipelines) where an unknown id is a bug.

- Linear: SD-2920
- 8 vitest cases pin behavior: BUILT_IN_COMMAND_IDS matches the runtime toolbar registry (drift guard), has() flips correctly across custom register/unregister, require() throws for unknown ids.
- Consumer-typecheck exercises every helper at value level.

**Verified**: \`pnpm --filter @superdoc/super-editor test src/ui/\` passes 181/181; \`pnpm --filter superdoc build\` clean; consumer-typecheck on the modified file clean.