### PR TITLE
chore: remove undefined-acronym TODO and refactor-history comment (SD-2923)

### DIFF
--- a/packages/document-api/src/contract/schemas.ts
+++ b/packages/document-api/src/contract/schemas.ts
@@ -981,8 +981,6 @@ const sdSelectorSchema: JsonSchema = {
   oneOf: [sdTextSelectorSchema, sdNodeSelectorSchema],
 };
 
-// sdAddressSchema removed: replaced by blockNodeAddressSchema, nodeAddressSchema, textAddressSchema
-
 const sdReadOptionsSchema = objectSchema({
   includeResolved: { type: 'boolean' },
   includeProvenance: { type: 'boolean' },

--- a/packages/superdoc/src/components/HrbrFieldsLayer/CheckboxField.vue
+++ b/packages/superdoc/src/components/HrbrFieldsLayer/CheckboxField.vue
@@ -42,7 +42,6 @@ const getPreviewStyle = computed(() => {
 
 <template>
   <div class="checkbox-container">
-    <!-- TODO: check when migrating CLM -->
     <div v-if="props.isEditing" class="checkbox-editing-placeholder"></div>
     <div v-else class="checkbox-preview" :style="getPreviewStyle">{{ getValue ? 'x' : '' }}</div>
   </div>


### PR DESCRIPTION
Two stale comments flagged in the SD-2923 audit:

- The `CLM` TODO in `CheckboxField.vue` - "CLM" is not defined anywhere in the codebase, so the marker is unactionable.
- The `sdAddressSchema removed:` note in `schemas.ts` - pure refactor history about a long-removed symbol. Per the new comment-policy.md taxonomy (`removed-dead`), this context belongs in the PR or git history, not in source comments.

No behavior change.

Related: SD-2923 (comment hygiene umbrella).