### PR TITLE
fix(types): drain bare @superdoc/common shim, reach zero shims (SD-2893)

### DIFF
--- a/packages/superdoc/scripts/audit-declarations.cjs
+++ b/packages/superdoc/scripts/audit-declarations.cjs
@@ -73,6 +73,7 @@ const RELOCATION_GUARD_PACKAGES = [
   '@superdoc/painter-dom',
   '@superdoc/pm-adapter',
   '@superdoc/style-engine',
+  '@superdoc/common',
   '@superdoc/common/list-marker-utils',
 ];
 

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -66,9 +66,11 @@ if (handwrittenCopiedSuperEditor > 0) {
 // public surface. Adding shared/ to vite-plugin-dts's `include` would shift the
 // common-ancestor of all source files to the repo root and reorganise the
 // entire dist tree, so we run tsc directly for just the files we relocate.
-// Today: list-marker-utils plus its sibling layout-constants. Add new entries
-// here in lockstep with `RELOCATION_RULES` below.
-const SHARED_COMMON_DTS_TARGETS = ['list-marker-utils.ts', 'layout-constants.ts'];
+// Today: list-marker-utils plus its sibling layout-constants, and
+// comments-types (the four Comment* types referenced via bare @superdoc/common
+// imports in three internal-only dist d.ts files). Add new entries here in
+// lockstep with `RELOCATION_RULES` below.
+const SHARED_COMMON_DTS_TARGETS = ['list-marker-utils.ts', 'layout-constants.ts', 'comments-types.ts'];
 {
   const { spawnSync: _spawnSync } = require('node:child_process');
   const tscBin = path.join(repoRoot, 'node_modules', '.bin', 'tsc');
@@ -285,6 +287,20 @@ const RELOCATION_RULES = [
     distEntry: 'layout-engine/style-engine/src/ooxml/index.d.ts',
     matchSubpaths: false,
   },
+  // SD-2893: bare @superdoc/common appears in three internal-only dist d.ts
+  // files for the four Comment* types (Comment, CommentContent, CommentJSON,
+  // CommentThreadingProfile). Point the bare specifier at comments-types.d.ts
+  // (emitted via SHARED_COMMON_DTS_TARGETS) so the rewrite resolves to a real
+  // file. matchSubpaths: false because only the bare specifier is referenced;
+  // any future @superdoc/common/<other-subpath> import would not be auto-
+  // rewritten, falling through to the audit gate. The runtime-value imports
+  // from the main entry (DOCX, PDF, HTML, getFileObject, compareVersions,
+  // BlankDOCX) are still handled by the inline-replacement step above.
+  {
+    pkg: '@superdoc/common',
+    distEntry: 'shared/common/comments-types.d.ts',
+    matchSubpaths: false,
+  },
 ];
 
 // Guard packages that must never fall back to `_internal-shims.d.ts`.
@@ -300,6 +316,7 @@ const RELOCATION_GUARD_PACKAGES = [
   '@superdoc/painter-dom',
   '@superdoc/pm-adapter',
   '@superdoc/style-engine',
+  '@superdoc/common',
   '@superdoc/common/list-marker-utils',
 ];
 


### PR DESCRIPTION
Drains the final shim entry. After this lands the published `_internal-shims.d.ts` has zero `declare module` entries.

The remaining `@superdoc/common` shim was referenced by three internal dist d.ts files for four Comment* types: `Comment`, `CommentContent`, `CommentJSON`, `CommentThreadingProfile`. All live in `shared/common/comments-types.ts`.

Approach mirrors the list-marker-utils pattern from #3150: tsc-emit `comments-types.ts` into `dist/shared/common/`, then map bare `@superdoc/common` imports to that file. `matchSubpaths: false` because only the bare specifier is referenced today; any future `@superdoc/common/<subpath>` import falls through to the shim generator and audit Rule 3 fires (the guard regex matches subpaths). Verified end-to-end with a synthetic injection.

Two paths through `ensure-types.cjs` address different `@superdoc/common` concerns and don't conflict:
- Existing inline-replacement (lines 89-119): runtime-value imports in the main entry (`DOCX`, `PDF`, `HTML`, `getFileObject`, `compareVersions`, `BlankDOCX`)
- New relocation rule: type imports in the 3 internal dist d.ts files

Verified: build:es clean (10 guarded packages, **0 shim modules**), consumer matrix 47/0/0, runtime smoke 4/4, dist target exists at `shared/common/comments-types.d.ts`, negative test confirms audit Rule 3 catches future `@superdoc/common` subpath leaks (exit 1).

Closes the SD-2893 shim drain. From the original 9 shim modules, all are now relocated, removed from the public surface, or guarded with explicit fail-loudly behavior. The published `superdoc` package no longer ships ambient `any` shims for any private workspace package.