### PR TITLE
fix(infra): emit declarations for rebuild:types (SD-2925)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:behavior:html": "pnpm --filter @superdoc-testing/behavior test:html",
     "type-check": "tsc -b tsconfig.references.json",
     "type-check:force": "tsc -b --force tsconfig.references.json",
-    "rebuild:types": "pnpm run --filter=@superdoc/common --filter=@superdoc/word-layout --filter=@superdoc/contracts --filter=@superdoc/dom-contract --filter=@superdoc/layout-resolved --filter=@superdoc/geometry-utils --filter=@superdoc/style-engine --filter=@superdoc/pm-adapter --filter=@superdoc/measuring-dom --filter=@superdoc/layout-engine --filter=@superdoc/layout-bridge --filter=@superdoc/painter-dom build",
+    "rebuild:types": "pnpm --workspace-concurrency=1 run --filter=@superdoc/common --filter=@superdoc/word-layout --filter=@superdoc/contracts --filter=@superdoc/dom-contract --filter=@superdoc/layout-resolved --filter=@superdoc/geometry-utils --filter=@superdoc/style-engine --filter=@superdoc/pm-adapter --filter=@superdoc/measuring-dom --filter=@superdoc/layout-engine --filter=@superdoc/layout-bridge build && pnpm --filter=@superdoc/painter-dom build",
     "validate:commands": "node scripts/validate-command-types.mjs",
     "unzip": "bash packages/super-editor/src/editors/v1/tests/helpers/unzip.sh",
     "dev": "pnpm --prefix packages/superdoc run dev",

--- a/packages/layout-engine/dom-contract/package.json
+++ b/packages/layout-engine/dom-contract/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc --project tsconfig.json --noEmit",
+    "build": "tsc --build tsconfig.json --emitDeclarationOnly",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/packages/layout-engine/dom-contract/tsconfig.json
+++ b/packages/layout-engine/dom-contract/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "composite": true,
     "declaration": true,
     "declarationMap": true

--- a/packages/layout-engine/geometry-utils/package.json
+++ b/packages/layout-engine/geometry-utils/package.json
@@ -9,7 +9,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.json --noEmit",
+    "build": "tsc --build tsconfig.json --emitDeclarationOnly",
     "test": "bun test"
   },
   "devDependencies": {

--- a/packages/layout-engine/geometry-utils/tsconfig.json
+++ b/packages/layout-engine/geometry-utils/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "composite": true,
     "declaration": true,
     "declarationMap": true


### PR DESCRIPTION
## What changed

- Make `@superdoc/geometry-utils` and `@superdoc/dom-contract` emit declaration artifacts during their package build.
- Keep each package's TypeScript build info under `dist/` so deleting generated output also resets incremental state.
- Serialize `pnpm run rebuild:types` enough that declaration producers build before `@superdoc/painter-dom`, avoiding the `layout-bridge` / `painter-dom` cycle race.

## Why

`pnpm run rebuild:types` failed in a clean worktree because `@superdoc/measuring-dom` project-references `@superdoc/geometry-utils` and expects `geometry-utils/dist/index.d.ts` to exist. The package tsconfig declared composite declaration output, but the build script used `--noEmit`, so the referenced declaration output was never written.

After fixing `geometry-utils`, the same mismatch surfaced for `@superdoc/dom-contract`, and the root rebuild script could still run `painter-dom` before `layout-bridge` had emitted its declarations. This PR fixes the declaration producers and the rebuild ordering.

## Verification

- `pnpm run rebuild:types`
- `pnpm run type-check`
- `git diff --check`
