### PR TITLE
docs(custom-ui): link configurable toolbar example (SD-2929)

### DIFF
--- a/apps/docs/editor/custom-ui/custom-commands.mdx
+++ b/apps/docs/editor/custom-ui/custom-commands.mdx
@@ -59,6 +59,8 @@ function InsertClauseButton() {
 }
 ```
 
+See the [configurable toolbar example](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/custom-ui/configurable-toolbar) for a runnable vanilla version that registers an `example.insertClause` command alongside the built-in bold / italic / underline buttons.
+
 ## Naming
 
 Use a namespace to avoid colliding with future built-ins. `company.insertClause`, `acme.aiRewrite`, `support.translate`. Bare names like `'rewrite'` will warn if SuperDoc later adds a built-in with the same id.

--- a/apps/docs/editor/custom-ui/toolbar-and-commands.mdx
+++ b/apps/docs/editor/custom-ui/toolbar-and-commands.mdx
@@ -67,6 +67,8 @@ function ToolbarButton({ id, label, title }: { id: string; label: string; title:
 }
 ```
 
+See the [configurable toolbar example](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/custom-ui/configurable-toolbar) for a runnable vanilla version: a config-driven button row that subscribes per-id and reads `disabled` / `active` straight from the controller.
+
 ## Commands with payloads
 
 Some commands take a value. Pass it to `execute()`.


### PR DESCRIPTION
Inline links from `apps/docs/editor/custom-ui/toolbar-and-commands.mdx` and `custom-commands.mdx` to the [`configurable-toolbar`](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/custom-ui/configurable-toolbar) example shipped in #3159. Same plain-link pattern used by the selection-capture link PR (#3143), no `<Card>` callouts.

The example teaches both halves (built-in command binding via `ui.commands.<id>.observe` + `ui.commands.register` for a custom command), so both docs pages link.

Stacked on `caio/sd-2929-configurable-toolbar`. Once #3159 lands on main, I'll rebase the base back to main automatically.

**Verified**: docs validate passes; net diff +4/-0 across two mdx files.