### PR TITLE
fix(ui): re-export PublicToolbarItemId from superdoc/ui (SD-2920)

### DIFF
--- a/packages/super-editor/src/ui/index.ts
+++ b/packages/super-editor/src/ui/index.ts
@@ -19,6 +19,7 @@
 export { createSuperDocUI } from './create-super-doc-ui.js';
 export { shallowEqual } from './equality.js';
 export { BUILT_IN_COMMAND_IDS } from '../headless-toolbar/types.js';
+export type { PublicToolbarItemId } from '../headless-toolbar/types.js';
 
 // Re-export the document-side shapes the controller surfaces so
 // consumers can type their components without reaching into the


### PR DESCRIPTION
The Custom UI toolbar-and-commands docs page tells consumers to import \`PublicToolbarItemId\` from \`superdoc/ui\` as the typed source of truth for command ids. SD-2920 shipped \`BUILT_IN_COMMAND_IDS\` at runtime through that path but never re-exported the derived type, so consumers writing the documented import couldn't actually find it from \`superdoc/ui\`.

\`skipLibCheck: true\` on most consumer tsconfigs masked the broken re-export from the typecheck signal. The dist now exposes the type through the same barrel as \`BUILT_IN_COMMAND_IDS\`, matching what the docs already promise.

- Linear: SD-2920
- One-line type re-export. No runtime change.
- Verified via \`pnpm --filter superdoc build\`; dist/super-editor/src/ui/index.d.ts now contains the type re-export.