### PR TITLE
feat: rtl support, body interaction reliability (phase 2)

### DIFF
--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -1467,7 +1467,6 @@ export type ParagraphAttrs = {
   /** Marks an empty paragraph that only exists to carry section properties. */
   sectPrMarker?: boolean;
   direction?: 'ltr' | 'rtl';
-  rtl?: boolean;
   isTocEntry?: boolean;
   tocInstruction?: string;
   /** Floating alignment for positioned paragraphs (from w:framePr/@w:xAlign). */

--- a/packages/layout-engine/layout-bridge/src/cache.ts
+++ b/packages/layout-engine/layout-bridge/src/cache.ts
@@ -391,9 +391,8 @@ const hashRuns = (block: FlowBlock): string => {
               if (sh.color) parts.push(`shc:${sh.color}`);
             }
 
-            // Direction and RTL
+            // Direction
             if (attrs.direction) parts.push(`dir:${attrs.direction}`);
-            if (attrs.rtl) parts.push('rtl');
 
             if (parts.length > 0) {
               cellHashes.push(`pa:${parts.join(':')}`);
@@ -547,9 +546,8 @@ const hashRuns = (block: FlowBlock): string => {
       parts.push(`tb:${tabsHash}`);
     }
 
-    // Direction and RTL
+    // Direction
     if (attrs.direction) parts.push(`dir:${attrs.direction}`);
-    if (attrs.rtl) parts.push('rtl');
 
     // Pagination properties
     if (attrs.keepNext) parts.push('kn');

--- a/packages/layout-engine/layout-bridge/src/diff.ts
+++ b/packages/layout-engine/layout-bridge/src/diff.ts
@@ -370,7 +370,6 @@ const paragraphAttrsEqual = (a?: ParagraphAttrs, b?: ParagraphAttrs): boolean =>
     a.keepNext !== b.keepNext ||
     a.keepLines !== b.keepLines ||
     a.direction !== b.direction ||
-    a.rtl !== b.rtl ||
     a.floatAlignment !== b.floatAlignment
   ) {
     return false;

--- a/packages/layout-engine/layout-bridge/src/paragraph-hash-utils.ts
+++ b/packages/layout-engine/layout-bridge/src/paragraph-hash-utils.ts
@@ -201,9 +201,8 @@ export const hashParagraphAttrs = (attrs: ParagraphAttrs | undefined): string =>
     if (sh.color) parts.push(`shc:${sh.color}`);
   }
 
-  // Direction and RTL
+  // Direction
   if (attrs.direction) parts.push(`dir:${attrs.direction}`);
-  if (attrs.rtl) parts.push('rtl');
 
   return parts.join(':');
 };

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -126,9 +126,6 @@ export const isRtlBlock = (block: FlowBlock): boolean => {
   if (typeof directionAttr === 'string' && directionAttr.toLowerCase() === 'rtl') {
     return true;
   }
-  if (typeof attrs.rtl === 'boolean') {
-    return attrs.rtl;
-  }
   return false;
 };
 

--- a/packages/layout-engine/layout-resolved/src/versionSignature.ts
+++ b/packages/layout-engine/layout-resolved/src/versionSignature.ts
@@ -292,7 +292,6 @@ export const deriveBlockVersion = (block: FlowBlock): string => {
           attrs.shading?.fill ?? '',
           attrs.shading?.color ?? '',
           attrs.direction ?? '',
-          attrs.rtl ? '1' : '',
           attrs.tabs?.length ? JSON.stringify(attrs.tabs) : '',
         ].join(':')
       : '';
