### PR TITLE
fix(types): drain layout-engine and useUiFontFamily shims (SD-2893)

### DIFF
--- a/packages/superdoc/scripts/audit-declarations.cjs
+++ b/packages/superdoc/scripts/audit-declarations.cjs
@@ -69,6 +69,7 @@ const RELOCATION_GUARD_PACKAGES = [
   '@superdoc/contracts',
   '@superdoc/dom-contract',
   '@superdoc/layout-bridge',
+  '@superdoc/layout-engine',
   '@superdoc/painter-dom',
   '@superdoc/pm-adapter',
 ];

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -219,6 +219,7 @@ const RELOCATION_RULES = [
   { pkg: '@superdoc/contracts',     distEntry: 'layout-engine/contracts/src/index.d.ts', matchSubpaths: true },
   { pkg: '@superdoc/dom-contract',  distEntry: 'layout-engine/dom-contract/src/index.d.ts', matchSubpaths: true },
   { pkg: '@superdoc/layout-bridge', distEntry: 'layout-engine/layout-bridge/src/index.d.ts', matchSubpaths: true },
+  { pkg: '@superdoc/layout-engine', distEntry: 'layout-engine/layout-engine/src/index.d.ts', matchSubpaths: true },
   { pkg: '@superdoc/painter-dom',   distEntry: 'layout-engine/painters/dom/src/index.d.ts', matchSubpaths: true },
   {
     pkg: '@superdoc/pm-adapter/converter-context.js',
@@ -241,6 +242,7 @@ const RELOCATION_GUARD_PACKAGES = [
   '@superdoc/contracts',
   '@superdoc/dom-contract',
   '@superdoc/layout-bridge',
+  '@superdoc/layout-engine',
   '@superdoc/painter-dom',
   '@superdoc/pm-adapter',
 ];

--- a/packages/superdoc/src/composables/useUiFontFamily.js
+++ b/packages/superdoc/src/composables/useUiFontFamily.js
@@ -21,23 +21,6 @@ export const DEFAULT_UI_FONT_FAMILY = 'Arial, Helvetica, sans-serif';
  *
  * @returns {{ uiFontFamily: import('vue').ComputedRef<string> }} An object containing:
  *   - uiFontFamily: A computed reference to the UI font-family string
- *
- * @example
- * // In a Vue component
- * import { useUiFontFamily } from '@superdoc/composables/useUiFontFamily.js';
- *
- * export default {
- *   setup() {
- *     const { uiFontFamily } = useUiFontFamily();
- *
- *     // Use in template or computed styles
- *     return { uiFontFamily };
- *   }
- * }
- *
- * @example
- * // In a template
- * <CommentsDropdown :content-style="{ fontFamily: uiFontFamily }" />
  */
 export function useUiFontFamily() {
   const instance = getCurrentInstance();

--- a/packages/superdoc/tsconfig.json
+++ b/packages/superdoc/tsconfig.json
@@ -29,6 +29,7 @@
     "../layout-engine/contracts/src",
     "../layout-engine/dom-contract/src",
     "../layout-engine/layout-bridge/src",
+    "../layout-engine/layout-engine/src",
     "../layout-engine/painters/dom/src",
     "../layout-engine/pm-adapter/src/converter-context.ts",
     "../layout-engine/pm-adapter/src/sections/types.ts"

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -132,6 +132,7 @@ export default defineConfig(({ mode, command }) => {
         '../layout-engine/contracts/src/**/*',
         '../layout-engine/dom-contract/src/**/*',
         '../layout-engine/layout-bridge/src/**/*',
+        '../layout-engine/layout-engine/src/**/*',
         '../layout-engine/painters/dom/src/**/*',
         // SD-2893: pm-adapter is included file-by-file (not via `src/**/*`)
         // because the full barrel pulls in @superdoc/style-engine and other


### PR DESCRIPTION
Stacked on #3133. Two cheap-win follow-ups to the D1 relocation, dropping the internal shim count from 6 to 4.

- useUiFontFamily: the bare `@superdoc/composables/useUiFontFamily.js` specifier only appeared in a JSDoc `@example` block. The example was also misleading. The composable is internal-only, not exported from any public entry, so a consumer cannot actually use the shown import. Removing the example clears the shim without changing public API.
- `@superdoc/layout-engine`: relocate via the same D1 pattern as contracts and layout-bridge. The package's source only imports from `@superdoc/contracts` (already relocated), so a full `src/**/*` glob is safe and does not pull additional internal packages into the declaration graph.

Remaining shims need more evaluation than a cheap-win slice: `@superdoc/common` (referenced by 5 dist files including public types), `common/components/BasicUpload.vue` (publicly re-exported runtime component), `common/list-marker-utils`, and `style-engine/ooxml` (10 files, deep dependency).

**Verified**: matrix 47/0/0, build:es clean, declaration audit clean (7 guarded packages, 4 modules in shim).