### PR TITLE
fix(template-builder): bump superdoc peer dep floor to 1.31.1 (IT-1002)

### DIFF
--- a/packages/template-builder/package.json
+++ b/packages/template-builder/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "superdoc": "^1.28.0"
+    "superdoc": "^1.31.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "catalog:",


### PR DESCRIPTION
Backport of #3122 to stable. Raises template-builder's `superdoc` peer dep floor from `^1.28.0` to `^1.31.1` so consumers can't land on broken 1.28-1.31.0 (SD-2930).

Sequencing: merge after #3121 publishes `superdoc@1.31.1`.