### PR TITLE
fix(template-builder): bump superdoc peer dep floor to 1.31.1 (IT-1002)

### DIFF
--- a/packages/template-builder/package.json
+++ b/packages/template-builder/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "superdoc": "^1.28.0"
+    "superdoc": "^1.31.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "catalog:",


### PR DESCRIPTION
Raises the template-builder peer dep floor for `superdoc` from `^1.28.0` to `^1.31.1`. Versions 1.28.0 through 1.31.0 ship spec-invalid `:where()` selectors that get minified into empty `:where()` blocks and fail sass-loader builds (SD-2930). 1.31.1 contains the fix.

Don't merge until SD-2930 ships as `superdoc@1.31.1` from #3121. After that, this just stops consumers from accidentally pinning to a broken range.