### PR TITLE
fix(types): relocate D1 layout declarations (SD-2893)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -101,7 +101,8 @@ import { resolveStoryRuntime } from '../../document-api-adapters/story-runtime/r
 import { BODY_STORY_KEY, buildStoryKey, parseStoryKey } from '../../document-api-adapters/story-runtime/story-key.js';
 import { createStoryEditor } from '../story-editor-factory.js';
 import { buildEndnoteBlocks } from './layout/EndnotesBuilder.js';
-import { toFlowBlocks, ConverterContext, FlowBlockCache } from '@superdoc/pm-adapter';
+import { toFlowBlocks, FlowBlockCache } from '@superdoc/pm-adapter';
+import type { ConverterContext } from '@superdoc/pm-adapter/converter-context.js';
 import { readSettingsRoot, readDefaultTableStyle } from '../../document-api-adapters/document-settings.js';
 import {
   incrementalLayout,

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/layout/EndnotesBuilder.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/layout/EndnotesBuilder.ts
@@ -1,6 +1,7 @@
 import type { EditorState } from 'prosemirror-state';
 import type { FlowBlock, Run as LayoutRun, TextRun } from '@superdoc/contracts';
-import { toFlowBlocks, type ConverterContext } from '@superdoc/pm-adapter';
+import { toFlowBlocks } from '@superdoc/pm-adapter';
+import type { ConverterContext } from '@superdoc/pm-adapter/converter-context.js';
 import { SUBSCRIPT_SUPERSCRIPT_SCALE } from '@superdoc/pm-adapter/constants.js';
 
 import type { ProseMirrorJSON } from '../../types/EditorTypes.js';

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/layout/FootnotesBuilder.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/layout/FootnotesBuilder.ts
@@ -20,7 +20,8 @@
 
 import type { EditorState } from 'prosemirror-state';
 import type { FlowBlock } from '@superdoc/contracts';
-import { toFlowBlocks, type ConverterContext } from '@superdoc/pm-adapter';
+import { toFlowBlocks } from '@superdoc/pm-adapter';
+import type { ConverterContext } from '@superdoc/pm-adapter/converter-context.js';
 import { SUBSCRIPT_SUPERSCRIPT_SCALE } from '@superdoc/pm-adapter/constants.js';
 
 import type { ProseMirrorJSON } from '../../types/EditorTypes.js';

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/FootnotesBuilder.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/FootnotesBuilder.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { EditorState } from 'prosemirror-state';
 import { buildFootnotesInput, type ConverterLike } from '../layout/FootnotesBuilder.js';
-import type { ConverterContext } from '@superdoc/pm-adapter';
+import type { ConverterContext } from '@superdoc/pm-adapter/converter-context.js';
 import { SUBSCRIPT_SUPERSCRIPT_SCALE } from '@superdoc/pm-adapter/constants.js';
 import { toFlowBlocks } from '@superdoc/pm-adapter';
 

--- a/packages/superdoc/scripts/audit-declarations.cjs
+++ b/packages/superdoc/scripts/audit-declarations.cjs
@@ -66,8 +66,10 @@ if (!fs.existsSync(distRoot)) {
 const RELOCATED_PACKAGES = [
   '@superdoc/document-api',
   '@superdoc/contracts',
+  '@superdoc/dom-contract',
   '@superdoc/layout-bridge',
   '@superdoc/painter-dom',
+  '@superdoc/pm-adapter',
 ];
 
 // Specifiers that may appear as bare imports in published d.ts files even

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -205,6 +205,15 @@ function rewriteDocApiPaths(fileContent, filePath) {
 // their declarations into superdoc's dist (via vite-plugin-dts include)
 // and redirect bare specifiers in emitted .d.ts files to relative
 // paths the consumer can resolve.
+//
+// SD-2893 note for pm-adapter: only specific type subpaths are
+// relocated (see vite.config.js include list). A bare `@superdoc/pm-adapter`
+// specifier would rewrite to a relative path that does not exist in dist.
+// The audit gate (RELOCATED_PACKAGES in audit-declarations.cjs) rejects
+// any unrewritten bare specifier at build time, so this is a build-time
+// failure rather than a silent consumer break. If a future public type
+// genuinely needs the pm-adapter barrel, widen the vite include and the
+// shim drain in lockstep.
 const RELOCATION_RULES = [
   { pkg: '@superdoc/contracts',     distEntry: 'layout-engine/contracts/src/index.d.ts' },
   { pkg: '@superdoc/dom-contract',  distEntry: 'layout-engine/dom-contract/src/index.d.ts' },

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -207,8 +207,10 @@ function rewriteDocApiPaths(fileContent, filePath) {
 // paths the consumer can resolve.
 const RELOCATION_RULES = [
   { pkg: '@superdoc/contracts',     distEntry: 'layout-engine/contracts/src/index.d.ts' },
+  { pkg: '@superdoc/dom-contract',  distEntry: 'layout-engine/dom-contract/src/index.d.ts' },
   { pkg: '@superdoc/layout-bridge', distEntry: 'layout-engine/layout-bridge/src/index.d.ts' },
   { pkg: '@superdoc/painter-dom',   distEntry: 'layout-engine/painters/dom/src/index.d.ts' },
+  { pkg: '@superdoc/pm-adapter',    distEntry: 'layout-engine/pm-adapter/src/index.d.ts' },
 ];
 
 function makeRelocationRewriter({ pkg, distEntry }) {

--- a/packages/superdoc/tsconfig.json
+++ b/packages/superdoc/tsconfig.json
@@ -27,7 +27,10 @@
     "../super-editor/src",
     "../document-api/src",
     "../layout-engine/contracts/src",
+    "../layout-engine/dom-contract/src",
     "../layout-engine/layout-bridge/src",
-    "../layout-engine/painters/dom/src"
+    "../layout-engine/painters/dom/src",
+    "../layout-engine/pm-adapter/src/converter-context.ts",
+    "../layout-engine/pm-adapter/src/sections/types.ts"
   ]
 }

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -133,6 +133,10 @@ export default defineConfig(({ mode, command }) => {
         '../layout-engine/dom-contract/src/**/*',
         '../layout-engine/layout-bridge/src/**/*',
         '../layout-engine/painters/dom/src/**/*',
+        // SD-2893: pm-adapter is included file-by-file (not via `src/**/*`)
+        // because the full barrel pulls in @superdoc/style-engine and other
+        // internal packages that would re-expand the shim list. Only the
+        // type subpaths reachable from the public surface are relocated.
         '../layout-engine/pm-adapter/src/converter-context.ts',
         '../layout-engine/pm-adapter/src/sections/types.ts',
       ],

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -130,8 +130,11 @@ export default defineConfig(({ mode, command }) => {
         // rewrite step in ensure-types can redirect bare specifiers to
         // local relative paths. Same pattern as @superdoc/document-api.
         '../layout-engine/contracts/src/**/*',
+        '../layout-engine/dom-contract/src/**/*',
         '../layout-engine/layout-bridge/src/**/*',
         '../layout-engine/painters/dom/src/**/*',
+        '../layout-engine/pm-adapter/src/converter-context.ts',
+        '../layout-engine/pm-adapter/src/sections/types.ts',
       ],
       outDir: 'dist',
       // vite-plugin-dts still gathers diagnostics for this mixed JS/Vue source


### PR DESCRIPTION
## Summary

- relocate `@superdoc/dom-contract` declarations into the published `superdoc` dist and guard them in the declaration audit
- relocate the public pm-adapter type subpaths currently reached by SuperDoc declarations (`converter-context.js`, `sections/types.js`) without publishing the full pm-adapter declaration tree
- switch `ConverterContext` imports in presentation-editor code to the pm-adapter type subpath so emitted declarations do not force consumers through the broad pm-adapter barrel

## Notes

This is the D1 slice of the SD-2830 / SD-2893 shim drain. It removes these entries from `_internal-shims.d.ts`:

- `@superdoc/dom-contract`
- `@superdoc/pm-adapter`
- `@superdoc/pm-adapter/sections/types.js`

The shim list now remains at 6 known modules:

- `@superdoc/common`
- `@superdoc/common/components/BasicUpload.vue`
- `@superdoc/common/list-marker-utils`
- `@superdoc/composables/useUiFontFamily.js`
- `@superdoc/layout-engine`
- `@superdoc/style-engine/ooxml`

I intentionally did not include all of `pm-adapter/src/**/*`; that pulled additional internal-only packages (`@superdoc/style-engine`, `@superdoc/word-layout`, `@superdoc/common/list-numbering`) into the emitted declaration graph and kept the shim count at 9. The PR keeps pm-adapter relocation to the two public-referenced type files.

## Verification

- `pnpm --filter superdoc run build:es`
- `node tests/consumer-typecheck/typecheck-matrix.mjs` -> `47 passed, 0 failed, 0 warnings`
- `pnpm run type-check`
- `pnpm --filter @superdoc/super-editor test src/editors/v1/core/presentation-editor/tests/FootnotesBuilder.test.ts`
- `git diff --check`