### PR TITLE
fix(types): drop accidental BasicUpload public re-export (SD-2893)

### DIFF
--- a/packages/super-editor/src/editors/v1/index.js
+++ b/packages/super-editor/src/editors/v1/index.js
@@ -33,7 +33,6 @@ import { Mark } from '@core/Mark.js';
 import ContextMenu from './components/context-menu/ContextMenu.vue';
 /** @deprecated Use ContextMenu instead */
 const SlashMenu = ContextMenu;
-import BasicUpload from '@superdoc/common/components/BasicUpload.vue';
 
 import SuperEditor from './components/SuperEditor.vue';
 import Toolbar from './components/toolbar/Toolbar.vue';
@@ -100,8 +99,6 @@ export {
   SuperEditor,
   /** @internal */
   SuperInput,
-  /** @internal */
-  BasicUpload,
   Toolbar,
   AIWriter,
   ContextMenu,

--- a/packages/superdoc/src/index.js
+++ b/packages/superdoc/src/index.js
@@ -28,7 +28,6 @@ import {
   // Vue components
   SuperEditor,
   SuperInput,
-  BasicUpload,
   Toolbar,
   AIWriter,
   ContextMenu,
@@ -289,7 +288,6 @@ export {
   // Vue components
   SuperEditor,
   SuperInput,
-  BasicUpload,
   Toolbar,
   AIWriter,
   ContextMenu,

--- a/tests/consumer-typecheck/src/customer-scenario.ts
+++ b/tests/consumer-typecheck/src/customer-scenario.ts
@@ -42,7 +42,6 @@ import {
   CommentsPluginKey,
   SuperEditor,
   SuperInput,
-  BasicUpload,
   Toolbar,
   AIWriter,
   ContextMenu,
@@ -831,7 +830,6 @@ function testAdditionalClasses() {
 function testVueComponents() {
   const superEditor = SuperEditor;
   const superInput = SuperInput;
-  const basicUpload = BasicUpload;
   const toolbarComponent = Toolbar;
   const aiWriter = AIWriter;
   const contextMenu = ContextMenu;


### PR DESCRIPTION
Drains the fourth shim entry by removing the accidental public re-export of `BasicUpload`. Shim count: 3 to 2.

`BasicUpload` was re-exported through `superdoc/super-editor` and `superdoc` despite being marked `@internal` at the export site itself ([editors/v1/index.js:103](https://github.com/superdoc-dev/superdoc/blob/4458d0232/packages/super-editor/src/editors/v1/index.js#L100-L106)). Customer-use audit found:

- No mention in any README, AGENTS guide, or app docs.
- No usage in any example app source (only cached/build artifacts).
- Both internal dev tools (`SuperdocDev.vue`, `DeveloperPlayground.vue`) import it directly from `@superdoc/common/components/BasicUpload.vue`, never via the public re-export.

Dropping the re-export is cleaner than relocating the `.vue` file because the widget is dev-tooling, not a documented public component. The shim entry for `@superdoc/common/components/BasicUpload.vue` goes away because nothing on the public surface references it anymore.

The consumer-typecheck `customer-scenario.ts` fixture was the only place the public re-export was exercised. Removed the assertion there too so the matrix stays green; this is consistent with the SD-2828 contract that public-facing assertions track the actual public surface.

Remaining shims (2): `@superdoc/common` (5 dist refs, catch-all bin), `@superdoc/style-engine/ooxml` (10 dist refs). Each needs exploratory work, not the simple dropping or relocation pattern.

**Verified**:
- `pnpm --filter superdoc build:es` clean (audit OK, 8 guarded packages, 2 shim modules)
- Consumer matrix: 47 passed, 0 failed, 0 warnings
- Runtime smoke 4/4 against the freshly-packed tarball, including explicit `assert.equal(m.BasicUpload, undefined)` on both `superdoc` and `superdoc/super-editor` entries