@@ -437,7 +436,6 @@ export const deriveBlockVersion = (block: FlowBlock): string => {
               hash = hashString(hash, attrs.shading?.fill ?? '');
               hash = hashString(hash, attrs.shading?.color ?? '');
               hash = hashString(hash, attrs.direction ?? '');
-              hash = hashString(hash, attrs.rtl ? '1' : '');
               if (attrs.borders) {
                 hash = hashString(hash, hashParagraphBorders(attrs.borders));
               }

--- a/packages/layout-engine/painters/dom/src/features/rtl-paragraph/rtl-styles.ts
+++ b/packages/layout-engine/painters/dom/src/features/rtl-paragraph/rtl-styles.ts
@@ -11,10 +11,8 @@ import type { ParagraphAttrs } from '@superdoc/contracts';
 
 /**
  * Returns true when the paragraph attributes indicate right-to-left direction.
- * Checks both the `direction` string and the legacy `rtl` boolean flag.
  */
-export const isRtlParagraph = (attrs: ParagraphAttrs | undefined): boolean =>
-  attrs?.direction === 'rtl' || attrs?.rtl === true;
+export const isRtlParagraph = (attrs: ParagraphAttrs | undefined): boolean => attrs?.direction === 'rtl';
 
 /**
  * Compute the effective CSS text-align for a paragraph.
@@ -45,6 +43,9 @@ export const applyRtlStyles = (element: HTMLElement, attrs: ParagraphAttrs | und
   if (rtl) {
     element.setAttribute('dir', 'rtl');
     element.style.direction = 'rtl';
+  } else {
+    element.removeAttribute('dir');
+    element.style.direction = '';
   }
   element.style.textAlign = resolveTextAlign(attrs?.alignment, rtl);
   return rtl;

--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -4726,7 +4726,6 @@ describe('DomPainter', () => {
         attrs: {
           alignment: 'center',
           direction: 'rtl',
-          rtl: true,
         },
       };
       const footerMeasure: Measure = {
@@ -8168,7 +8167,7 @@ describe('DomPainter', () => {
       kind: 'paragraph',
       id: 'rtl-block',
       runs: [{ text: 'مرحبا', fontFamily: 'Arial', fontSize: 16 }],
-      attrs: { direction: 'rtl' as const, rtl: true, ...attrs },
+      attrs: { direction: 'rtl' as const, ...attrs },
     });
 
     const rtlMeasure: Measure = {
@@ -8223,7 +8222,7 @@ describe('DomPainter', () => {
           { kind: 'tab', width: 40, fontFamily: 'Arial', fontSize: 16 } as any,
           { text: 'عالم', fontFamily: 'Arial', fontSize: 16 },
         ],
-        attrs: { direction: 'rtl' as const, rtl: true },
+        attrs: { direction: 'rtl' as const },
       };
 
       const tabMeasure: Measure = {

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -7596,7 +7596,7 @@ const hasListMarkerProperties = (
  * - Position markers (pmStart, pmEnd)
  * - Special tokens (page numbers, etc.)
  * - List marker properties (numId, ilvl, markerText) - for list indent changes
- * - Paragraph attributes (alignment, spacing, indent, borders, shading, direction, rtl, tabs)
+ * - Paragraph attributes (alignment, spacing, indent, borders, shading, direction, tabs)
  * - Table cell content and paragraph formatting within cells
  *
  * For table blocks, a deep hash is computed across all rows and cells, including:
@@ -7740,7 +7740,6 @@ const deriveBlockVersion = (block: FlowBlock): string => {
           attrs.shading?.fill ?? '',
           attrs.shading?.color ?? '',
           attrs.direction ?? '',
-          attrs.rtl ? '1' : '',
           attrs.tabs?.length ? JSON.stringify(attrs.tabs) : '',
         ].join(':')
       : '';
@@ -7927,7 +7926,6 @@ const deriveBlockVersion = (block: FlowBlock): string => {
               hash = hashString(hash, attrs.shading?.fill ?? '');
               hash = hashString(hash, attrs.shading?.color ?? '');
               hash = hashString(hash, attrs.direction ?? '');
-              hash = hashString(hash, attrs.rtl ? '1' : '');
               if (attrs.borders) {
                 hash = hashString(hash, hashParagraphBorders(attrs.borders));
               }
@@ -8151,28 +8149,6 @@ export const applyRunDataAttributes = (element: HTMLElement, dataAttrs?: Record<
       }
     }
   });
-};
-
-const resolveParagraphDirection = (attrs?: ParagraphAttrs): 'ltr' | 'rtl' | undefined => {
-  if (attrs?.direction) {
-    return attrs.direction;
-  }
-  if (attrs?.rtl === true) {
-    return 'rtl';
-  }
-  if (attrs?.rtl === false) {
-    return 'ltr';
-  }
-  return undefined;
-};
-
-const applyParagraphDirection = (element: HTMLElement, attrs?: ParagraphAttrs): void => {
-  const direction = resolveParagraphDirection(attrs);
-  if (!direction) {
-    return;
-  }
-  element.setAttribute('dir', direction);
-  element.style.direction = direction;
 };
 
 const applyParagraphBlockStyles = (element: HTMLElement, attrs?: ParagraphAttrs): void => {

--- a/packages/layout-engine/pm-adapter/src/attributes/paragraph.test.ts
+++ b/packages/layout-engine/pm-adapter/src/attributes/paragraph.test.ts
@@ -15,6 +15,7 @@ import {
   normalizeFramePr,
   normalizeDropCap,
   computeParagraphAttrs,
+  resolveEffectiveParagraphDirection,
   computeRunAttrs,
   hasExplicitParagraphRunProperties,
 } from './paragraph.js';
@@ -273,7 +274,117 @@ describe('computeParagraphAttrs', () => {
     const { paragraphAttrs } = computeParagraphAttrs(paragraph as never);
 
     expect(paragraphAttrs.direction).toBe('rtl');
-    expect(paragraphAttrs.rtl).toBe(true);
+  });
+
+  it('uses section direction fallback when paragraph direction is not explicit', () => {
+    const paragraph: PMNode = {
+      type: { name: 'paragraph' },
+      attrs: {
+        paragraphProperties: {},
+      },
+    };
+
+    const converterContext = {
+      sectionDirection: 'rtl',
+      translatedNumbering: {},
+      translatedLinkedStyles: { docDefaults: {}, styles: {} },
+      tableInfo: null,
+    };
+
+    const { paragraphAttrs } = computeParagraphAttrs(paragraph as never, converterContext as never);
+    expect(paragraphAttrs.direction).toBe('rtl');
+  });
+});
+
+describe('resolveEffectiveParagraphDirection', () => {
+  it('prefers resolved paragraph rightToLeft over section direction', () => {
+    const paragraph: PMNode = {
+      type: { name: 'paragraph' },
+      attrs: {
+        paragraphProperties: {
+          rightToLeft: true,
+        },
+      },
+    };
+
+    const direction = resolveEffectiveParagraphDirection(paragraph as never, { rightToLeft: true } as never, 'ltr');
+    expect(direction).toBe('rtl');
+  });
+
+  it('uses section direction when paragraph direction is not explicit', () => {
+    const paragraph: PMNode = {
+      type: { name: 'paragraph' },
+      attrs: {
+        paragraphProperties: {},
+      },
+    };
+
+    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never, 'rtl');
+    expect(direction).toBe('rtl');
+  });
+
+  it('infers rtl when all runs with explicit direction are rtl', () => {
+    const paragraph: PMNode = {
+      type: { name: 'paragraph' },
+      content: [
+        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'אבג' }] },
+        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'דהו' }] },
+      ],
+    };
+
+    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never);
+    expect(direction).toBe('rtl');
+  });
+
+  it('infers ltr when explicit ltr runs are the majority', () => {
+    const paragraph: PMNode = {
+      type: { name: 'paragraph' },
+      content: [
+        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'אבג' }] },
+        { type: 'run', attrs: { runProperties: { rightToLeft: false } }, content: [{ type: 'text', text: 'abc' }] },
+        { type: 'run', attrs: { runProperties: { rightToLeft: false } }, content: [{ type: 'text', text: 'def' }] },
+      ],
+    };
+
+    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never);
+    expect(direction).toBe('ltr');
+  });
+
+  it('infers rtl when explicit rtl runs are the majority', () => {
+    const paragraph: PMNode = {
+      type: { name: 'paragraph' },
+      content: [
+        { type: 'run', attrs: { runProperties: { rightToLeft: false } }, content: [{ type: 'text', text: 'abc' }] },
+        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'אבג' }] },
+        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'דהו' }] },
+      ],
+    };
+
+    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never);
+    expect(direction).toBe('rtl');
+  });
+
+  it('uses first explicit run direction as tie-breaker for mixed runs', () => {
+    const paragraph: PMNode = {
+      type: { name: 'paragraph' },
+      content: [
+        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'אבג' }] },
+        { type: 'run', attrs: { runProperties: { rightToLeft: false } }, content: [{ type: 'text', text: 'abc' }] },
+      ],
+    };
+
+    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never);
+    expect(direction).toBe('rtl');
+  });
+
+  it('returns undefined when no direction signal exists', () => {
+    const paragraph: PMNode = {
+      type: { name: 'paragraph' },
+      content: [{ type: 'run', attrs: { runProperties: {} }, content: [{ type: 'text', text: 'plain text' }] }],
+    };
+
+    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never);
+    expect(direction).toBeUndefined();
   });
 });
 

--- a/packages/layout-engine/pm-adapter/src/attributes/paragraph.ts
+++ b/packages/layout-engine/pm-adapter/src/attributes/paragraph.ts
@@ -37,6 +37,7 @@ import {
 
 const DEFAULT_DECIMAL_SEPARATOR = '.';
 const DEFAULT_TAB_INTERVAL_TWIPS = 720; // 0.5 inch
+type ParagraphDirection = 'ltr' | 'rtl';
 
 const normalizeColor = (value?: unknown): string | undefined => {
   if (typeof value !== 'string') return undefined;
@@ -60,6 +61,43 @@ export const deepClone = <T>(obj: T): T => {
     }
   }
   return clone as T;
+};
+
+const inferDirectionFromRuns = (para: PMNode): ParagraphDirection | undefined => {
+  const content = Array.isArray(para.content) ? para.content : [];
+  let rtlRunCount = 0;
+  let ltrRunCount = 0;
+  let firstExplicitDirection: ParagraphDirection | undefined;
+
+  for (const node of content) {
+    if (node?.type !== 'run') continue;
+    const runDirection = (node.attrs?.runProperties as { rightToLeft?: unknown } | undefined)?.rightToLeft;
+    if (runDirection === true) {
+      rtlRunCount += 1;
+      if (!firstExplicitDirection) firstExplicitDirection = 'rtl';
+      continue;
+    }
+    if (runDirection === false) {
+      ltrRunCount += 1;
+      if (!firstExplicitDirection) firstExplicitDirection = 'ltr';
+    }
+  }
+
+  if (rtlRunCount === 0 && ltrRunCount === 0) return undefined;
+  if (rtlRunCount > ltrRunCount) return 'rtl';
+  if (ltrRunCount > rtlRunCount) return 'ltr';
+  return firstExplicitDirection;
+};
+
+export const resolveEffectiveParagraphDirection = (
+  para: PMNode,
+  resolvedParagraphProperties: ParagraphProperties,
+  sectionDirection?: ParagraphDirection,
+): ParagraphDirection | undefined => {
+  if (resolvedParagraphProperties.rightToLeft === true) return 'rtl';
+  if (resolvedParagraphProperties.rightToLeft === false) return 'ltr';
+  if (sectionDirection) return sectionDirection;
+  return inferDirectionFromRuns(para);
 };
 
 /**
@@ -273,7 +311,12 @@ export const computeParagraphAttrs = (
     );
   }
 
-  const isRtl = resolvedParagraphProperties.rightToLeft === true;
+  const normalizedDirection = resolveEffectiveParagraphDirection(
+    para,
+    resolvedParagraphProperties,
+    converterContext?.sectionDirection,
+  );
+  const isRtl = normalizedDirection === 'rtl';
 
   const normalizedSpacing = normalizeParagraphSpacing(
     resolvedParagraphProperties.spacing,
@@ -287,12 +330,6 @@ export const computeParagraphAttrs = (
   const paragraphDecimalSeparator = DEFAULT_DECIMAL_SEPARATOR;
   const tabIntervalTwips = DEFAULT_TAB_INTERVAL_TWIPS;
   const normalizedFramePr = normalizeFramePr(resolvedParagraphProperties.framePr);
-  const normalizedDirection =
-    resolvedParagraphProperties.rightToLeft === true
-      ? 'rtl'
-      : resolvedParagraphProperties.rightToLeft === false
-        ? 'ltr'
-        : undefined;
   const floatAlignment = normalizedFramePr?.xAlign;
   const normalizedNumberingProperties = normalizeNumberingProperties(resolvedParagraphProperties.numberingProperties);
   const dropCapDescriptor = normalizeDropCap(resolvedParagraphProperties.framePr, para, converterContext);
@@ -322,7 +359,7 @@ export const computeParagraphAttrs = (
     keepLines: resolvedParagraphProperties.keepLines,
     floatAlignment: floatAlignment,
     pageBreakBefore: resolvedParagraphProperties.pageBreakBefore,
-    ...(normalizedDirection ? { direction: normalizedDirection as 'rtl' | 'ltr', rtl: isRtl } : {}),
+    ...(normalizedDirection ? { direction: normalizedDirection } : {}),
   };
 
   if (normalizedNumberingProperties && normalizedListRendering) {

--- a/packages/layout-engine/pm-adapter/src/converter-context.ts
+++ b/packages/layout-engine/pm-adapter/src/converter-context.ts
@@ -20,6 +20,7 @@ export type TableStyleParagraphProps = {
 };
 
 export type ConverterContext = {
+  sectionDirection?: 'ltr' | 'rtl';
   docx?: Record<string, unknown>;
   translatedNumbering: NumberingProperties;
   translatedLinkedStyles: StylesDocumentProperties;

--- a/packages/layout-engine/pm-adapter/src/converters/paragraph.test.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/paragraph.test.ts
@@ -3004,6 +3004,61 @@ describe('paragraph converters', () => {
         expect(context.blocks).toHaveLength(1);
         expect(getMarkerText(context.blocks[0])).toBe('二.');
       });
+
+      it('updates converterContext.sectionDirection when crossing to next section', () => {
+        const trackedChanges: TrackedChangesConfig = {
+          mode: 'review',
+          enabled: true,
+        };
+        const context = createParagraphHandlerContext(trackedChanges);
+        context.converterContext.sectionDirection = 'rtl';
+        context.sectionState = {
+          ranges: [
+            {
+              sectionIndex: 0,
+              startParagraphIndex: 0,
+              endParagraphIndex: 0,
+              sectPr: null,
+              margins: null,
+              pageSize: null,
+              orientation: null,
+              columns: null,
+              type: 'nextPage',
+              titlePg: false,
+            },
+            {
+              sectionIndex: 1,
+              startParagraphIndex: 0,
+              endParagraphIndex: 1,
+              sectPr: {
+                type: 'element',
+                name: 'w:sectPr',
+                elements: [{ type: 'element', name: 'w:bidi', attributes: { 'w:val': '0' } }],
+              },
+              margins: null,
+              pageSize: null,
+              orientation: null,
+              columns: null,
+              type: 'nextPage',
+              titlePg: false,
+            },
+          ] as any,
+          currentSectionIndex: 0,
+          currentParagraphIndex: 0,
+        };
+
+        handleParagraphNode(
+          {
+            type: 'paragraph',
+            attrs: { paragraphProperties: {} },
+            content: [{ type: 'text', text: 'section switch paragraph' }],
+          } as PMNode,
+          context,
+        );
+
+        expect(context.sectionState.currentSectionIndex).toBe(1);
+        expect(context.converterContext.sectionDirection).toBe('ltr');
+      });
     });
 
     describe('Run merging', () => {

--- a/packages/layout-engine/pm-adapter/src/converters/paragraph.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/paragraph.ts
@@ -76,6 +76,17 @@ import {
 import { chartNodeToDrawingBlock } from './chart.js';
 import { tableNodeToBlock } from './table.js';
 
+function resolveSectionDirectionFromSectPr(sectPr: unknown): 'ltr' | 'rtl' | undefined {
+  if (!sectPr || typeof sectPr !== 'object') return undefined;
+  const elements = (sectPr as { elements?: Array<{ name?: string; attributes?: Record<string, unknown> }> }).elements;
+  if (!Array.isArray(elements)) return undefined;
+  const bidi = elements.find((element) => element?.name === 'w:bidi');
+  if (!bidi) return undefined;
+  const val = bidi.attributes?.['w:val'] ?? bidi.attributes?.val;
+  if (val === '0' || val === 0 || val === false || val === 'false' || val === 'off') return 'ltr';
+  return 'rtl';
+}
+
 function sourceAnchorFromNode(node: PMNode): SourceAnchor | undefined {
   const sourceAnchor = (node.attrs as Record<string, unknown> | undefined)?.sourceAnchor;
   return sourceAnchor && typeof sourceAnchor === 'object' && !Array.isArray(sourceAnchor)
@@ -1081,6 +1092,7 @@ export function handleParagraphNode(node: PMNode, context: NodeHandlerContext): 
       blocks.push(sectionBreak);
       recordBlockKind?.(sectionBreak.kind);
       sectionState!.currentSectionIndex++;
+      converterContext.sectionDirection = resolveSectionDirectionFromSectPr(nextSection.sectPr);
     }
   }
 

--- a/packages/layout-engine/pm-adapter/src/index.test.ts
+++ b/packages/layout-engine/pm-adapter/src/index.test.ts
@@ -3189,7 +3189,6 @@ describe('toFlowBlocks', () => {
       const paragraph = blocks[0];
       expect(paragraph.kind).toBe('paragraph');
       expect(paragraph.attrs?.direction).toBe('rtl');
-      expect(paragraph.attrs?.rtl).toBe(true);
       expect(paragraph.attrs?.indent?.left).toBe(24);
       expect(paragraph.attrs?.indent?.right).toBe(12);
     });
@@ -3216,7 +3215,62 @@ describe('toFlowBlocks', () => {
       const paragraph = blocks[0];
       expect(paragraph.kind).toBe('paragraph');
       expect(paragraph.attrs?.direction).toBe('ltr');
-      expect(paragraph.attrs?.rtl).toBe(false);
+    });
+
+    it('inherits paragraph direction from body sectPr w:bidi when paragraph direction is missing', () => {
+      const pmDoc = {
+        type: 'doc',
+        attrs: {
+          bodySectPr: {
+            type: 'element',
+            name: 'w:sectPr',
+            elements: [{ type: 'element', name: 'w:bidi', attributes: {} }],
+          },
+        },
+        content: [
+          {
+            type: 'paragraph',
+            attrs: {
+              paragraphProperties: {},
+            },
+            content: [{ type: 'text', text: 'Section inherited RTL' }],
+          },
+        ],
+      };
+
+      const { blocks } = toFlowBlocks(pmDoc);
+      expect(blocks).toHaveLength(1);
+      const paragraph = blocks[0];
+      expect(paragraph.kind).toBe('paragraph');
+      expect(paragraph.attrs?.direction).toBe('rtl');
+    });
+
+    it('does not inherit RTL direction when body sectPr w:bidi is explicitly false', () => {
+      const pmDoc = {
+        type: 'doc',
+        attrs: {
+          bodySectPr: {
+            type: 'element',
+            name: 'w:sectPr',
+            elements: [{ type: 'element', name: 'w:bidi', attributes: { 'w:val': '0' } }],
+          },
+        },
+        content: [
+          {
+            type: 'paragraph',
+            attrs: {
+              paragraphProperties: {},
+            },
+            content: [{ type: 'text', text: 'Section inherited LTR' }],
+          },
+        ],
+      };
+
+      const { blocks } = toFlowBlocks(pmDoc);
+      expect(blocks).toHaveLength(1);
+      const paragraph = blocks[0];
+      expect(paragraph.kind).toBe('paragraph');
+      expect(paragraph.attrs?.direction).toBe('ltr');
     });
 
     it('handles multiple page breaks', () => {
@@ -4562,7 +4616,6 @@ describe('toFlowBlocks', () => {
 
       expect(blocks).toHaveLength(1);
       expect(blocks[0].attrs?.direction).toBe('rtl');
-      expect(blocks[0].attrs?.rtl).toBe(true);
       expect(blocks[0].attrs?.alignment).toBeUndefined();
     });
 
@@ -4592,7 +4645,6 @@ describe('toFlowBlocks', () => {
 
       expect(blocks).toHaveLength(1);
       expect(blocks[0].attrs?.direction).toBe('rtl');
-      expect(blocks[0].attrs?.rtl).toBe(true);
       expect(blocks[0].attrs).toMatchObject({
         alignment: 'center',
       });
@@ -4625,7 +4677,6 @@ describe('toFlowBlocks', () => {
 
       expect(blocks).toHaveLength(1);
       expect(blocks[0].attrs?.direction).toBe('rtl');
-      expect(blocks[0].attrs?.rtl).toBe(true);
       expect(blocks[0].attrs).toMatchObject({
         alignment: 'left',
       });

--- a/packages/layout-engine/pm-adapter/src/internal.ts
+++ b/packages/layout-engine/pm-adapter/src/internal.ts
@@ -65,6 +65,17 @@ import type {
 const DEFAULT_FONT = 'Times New Roman';
 const DEFAULT_SIZE = 10 / 0.75; // 10pt in pixels
 
+function resolveSectionDirectionFromSectPr(sectPr: unknown): 'ltr' | 'rtl' | undefined {
+  if (!sectPr || typeof sectPr !== 'object') return undefined;
+  const elements = (sectPr as { elements?: Array<{ name?: string; attributes?: Record<string, unknown> }> }).elements;
+  if (!Array.isArray(elements)) return undefined;
+  const bidi = elements.find((element) => element?.name === 'w:bidi');
+  if (!bidi) return undefined;
+  const val = bidi.attributes?.['w:val'] ?? bidi.attributes?.val;
+  if (val === '0' || val === 0 || val === false || val === 'false' || val === 'off') return 'ltr';
+  return 'rtl';
+}
+
 /**
  * Dispatch map for node type handlers.
  * Maps node type names to their corresponding handler functions.
@@ -181,6 +192,8 @@ export function toFlowBlocks(pmDoc: PMNode | object, options?: AdapterOptions): 
 
   // Range-aware section analysis (matches toFlowBlocks semantics)
   const bodySectionProps = doc.attrs?.bodySectPr ?? doc.attrs?.sectPr;
+  converterContext.sectionDirection =
+    converterContext.sectionDirection ?? resolveSectionDirectionFromSectPr(bodySectionProps);
   const sectionRanges = options?.emitSectionBreaks ? analyzeSectionRanges(doc, bodySectionProps) : [];
   publishSectionMetadata(sectionRanges, options);
 

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/selection/CaretGeometry.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/selection/CaretGeometry.ts
@@ -196,7 +196,9 @@ export function computeCaretLayoutRectGeometry(
 
   const availableWidth = Math.max(0, fragment.width - (indentAdjust + indent.right));
   const charX = measureCharacterX(block, line, pmOffset, availableWidth);
-  const localX = fragment.x + indentAdjust + charX;
+  const isRtlParagraph = block.attrs?.direction === 'rtl';
+  const resolvedCharX = isRtlParagraph ? Math.max(0, availableWidth - charX) : charX;
+  const localX = fragment.x + indentAdjust + resolvedCharX;
   const lineOffset = lineHeightBeforeIndex(measure.lines, fragment.fromLine, index);
   const localY = fragment.y + lineOffset;
 

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/CaretGeometry.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/CaretGeometry.test.ts
@@ -434,5 +434,144 @@ describe('CaretGeometry', () => {
       expect(result).not.toBe(null);
       expect(result?.pageIndex).toBe(0);
     });
+
+    it('places caret at right edge for RTL paragraph start boundary', () => {
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'rtl-para',
+        runs: [{ text: 'אבגדה', fontFamily: 'Arial', fontSize: 14, pmStart: 1, pmEnd: 6 }],
+        attrs: { direction: 'rtl' },
+      };
+      const line: Line = {
+        fromRun: 0,
+        toRun: 0,
+        fromChar: 0,
+        toChar: 5,
+        width: 100,
+        ascent: 12,
+        descent: 4,
+        lineHeight: 16,
+      };
+      const measure = createMockParagraphMeasure([line]);
+      const fragment = createMockParaFragment('rtl-para', 10, 10, 200, 16, 0, 1, 1, 6);
+      const layout = createMockLayout(fragment);
+
+      const deps: ComputeCaretLayoutRectGeometryDeps = {
+        layout,
+        blocks: [block],
+        measures: [measure],
+        painterHost: null,
+        viewportHost: mockDom.viewportHost,
+        visibleHost: mockDom.visibleHost,
+        zoom: 1,
+      };
+
+      const result = computeCaretLayoutRectGeometry(deps, 1, false);
+      expect(result).not.toBe(null);
+      expect(result?.x).toBeCloseTo(210, 3);
+    });
+
+    it('keeps caret on right side for RTL empty paragraph boundary fallback', () => {
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'rtl-empty',
+        runs: [{ text: '', fontFamily: 'Arial', fontSize: 14, pmStart: 1, pmEnd: 1 }],
+        attrs: { direction: 'rtl' },
+      };
+      const line: Line = {
+        fromRun: 0,
+        toRun: 0,
+        fromChar: 0,
+        toChar: 0,
+        width: 0,
+        ascent: 12,
+        descent: 4,
+        lineHeight: 16,
+      };
+      const measure = createMockParagraphMeasure([line]);
+      const fragment = createMockParaFragment('rtl-empty', 10, 10, 200, 16, 0, 1, 1, 1);
+      const layout = createMockLayout(fragment);
+
+      const deps: ComputeCaretLayoutRectGeometryDeps = {
+        layout,
+        blocks: [block],
+        measures: [measure],
+        painterHost: null,
+        viewportHost: mockDom.viewportHost,
+        visibleHost: mockDom.visibleHost,
+        zoom: 1,
+      };
+
+      const result = computeCaretLayoutRectGeometry(deps, 1, false);
+      expect(result).not.toBe(null);
+      expect(result?.x).toBeCloseTo(210, 3);
+    });
+
+    it('places caret at visual left for RTL line end boundary', () => {
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'rtl-line-end',
+        runs: [{ text: 'אבגדה', fontFamily: 'Arial', fontSize: 14, pmStart: 1, pmEnd: 6 }],
+        attrs: { direction: 'rtl' },
+      };
+      const line: Line = {
+        fromRun: 0,
+        toRun: 0,
+        fromChar: 0,
+        toChar: 5,
+        width: 100,
+        ascent: 12,
+        descent: 4,
+        lineHeight: 16,
+      };
+      const measure = createMockParagraphMeasure([line]);
+      const fragment = createMockParaFragment('rtl-line-end', 10, 10, 200, 16, 0, 1, 1, 6);
+      const layout = createMockLayout(fragment);
+
+      const deps: ComputeCaretLayoutRectGeometryDeps = {
+        layout,
+        blocks: [block],
+        measures: [measure],
+        painterHost: null,
+        viewportHost: mockDom.viewportHost,
+        visibleHost: mockDom.visibleHost,
+        zoom: 1,
+      };
+
+      const result = computeCaretLayoutRectGeometry(deps, 6, false);
+      expect(result).not.toBe(null);
+      expect(result?.x).toBeCloseTo(110, 3);
+    });
+
+    it('computes decreasing X across mid-line positions for RTL paragraphs without DOM fallback', () => {
+      const block: FlowBlock = {
+        ...createMockParagraphBlock('rtl-midline', 1, 12),
+        attrs: { direction: 'rtl' },
+      };
+      const line = createMockLine(1, 12, 16);
+      const measure = createMockParagraphMeasure([line]);
+      const fragment = createMockParaFragment('rtl-midline', 10, 10, 200, 16, 0, 1, 1, 12);
+      const layout = createMockLayout(fragment);
+
+      const deps: ComputeCaretLayoutRectGeometryDeps = {
+        layout,
+        blocks: [block],
+        measures: [measure],
+        painterHost: null,
+        viewportHost: mockDom.viewportHost,
+        visibleHost: mockDom.visibleHost,
+        zoom: 1,
+      };
+
+      const start = computeCaretLayoutRectGeometry(deps, 1, false);
+      const middle = computeCaretLayoutRectGeometry(deps, 6, false);
+      const end = computeCaretLayoutRectGeometry(deps, 11, false);
+
+      expect(start).not.toBeNull();
+      expect(middle).not.toBeNull();
+      expect(end).not.toBeNull();
+      expect(start!.x).toBeGreaterThan(middle!.x);
+      expect(middle!.x).toBeGreaterThan(end!.x);
+    });
   });
 });

--- a/packages/super-editor/src/editors/v1/extensions/vertical-navigation/vertical-navigation.js
+++ b/packages/super-editor/src/editors/v1/extensions/vertical-navigation/vertical-navigation.js
@@ -83,9 +83,19 @@ export const VerticalNavigation = Extension.create({
         handleKeyDown(view, event) {
           // Guard clauses
           if (view.composing || !editor.isEditable) return false;
-          if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End') {
+          if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
             view.dispatch(view.state.tr.setMeta(VerticalNavigationPluginKey, { type: 'reset-goal-x' }));
             return false;
+          }
+          if (event.key === 'Home' || event.key === 'End') {
+            view.dispatch(view.state.tr.setMeta(VerticalNavigationPluginKey, { type: 'reset-goal-x' }));
+            if (!isPresenting(editor)) return false;
+            const targetPos = resolveLineBoundaryPosition(editor, view.state.selection, event.key);
+            if (!Number.isFinite(targetPos)) return false;
+            const selection = buildSelection(view.state, targetPos, event.shiftKey);
+            if (!selection) return false;
+            view.dispatch(view.state.tr.setSelection(selection));
+            return true;
           }
           if (event.key === 'PageUp' || event.key === 'PageDown') {
             view.dispatch(view.state.tr.setMeta(VerticalNavigationPluginKey, { type: 'reset-goal-x' }));
@@ -232,6 +242,29 @@ function getCurrentCoords(editor, selection) {
     x: layoutSpaceCoords.x,
     y: layoutSpaceCoords.y,
   };
+}
+
+/**
+ * Resolves the PM boundary position for Home/End within the current visual line.
+ *
+ * @param {Object} editor
+ * @param {import('prosemirror-state').Selection} selection
+ * @param {'Home'|'End'} key
+ * @returns {number | null}
+ */
+function resolveLineBoundaryPosition(editor, selection, key) {
+  const coords = getCurrentCoords(editor, selection);
+  if (!coords) return null;
+  const doc = editor.presentationEditor?.visibleHost?.ownerDocument ?? document;
+  const caretX = coords.clientX;
+  const caretY = coords.clientY + coords.height / 2;
+  const lineEl = findLineElementAtPoint(doc, caretX, caretY);
+  if (!lineEl) return null;
+
+  const pmStart = Number(lineEl.dataset?.pmStart);
+  const pmEnd = Number(lineEl.dataset?.pmEnd);
+  if (!Number.isFinite(pmStart) || !Number.isFinite(pmEnd)) return null;
+  return key === 'Home' ? pmStart : pmEnd;
 }
 
 /**

--- a/packages/super-editor/src/editors/v1/extensions/vertical-navigation/vertical-navigation.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/vertical-navigation/vertical-navigation.test.js
@@ -151,6 +151,64 @@ afterEach(() => {
 });
 
 describe('VerticalNavigation', () => {
+  it('handles Home within current visual line using line pmStart', () => {
+    const { line1 } = createDomStructure();
+    line1.dataset.pmStart = '10';
+    line1.dataset.pmEnd = '20';
+    document.elementsFromPoint = vi.fn(() => [line1]);
+
+    const { plugin, view } = createEnvironment();
+    const handled = plugin.props.handleKeyDown(view, { key: 'Home', shiftKey: false });
+
+    expect(handled).toBe(true);
+    expect(view.state.selection.from).toBe(10);
+    expect(view.state.selection.to).toBe(10);
+  });
+
+  it('handles End with Shift within current visual line using line pmEnd', () => {
+    const { line1 } = createDomStructure();
+    line1.dataset.pmStart = '10';
+    line1.dataset.pmEnd = '20';
+    document.elementsFromPoint = vi.fn(() => [line1]);
+
+    const { plugin, view } = createEnvironment();
+    const handled = plugin.props.handleKeyDown(view, { key: 'End', shiftKey: true });
+
+    expect(handled).toBe(true);
+    expect(view.state.selection.from).toBe(1);
+    expect(view.state.selection.to).toBe(20);
+  });
+
+  it('maps Home to pmStart for RTL visual line', () => {
+    const { line1 } = createDomStructure();
+    line1.dataset.pmStart = '30';
+    line1.dataset.pmEnd = '40';
+    line1.setAttribute('dir', 'rtl');
+    document.elementsFromPoint = vi.fn(() => [line1]);
+
+    const { plugin, view } = createEnvironment();
+    const handled = plugin.props.handleKeyDown(view, { key: 'Home', shiftKey: false });
+
+    expect(handled).toBe(true);
+    expect(view.state.selection.from).toBe(30);
+    expect(view.state.selection.to).toBe(30);
+  });
+
+  it('maps End to pmEnd for RTL visual line', () => {
+    const { line1 } = createDomStructure();
+    line1.dataset.pmStart = '30';
+    line1.dataset.pmEnd = '40';
+    line1.setAttribute('dir', 'rtl');
+    document.elementsFromPoint = vi.fn(() => [line1]);
+
+    const { plugin, view } = createEnvironment();
+    const handled = plugin.props.handleKeyDown(view, { key: 'End', shiftKey: false });
+
+    expect(handled).toBe(true);
+    expect(view.state.selection.from).toBe(40);
+    expect(view.state.selection.to).toBe(40);
+  });
+
   it('returns false when editor is not presenting', () => {
     const { plugin, view } = createEnvironment({ presenting: false });
 

--- a/tests/behavior/tests/endnotes/double-click-edit-endnote.spec.ts
+++ b/tests/behavior/tests/endnotes/double-click-edit-endnote.spec.ts
@@ -4,6 +4,7 @@ import {
   activateNote,
   expectActiveStoryTextToContain,
   getBodyStoryText,
+  moveActiveStoryCursorToEnd,
   waitForActiveStory,
 } from '../../helpers/story-surfaces.js';
 
@@ -36,9 +37,11 @@ test('double-click rendered endnote to edit it through the presentation surface'
     noteId: '1',
   });
 
-  await superdoc.page.keyboard.press('End');
+  // Stabilize caret in the active note editor before typing.
+  await moveActiveStoryCursorToEnd(superdoc.page);
   await superdoc.page.keyboard.insertText(' edited');
   await superdoc.waitForStable();
+  await expectActiveStoryTextToContain(superdoc.page, 'simple endnote edited');
   await expect(endnote).toContainText('This is a simple endnote edited');
 
   await superdoc.page.keyboard.press('Backspace');

--- a/tests/behavior/tests/selection/rtl-arrow-key-movement.spec.ts
+++ b/tests/behavior/tests/selection/rtl-arrow-key-movement.spec.ts
@@ -115,4 +115,184 @@ test.describe('RTL arrow key cursor movement (SD-2390)', () => {
     expect(xAfter).toBeGreaterThan(xBefore);
     expect(after.from).toBeGreaterThan(before.from);
   });
+
+  test('Shift+ArrowLeft expands selection visually left in RTL paragraph', async ({ superdoc }) => {
+    await superdoc.loadDocument(DOC_PATH);
+    await superdoc.waitForStable();
+
+    const rtlLine = superdoc.page.locator('.superdoc-line').first();
+    const box = await rtlLine.boundingBox();
+    if (!box) throw new Error('RTL line not visible');
+
+    await superdoc.page.mouse.click(box.x + box.width - 20, box.y + box.height / 2);
+    await superdoc.waitForStable();
+
+    const before = await superdoc.getSelection();
+
+    await superdoc.page.keyboard.down('Shift');
+    await superdoc.page.keyboard.press('ArrowLeft');
+    await superdoc.page.keyboard.up('Shift');
+    await superdoc.waitForStable();
+
+    const after = await superdoc.getSelection();
+    expect(after.to - after.from).toBeGreaterThan(0);
+  });
+
+  test('Shift+ArrowRight expands selection visually right in RTL paragraph', async ({ superdoc }) => {
+    await superdoc.loadDocument(DOC_PATH);
+    await superdoc.waitForStable();
+
+    const rtlLine = superdoc.page.locator('.superdoc-line').first();
+    const box = await rtlLine.boundingBox();
+    if (!box) throw new Error('RTL line not visible');
+
+    await superdoc.page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await superdoc.waitForStable();
+
+    const before = await superdoc.getSelection();
+
+    await superdoc.page.keyboard.down('Shift');
+    await superdoc.page.keyboard.press('ArrowRight');
+    await superdoc.page.keyboard.up('Shift');
+    await superdoc.waitForStable();
+
+    const after = await superdoc.getSelection();
+    expect(after.to - after.from).toBeGreaterThan(0);
+  });
+
+  test('Home moves caret to visual start (right edge) of RTL line', async ({ superdoc }) => {
+    await superdoc.loadDocument(DOC_PATH);
+    await superdoc.waitForStable();
+
+    const rtlLine = superdoc.page.locator('.superdoc-line').first();
+    const box = await rtlLine.boundingBox();
+    if (!box) throw new Error('RTL line not visible');
+
+    // Click near line middle to avoid already being at boundary.
+    await superdoc.page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await superdoc.waitForStable();
+
+    const before = await superdoc.getSelection();
+    const xBefore = await superdoc.page.evaluate((pos) => {
+      const pe = (window as any).superdoc?.activeEditor?.presentationEditor;
+      return pe?.computeCaretLayoutRect(pos)?.x;
+    }, before.from);
+
+    await superdoc.page.keyboard.press('Home');
+    await superdoc.waitForStable();
+
+    const after = await superdoc.getSelection();
+    const xAfter = await superdoc.page.evaluate((pos) => {
+      const pe = (window as any).superdoc?.activeEditor?.presentationEditor;
+      return pe?.computeCaretLayoutRect(pos)?.x;
+    }, after.from);
+
+    expect(after.from).not.toBe(before.from);
+    expect(xAfter).toBeGreaterThan(xBefore);
+  });
+
+  test('End moves caret to visual end (left edge) of RTL line', async ({ superdoc }) => {
+    await superdoc.loadDocument(DOC_PATH);
+    await superdoc.waitForStable();
+
+    const rtlLine = superdoc.page.locator('.superdoc-line').first();
+    const box = await rtlLine.boundingBox();
+    if (!box) throw new Error('RTL line not visible');
+
+    // Click near line middle first, then force known start state via Home.
+    await superdoc.page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await superdoc.waitForStable();
+
+    await superdoc.page.keyboard.press('Home');
+    await superdoc.waitForStable();
+
+    const beforeHome = await superdoc.getSelection();
+    const xBeforeHome = await superdoc.page.evaluate((pos) => {
+      const pe = (window as any).superdoc?.activeEditor?.presentationEditor;
+      return pe?.computeCaretLayoutRect(pos)?.x;
+    }, beforeHome.from);
+
+    await superdoc.page.keyboard.press('End');
+    await superdoc.waitForStable();
+
+    const after = await superdoc.getSelection();
+    const xAfter = await superdoc.page.evaluate((pos) => {
+      const pe = (window as any).superdoc?.activeEditor?.presentationEditor;
+      return pe?.computeCaretLayoutRect(pos)?.x;
+    }, after.from);
+
+    expect(xAfter).toBeLessThanOrEqual(xBeforeHome);
+
+    await superdoc.page.keyboard.press('End');
+    await superdoc.waitForStable();
+
+    const afterSecondEnd = await superdoc.getSelection();
+    const xAfterSecondEnd = await superdoc.page.evaluate((pos) => {
+      const pe = (window as any).superdoc?.activeEditor?.presentationEditor;
+      return pe?.computeCaretLayoutRect(pos)?.x;
+    }, afterSecondEnd.from);
+
+    // Boundary behavior can differ by 1 PM position across engines; keep a visual invariant:
+    // repeated End should not move caret to the visual right.
+    expect(xAfterSecondEnd).toBeLessThanOrEqual(xAfter + 0.5);
+  });
+
+  test('Mod+A selects full document with RTL content', async ({ superdoc }) => {
+    await superdoc.loadDocument(DOC_PATH);
+    await superdoc.waitForStable();
+
+    const firstLine = superdoc.page.locator('.superdoc-line').first();
+    const firstLineBox = await firstLine.boundingBox();
+    if (!firstLineBox) throw new Error('First line not visible');
+    await superdoc.page.mouse.click(firstLineBox.x + 20, firstLineBox.y + firstLineBox.height / 2);
+    await superdoc.waitForStable();
+
+    const selectAllShortcut = process.platform === 'darwin' ? 'Meta+A' : 'Control+A';
+    await superdoc.page.keyboard.press(selectAllShortcut);
+    await superdoc.waitForStable();
+
+    const stateSelection = await superdoc.page.evaluate(() => {
+      const state = (window as any).superdoc?.activeEditor?.state;
+      if (!state?.selection) return null;
+      return {
+        from: state.selection.from,
+        to: state.selection.to,
+        min: 0,
+        max: state.doc.content.size,
+      };
+    });
+
+    expect(stateSelection).not.toBeNull();
+    expect(
+      (stateSelection as { to: number; from: number }).to - (stateSelection as { to: number; from: number }).from,
+    ).toBeGreaterThan(0);
+    expect((stateSelection as { min: number; from: number }).from).toBe(
+      (stateSelection as { min: number; from: number }).min,
+    );
+    expect((stateSelection as { max: number; to: number }).to).toBe(
+      (stateSelection as { max: number; to: number }).max,
+    );
+  });
+
+  test('Typing in a new empty paragraph created from RTL line keeps RTL direction', async ({ superdoc }) => {
+    await superdoc.loadDocument(DOC_PATH);
+    await superdoc.waitForStable();
+
+    const rtlLine = superdoc.page.locator('.superdoc-line').first();
+    const rtlEnd = Number(await rtlLine.getAttribute('data-pm-end'));
+    if (!Number.isFinite(rtlEnd)) throw new Error('RTL line end is not available');
+
+    await superdoc.setTextSelection(rtlEnd, rtlEnd);
+    await superdoc.page.keyboard.press('Enter');
+    await superdoc.waitForStable();
+
+    await superdoc.page.keyboard.insertText('ا');
+    await superdoc.waitForStable();
+
+    const insertedLine = superdoc.page.locator('.superdoc-line').nth(1);
+    await expect(insertedLine).toContainText('ا');
+
+    const direction = await insertedLine.evaluate((el) => getComputedStyle(el).direction);
+    expect(direction).toBe('rtl');
+  });
 });


### PR DESCRIPTION
Linear: SD-2808

1. Completed Phase 2 RTL body interaction scope.
2. Removed legacy paragraph `rtl` usage from the layout path and standardized on `direction` as the single source of truth.
3. Added section-direction fallback handling and hardened section bidi parsing (`w:val` and `val` support).
4. Fixed RTL caret geometry issues:
   1. boundary fallback behavior in `CaretGeometry`
   2. mid-line RTL caret X calculation (not only offset `0`)
5. Implemented visual-line `Home/End` handling in vertical navigation and stabilized related behavior tests.
6. Fixed RTL/LTR style transition in DomPainter by clearing stale `dir`/`direction` when returning to LTR.
7. Improved run-based direction inference to majority-based logic with deterministic tie-breaker.
8. Expanded/stabilized RTL behavior coverage for:
   1. ArrowLeft/ArrowRight
   2. Shift+ArrowLeft/Shift+ArrowRight
   3. Home/End
   4. Select All in RTL document
   5. typing in a newly created empty RTL paragraph
   
Note:
- For RTL validation, Hebrew should be used as the primary test language; mixed-direction behavior will be tested/fixed separately.