### PR TITLE
feat(ui): add ui.selection.getRects and getAnchorRect (SD-2936)

### DIFF
--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -1601,19 +1601,37 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
       if (!slice.target && !slice.selectionTarget) return null;
       return deepFreeze(deepClone(slice));
     },
-    // Painted-selection rects route through the host editor.
-    // PresentationEditor lives at the host, and the live-selection rect
-    // the painter knows about reflects the routed editor's PM selection
-    // already, so calling against the host returns the right answer for
-    // body / header / footer / note alike.
+    // Painted-selection rects need both editors:
+    //
+    // - The host editor owns the presentation layer (the rect engine
+    //   lives there). The live path also flows through it because
+    //   `presentationEditor.getSelectionRects()` calls `getActiveEditor()`
+    //   internally and dispatches to the routed surface.
+    // - The routed editor owns the PM document that captured block ids
+    //   belong to. For body captures the two editors are the same; for
+    //   captures taken while editing a header / footer / footnote /
+    //   endnote, the routed editor is the story editor and the host
+    //   editor's PM doc would silently fail to resolve those ids.
+    //
+    // When focus has moved to a sidebar / composer by call time, the
+    // routed editor falls back to the body, and a non-body capture's
+    // block ids won't resolve there. The helper returns [] gracefully
+    // in that case (rather than wrong rects from another surface).
     getRects(capture) {
-      const editor = resolveHostEditor(superdoc);
-      return getSelectionRects(editor as unknown as Parameters<typeof getSelectionRects>[0], capture);
+      const hostEditor = resolveHostEditor(superdoc);
+      const routedEditor = resolveRoutedEditor(superdoc);
+      return getSelectionRects(
+        hostEditor as unknown as Parameters<typeof getSelectionRects>[0],
+        routedEditor as unknown as Parameters<typeof getSelectionRects>[1],
+        capture,
+      );
     },
     getAnchorRect(options, capture) {
-      const editor = resolveHostEditor(superdoc);
+      const hostEditor = resolveHostEditor(superdoc);
+      const routedEditor = resolveRoutedEditor(superdoc);
       return getSelectionAnchorRect(
-        editor as unknown as Parameters<typeof getSelectionAnchorRect>[0],
+        hostEditor as unknown as Parameters<typeof getSelectionAnchorRect>[0],
+        routedEditor as unknown as Parameters<typeof getSelectionAnchorRect>[1],
         options,
         capture,
       );

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -16,6 +16,7 @@ import type {
 } from '@superdoc/document-api';
 import { shallowEqual } from './equality.js';
 import { scrollRangeIntoView } from './scroll-into-view.js';
+import { getSelectionAnchorRect, getSelectionRects } from './selection-rects.js';
 import { createCustomCommandsRegistry } from './custom-commands.js';
 import { createScope } from './scope.js';
 import type {
@@ -1599,6 +1600,23 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
       const slice = computeState().selection;
       if (!slice.target && !slice.selectionTarget) return null;
       return deepFreeze(deepClone(slice));
+    },
+    // Painted-selection rects route through the host editor.
+    // PresentationEditor lives at the host, and the live-selection rect
+    // the painter knows about reflects the routed editor's PM selection
+    // already, so calling against the host returns the right answer for
+    // body / header / footer / note alike.
+    getRects(capture) {
+      const editor = resolveHostEditor(superdoc);
+      return getSelectionRects(editor as unknown as Parameters<typeof getSelectionRects>[0], capture);
+    },
+    getAnchorRect(options, capture) {
+      const editor = resolveHostEditor(superdoc);
+      return getSelectionAnchorRect(
+        editor as unknown as Parameters<typeof getSelectionAnchorRect>[0],
+        options,
+        capture,
+      );
     },
   };
 

