### PR TITLE
docs(custom-ui): link selection capture example

### DIFF
--- a/apps/docs/editor/custom-ui/comments.mdx
+++ b/apps/docs/editor/custom-ui/comments.mdx
@@ -124,6 +124,8 @@ export function CommentComposer({ onPosted }: { onPosted(): void }) {
 
 `captured.target` is the same shape `editor.doc.comments.create({ target })` accepts. `quotedText` gives you the anchored text for previewing in the composer.
 
+See the [selection capture example](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/custom-ui/selection-capture) for a runnable vanilla version: open a composer, move focus to a textarea, and post against the original selection.
+
 ## Resolve and reopen
 
 ```tsx

--- a/apps/docs/editor/custom-ui/selection-and-viewport.mdx
+++ b/apps/docs/editor/custom-ui/selection-and-viewport.mdx
@@ -72,6 +72,8 @@ export function LinkComposer({ onPosted }: { onPosted(): void }) {
 
 `capture()` returns `null` when the selection has no positional target. Captures are deep-frozen at runtime, so the consumer copy can't mutate the controller's memo.
 
+See the [selection capture example](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/custom-ui/selection-capture) for a runnable vanilla version showing why a captured selection survives composer focus changes.
+
 ## Scroll an entity into view
 
 ```ts


### PR DESCRIPTION
## Summary
- Add GitHub example cards to the Custom UI Comments page and Selection and viewport page
- Keep the links focused on the selection-capture pattern added in #3138

## Validation
- pnpm --dir apps/docs run validate