### PR TITLE
docs(super-editor): drop dangling plans/unified-history.md @see references (SD-2923)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -1648,8 +1648,6 @@ export class PresentationEditor extends EventEmitter {
    * them safe to run multiple times.
    *
    * No-op when unified history is disabled.
-   *
-   * @see plans/unified-history.md § Phase 4
    */
   recordHistoryBatch(batch: BatchHistoryRecord): void {
     this.#historyCoordinator?.withHistoryBatch(batch);
@@ -5332,8 +5330,8 @@ export class PresentationEditor extends EventEmitter {
   // ===========================================================================
   // Unified History Coordinator (enabled by default; explicit false disables)
   //
-  // See plans/unified-history.md. When the kill-switch is off, these helpers are
-  // no-ops so the legacy active-editor-first routing stays intact.
+  // When the kill-switch is off, these helpers are no-ops so the legacy
+  // active-editor-first routing stays intact.
   // ===========================================================================
 
   #isUnifiedHistoryEnabled(): boolean {

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/history/NoteEditorRegistry.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/history/NoteEditorRegistry.ts
@@ -14,8 +14,6 @@
  *     entries in lockstep.
  *   - Idle disposal policy lives here (a story runtime cache miss should not
  *     kill an editor the coordinator still references).
- *
- * See `plans/unified-history.md`, Phase 2.
  */
 
 import type { FootnoteStoryLocator, EndnoteStoryLocator } from '@superdoc/document-api';

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/history/batch-history-adapter.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/history/batch-history-adapter.ts
@@ -10,8 +10,6 @@
  * Each `withHistoryBatch()` call pushes one batch record here. The batch's
  * `undo` / `redo` callbacks are what the coordinator actually runs when it
  * reaches this adapter during replay — there is no underlying editor step.
- *
- * See `plans/unified-history.md`, Phase 4.
  */
 
 import type { HistorySnapshotAdapter, ParticipantHistorySnapshot } from './types.js';

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/history/types.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/history/types.ts
@@ -1,7 +1,7 @@
 /**
  * Shared types for the unified document-wide history coordinator.
  *
- * See `plans/unified-history.md` for the full design rationale. At a glance:
+ * Design at a glance:
  *   - Each editable surface (body, header/footer, …) registers as a
  *     `HistoryParticipant` with its own local PM/Yjs history engine.
  *   - The coordinator observes local history snapshots and maintains a global

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/types.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/types.ts
@@ -224,7 +224,6 @@ export type PresentationEditorOptions = ConstructorParameters<typeof Editor>[0] 
      * active-surface undo routing.
      *
      * @default true
-     * @see plans/unified-history.md
      */
     unifiedHistory?: boolean;
   };


### PR DESCRIPTION
The design doc at `plans/unified-history.md` does not exist in this repo and was never committed. Six `@see` references across the presentation-editor history coordinator pointed at it. The surrounding comments already carry the design rationale inline (participant model, batch adapter purpose, kill-switch fallback path), so removing the dead cross-references is the lowest-risk fix.

If the doc resurfaces somewhere, add a real link back. Until then, a broken `@see` is actively harmful per the comment policy ("treat stale comments and stale agent-facing docs as bugs").

- 5 files changed, +3 / -10.
- One file (`history/types.ts`) had a dead anchor introducing a still-valid inline summary; replaced the prefix with "Design at a glance:" so the bullets stay anchored.
- One spot in `PresentationEditor.ts` had the dead prefix inline in a paragraph; dropped it and reflowed.
- The other four were standalone `@see` lines deleted outright.

Related: SD-2923 (comment hygiene umbrella).