### PR TITLE
fix: invalid css (SD-2930)

### DIFF
--- a/packages/super-editor/src/editors/v1/assets/styles/helpers/isolation.css
+++ b/packages/super-editor/src/editors/v1/assets/styles/helpers/isolation.css
@@ -5,8 +5,8 @@
  */
 .sd-editor-scoped,
 .sd-editor-scoped :where(*:not(svg):not(svg *):not(.annotation):not([data-drag-handle])),
-.sd-editor-scoped :where(*:not(svg):not(svg *)::before),
-.sd-editor-scoped :where(*:not(svg):not(svg *)::after) {
+.sd-editor-scoped :where(*:not(svg):not(svg *))::before,
+.sd-editor-scoped :where(*:not(svg):not(svg *))::after {
   all: revert;
   box-sizing: border-box;
 }


### PR DESCRIPTION
Backport of #3115 to stable. The published `style.css` contains spec-invalid `:where(*:not(svg):not(svg *)::before)` selectors. Pseudo-elements aren't valid inside `:where()`, so when consumer bundlers run the CSS through Lightning CSS, the minifier strips them and emits empty `:where()` blocks that fail sass-loader.

Moves `::before`/`::after` outside `:where()` to produce valid, minifiable CSS. One-line behavioral note: the original selector silently never matched anything in any browser (spec-invalid), so the isolation reset now actually applies to pseudo-elements for the first time. That's the original intent.

**Verified**: lightningcss-cli on the source before the fix → two empty `:where()` selectors; after the fix → valid `:where(...)::before` / `::after` output.