### PR TITLE
refactor(superdoc): widen User.email to string | null | undefined (SD-2867)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/types/EditorConfig.ts
+++ b/packages/super-editor/src/editors/v1/core/types/EditorConfig.ts
@@ -125,8 +125,13 @@ export interface User {
   /** The user's name */
   name?: string;
 
-  /** The user's email */
-  email?: string;
+  /**
+   * The user's email. Optional, and may be `null` when SuperDoc fell back
+   * to the built-in default user without an email; the runtime has always
+   * exposed `null` here, so the typedef accepts it explicitly. Consumers
+   * must narrow before performing string operations on this field.
+   */
+  email?: string | null;
 
   /** The user's photo URL */
   image?: string | null;

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -186,7 +186,12 @@ export class SuperDoc extends EventEmitter {
     editorExtensions: [],
 
     colors: [],
-    user: { name: null, email: null },
+    // `user` is intentionally not initialized here. `#init` always
+    // normalizes `this.config.user` (spreading `DEFAULT_USER` over the
+    // consumer-supplied user, or using `DEFAULT_USER` outright when the
+    // consumer passes nothing). The previous `{ name: null, email: null }`
+    // placeholder was overwritten unconditionally before any consumer
+    // could observe it.
     users: [],
 
     modules: {}, // Optional: Modules to load. Use modules.ai.{your_key} to pass in your key

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -43,10 +43,21 @@ export type CommentAddress = SuperEditorCommentAddress;
 export type TrackedChangeAddress = SuperEditorTrackedChangeAddress;
 export type NavigableAddress = SuperEditorNavigableAddress;
 
-/** The current user of this superdoc. */
+/**
+ * The current user of this superdoc.
+ *
+ * Every field is optional on input. `SuperDoc.#init` normalizes a missing
+ * or partial `user` by spreading `DEFAULT_USER` over consumer input, so
+ * `name` and `email` always have a value at runtime even when the
+ * consumer omits them. The typedef stays open so consumers can pass
+ * `{ name: 'Ada' }` without a typecheck failure.
+ *
+ * Kept structurally compatible with the publicly re-exported
+ * `User` from `@superdoc/super-editor` (also optional name/email).
+ */
 export interface User {
   /** The user's name. */
-  name: string;
+  name?: string;
   /**
    * The user's email. May be `null` when the consumer did not provide an
    * email and SuperDoc fell back to the built-in default user; the runtime
@@ -54,7 +65,7 @@ export interface User {
    * rather than narrowing to `string`. Consumers must narrow before
    * performing string operations on this field.
    */
-  email: string | null;
+  email?: string | null;
   /** The user's photo. */
   image?: string | null;
   /**

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -47,8 +47,14 @@ export type NavigableAddress = SuperEditorNavigableAddress;
 export interface User {
   /** The user's name. */
   name: string;
-  /** The user's email. */
-  email: string;
+  /**
+   * The user's email. May be `null` when the consumer did not provide an
+   * email and SuperDoc fell back to the built-in default user; the runtime
+   * has always exposed `null` here, so the typedef accepts it explicitly
+   * rather than narrowing to `string`. Consumers must narrow before
+   * performing string operations on this field.
+   */
+  email: string | null;
   /** The user's photo. */
   image?: string | null;
   /**

--- a/tests/consumer-typecheck/src/user-email-nullable.ts
+++ b/tests/consumer-typecheck/src/user-email-nullable.ts
@@ -13,7 +13,7 @@
  * under strict mode. If a future change re-narrows `email` to disallow
  * `null`, the `null` cases stop compiling and CI fails.
  */
-import type { User } from 'superdoc';
+import type { Config, User } from 'superdoc';
 
 // All three of string, null, undefined are valid email values.
 const userWithEmail: User = { name: 'Alice', email: 'alice@example.com' };
@@ -24,6 +24,14 @@ const userOmittingEmail: User = { name: 'Default' };
 // Optional fields stay independent of the email change.
 const userWithImage: User = { name: 'Alice', email: 'a@b.com', image: 'avatar.png' };
 const userWithImageNull: User = { name: 'Default', email: null, image: null };
+
+// `Config.user` accepts the same shape on input. `#init` normalizes a
+// partial user by spreading `DEFAULT_USER` over it, so consumers can
+// omit `email` (or `name`) without a typecheck failure.
+const cfgWithFullUser: Config['user'] = { name: 'Ada', email: 'ada@example.com' };
+const cfgWithMinimalUser: Config['user'] = { name: 'Ada' };
+const cfgWithNullEmail: Config['user'] = { name: 'Ada', email: null };
+const cfgWithEmptyUser: Config['user'] = {};
 
 // Consumers must narrow before string operations on `email`.
 function emailLength(u: User): number {
@@ -42,6 +50,10 @@ void [
   userOmittingEmail,
   userWithImage,
   userWithImageNull,
+  cfgWithFullUser,
+  cfgWithMinimalUser,
+  cfgWithNullEmail,
+  cfgWithEmptyUser,
   emailLength,
   fallback,
 ];

--- a/tests/consumer-typecheck/src/user-email-nullable.ts
+++ b/tests/consumer-typecheck/src/user-email-nullable.ts
@@ -1,0 +1,47 @@
+/**
+ * Consumer typecheck: `User.email` accepts `string | null | undefined`
+ * (SD-2867 Kind II).
+ *
+ * The runtime has always exposed `null` for `superdoc.config.user.email`
+ * when the consumer did not provide an email — `DEFAULT_USER.email` is
+ * `null`. The public `User` typedef previously narrowed `email?: string`
+ * (string or undefined only), which was a lie about runtime behavior.
+ * Widening to `email?: string | null` makes the typedef match what
+ * consumers can actually observe.
+ *
+ * This fixture pins the contract: each assignment below must compile
+ * under strict mode. If a future change re-narrows `email` to disallow
+ * `null`, the `null` cases stop compiling and CI fails.
+ */
+import type { User } from 'superdoc';
+
+// All three of string, null, undefined are valid email values.
+const userWithEmail: User = { name: 'Alice', email: 'alice@example.com' };
+const userWithNullEmail: User = { name: 'Default', email: null };
+const userWithUndefinedEmail: User = { name: 'Default', email: undefined };
+const userOmittingEmail: User = { name: 'Default' };
+
+// Optional fields stay independent of the email change.
+const userWithImage: User = { name: 'Alice', email: 'a@b.com', image: 'avatar.png' };
+const userWithImageNull: User = { name: 'Default', email: null, image: null };
+
+// Consumers must narrow before string operations on `email`.
+function emailLength(u: User): number {
+  if (u.email === null || u.email === undefined) return 0;
+  return u.email.length;
+}
+
+// Consumer-side narrowing pattern: nullish-coalesce to a fallback.
+const fallback: string = userWithNullEmail.email ?? '';
+
+// Reference all bindings so `tsc --noEmit` doesn't strip them.
+void [
+  userWithEmail,
+  userWithNullEmail,
+  userWithUndefinedEmail,
+  userOmittingEmail,
+  userWithImage,
+  userWithImageNull,
+  emailLength,
+  fallback,
+];

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -449,6 +449,28 @@ const scenarios = [
     files: ['src/can-perform-permission-payload.ts'],
     mustPass: true,
   },
+  // SD-2867 Kind II: `User.email` accepts both `string` and `null`. The
+  // runtime has always exposed `null` (DEFAULT_USER.email), and this
+  // fixture pins the typedef to that contract so a future PR cannot
+  // re-narrow `email` to `string` without a typecheck failure here.
+  {
+    name: 'bundler / User.email accepts string | null (SD-2867)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: true,
+    strict: true,
+    files: ['src/user-email-nullable.ts'],
+    mustPass: true,
+  },
+  {
+    name: 'node16 / User.email accepts string | null (SD-2867)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: true,
+    strict: true,
+    files: ['src/user-email-nullable.ts'],
+    mustPass: true,
+  },
 ];
 
 const tscPath = join(__dirname, 'node_modules', '.bin', 'tsc');


### PR DESCRIPTION
SD-2867 Kind II. Makes the public `User.email` typedef match the runtime.

**The runtime has always emitted `null` for `superdoc.config.user.email`** when the consumer didn't provide one — `DEFAULT_USER` (in `SuperDoc.js`) is `{ name: 'Default SuperDoc user', email: null }`. The public `User` typedef declared `email?: string`, which lied about that. This PR aligns the typedef.

**Public type change** (the only consumer-observable change in this PR):

```diff
 export interface User {
   name?: string;
-  email?: string;
+  email?: string | null;
   image?: string | null;
   permissionPrincipals?: string[];
 }
```

`User` is publicly exported from `superdoc` (re-exported from `@superdoc/super-editor`), so this is a public-contract widening. Consumer code calling string methods on `user.email` (e.g. `user.email.length`) will need a narrow. The typical `if (user.email) { ... }` truthy pattern is unchanged because `null` and `undefined` both fall through.

**Other changes**:

- `packages/superdoc/src/core/types/index.ts`: also widens the internal `User` interface used to type `Config.user` so it stays in sync with the public re-export.
- `packages/superdoc/src/core/SuperDoc.js`: drops the stale `user: { name: null, email: null }` placeholder from the class-field `config` initializer. `#init` always normalizes `this.config.user` (lines 323-334) by spreading `DEFAULT_USER` over the consumer-supplied user (or using `DEFAULT_USER` outright when the consumer passes nothing or a non-object). The placeholder was overwritten unconditionally before any consumer could observe it.

**Regression net**: new consumer-typecheck fixture `tests/consumer-typecheck/src/user-email-nullable.ts` asserts that `User.email` accepts `string`, `null`, and `undefined`. Two matrix scenarios (bundler + node16) added; both required to pass.

**Verified**:
- `pnpm --filter superdoc check:jsdoc` → 3 gated files clean.
- `pnpm --filter superdoc build:es` → no FAIL-level findings.
- `node tests/consumer-typecheck/typecheck-matrix.mjs` → 35 passed (33 existing + 2 new), 0 failed.
- `pnpm exec vitest run src/core/SuperDoc.test.js` → 78 passed.

**Must stay the same**: `DEFAULT_USER.email` keeps its runtime `null`; consumer-passed user values are unchanged; no behavior change for any value that travels through `#init`.

**Review**: confirm the emitted `User.email` in `dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts` is `string | null` (verified via `tar -xzOf` against the packed tarball).