### PR TITLE
fix(types): drain @superdoc/common/list-marker-utils shim (SD-2893)

### DIFF
--- a/packages/superdoc/scripts/audit-declarations.cjs
+++ b/packages/superdoc/scripts/audit-declarations.cjs
@@ -72,6 +72,7 @@ const RELOCATION_GUARD_PACKAGES = [
   '@superdoc/layout-engine',
   '@superdoc/painter-dom',
   '@superdoc/pm-adapter',
+  '@superdoc/common/list-marker-utils',
 ];
 
 // Specifiers that may appear as bare imports in published d.ts files even

--- a/packages/superdoc/scripts/audit-declarations.cjs
+++ b/packages/superdoc/scripts/audit-declarations.cjs
@@ -69,6 +69,7 @@ const RELOCATION_GUARD_PACKAGES = [
   '@superdoc/contracts',
   '@superdoc/dom-contract',
   '@superdoc/layout-bridge',
+  '@superdoc/layout-engine',
   '@superdoc/painter-dom',
   '@superdoc/pm-adapter',
 ];

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -219,6 +219,7 @@ const RELOCATION_RULES = [
   { pkg: '@superdoc/contracts',     distEntry: 'layout-engine/contracts/src/index.d.ts', matchSubpaths: true },
   { pkg: '@superdoc/dom-contract',  distEntry: 'layout-engine/dom-contract/src/index.d.ts', matchSubpaths: true },
   { pkg: '@superdoc/layout-bridge', distEntry: 'layout-engine/layout-bridge/src/index.d.ts', matchSubpaths: true },
+  { pkg: '@superdoc/layout-engine', distEntry: 'layout-engine/layout-engine/src/index.d.ts', matchSubpaths: true },
   { pkg: '@superdoc/painter-dom',   distEntry: 'layout-engine/painters/dom/src/index.d.ts', matchSubpaths: true },
   {
     pkg: '@superdoc/pm-adapter/converter-context.js',
@@ -241,6 +242,7 @@ const RELOCATION_GUARD_PACKAGES = [
   '@superdoc/contracts',
   '@superdoc/dom-contract',
   '@superdoc/layout-bridge',
+  '@superdoc/layout-engine',
   '@superdoc/painter-dom',
   '@superdoc/pm-adapter',
 ];

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -62,6 +62,41 @@ if (handwrittenCopiedSuperEditor > 0) {
   console.log(`[ensure-types] ✓ Copied ${handwrittenCopiedSuperEditor} hand-written .d.ts files from super-editor/src`);
 }
 
+// SD-2893: emit declarations for the shared/common subpaths reachable from the
+// public surface. Adding shared/ to vite-plugin-dts's `include` would shift the
+// common-ancestor of all source files to the repo root and reorganise the
+// entire dist tree, so we run tsc directly for just the files we relocate.
+// Today: list-marker-utils plus its sibling layout-constants. Add new entries
+// here in lockstep with `RELOCATION_RULES` below.
+const SHARED_COMMON_DTS_TARGETS = ['list-marker-utils.ts', 'layout-constants.ts'];
+{
+  const { spawnSync: _spawnSync } = require('node:child_process');
+  const tscBin = path.join(repoRoot, 'node_modules', '.bin', 'tsc');
+  const sharedCommonDistDir = path.join(distRoot, 'shared/common');
+  fs.mkdirSync(sharedCommonDistDir, { recursive: true });
+  const sources = SHARED_COMMON_DTS_TARGETS.map((f) => path.join(repoRoot, 'shared/common', f));
+  const tscResult = _spawnSync(
+    tscBin,
+    [
+      '--declaration',
+      '--emitDeclarationOnly',
+      '--skipLibCheck',
+      '--target', 'ES2022',
+      '--module', 'ESNext',
+      '--moduleResolution', 'bundler',
+      '--outDir', sharedCommonDistDir,
+      '--rootDir', path.join(repoRoot, 'shared/common'),
+      ...sources,
+    ],
+    { stdio: 'inherit' },
+  );
+  if (tscResult.status !== 0) {
+    console.error('[ensure-types] tsc failed emitting shared/common declarations');
+    process.exit(1);
+  }
+  console.log(`[ensure-types] ✓ Emitted ${SHARED_COMMON_DTS_TARGETS.length} shared/common declarations`);
+}
+
 const requiredEntryPoints = [
   'superdoc/src/index.d.ts',
   'superdoc/src/super-editor.d.ts',
@@ -231,6 +266,15 @@ const RELOCATION_RULES = [
     distEntry: 'layout-engine/pm-adapter/src/sections/types.d.ts',
     matchSubpaths: false,
   },
+  // SD-2893: list-marker-utils is the only @superdoc/common subpath publicly
+  // reachable today (via painter-dom). Relocate just this file so the bare
+  // @superdoc/common shim does not capture it; the parent @superdoc/common
+  // package and other subpaths stay shimmed until separately drained.
+  {
+    pkg: '@superdoc/common/list-marker-utils',
+    distEntry: 'shared/common/list-marker-utils.d.ts',
+    matchSubpaths: false,
+  },
 ];
 
 // Guard packages that must never fall back to `_internal-shims.d.ts`.
@@ -245,6 +289,7 @@ const RELOCATION_GUARD_PACKAGES = [
   '@superdoc/layout-engine',
   '@superdoc/painter-dom',
   '@superdoc/pm-adapter',
+  '@superdoc/common/list-marker-utils',
 ];
 
 function isRelocatedSpecifier(mod) {

--- a/packages/superdoc/src/composables/useUiFontFamily.js
+++ b/packages/superdoc/src/composables/useUiFontFamily.js
@@ -21,23 +21,6 @@ export const DEFAULT_UI_FONT_FAMILY = 'Arial, Helvetica, sans-serif';
  *
  * @returns {{ uiFontFamily: import('vue').ComputedRef<string> }} An object containing:
  *   - uiFontFamily: A computed reference to the UI font-family string
- *
- * @example
- * // In a Vue component
- * import { useUiFontFamily } from '@superdoc/composables/useUiFontFamily.js';
- *
- * export default {
- *   setup() {
- *     const { uiFontFamily } = useUiFontFamily();
- *
- *     // Use in template or computed styles
- *     return { uiFontFamily };
- *   }
- * }
- *
- * @example
- * // In a template
- * <CommentsDropdown :content-style="{ fontFamily: uiFontFamily }" />
  */
 export function useUiFontFamily() {
   const instance = getCurrentInstance();

--- a/packages/superdoc/tsconfig.json
+++ b/packages/superdoc/tsconfig.json
@@ -29,6 +29,7 @@
     "../layout-engine/contracts/src",
     "../layout-engine/dom-contract/src",
     "../layout-engine/layout-bridge/src",
+    "../layout-engine/layout-engine/src",
     "../layout-engine/painters/dom/src",
     "../layout-engine/pm-adapter/src/converter-context.ts",
     "../layout-engine/pm-adapter/src/sections/types.ts"

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -132,6 +132,7 @@ export default defineConfig(({ mode, command }) => {
         '../layout-engine/contracts/src/**/*',
         '../layout-engine/dom-contract/src/**/*',
         '../layout-engine/layout-bridge/src/**/*',
+        '../layout-engine/layout-engine/src/**/*',
         '../layout-engine/painters/dom/src/**/*',
         // SD-2893: pm-adapter is included file-by-file (not via `src/**/*`)
         // because the full barrel pulls in @superdoc/style-engine and other


### PR DESCRIPTION
Stacked on #3140. Drains the third remaining shim entry, dropping the count from 4 to 3.

`list-marker-utils` is the only `@superdoc/common` subpath publicly reachable today, via `painter-dom/src/utils/marker-helpers`. The bare `@superdoc/common` package and other subpaths stay shimmed for separate follow-ups.

Why this doesn't add to vite-plugin-dts's `include`: extending the include list with `../../shared/common/...` shifts the common-ancestor to the repo root and reorganises the whole dist tree. To avoid that, the postbuild step runs `tsc` directly on the two source files (`list-marker-utils.ts` plus its sibling `layout-constants.ts` dependency) and emits the declarations into `dist/shared/common/`. Same effect, no tree-shape change.

The exact relocation rule + guard entry follow the SD-2893 pattern established by the pm-adapter subpath rules. Audit Rule 1 / Rule 3 still cover the bare `@superdoc/common` shim that remains.

Remaining shims (3): `@superdoc/common`, `@superdoc/common/components/BasicUpload.vue`, `@superdoc/style-engine/ooxml`.

**Verified**:
- `pnpm --filter superdoc build:es` clean (audit OK, 8 guarded packages, 3 shim modules)
- Consumer matrix: 47 passed, 0 failed, 0 warnings
- Runtime smoke: 4/4 against the freshly packed tarball
- Negative test: `import('@superdoc/common/list-marker-utils')` rewrites to `./shared/common/list-marker-utils.js` and the target file exists in dist