### PR TITLE
docs: apply comment-policy.md to existing comments

### DIFF
--- a/apps/cli/src/commands/close.ts
+++ b/apps/cli/src/commands/close.ts
@@ -42,9 +42,12 @@ export async function runClose(tokens: string[], context: CommandContext): Promi
         );
       }
 
-      // Only read/clear the project-global active-session pointer in oneshot
-      // (CLI) mode. Host mode must never touch this file — it causes
-      // cross-document contamination between SDK clients.
+      // AIDEV-NOTE: the project-global active-session pointer may
+      // only be read or cleared in oneshot (CLI) mode. Host mode must
+      // never touch this file: multiple SDK clients can share one
+      // project root, and any read/clear here cross-contaminates their
+      // sessions. Mirror the same guard in open.ts when changing this
+      // rule.
       let wasDefaultSession = false;
       if (context.executionMode !== 'host') {
         const activeSessionId = await getActiveSessionId();

--- a/apps/cli/src/commands/open.ts
+++ b/apps/cli/src/commands/open.ts
@@ -211,9 +211,11 @@ export async function runOpen(tokens: string[], context: CommandContext): Promis
 
         await writeContextMetadata(paths, metadata);
 
-        // Only update the project-global active-session pointer in oneshot (CLI) mode.
-        // Host mode must never write this file — it causes cross-document contamination
-        // when multiple SDK clients share the same project root.
+        // AIDEV-NOTE: the project-global active-session pointer may
+        // only be written in oneshot (CLI) mode. Host mode must never
+        // touch this file: multiple SDK clients can share one project
+        // root, and a write here cross-contaminates their sessions.
+        // Mirror the same guard in close.ts when changing this rule.
         if (context.executionMode !== 'host') {
           await setActiveSessionId(metadata.contextId);
         }

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 import { Console } from 'node:console';
 
-// Redirect ALL console output to stderr BEFORE anything else runs.
-// stdout is reserved exclusively for the MCP JSON-RPC protocol.
-// Any stray output (e.g. "[super-editor] Telemetry: enabled" from
-// console.debug in Editor.ts) will corrupt the transport and crash
-// the MCP client (rmcp serde parse error at the non-JSON line).
+// AIDEV-NOTE: stdout is reserved exclusively for the MCP JSON-RPC
+// protocol. Any stray write (e.g. "[super-editor] Telemetry: enabled"
+// from console.debug in Editor.ts) corrupts the transport and crashes
+// the MCP client (rmcp serde parse error at the non-JSON line). All
+// console output is redirected to stderr before anything else runs;
+// new code in this entry must not write to stdout outside the JSON-RPC
+// path.
 globalThis.console = new Console(process.stderr) as unknown as typeof console;
 const _error = console.error.bind(console);
 console.log = (...args: unknown[]) => _error('[mcp:log]', ...args);

--- a/apps/vscode-ext/webview/main.js
+++ b/apps/vscode-ext/webview/main.js
@@ -40,22 +40,18 @@ let editor = null;
 let saveTimeout = null;
 let isInitialLoad = true;
 
-// Configuration
 const AUTO_SAVE_DELAY = 1000; // milliseconds
 
-// Initialize editor with file data
 function initializeEditor(fileArrayBuffer) {
   debug('Initializing editor with file buffer');
 
   try {
-    // Convert ArrayBuffer to File object
     const file = new File([fileArrayBuffer], 'document.docx', {
       type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     });
 
     debug(`File created: ${file.name}, ${file.size} bytes`);
 
-    // Clean up previous editor instance
     if (editor) {
       debug('Destroying previous editor...');
       try {
@@ -69,14 +65,11 @@ function initializeEditor(fileArrayBuffer) {
       debug('Destroyed previous editor');
     }
 
-    // Reset state for new editor
     isInitialLoad = true;
 
-    // Check if DOM elements exist
     const superdocElement = document.getElementById('superdoc');
     const toolbarElement = document.getElementById('superdoc-toolbar');
 
-    // Clear existing content from containers
     if (superdocElement) {
       superdocElement.innerHTML = '';
     }
@@ -121,7 +114,6 @@ function initializeEditor(fileArrayBuffer) {
   }
 }
 
-// Setup editor listeners for content changes (debounced save on update)
 function setupEditorListeners() {
   if (!editor?.activeEditor) {
     debug('No editor or activeEditor available');
@@ -141,20 +133,16 @@ function setupEditorListeners() {
   debug('Editor update listener ready');
 }
 
-// Schedule auto-save with debouncing
 function scheduleAutoSave() {
-  // Clear existing timeout
   if (saveTimeout) {
     clearTimeout(saveTimeout);
   }
 
-  // Schedule new save
   saveTimeout = setTimeout(() => {
     saveDocument();
   }, AUTO_SAVE_DELAY);
 }
 
-// Save document back to VS Code
 async function saveDocument() {
   if (!editor) {
     debug('No editor available for saving');
@@ -186,7 +174,6 @@ async function saveDocument() {
   }
 }
 
-// Handle messages from VS Code
 window.addEventListener('message', async (event) => {
   const message = event.data;
   if (!message?.type) {

--- a/packages/layout-engine/layout-engine/src/index.ts
+++ b/packages/layout-engine/layout-engine/src/index.ts
@@ -638,10 +638,6 @@ const hasOnlySectionBreakBlocks = (blocks: readonly FlowBlock[]): boolean => {
   return blocks.length > 0 && blocks.every((block) => block.kind === 'sectionBreak');
 };
 
-// List constants sourced from shared/common
-
-// Context types moved to modular layouters
-
 const layoutDebugEnabled =
   typeof process !== 'undefined' && typeof process.env !== 'undefined' && Boolean(process.env.SD_DEBUG_LAYOUT);
 

--- a/packages/super-editor/src/editors/v1/components/context-menu/menuItems.js
+++ b/packages/super-editor/src/editors/v1/components/context-menu/menuItems.js
@@ -269,7 +269,6 @@ export function getItems(context, customItems = [], includeDefaultItems = true) 
           action: (editor) => {
             editor.commands.createDocumentSection();
           },
-          // TODO: Temporarily disabled - restore original: `return trigger === TRIGGERS.click;`
           showWhen: () => {
             return false;
           },

--- a/packages/superdoc/src/components/HrbrFieldsLayer/CheckboxField.vue
+++ b/packages/superdoc/src/components/HrbrFieldsLayer/CheckboxField.vue
@@ -42,7 +42,6 @@ const getPreviewStyle = computed(() => {
 
 <template>
   <div class="checkbox-container">
-    <!-- TODO: check when migrating CLM -->
     <div v-if="props.isEditing" class="checkbox-editing-placeholder"></div>
     <div v-else class="checkbox-preview" :style="getPreviewStyle">{{ getValue ? 'x' : '' }}</div>
   </div>


### PR DESCRIPTION
First sweep against [`comment-policy.md`](../blob/main/comment-policy.md) (linked from `CLAUDE.md` and `AGENTS.md`). All five audit findings, comment-only — no logic touched. Net -12 lines.

**Removed** (paraphrase / orphan / vague):
- `apps/vscode-ext/webview/main.js` — section-label cluster ("Configuration", "Initialize editor", "Convert ArrayBuffer", "Clear existing timeout", "Schedule new save", etc.). Each paraphrased the next line or function name.
- `packages/layout-engine/layout-engine/src/index.ts` — two orphan historical comments after refactors ("List constants sourced from shared/common", "Context types moved to modular layouters").
- `packages/super-editor/.../menuItems.js:272` — vague "Temporarily disabled - restore original" TODO. The committing PR (#2926) was unrelated work and named no rationale; per the policy, vague TODOs without a rule, ticket, or consequence are a bug.
- `packages/superdoc/.../CheckboxField.vue:45` — "TODO: check when migrating CLM" placeholder, no anchor.

**Promoted to `AIDEV-NOTE:`** (load-bearing constraints that must survive future agent edits):
- `apps/mcp/src/index.ts` — stdout reserved for MCP JSON-RPC; stray write corrupts transport (rmcp serde parse error).
- `apps/cli/src/commands/open.ts` — project-global active-session pointer may only be written in oneshot mode; host mode must not (SDK-client cross-contamination on shared project root).
- `apps/cli/src/commands/close.ts` — same rule, mirrored on the read/clear path.

Each promoted note names the rule, the consequence, and the mirror site so it stands up under the policy.