### PR TITLE
fix(types): drain @superdoc/style-engine/ooxml shim (SD-2893)

### DIFF
--- a/packages/layout-engine/style-engine/src/cascade.ts
+++ b/packages/layout-engine/style-engine/src/cascade.ts
@@ -24,27 +24,6 @@ export type PropertyObject = ParagraphProperties | RunProperties | TableCellProp
  * @param propertiesArray - Ordered list of property objects to combine (low -> high priority).
  * @param options - Configuration for full overrides and special handling.
  * @returns Combined property object.
- *
- * @example
- * ```typescript
- * import { combineProperties } from '@superdoc/style-engine/cascade';
- *
- * const result = combineProperties([
- *   { fontSize: 22, bold: true },           // from style
- *   { fontSize: 24, italic: true },         // from inline (wins for fontSize)
- * ]);
- * // result: { fontSize: 24, bold: true, italic: true }
- *
- * // With full override for color (replaces entire object, not merge):
- * const result2 = combineProperties(
- *   [
- *     { color: { val: 'FF0000', theme: 'accent1' } },
- *     { color: { val: '00FF00' } },
- *   ],
- *   { fullOverrideProps: ['color'] }
- * );
- * // result2: { color: { val: '00FF00' } } - NOT merged
- * ```
  */
 export function combineProperties<T extends PropertyObject>(
   propertiesArray: T[],

--- a/packages/super-editor/src/editors/v1/index.js
+++ b/packages/super-editor/src/editors/v1/index.js
@@ -33,7 +33,6 @@ import { Mark } from '@core/Mark.js';
 import ContextMenu from './components/context-menu/ContextMenu.vue';
 /** @deprecated Use ContextMenu instead */
 const SlashMenu = ContextMenu;
-import BasicUpload from '@superdoc/common/components/BasicUpload.vue';
 
 import SuperEditor from './components/SuperEditor.vue';
 import Toolbar from './components/toolbar/Toolbar.vue';
@@ -100,8 +99,6 @@ export {
   SuperEditor,
   /** @internal */
   SuperInput,
-  /** @internal */
-  BasicUpload,
   Toolbar,
   AIWriter,
   ContextMenu,

--- a/packages/superdoc/scripts/audit-declarations.cjs
+++ b/packages/superdoc/scripts/audit-declarations.cjs
@@ -72,6 +72,7 @@ const RELOCATION_GUARD_PACKAGES = [
   '@superdoc/layout-engine',
   '@superdoc/painter-dom',
   '@superdoc/pm-adapter',
+  '@superdoc/style-engine',
   '@superdoc/common/list-marker-utils',
 ];
 

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -275,6 +275,16 @@ const RELOCATION_RULES = [
     distEntry: 'shared/common/list-marker-utils.d.ts',
     matchSubpaths: false,
   },
+  // SD-2893: only the /ooxml subpath of style-engine is publicly reachable.
+  // Relocate just this subpath plus its sibling cascade.ts dependency
+  // (see vite.config.js include list). The bare @superdoc/style-engine is
+  // guarded but unrewritten; if a future bare-barrel leak appears the audit
+  // gate fails rather than producing a missing relative path.
+  {
+    pkg: '@superdoc/style-engine/ooxml',
+    distEntry: 'layout-engine/style-engine/src/ooxml/index.d.ts',
+    matchSubpaths: false,
+  },
 ];
 
 // Guard packages that must never fall back to `_internal-shims.d.ts`.
@@ -289,6 +299,7 @@ const RELOCATION_GUARD_PACKAGES = [
   '@superdoc/layout-engine',
   '@superdoc/painter-dom',
   '@superdoc/pm-adapter',
+  '@superdoc/style-engine',
   '@superdoc/common/list-marker-utils',
 ];
 
@@ -329,6 +340,7 @@ const RELOCATION_REWRITERS = RELOCATION_RULES.map((rule) => ({
 // shim after we intentionally skip shim generation.
 const UNSHIMMED_PRIVATE_SPECIFIERS = new Set([
   '@superdoc/pm-adapter',
+  '@superdoc/style-engine',
 ]);
 
 function shouldSkipWorkspaceShim(mod) {

--- a/packages/superdoc/src/index.js
+++ b/packages/superdoc/src/index.js
@@ -28,7 +28,6 @@ import {
   // Vue components
   SuperEditor,
   SuperInput,
-  BasicUpload,
   Toolbar,
   AIWriter,
   ContextMenu,
@@ -289,7 +288,6 @@ export {
   // Vue components
   SuperEditor,
   SuperInput,
-  BasicUpload,
   Toolbar,
   AIWriter,
   ContextMenu,

--- a/packages/superdoc/tsconfig.json
+++ b/packages/superdoc/tsconfig.json
@@ -32,6 +32,8 @@
     "../layout-engine/layout-engine/src",
     "../layout-engine/painters/dom/src",
     "../layout-engine/pm-adapter/src/converter-context.ts",
-    "../layout-engine/pm-adapter/src/sections/types.ts"
+    "../layout-engine/pm-adapter/src/sections/types.ts",
+    "../layout-engine/style-engine/src/ooxml",
+    "../layout-engine/style-engine/src/cascade.ts"
   ]
 }

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -140,6 +140,12 @@ export default defineConfig(({ mode, command }) => {
         // type subpaths reachable from the public surface are relocated.
         '../layout-engine/pm-adapter/src/converter-context.ts',
         '../layout-engine/pm-adapter/src/sections/types.ts',
+        // SD-2893: only the /ooxml subpath of style-engine is publicly
+        // reachable today. Include the ooxml subtree plus the cascade.ts
+        // sibling it depends on. The full src/**/* glob pulls the broader
+        // project graph through contracts project references.
+        '../layout-engine/style-engine/src/ooxml/**/*',
+        '../layout-engine/style-engine/src/cascade.ts',
       ],
       outDir: 'dist',
       // vite-plugin-dts still gathers diagnostics for this mixed JS/Vue source

--- a/tests/consumer-typecheck/src/customer-scenario.ts
+++ b/tests/consumer-typecheck/src/customer-scenario.ts
@@ -42,7 +42,6 @@ import {
   CommentsPluginKey,
   SuperEditor,
   SuperInput,
-  BasicUpload,
   Toolbar,
   AIWriter,
   ContextMenu,
@@ -831,7 +830,6 @@ function testAdditionalClasses() {
 function testVueComponents() {
   const superEditor = SuperEditor;
   const superInput = SuperInput;
-  const basicUpload = BasicUpload;
   const toolbarComponent = Toolbar;
   const aiWriter = AIWriter;
   const contextMenu = ContextMenu;


### PR DESCRIPTION
Stacked on #3151. Drains the fifth shim entry (`@superdoc/style-engine/ooxml`), bringing the count to 1. Only `@superdoc/common` remains.

The `/ooxml` subpath is the only part of style-engine publicly reachable - 10 dist d.ts references across pm-adapter, the diffing extension, super-converter, parts adapters, and plan-engine. The bare `@superdoc/style-engine` is internal-only.

Approach mirrors the pm-adapter narrow-scope pattern from #3144:

- Include only the `ooxml/**` subtree plus its sibling `cascade.ts` dependency in `vite.config.js`/`tsconfig.json`. A full `src/**/*` glob pulls the broader project graph through `@superdoc/contracts` project references and re-expands the shim list (verified during probe).
- Add an exact relocation rule for `@superdoc/style-engine/ooxml`.
- Guard the bare `@superdoc/style-engine` root in both `RELOCATION_GUARD_PACKAGES` and `UNSHIMMED_PRIVATE_SPECIFIERS` so a future bare-barrel leak fails audit Rule 1 instead of producing a broken relative path.

Also removes a misleading JSDoc `@example` block from `cascade.ts`. The example showed `import from '@superdoc/style-engine/cascade'`, but `cascade` is not in the package's `exports` field. Same false-positive class as the `useUiFontFamily` cleanup in #3140 - the bare specifier inside the `@example` was being captured by the workspace-import scanner.

**Verified**:
- `pnpm --filter superdoc build:es` clean (audit OK, 9 guarded packages, 1 shim module)
- Consumer matrix: 47 passed, 0 failed, 0 warnings
- Runtime smoke 4/4 against the freshly packed tarball
- Dist has the 6 expected declaration files: `cascade.d.ts`, `ooxml/{index,types,numbering-types,styles-types,table-style-selection}.d.ts`
- Negative tests: `import('@superdoc/style-engine/ooxml')` rewrites to a real target file in dist; `import('@superdoc/style-engine')` (bare) is preserved unchanged and audit Rule 1 fails with exit 1

After this lands, only `@superdoc/common` (5 dist refs, catch-all bin) remains. That's the hardest of the original 9 shims and needs per-type analysis (Comment, CommentJSON, CommentContent, CommentThreadingProfile - each gets an inline-vs-relocate-vs-remove decision).