### PR TITLE
test(superdoc): cover SuperDoc constructor with partial user (SD-2867)

### DIFF
--- a/tests/consumer-typecheck/src/user-email-nullable.ts
+++ b/tests/consumer-typecheck/src/user-email-nullable.ts
@@ -14,6 +14,7 @@
  * `null`, the `null` cases stop compiling and CI fails.
  */
 import type { Config, User } from 'superdoc';
+import { SuperDoc } from 'superdoc';
 
 // All three of string, null, undefined are valid email values.
 const userWithEmail: User = { name: 'Alice', email: 'alice@example.com' };
@@ -32,6 +33,18 @@ const cfgWithFullUser: Config['user'] = { name: 'Ada', email: 'ada@example.com' 
 const cfgWithMinimalUser: Config['user'] = { name: 'Ada' };
 const cfgWithNullEmail: Config['user'] = { name: 'Ada', email: null };
 const cfgWithEmptyUser: Config['user'] = {};
+
+// Same contract through the `new SuperDoc(...)` constructor parameter.
+// Consumers commonly write `new SuperDoc({ selector, user: { name } })`;
+// these type-only assignments pin the constructor surface a consumer
+// would actually hit. (Type-level only, no runtime construction.)
+type SuperDocCtorArg = ConstructorParameters<typeof SuperDoc>[0];
+const ctorWithFullUser: SuperDocCtorArg = { selector: '#x', user: { name: 'Ada', email: 'ada@example.com' } };
+const ctorWithMinimalUser: SuperDocCtorArg = { selector: '#x', user: { name: 'Ada' } };
+const ctorWithNullEmail: SuperDocCtorArg = { selector: '#x', user: { name: 'Ada', email: null } };
+const ctorWithUndefinedEmail: SuperDocCtorArg = { selector: '#x', user: { name: 'Ada', email: undefined } };
+const ctorWithEmptyUser: SuperDocCtorArg = { selector: '#x', user: {} };
+const ctorWithoutUser: SuperDocCtorArg = { selector: '#x' };
 
 // Consumers must narrow before string operations on `email`.
 function emailLength(u: User): number {
@@ -54,6 +67,12 @@ void [
   cfgWithMinimalUser,
   cfgWithNullEmail,
   cfgWithEmptyUser,
+  ctorWithFullUser,
+  ctorWithMinimalUser,
+  ctorWithNullEmail,
+  ctorWithUndefinedEmail,
+  ctorWithEmptyUser,
+  ctorWithoutUser,
   emailLength,
   fallback,
 ];


### PR DESCRIPTION
Follow-up to #3099. The original fixture covered the exported `User` alias and `Config['user']` directly; an external reviewer noted that the failure mode consumers actually hit is `new SuperDoc({ selector, user: { name: 'Ada' } })` — through `ConstructorParameters<typeof SuperDoc>`. This PR extends the fixture to pin that path explicitly so a future re-narrowing of `User` would surface here through the public constructor surface.

**Adds 6 type-only constructor cases** (no runtime construction):

```ts
type SuperDocCtorArg = ConstructorParameters<typeof SuperDoc>[0];
const ctorWithFullUser: SuperDocCtorArg = { selector: '#x', user: { name: 'Ada', email: 'ada@example.com' } };
const ctorWithMinimalUser: SuperDocCtorArg = { selector: '#x', user: { name: 'Ada' } };
const ctorWithNullEmail: SuperDocCtorArg = { selector: '#x', user: { name: 'Ada', email: null } };
const ctorWithUndefinedEmail: SuperDocCtorArg = { selector: '#x', user: { name: 'Ada', email: undefined } };
const ctorWithEmptyUser: SuperDocCtorArg = { selector: '#x', user: {} };
const ctorWithoutUser: SuperDocCtorArg = { selector: '#x' };
```

Each must compile under strict mode. Together they pin: full user, name-only (the original reviewer ask), explicit `null`, explicit `undefined`, empty user object, and omitted user.

**Verified**:
- `pnpm --filter superdoc check:jsdoc` → 3 gated files clean.
- `pnpm --filter superdoc build:es` → no FAIL-level findings.
- `node tests/consumer-typecheck/typecheck-matrix.mjs` → 35 passed, 0 failed.

**No production code changes.** Pure regression-net extension of the existing fixture.