--- a/packages/super-editor/src/ui/index.ts
+++ b/packages/super-editor/src/ui/index.ts
@@ -91,6 +91,7 @@ export type {
   SuperDocUIState,
 
   // Selection
+  SelectionAnchorRectOptions,
   SelectionCapture,
   SelectionHandle,
   SelectionSlice,

--- a/packages/super-editor/src/ui/selection-rects.test.ts
+++ b/packages/super-editor/src/ui/selection-rects.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSuperDocUI } from './create-super-doc-ui.js';
+import type { SuperDocLike } from './types.js';
+
+/**
+ * Stub for `ui.selection.getRects` / `ui.selection.getAnchorRect` tests.
+ * Models the minimal `presentationEditor` surface the controller calls:
+ * `getSelectionRects()` for the live path and `getRangeRects(from, to)`
+ * for the captured path.
+ */
+function makeStubs(
+  initial: {
+    selectionRects?: Array<{
+      pageIndex: number;
+      left: number;
+      top: number;
+      right: number;
+      bottom: number;
+      width: number;
+      height: number;
+    }>;
+    rangeRects?: Array<{
+      pageIndex: number;
+      left: number;
+      top: number;
+      right: number;
+      bottom: number;
+      width: number;
+      height: number;
+    }>;
+    resolveTextTarget?: (target: { blockId: string }) => { from: number; to: number } | null;
+  } = {},
+) {
+  const getSelectionRects = vi.fn(() => initial.selectionRects ?? []);
+  const getRangeRects = vi.fn((_from: number, _to: number) => initial.rangeRects ?? []);
+
+  const editor: {
+    on: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
+    doc: unknown;
+    presentationEditor: unknown;
+  } = {
+    on: vi.fn(),
+    off: vi.fn(),
+    doc: {
+      selection: { current: vi.fn(() => ({ empty: true })) },
+      comments: {
+        list: vi.fn(() => ({
+          evaluatedRevision: 'r1',
+          total: 0,
+          items: [],
+          page: { limit: 0, offset: 0, returned: 0 },
+        })),
+      },
+      trackChanges: {
+        list: vi.fn(() => ({
+          evaluatedRevision: 'r1',
+          total: 0,
+          items: [],
+          page: { limit: 0, offset: 0, returned: 0 },
+        })),
+      },
+    },
+    presentationEditor: undefined,
+  };
+  editor.presentationEditor = {
+    getSelectionRects,
+    getRangeRects,
+    getActiveEditor: () => editor,
+  };
+
+  const superdoc: SuperDocLike = {
+    activeEditor: editor as never,
+    config: { documentMode: 'editing' },
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+
+  return { superdoc, editor, mocks: { getSelectionRects, getRangeRects } };
+}
+
+describe('ui.selection.getRects — live selection', () => {
+  it('returns the painted rects from presentationEditor.getSelectionRects', () => {
+    const { superdoc, mocks } = makeStubs({
+      selectionRects: [
+        { pageIndex: 0, left: 100, top: 200, right: 240, bottom: 220, width: 140, height: 20 },
+        { pageIndex: 0, left: 80, top: 224, right: 200, bottom: 244, width: 120, height: 20 },
+      ],
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    const rects = ui.selection.getRects();
+
+    expect(mocks.getSelectionRects).toHaveBeenCalledTimes(1);
+    expect(rects).toHaveLength(2);
+    expect(rects[0]).toEqual({ pageIndex: 0, left: 100, top: 200, width: 140, height: 20 });
+    expect(rects[1]).toEqual({ pageIndex: 0, left: 80, top: 224, width: 120, height: 20 });
+  });
+
+  it('returns [] when no presentation editor is mounted (SSR / non-paginated stub)', () => {
+    const { superdoc, editor } = makeStubs();
+    (editor as { presentationEditor: unknown }).presentationEditor = undefined;
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.selection.getRects()).toEqual([]);
+  });
+
+  it('returns [] when getSelectionRects throws', () => {
+    const { superdoc, mocks } = makeStubs({ selectionRects: [] });
+    mocks.getSelectionRects.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.selection.getRects()).toEqual([]);
+  });
+});
+
+describe('ui.selection.getAnchorRect — placement', () => {
+  const lineRects = [
+    { pageIndex: 0, left: 100, top: 200, right: 240, bottom: 220, width: 140, height: 20 },
+    { pageIndex: 0, left: 80, top: 224, right: 260, bottom: 244, width: 180, height: 20 },
+    { pageIndex: 0, left: 80, top: 248, right: 200, bottom: 268, width: 120, height: 20 },
+  ];
+
+  it("placement: 'start' (default) returns the first line rect", () => {
+    const { superdoc } = makeStubs({ selectionRects: lineRects });
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.selection.getAnchorRect()).toEqual({
+      pageIndex: 0,
+      left: 100,
+      top: 200,
+      width: 140,
+      height: 20,
+    });
+    expect(ui.selection.getAnchorRect({ placement: 'start' })).toEqual({
+      pageIndex: 0,
+      left: 100,
+      top: 200,
+      width: 140,
+      height: 20,
+    });
+  });
+
+  it("placement: 'end' returns the last line rect", () => {
+    const { superdoc } = makeStubs({ selectionRects: lineRects });
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.selection.getAnchorRect({ placement: 'end' })).toEqual({
+      pageIndex: 0,
+      left: 80,
+      top: 248,
+      width: 120,
+      height: 20,
+    });
+  });
+
+  it("placement: 'union' returns the bounding rect across all lines", () => {
+    const { superdoc } = makeStubs({ selectionRects: lineRects });
+    const ui = createSuperDocUI({ superdoc });
+
+    // Union: top=200, left=80, right=260, bottom=268 → width=180, height=68.
+    expect(ui.selection.getAnchorRect({ placement: 'union' })).toEqual({
+      pageIndex: 0,
+      left: 80,
+      top: 200,
+      width: 180,
+      height: 68,
+    });
+  });
+
+  it('returns null when there are no rects', () => {
+    const { superdoc } = makeStubs({ selectionRects: [] });
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.selection.getAnchorRect()).toBeNull();
+    expect(ui.selection.getAnchorRect({ placement: 'union' })).toBeNull();
+  });
+});
+
+describe('ui.selection.getRects — captured selection', () => {
+  it('returns [] for a capture with no addressable target', () => {
+    const { superdoc } = makeStubs();
+    const ui = createSuperDocUI({ superdoc });
+
+    // Synthetic frozen capture with no segments — exercises the early
+    // return path before the resolver is touched.
+    const fakeCapture = Object.freeze({
+      empty: false,
+      target: null,
+      selectionTarget: null,
+      activeMarks: [],
+      activeCommentIds: [],
+      activeChangeIds: [],
+      quotedText: '',
+    }) as never;
+
+    expect(ui.selection.getRects(fakeCapture)).toEqual([]);
+  });
+
+  it('returns [] when getRangeRects is missing on the presentation stub', () => {
+    const { superdoc, editor } = makeStubs();
+    (editor as { presentationEditor: unknown }).presentationEditor = {
+      getSelectionRects: () => [],
+      getActiveEditor: () => editor,
+    } as never;
+    const ui = createSuperDocUI({ superdoc });
+
+    const fakeCapture = Object.freeze({
+      empty: false,
+      target: { kind: 'text', segments: [{ blockId: 'b1', range: { start: 0, end: 4 } }] },
+      selectionTarget: null,
+      activeMarks: [],
+      activeCommentIds: [],
+      activeChangeIds: [],
+      quotedText: 'test',
+    }) as never;
+
+    expect(ui.selection.getRects(fakeCapture)).toEqual([]);
+  });
+});

