### PR TITLE
ci(sync-patches): guard conflict-resolution path against empty commits

### DIFF
--- a/.github/workflows/sync-patches.yml
+++ b/.github/workflows/sync-patches.yml
@@ -93,6 +93,13 @@ jobs:
 
             # Check if all conflicts are resolved
             if [ -z "$(git diff --name-only --diff-filter=U)" ]; then
+              # If every conflict was auto-resolved to main's version, the index
+              # may now be clean (nothing to sync). Same guard as the no-conflict path.
+              if git diff --cached --quiet; then
+                echo "No changes to sync - auto-resolution kept main's version for everything."
+                exit 0
+              fi
+
               git commit -m "chore: merge stable into main (release conflicts auto-resolved)"
               git push origin "$SYNC_BRANCH"
 


### PR DESCRIPTION
The sync-patches workflow has two paths for merging stable into main: a clean-merge path and a conflict-resolution path. Both eventually call `git commit`. The clean-merge path checks `git diff --cached --quiet` first and exits early if nothing is staged, but the conflict-resolution path doesn't.

That gap surfaced after PR #3123 merged: the only conflicts were release-managed files (package.json versions, etc.), all auto-resolved to main's version, leaving the index clean. The bare `git commit` then exited 1 and the run went red, even though stable and main were correctly in sync (run https://github.com/superdoc-dev/superdoc/actions/runs/25338598551).

This adds the same early-exit guard to the conflict-resolution path. No behavior change when there's actually content to sync.