### PR TITLE
refactor(superdoc): cast role and isInternal at canPerformPermission isAllowed call (SD-2867)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -1236,7 +1236,7 @@ export class SuperDoc extends EventEmitter {
       trackedChange: trackedChange ?? null,
     };
 
-    return isAllowed(permission, role, isInternal, context);
+    return isAllowed(permission, /** @type {string} */ (role), /** @type {boolean} */ (isInternal), context);
   }
 
   #addToolbar() {


### PR DESCRIPTION
Re-adds two type casts at `canPerformPermission`'s `isAllowed(...)` call. These casts were dropped from #3090 because the call site was untested and would have dragged patch coverage under the gate. #3094 added 9 unit tests covering the public method, so the casts can now land without coverage regression.

**Change** (1 line, both casts inline):

```js
return isAllowed(permission, /** @type {string} */ (role), /** @type {boolean} */ (isInternal), context);
```

`role` and `isInternal` come from destructure defaults that fall back to `this.config.role` (typed `string | undefined`) and `this.config.isInternal` (typed `boolean | undefined`). The class-field initializer always populates both (`role: 'editor'`, `isInternal: false`), so the runtime invariant holds; the cast just makes that explicit at the call boundary.

**Closes** 2 TS2345 errors. No public surface change. No runtime change.

**Verified**:
- `pnpm --filter superdoc check:jsdoc` → 3 gated files clean.
- `pnpm --filter superdoc build:es` → no FAIL-level findings.
- `node tests/consumer-typecheck/typecheck-matrix.mjs` → 33 passed, 0 failed.
- `pnpm exec vitest run src/core/SuperDoc.test.js` → 78 passed (includes the 9 canPerformPermission tests added in #3094).