--- a/packages/super-editor/src/ui/selection-rects.test.ts
+++ b/packages/super-editor/src/ui/selection-rects.test.ts
@@ -200,30 +200,6 @@ describe('ui.selection.getRects — captured selection', () => {
     expect(ui.selection.getRects(fakeCapture)).toEqual([]);
   });
 
-  it('returns [] for a capture whose target lives in a non-body story (body-only limitation)', () => {
-    const { superdoc, mocks } = makeStubs({
-      rangeRects: [{ pageIndex: 0, left: 10, top: 10, right: 50, bottom: 30, width: 40, height: 20 }],
-    });
-    const ui = createSuperDocUI({ superdoc });
-
-    const headerCapture = Object.freeze({
-      empty: false,
-      target: {
-        kind: 'text',
-        story: 'header',
-        segments: [{ blockId: 'b1', range: { start: 0, end: 4 } }],
-      },
-      selectionTarget: null,
-      activeMarks: [],
-      activeCommentIds: [],
-      activeChangeIds: [],
-      quotedText: 'test',
-    }) as never;
-
-    expect(ui.selection.getRects(headerCapture)).toEqual([]);
-    expect(mocks.getRangeRects).not.toHaveBeenCalled();
-  });
-
   it('returns [] when getRangeRects is missing on the presentation stub', () => {
     const { superdoc, editor } = makeStubs();
     (editor as { presentationEditor: unknown }).presentationEditor = {

--- a/packages/super-editor/src/ui/selection-rects.test.ts
+++ b/packages/super-editor/src/ui/selection-rects.test.ts
@@ -200,6 +200,30 @@ describe('ui.selection.getRects — captured selection', () => {
     expect(ui.selection.getRects(fakeCapture)).toEqual([]);
   });
 
+  it('returns [] for a capture whose target lives in a non-body story (body-only limitation)', () => {
+    const { superdoc, mocks } = makeStubs({
+      rangeRects: [{ pageIndex: 0, left: 10, top: 10, right: 50, bottom: 30, width: 40, height: 20 }],
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    const headerCapture = Object.freeze({
+      empty: false,
+      target: {
+        kind: 'text',
+        story: 'header',
+        segments: [{ blockId: 'b1', range: { start: 0, end: 4 } }],
+      },
+      selectionTarget: null,
+      activeMarks: [],
+      activeCommentIds: [],
+      activeChangeIds: [],
+      quotedText: 'test',
+    }) as never;
+
+    expect(ui.selection.getRects(headerCapture)).toEqual([]);
+    expect(mocks.getRangeRects).not.toHaveBeenCalled();
+  });
+
   it('returns [] when getRangeRects is missing on the presentation stub', () => {
     const { superdoc, editor } = makeStubs();
     (editor as { presentationEditor: unknown }).presentationEditor = {

--- a/packages/super-editor/src/ui/selection-rects.ts
+++ b/packages/super-editor/src/ui/selection-rects.ts
@@ -1,0 +1,131 @@
+/**
+ * Painted-selection rect helper for `superdoc/ui`. Drives
+ * `ui.selection.getRects` and `ui.selection.getAnchorRect` so consumers
+ * positioning floating UI (bubble menus, link popovers, mention lists)
+ * read painted-DOM coordinates instead of the offscreen ProseMirror
+ * DOM that `window.getSelection()` reports against.
+ */
+
+import type { Editor } from '../editors/v1/core/Editor.js';
+import { resolveTextTarget } from '../editors/v1/document-api-adapters/helpers/adapter-utils.js';
+import type { SelectionCapture, SelectionAnchorRectOptions, ViewportRect } from './types.js';
+
+interface RawRangeRect {
+  pageIndex: number;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Resolve the painted rects of the current selection, or of a captured
+ * one when `capture` is provided. Empty array when the editor has no
+ * presentation layer (SSR / non-paginated mounts), no current selection,
+ * or a stale capture whose target no longer resolves.
+ */
+export function getSelectionRects(editor: Editor | null, capture?: SelectionCapture | null): ViewportRect[] {
+  const presentation = editor?.presentationEditor;
+  if (!presentation) return [];
+
+  if (capture) {
+    return getCapturedSelectionRects(editor!, capture);
+  }
+
+  if (typeof presentation.getSelectionRects !== 'function') return [];
+  try {
+    const rects = presentation.getSelectionRects();
+    return rects.map(toViewportRect);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Single anchor rect derived from {@link getSelectionRects}. Returns
+ * `null` when the selection produces no painted rects.
+ */
+export function getSelectionAnchorRect(
+  editor: Editor | null,
+  options?: SelectionAnchorRectOptions,
+  capture?: SelectionCapture | null,
+): ViewportRect | null {
+  const rects = getSelectionRects(editor, capture);
+  if (rects.length === 0) return null;
+
+  const placement = options?.placement ?? 'start';
+  if (placement === 'end') return rects[rects.length - 1]!;
+  if (placement === 'union') return computeUnionRect(rects);
+  return rects[0]!;
+}
+
+function getCapturedSelectionRects(editor: Editor, capture: SelectionCapture): ViewportRect[] {
+  const presentation = editor.presentationEditor;
+  if (!presentation || typeof presentation.getRangeRects !== 'function') return [];
+
+  const segments = capture.target?.segments;
+  if (!segments || segments.length === 0) return [];
+
+  // Multi-segment selections span multiple blocks but produce a single
+  // continuous PM range — `from` is the first segment's start, `to` is
+  // the last segment's end. Resolving each end independently keeps the
+  // logic simple and matches how the doc-api represents the selection
+  // internally.
+  const first = segments[0]!;
+  const last = segments[segments.length - 1]!;
+
+  let fromResolved: { from: number; to: number } | null = null;
+  let toResolved: { from: number; to: number } | null = null;
+  try {
+    fromResolved = resolveTextTarget(editor, {
+      kind: 'text',
+      blockId: first.blockId,
+      range: first.range,
+    });
+    toResolved = resolveTextTarget(editor, {
+      kind: 'text',
+      blockId: last.blockId,
+      range: last.range,
+    });
+  } catch {
+    return [];
+  }
+  if (!fromResolved || !toResolved) return [];
+
+  try {
+    const rects = presentation.getRangeRects(fromResolved.from, toResolved.to);
+    return rects.map(toViewportRect);
+  } catch {
+    return [];
+  }
+}
+
+function toViewportRect(rect: RawRangeRect): ViewportRect {
+  return {
+    top: rect.top,
+    left: rect.left,
+    width: rect.width,
+    height: rect.height,
+    pageIndex: rect.pageIndex,
+  };
+}
+
+function computeUnionRect(rects: ViewportRect[]): ViewportRect {
+  let top = Infinity;
+  let left = Infinity;
+  let bottom = -Infinity;
+  let right = -Infinity;
+  // Page index of the union is the first rect's page; multi-page
+  // selections lose page granularity here, but the union shape is what
+  // a single-rect overlay needs.
+  const pageIndex = rects[0]!.pageIndex;
+  for (const rect of rects) {
+    if (rect.top < top) top = rect.top;
+    if (rect.left < left) left = rect.left;
+    if (rect.top + rect.height > bottom) bottom = rect.top + rect.height;
+    if (rect.left + rect.width > right) right = rect.left + rect.width;
+  }
+  return { top, left, width: right - left, height: bottom - top, pageIndex };
+}

--- a/packages/super-editor/src/ui/selection-rects.ts
+++ b/packages/super-editor/src/ui/selection-rects.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Editor } from '../editors/v1/core/Editor.js';
+import { DocumentApiAdapterError } from '../editors/v1/document-api-adapters/errors.js';
 import { resolveTextTarget } from '../editors/v1/document-api-adapters/helpers/adapter-utils.js';
 import type { SelectionCapture, SelectionAnchorRectOptions, ViewportRect } from './types.js';
 
@@ -20,17 +21,44 @@ interface RawRangeRect {
   height: number;
 }
 
+// Captures whose target lives in a non-body story (header, footer,
+// footnote, endnote) need a story-aware rect resolver on
+// `PresentationEditor` that doesn't yet exist publicly. The live path
+// works for non-body selections because `presentationEditor
+// .getSelectionRects()` calls `getActiveEditor()` internally and
+// dispatches to the right surface; the captured path can't, because by
+// the time the consumer is asking for rects, focus has often moved away
+// (composer textarea, sidebar, modal) and the active surface is back on
+// body. Until a follow-up surfaces a `getRangeRectsForStory(from, to,
+// story)` primitive, captures referencing non-body stories return [].
+// Same posture as `scroll-into-view`'s text-anchored path.
+function captureIsBodyOnly(capture: SelectionCapture): boolean {
+  const story = (capture.target as { story?: unknown } | null)?.story;
+  if (story === undefined || story === null) return true;
+  if (typeof story === 'string') return story === 'body';
+  if (typeof story === 'object') {
+    const kind = (story as { kind?: unknown }).kind;
+    return kind === undefined || kind === 'body';
+  }
+  return true;
+}
+
 /**
  * Resolve the painted rects of the current selection, or of a captured
  * one when `capture` is provided. Empty array when the editor has no
  * presentation layer (SSR / non-paginated mounts), no current selection,
  * or a stale capture whose target no longer resolves.
+ *
+ * Captures referencing non-body stories return [] — the underlying
+ * story-aware rect resolver is a follow-up (body-only matches the same
+ * posture as `scroll-into-view`'s text-anchored path).
  */
 export function getSelectionRects(editor: Editor | null, capture?: SelectionCapture | null): ViewportRect[] {
   const presentation = editor?.presentationEditor;
   if (!presentation) return [];
 
   if (capture) {
+    if (!captureIsBodyOnly(capture)) return [];
     return getCapturedSelectionRects(editor!, capture);
   }
 
@@ -68,11 +96,9 @@ function getCapturedSelectionRects(editor: Editor, capture: SelectionCapture): V
   const segments = capture.target?.segments;
   if (!segments || segments.length === 0) return [];
 
-  // Multi-segment selections span multiple blocks but produce a single
-  // continuous PM range — `from` is the first segment's start, `to` is
-  // the last segment's end. Resolving each end independently keeps the
-  // logic simple and matches how the doc-api represents the selection
-  // internally.
+  // Multi-segment captures collapse to one PM range bounded by the
+  // first segment's start and the last segment's end — matching how
+  // the doc-api represents a selection in the unified PM document.
   const first = segments[0]!;
   const last = segments[segments.length - 1]!;
 
@@ -89,7 +115,14 @@ function getCapturedSelectionRects(editor: Editor, capture: SelectionCapture): V
       blockId: last.blockId,
       range: last.range,
     });
-  } catch {
+  } catch (err) {
+    // resolveTextTarget re-throws AMBIGUOUS_TARGET so callers can log
+    // the precise diagnostic. Surface it to the console rather than
+    // swallowing silently — bare `return []` would hide a real document
+    // problem (two blocks sharing an id) behind "no rects".
+    if (err instanceof DocumentApiAdapterError) {
+      console.warn(`[superdoc/ui] ui.selection.getRects: ${err.code}: ${err.message}`);
+    }
     return [];
   }
   if (!fromResolved || !toResolved) return [];

--- a/packages/super-editor/src/ui/selection-rects.ts
+++ b/packages/super-editor/src/ui/selection-rects.ts
@@ -21,45 +21,33 @@ interface RawRangeRect {
   height: number;
 }
 
-// Captures whose target lives in a non-body story (header, footer,
-// footnote, endnote) need a story-aware rect resolver on
-// `PresentationEditor` that doesn't yet exist publicly. The live path
-// works for non-body selections because `presentationEditor
-// .getSelectionRects()` calls `getActiveEditor()` internally and
-// dispatches to the right surface; the captured path can't, because by
-// the time the consumer is asking for rects, focus has often moved away
-// (composer textarea, sidebar, modal) and the active surface is back on
-// body. Until a follow-up surfaces a `getRangeRectsForStory(from, to,
-// story)` primitive, captures referencing non-body stories return [].
-// Same posture as `scroll-into-view`'s text-anchored path.
-function captureIsBodyOnly(capture: SelectionCapture): boolean {
-  const story = (capture.target as { story?: unknown } | null)?.story;
-  if (story === undefined || story === null) return true;
-  if (typeof story === 'string') return story === 'body';
-  if (typeof story === 'object') {
-    const kind = (story as { kind?: unknown }).kind;
-    return kind === undefined || kind === 'body';
-  }
-  return true;
-}
-
 /**
  * Resolve the painted rects of the current selection, or of a captured
  * one when `capture` is provided. Empty array when the editor has no
  * presentation layer (SSR / non-paginated mounts), no current selection,
  * or a stale capture whose target no longer resolves.
  *
- * Captures referencing non-body stories return [] — the underlying
- * story-aware rect resolver is a follow-up (body-only matches the same
- * posture as `scroll-into-view`'s text-anchored path).
+ * Two editors are accepted because the capture path needs both:
+ * - `hostEditor` owns the presentation layer (`getRangeRects`).
+ * - `routedEditor` owns the PM document that captured block ids belong
+ *   to. For body-only captures these are the same instance; for
+ *   captures taken while editing a header / footer / footnote /
+ *   endnote, the routed editor is the story editor.
+ *
+ * The live path uses only `hostEditor.presentationEditor.getSelectionRects()`,
+ * which routes through its internal `getActiveEditor()` and works on
+ * every surface.
  */
-export function getSelectionRects(editor: Editor | null, capture?: SelectionCapture | null): ViewportRect[] {
-  const presentation = editor?.presentationEditor;
+export function getSelectionRects(
+  hostEditor: Editor | null,
+  routedEditor: Editor | null,
+  capture?: SelectionCapture | null,
+): ViewportRect[] {
+  const presentation = hostEditor?.presentationEditor;
   if (!presentation) return [];
 
   if (capture) {
-    if (!captureIsBodyOnly(capture)) return [];
-    return getCapturedSelectionRects(editor!, capture);
+    return getCapturedSelectionRects(hostEditor!, routedEditor ?? hostEditor!, capture);
   }
 
   if (typeof presentation.getSelectionRects !== 'function') return [];
@@ -76,11 +64,12 @@ export function getSelectionRects(editor: Editor | null, capture?: SelectionCapt
  * `null` when the selection produces no painted rects.
  */
 export function getSelectionAnchorRect(
-  editor: Editor | null,
+  hostEditor: Editor | null,
+  routedEditor: Editor | null,
   options?: SelectionAnchorRectOptions,
   capture?: SelectionCapture | null,
 ): ViewportRect | null {
-  const rects = getSelectionRects(editor, capture);
+  const rects = getSelectionRects(hostEditor, routedEditor, capture);
   if (rects.length === 0) return null;
 
   const placement = options?.placement ?? 'start';
@@ -89,8 +78,12 @@ export function getSelectionAnchorRect(
   return rects[0]!;
 }
 
-function getCapturedSelectionRects(editor: Editor, capture: SelectionCapture): ViewportRect[] {
-  const presentation = editor.presentationEditor;
+function getCapturedSelectionRects(
+  hostEditor: Editor,
+  routedEditor: Editor,
+  capture: SelectionCapture,
+): ViewportRect[] {
+  const presentation = hostEditor.presentationEditor;
   if (!presentation || typeof presentation.getRangeRects !== 'function') return [];
 
   const segments = capture.target?.segments;
@@ -102,15 +95,22 @@ function getCapturedSelectionRects(editor: Editor, capture: SelectionCapture): V
   const first = segments[0]!;
   const last = segments[segments.length - 1]!;
 
+  // Resolve block ids against the routed editor so captures taken in
+  // header / footer / footnote / endnote stories still resolve while
+  // the user remains in that story (the routed editor is the one whose
+  // PM document those block ids belong to). When focus has moved
+  // elsewhere by call time, the routed editor falls back to the body,
+  // and a non-body capture's block ids won't resolve there — the
+  // function returns [] gracefully.
   let fromResolved: { from: number; to: number } | null = null;
   let toResolved: { from: number; to: number } | null = null;
   try {
-    fromResolved = resolveTextTarget(editor, {
+    fromResolved = resolveTextTarget(routedEditor, {
       kind: 'text',
       blockId: first.blockId,
       range: first.range,
     });
-    toResolved = resolveTextTarget(editor, {
+    toResolved = resolveTextTarget(routedEditor, {
       kind: 'text',
       blockId: last.blockId,
       range: last.range,

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -799,14 +799,15 @@ export interface SelectionHandle {
    * footer, footnote, endnote — because `PresentationEditor` routes
    * selection-rect lookups through its currently active editor.
    *
-   * The captured path is body-only today: captures whose target lives
-   * in a non-body story return `[]`. Story-aware rect resolution for
-   * captures requires a `getRangeRectsForStory(from, to, story)`
-   * primitive on PresentationEditor that doesn't yet exist; until that
-   * lands, consumers building floating UI on header / footer / note
-   * surfaces should query rects from the live selection (no capture)
-   * before focus moves elsewhere. Same posture as
-   * `ui.viewport.scrollIntoView` for text-anchored targets.
+   * The captured path resolves block ids against the currently routed
+   * editor, so captures taken in a non-body story still produce the
+   * right rects while the user remains in that story (the common case
+   * for a bubble menu or composer that opens a sidebar). When focus
+   * has moved to a different story (or the body) by call time, the
+   * captured block ids no longer resolve and the call returns `[]`
+   * rather than rects from the wrong surface — fully cross-surface
+   * captured rects need a story-keyed lookup that doesn't yet exist
+   * publicly on `PresentationEditor`.
    */
   getRects(capture?: SelectionCapture | null): ViewportRect[];
   /**

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -794,6 +794,19 @@ export interface SelectionHandle {
    * for a frozen selection — useful when a composer has stolen focus
    * and the editor's live selection is gone but you still want to
    * position UI relative to where the user originally selected.
+   *
+   * The live path (no capture) handles all surfaces — body, header,
+   * footer, footnote, endnote — because `PresentationEditor` routes
+   * selection-rect lookups through its currently active editor.
+   *
+   * The captured path is body-only today: captures whose target lives
+   * in a non-body story return `[]`. Story-aware rect resolution for
+   * captures requires a `getRangeRectsForStory(from, to, story)`
+   * primitive on PresentationEditor that doesn't yet exist; until that
+   * lands, consumers building floating UI on header / footer / note
+   * surfaces should query rects from the live selection (no capture)
+   * before focus moves elsewhere. Same posture as
+   * `ui.viewport.scrollIntoView` for text-anchored targets.
    */
   getRects(capture?: SelectionCapture | null): ViewportRect[];
   /**

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -129,12 +129,38 @@ export interface SuperDocEditorLike {
    * PresentationEditor handle. Browser-only. The controller calls
    * `presentationEditor.getEntityRects(target)` from `ui.viewport.getRect`
    * to look up the painted-DOM rectangles for an entity (comment or
-   * tracked change) without leaking DOM elements through the public
-   * `ui.viewport` surface. Optional in the structural typing to keep
+   * tracked change), and `presentationEditor.getSelectionRects()` /
+   * `getRangeRects(from, to)` from `ui.selection.getRects` /
+   * `ui.selection.getAnchorRect` to anchor floating UI to the painted
+   * selection without consumers reaching for `window.getSelection()`
+   * (which reads from the offscreen ProseMirror DOM and returns the
+   * wrong coordinates). Optional in the structural typing to keep
    * SSR / non-browser stubs valid.
    */
   presentationEditor?: {
     getEntityRects?(target: { entityType?: unknown; entityId?: unknown; story?: unknown }): Array<{
+      pageIndex: number;
+      left: number;
+      right: number;
+      top: number;
+      bottom: number;
+      width: number;
+      height: number;
+    }>;
+    getSelectionRects?(relativeTo?: HTMLElement): Array<{
+      pageIndex: number;
+      left: number;
+      right: number;
+      top: number;
+      bottom: number;
+      width: number;
+      height: number;
+    }>;
+    getRangeRects?(
+      from: number,
+      to: number,
+      relativeTo?: HTMLElement,
+    ): Array<{
       pageIndex: number;
       left: number;
       right: number;
@@ -749,6 +775,51 @@ export interface SelectionHandle {
    * doc-api primitive does.
    */
   capture(): SelectionCapture | null;
+  /**
+   * Look up the painted rectangles of the current selection (or a
+   * captured one) in viewport coordinates.
+   *
+   * SuperDoc renders the visible page through the layout engine, not
+   * the hidden ProseMirror DOM. `window.getSelection().getRangeAt(0)
+   * .getBoundingClientRect()` reads from the offscreen PM and returns
+   * coordinates that don't match what the user sees — every consumer
+   * who reaches for it ships a broken bubble menu. This method asks
+   * the painter directly so the rects align with what's painted.
+   *
+   * Multi-line selections produce one rect per painted line in
+   * document order. Empty selections, no-editor state, or captures
+   * whose target no longer resolves return `[]`.
+   *
+   * Pass a `SelectionCapture` (from {@link capture}) to query rects
+   * for a frozen selection — useful when a composer has stolen focus
+   * and the editor's live selection is gone but you still want to
+   * position UI relative to where the user originally selected.
+   */
+  getRects(capture?: SelectionCapture | null): ViewportRect[];
+  /**
+   * Single anchor rect for floating UI (bubble menu, link popover,
+   * mention list). Sugar over {@link getRects}: returns the first
+   * line rect when `placement` is `'start'` (default), the last when
+   * `'end'`, or the union bounding box across all line rects when
+   * `'union'`. Returns `null` when there are no rects.
+   */
+  getAnchorRect(options?: SelectionAnchorRectOptions, capture?: SelectionCapture | null): ViewportRect | null;
+}
+
+/**
+ * Options for {@link SelectionHandle.getAnchorRect}.
+ */
+export interface SelectionAnchorRectOptions {
+  /**
+   * Which line of a multi-line selection to anchor to.
+   *
+   * - `'start'` (default): top-most line. Matches Word / Google Docs
+   *    bubble menu placement.
+   * - `'end'`: bottom-most line. Useful when the popover lives below.
+   * - `'union'`: bounding rect across every line. Useful for selection
+   *    overlays / shaded backgrounds.
+   */
+  placement?: 'start' | 'end' | 'union';
 }
 
 /**


### PR DESCRIPTION
Lifts the painted selection rect from the internal `PresentationEditor` to the public controller, so consumers building floating selection toolbars stop reaching for `window.getSelection()` (which reads from the offscreen ProseMirror DOM and returns coordinates that don't match what the painter shows). Today the only working path is an untyped cast through `useSuperDocHost()` into `superdoc.activeEditor.presentationEditor.getSelectionRects()`. Now it's `ui.selection.getAnchorRect()`.

`getRects(capture?)` returns viewport-relative `ViewportRect[]` for the live selection or a captured one. `getAnchorRect(options?, capture?)` returns a single rect; `placement: 'start'` (default) matches Word/GDocs bubble-menu placement, `'end'` and `'union'` cover bottom-anchored popovers and selection overlays. Empty selection, no-presentation-layer, and stale captures all return `[]` / `null` rather than throw.

Captured rects route block-id resolution through the routed editor (so captures taken in a header / footer / footnote / endnote still resolve while the user remains in that story) and the rect engine through the host's presentation layer. When focus has moved to a sidebar / composer by call time and the routed editor has fallen back to the body, captured non-body ids fail to resolve and the call returns `[]` gracefully rather than mixing surfaces — fully cross-surface captured rects need a story-keyed editor lookup on `PresentationEditor` that doesn't yet exist publicly. Live rects work on every surface because `presentationEditor.getSelectionRects()` routes through `getActiveEditor()` internally.

`AMBIGUOUS_TARGET` errors from `resolveTextTarget` are surfaced via `console.warn` rather than swallowed, matching the diagnostic contract that helper sets out for callers.

First in a stack of five PRs against SD-2936. Subsequent PRs (entityAt, context-menu contribution, selection.restore, command shortcuts) build on this.

**Verified**: `pnpm exec vitest run src/ui` → 205 passed (13 files); `pnpm --filter @superdoc/super-editor build` → clean; `pnpm --filter superdoc build` → clean.
