### PR TITLE
feat: render w:noBreakHyphen tags (SD-2746)

### DIFF
--- a/packages/layout-engine/pm-adapter/src/constants.ts
+++ b/packages/layout-engine/pm-adapter/src/constants.ts
@@ -89,6 +89,7 @@ export const DEFAULT_HYPERLINK_CONFIG: HyperlinkConfig = {
  * - page-number, total-page-number: Document tokens
  * - indexEntry: Index entry field markers (see index-entry.js)
  * - tab: Tab stops (see tab.js)
+ * - noBreakHyphen: Non-breaking hyphen (U+2011 from <w:noBreakHyphen/>; see no-break-hyphen.js)
  * - passthroughInline: Passthrough content like FORMCHECKBOX (see passthrough.js)
  * - bookmarkEnd: Bookmark end markers (see bookmark-end.js)
  *
@@ -103,6 +104,7 @@ export const ATOMIC_INLINE_TYPES = new Set([
   'total-page-number',
   'indexEntry',
   'tab',
+  'noBreakHyphen',
   'footnoteReference',
   'mathInline',
   'passthroughInline',

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/no-break-hyphen.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/no-break-hyphen.ts
@@ -1,0 +1,58 @@
+import type { TextRun } from '@superdoc/contracts';
+import { applyMarksToRun } from '../../marks/index.js';
+import { applyInlineRunProperties, type InlineConverterParams } from './common.js';
+import { DEFAULT_HYPERLINK_CONFIG } from '../../constants.js';
+
+const NON_BREAKING_HYPHEN = '‑';
+
+/**
+ * Converts a noBreakHyphen PM atom to a TextRun carrying U+2011.
+ *
+ * Renders identically to a literal U+2011 in <w:t>; the atom exists purely to preserve
+ * round-trip identity back to <w:noBreakHyphen/> on export. DomPainter handles the glyph
+ * via the existing text-rendering path — no painter changes needed.
+ */
+export function noBreakHyphenNodeToRun({
+  node,
+  positions,
+  storyKey,
+  defaultFont,
+  defaultSize,
+  inheritedMarks = [],
+  sdtMetadata,
+  hyperlinkConfig = DEFAULT_HYPERLINK_CONFIG,
+  themeColors,
+  enableComments,
+  runProperties,
+  converterContext,
+}: InlineConverterParams): TextRun {
+  let run: TextRun = {
+    text: NON_BREAKING_HYPHEN,
+    fontFamily: defaultFont,
+    fontSize: defaultSize,
+  };
+
+  const pos = positions.get(node);
+  if (pos) {
+    run.pmStart = pos.start;
+    run.pmEnd = pos.end;
+  }
+
+  applyMarksToRun(
+    run,
+    [...(node.marks ?? []), ...(inheritedMarks ?? [])],
+    hyperlinkConfig,
+    themeColors,
+    converterContext?.backgroundColor,
+    enableComments,
+    storyKey,
+  );
+
+  if (sdtMetadata) {
+    run.sdt = sdtMetadata;
+  }
+
+  run = applyInlineRunProperties(run, runProperties, converterContext);
+
+  return run;
+}

--- a/packages/layout-engine/pm-adapter/src/converters/paragraph.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/paragraph.ts
@@ -52,6 +52,7 @@ import { fieldAnnotationNodeToRun } from './inline-converters/field-annotation.j
 import { bookmarkStartNodeToBlocks } from './inline-converters/bookmark-start.js';
 import { bookmarkEndNodeToRun } from './inline-converters/bookmark-end.js';
 import { tabNodeToRun } from './inline-converters/tab.js';
+import { noBreakHyphenNodeToRun } from './inline-converters/no-break-hyphen.js';
 import { tokenNodeToRun } from './inline-converters/generic-token.js';
 import { imageNodeToRun } from './inline-converters/image.js';
 import { crossReferenceNodeToRun } from './inline-converters/cross-reference.js';
@@ -1005,6 +1006,9 @@ const INLINE_CONVERTERS_REGISTRY: Record<string, InlineConverterSpec> = {
   },
   tab: {
     inlineConverter: tabNodeToRun,
+  },
+  noBreakHyphen: {
+    inlineConverter: noBreakHyphenNodeToRun,
   },
   image: {
     inlineConverter: imageNodeToRun,

--- a/packages/super-editor/src/editors/v1/core/Schema.js
+++ b/packages/super-editor/src/editors/v1/core/Schema.js
@@ -68,6 +68,10 @@ export class Schema {
         code: callOrGet(getExtensionConfigField(extension, 'code', context)),
         defining: callOrGet(getExtensionConfigField(extension, 'defining', context)),
         isolating: callOrGet(getExtensionConfigField(extension, 'isolating', context)),
+        // leafText is a function-valued NodeSpec field; it must NOT be invoked here.
+        // It's surfaced into the spec so PM's textBetween (and helpers like
+        // textBetweenWithTabs) can flatten atomic leaves to their visible text.
+        leafText: getExtensionConfigField(extension, 'leafText', context),
         summary: getExtensionConfigField(extension, 'summary', context),
         attrs,
         ...additionalNodeFields,

--- a/packages/super-editor/src/editors/v1/core/commands/backspaceAtomBefore.js
+++ b/packages/super-editor/src/editors/v1/core/commands/backspaceAtomBefore.js
@@ -1,0 +1,97 @@
+import { Selection } from 'prosemirror-state';
+
+/**
+ * Atom inline node types that should be treated as a single deletable unit
+ * when Backspace is pressed with the cursor immediately after them.
+ *
+ * Why opt-in (rather than "any atom"):
+ *   `findPreviousTextDeleteRange` deliberately skips atoms like bookmarkEnd
+ *   so backspace deletes the previous text character, not the bookmark marker.
+ *   Generalizing atom-deletion would break that behavior. This list captures
+ *   atoms whose semantics are "a glyph the user inserted" — closer to text
+ *   than to a marker — so deleting them on Backspace matches Word/intuition.
+ */
+const DELETABLE_INLINE_ATOMS = new Set(['noBreakHyphen']);
+
+/**
+ * Returns the deletable atom inside a single-child run, or null otherwise.
+ * After import, atoms like noBreakHyphen always live inside their own `run`
+ * wrapper. From a paragraph-level cursor, `nodeBefore` is that wrapper run —
+ * not the atom directly — so we have to peek one level deeper.
+ */
+const onlyChildAtomIn = (runNode) => {
+  if (!runNode || runNode.type.name !== 'run') return null;
+  if (runNode.content.childCount !== 1) return null;
+  const child = runNode.content.firstChild;
+  if (!child?.isAtom || !child.isInline) return null;
+  if (!DELETABLE_INLINE_ATOMS.has(child.type.name)) return null;
+  return child;
+};
+
+/**
+ * Backspace handler that deletes a deletable inline atom (and its wrapper run,
+ * if any) directly before the cursor as a single unit.
+ *
+ * Three caret positions resolve to "right after the atom" in the rendered doc:
+ *   1. Inside the atom's run, after the atom        → nodeBefore = atom
+ *   2. At paragraph level, between runs             → nodeBefore = atom-wrapper run
+ *   3. At the start of the run after the atom       → walk one level up
+ *
+ * Slotted into the keymap chain BEFORE `backspaceAcrossRuns` so the run-aware
+ * scanner does not walk past the atom and delete a character from the previous
+ * run instead.
+ *
+ * @returns {import('@core/commands/types').Command}
+ */
+export const backspaceAtomBefore =
+  () =>
+  ({ state, tr, dispatch }) => {
+    const sel = state.selection;
+    if (!sel.empty) return false;
+
+    const $pos = sel.$from;
+    let from = -1;
+    let to = -1;
+
+    // Case 1: inside the atom's run, immediately after the atom. If the atom
+    // is the run's only child, remove the whole wrapper for parity with cases
+    // 2 and 3 — otherwise we leak an empty run that would have to be cleaned
+    // up later. If the run holds other inline content too, just delete the atom.
+    const direct = $pos.nodeBefore;
+    if (direct?.isInline && direct.isAtom && DELETABLE_INLINE_ATOMS.has(direct.type.name)) {
+      const parent = $pos.parent;
+      if (parent.type.name === 'run' && parent.content.childCount === 1) {
+        const runStart = $pos.before($pos.depth);
+        from = runStart;
+        to = runStart + parent.nodeSize;
+      } else {
+        from = $pos.pos - direct.nodeSize;
+        to = $pos.pos;
+      }
+    }
+
+    // Case 2: at paragraph level, nodeBefore is the run wrapping the atom.
+    if (from === -1 && onlyChildAtomIn(direct)) {
+      from = $pos.pos - direct.nodeSize;
+      to = $pos.pos;
+    }
+
+    // Case 3: at the start of the run that follows the atom-run. The cursor's
+    // parent is a run, parentOffset is 0, and the previous paragraph-level
+    // sibling is the atom-wrapper run.
+    if (from === -1 && $pos.parent.type.name === 'run' && $pos.parentOffset === 0) {
+      const parentBefore = state.doc.resolve($pos.before($pos.depth)).nodeBefore;
+      if (onlyChildAtomIn(parentBefore)) {
+        from = $pos.before($pos.depth) - parentBefore.nodeSize;
+        to = $pos.before($pos.depth);
+      }
+    }
+
+    if (from === -1) return false;
+
+    if (dispatch) {
+      tr.delete(from, to).setSelection(Selection.near(tr.doc.resolve(from)));
+      dispatch(tr.scrollIntoView());
+    }
+    return true;
+  };

--- a/packages/super-editor/src/editors/v1/core/commands/core-command-map.d.ts
+++ b/packages/super-editor/src/editors/v1/core/commands/core-command-map.d.ts
@@ -64,6 +64,7 @@ type CoreCommandNames =
   | 'backspaceAtomBefore'
   | 'deleteSkipEmptyRun'
   | 'deleteNextToRun'
+  | 'deleteAtomAfter'
   | 'skipTab';
 
 export type CoreCommandSignatures = {

--- a/packages/super-editor/src/editors/v1/core/commands/core-command-map.d.ts
+++ b/packages/super-editor/src/editors/v1/core/commands/core-command-map.d.ts
@@ -61,6 +61,7 @@ type CoreCommandNames =
   | 'backspaceSkipEmptyRun'
   | 'backspaceNextToRun'
   | 'backspaceAcrossRuns'
+  | 'backspaceAtomBefore'
   | 'deleteSkipEmptyRun'
   | 'deleteNextToRun'
   | 'skipTab';

--- a/packages/super-editor/src/editors/v1/core/commands/deleteAtomAfter.js
+++ b/packages/super-editor/src/editors/v1/core/commands/deleteAtomAfter.js
@@ -41,6 +41,11 @@ export const deleteAtomAfter =
     // Case 1 only: caret is inside the atom's wrapper run, immediately
     // before the atom, and the atom is that run's only child. Remove the
     // whole wrapper as a single unit so we don't leak an empty run.
+    // Note: `childCount !== 1` is defensive — `calculateInlineRunPropertiesPlugin`
+    // segments runs by inline properties on every change, so a run holding
+    // text+atom+text is always split back into three single-content runs
+    // before this command runs. The guard documents the invariant; it isn't
+    // reachable through normal editing.
     const parent = $pos.parent;
     if (parent.type.name !== 'run' || parent.content.childCount !== 1) return false;
 

--- a/packages/super-editor/src/editors/v1/core/commands/deleteAtomAfter.js
+++ b/packages/super-editor/src/editors/v1/core/commands/deleteAtomAfter.js
@@ -1,0 +1,56 @@
+import { Selection } from 'prosemirror-state';
+
+/**
+ * Atom inline node types that should be treated as a single deletable unit
+ * when Delete is pressed with the cursor immediately before them. Mirrors
+ * `backspaceAtomBefore`'s allowlist — same opt-in policy, same rationale
+ * (don't accidentally delete bookmarkEnd-style markers).
+ */
+const DELETABLE_INLINE_ATOMS = new Set(['noBreakHyphen']);
+
+/**
+ * Forward-Delete handler that targets the deletable inline atom directly
+ * after the cursor.
+ *
+ * Only handles the case the rest of the Delete chain misses: caret inside
+ * the atom's wrapper run with `nodeAfter` being the atom itself. At that
+ * caret, `deleteNextToRun` bails (its early return excludes any nodeAfter
+ * that isn't a `run`), `deleteSelection` is a no-op for empty selections,
+ * `joinForward` only fires at textblock end, and `selectNodeForward` skips
+ * non-selectable atoms — so the chain falls through and nothing happens.
+ *
+ * Paragraph-level boundary cases (caret between runs, or at the end of the
+ * previous run with the atom-wrapper run as the next sibling) already work
+ * via `deleteNextToRun`, which removes the atom and lets PM's replace fold
+ * the now-empty wrapper into the surrounding paragraph. Don't intercept
+ * those — leave the existing path alone.
+ *
+ * @returns {import('@core/commands/types').Command}
+ */
+export const deleteAtomAfter =
+  () =>
+  ({ state, tr, dispatch }) => {
+    const sel = state.selection;
+    if (!sel.empty) return false;
+
+    const $pos = sel.$from;
+    const after = $pos.nodeAfter;
+    if (!after || !after.isInline || !after.isAtom) return false;
+    if (!DELETABLE_INLINE_ATOMS.has(after.type.name)) return false;
+
+    // Case 1 only: caret is inside the atom's wrapper run, immediately
+    // before the atom, and the atom is that run's only child. Remove the
+    // whole wrapper as a single unit so we don't leak an empty run.
+    const parent = $pos.parent;
+    if (parent.type.name !== 'run' || parent.content.childCount !== 1) return false;
+
+    const runStart = $pos.before($pos.depth);
+    const from = runStart;
+    const to = runStart + parent.nodeSize;
+
+    if (dispatch) {
+      tr.delete(from, to).setSelection(Selection.near(tr.doc.resolve(from)));
+      dispatch(tr.scrollIntoView());
+    }
+    return true;
+  };

--- a/packages/super-editor/src/editors/v1/core/commands/index.js
+++ b/packages/super-editor/src/editors/v1/core/commands/index.js
@@ -53,6 +53,7 @@ export * from './backspaceAcrossRuns.js';
 export * from './backspaceAtomBefore.js';
 export * from './deleteSkipEmptyRun.js';
 export * from './deleteNextToRun.js';
+export * from './deleteAtomAfter.js';
 export * from './skipTab.js';
 
 // Tables

--- a/packages/super-editor/src/editors/v1/core/commands/index.js
+++ b/packages/super-editor/src/editors/v1/core/commands/index.js
@@ -50,6 +50,7 @@ export * from './backspaceEmptyRunParagraph.js';
 export * from './backspaceSkipEmptyRun.js';
 export * from './backspaceNextToRun.js';
 export * from './backspaceAcrossRuns.js';
+export * from './backspaceAtomBefore.js';
 export * from './deleteSkipEmptyRun.js';
 export * from './deleteNextToRun.js';
 export * from './skipTab.js';

--- a/packages/super-editor/src/editors/v1/core/extensions/keymap.js
+++ b/packages/super-editor/src/editors/v1/core/extensions/keymap.js
@@ -56,6 +56,7 @@ export const handleDelete = (editor) => {
 
   return editor.commands.first(({ commands }) => [
     () => commands.deleteSkipEmptyRun(),
+    () => commands.deleteAtomAfter(),
     () => commands.deleteNextToRun(),
     () => commands.deleteSelection(),
     () => commands.joinForward(),

--- a/packages/super-editor/src/editors/v1/core/extensions/keymap.js
+++ b/packages/super-editor/src/editors/v1/core/extensions/keymap.js
@@ -39,6 +39,7 @@ export const handleBackspace = (editor) => {
     },
     () => commands.backspaceEmptyRunParagraph(),
     () => commands.backspaceSkipEmptyRun(),
+    () => commands.backspaceAtomBefore(),
     () => commands.backspaceNextToRun(),
     () => commands.backspaceAcrossRuns(),
     () => commands.deleteSelection(),

--- a/packages/super-editor/src/editors/v1/core/super-converter/exporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/exporter.js
@@ -5,6 +5,7 @@ import { translateChildNodes } from './v2/exporter/helpers/index.js';
 import { translator as wBrNodeTranslator } from './v3/handlers/w/br/br-translator.js';
 import { translator as wHighlightTranslator } from './v3/handlers/w/highlight/highlight-translator.js';
 import { translator as wTabNodeTranslator } from './v3/handlers/w/tab/tab-translator.js';
+import { translator as wNoBreakHyphenNodeTranslator } from './v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.js';
 import { translator as wPNodeTranslator } from './v3/handlers/w/p/p-translator.js';
 import { translator as wRNodeTranslator } from './v3/handlers/w/r/r-translator.js';
 import { translator as wTcNodeTranslator } from './v3/handlers/w/tc/tc-translator';
@@ -178,6 +179,7 @@ export function exportSchemaToJson(params) {
     bookmarkEnd: wBookmarkEndTranslator,
     fieldAnnotation: wSdtNodeTranslator,
     tab: wTabNodeTranslator,
+    noBreakHyphen: wNoBreakHyphenNodeTranslator,
     image: [wDrawingNodeTranslator, pictTranslator],
     hardBreak: wBrNodeTranslator,
     commentRangeStart: wCommentRangeStartTranslator,

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
@@ -25,6 +25,7 @@ import { importFootnoteData, importEndnoteData } from './documentFootnotesImport
 import { getDefaultStyleDefinition } from '@converter/docx-helpers/index.js';
 import { pruneIgnoredNodes } from './ignoredNodes.js';
 import { tabNodeEntityHandler } from './tabImporter.js';
+import { noBreakHyphenNodeEntityHandler } from './noBreakHyphenImporter.js';
 import { footnoteReferenceHandlerEntity } from './footnoteReferenceImporter.js';
 import { endnoteReferenceHandlerEntity } from './endnoteReferenceImporter.js';
 import { tableNodeHandlerEntity } from './tableImporter.js';
@@ -246,6 +247,7 @@ export const defaultNodeListHandler = () => {
     footnoteReferenceHandlerEntity,
     endnoteReferenceHandlerEntity,
     tabNodeEntityHandler,
+    noBreakHyphenNodeEntityHandler,
     tableOfContentsHandlerEntity,
     indexHandlerEntity,
     bibliographyHandlerEntity,

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/noBreakHyphenImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/noBreakHyphenImporter.js
@@ -1,0 +1,26 @@
+// @ts-check
+import { translator as wNoBreakHyphenNodeTranslator } from '../../v3/handlers/w/noBreakHyphen/index.js';
+
+/**
+ * Non-breaking hyphen node handler.
+ * Captures <w:noBreakHyphen/> before it falls through to the passthrough handler.
+ * @param {import('../../v3/node-translator').SCEncoderConfig} params
+ * @returns {Object} Handler result
+ */
+const handleNoBreakHyphenNode = (params) => {
+  const { nodes } = params;
+  if (!nodes.length || nodes[0].name !== 'w:noBreakHyphen') {
+    return { nodes: [], consumed: 0 };
+  }
+  const node = wNoBreakHyphenNodeTranslator.encode(params);
+  return { nodes: [node], consumed: 1 };
+};
+
+/**
+ * Non-breaking hyphen node handler entity.
+ * @type {Object} Handler entity
+ */
+export const noBreakHyphenNodeEntityHandler = {
+  handlerName: 'w:noBreakHyphenTranslator',
+  handler: handleNoBreakHyphenNode,
+};

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/index.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/index.js
@@ -150,6 +150,7 @@ import { translator as w_sz_translator } from './w/sz/sz-translator.js';
 import { translator as w_szCs_translator } from './w/szcs/szcs-translator.js';
 import { translator as w_t_translator } from './w/t/t-translator.js';
 import { translator as w_tab_translator } from './w/tab/tab-translator.js';
+import { translator as w_noBreakHyphen_translator } from './w/noBreakHyphen/no-break-hyphen-translator.js';
 import { translator as w_tabs_translator } from './w/tabs/tabs-translator.js';
 import { translator as w_tbl_translator } from './w/tbl/tbl-translator.js';
 import { translator as w_tblBorders_translator } from './w/tblBorders/tblBorders-translator.js';
@@ -358,6 +359,7 @@ const translatorList = Array.from(
     w_szCs_translator,
     w_t_translator,
     w_tab_translator,
+    w_noBreakHyphen_translator,
     w_tabs_translator,
     w_tbl_translator,
     w_tblBorders_translator,

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/del/del-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/del/del-translator.js
@@ -86,10 +86,10 @@ function decode(params) {
   node.marks = marks.filter((m) => !trackingMarks.includes(m.type));
 
   const translatedTextNode = exportSchemaToJson({ ...params, node });
-  // ECMA-376 only renames w:t → w:delText (and w:instrText → w:delInstrText)
-  // inside <w:del>. Other inline content — w:noBreakHyphen, w:tab, w:br, etc.
-  // — stays as-is; the deletion is conveyed by the <w:del> wrapper alone.
-  // Guard the rename so non-text atoms inside <w:del> don't crash.
+  // ECMA-376 renames w:t → w:delText inside <w:del>. Other inline content —
+  // w:noBreakHyphen, w:tab, w:br, etc. — stays as-is; the deletion is
+  // conveyed by the <w:del> wrapper alone. Guard the rename so non-text
+  // atoms inside <w:del> don't crash.
   const textNode = translatedTextNode.elements.find((n) => n.name === 'w:t');
   if (textNode) textNode.name = 'w:delText';
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/del/del-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/del/del-translator.js
@@ -86,8 +86,12 @@ function decode(params) {
   node.marks = marks.filter((m) => !trackingMarks.includes(m.type));
 
   const translatedTextNode = exportSchemaToJson({ ...params, node });
+  // ECMA-376 only renames w:t → w:delText (and w:instrText → w:delInstrText)
+  // inside <w:del>. Other inline content — w:noBreakHyphen, w:tab, w:br, etc.
+  // — stays as-is; the deletion is conveyed by the <w:del> wrapper alone.
+  // Guard the rename so non-text atoms inside <w:del> don't crash.
   const textNode = translatedTextNode.elements.find((n) => n.name === 'w:t');
-  textNode.name = 'w:delText';
+  if (textNode) textNode.name = 'w:delText';
 
   return {
     name: 'w:del',

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/del/del-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/del/del-translator.test.js
@@ -207,5 +207,23 @@ describe('w:del translator', () => {
         }),
       );
     });
+
+    it('does not crash when the deleted run holds non-text content (e.g. w:noBreakHyphen)', () => {
+      // ECMA-376: only w:t / w:instrText are renamed inside <w:del>. Atoms like
+      // w:noBreakHyphen, w:tab, w:br stay as-is. The decoder used to assume a
+      // w:t was always present and would throw setting `.name` on undefined.
+      exportSchemaToJson.mockReturnValue({ elements: [{ name: 'w:noBreakHyphen', elements: [] }] });
+
+      const node = {
+        type: 'noBreakHyphen',
+        marks: [{ type: 'trackDelete', attrs: { id: '7', author: 'A', authorEmail: 'a@x', date: 'd' } }],
+      };
+
+      const result = config.decode({ node });
+
+      expect(result.name).toBe('w:del');
+      // The non-text element survives unchanged inside the wrapper.
+      expect(result.elements[0].elements[0]).toEqual({ name: 'w:noBreakHyphen', elements: [] });
+    });
   });
 });

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/index.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/index.js
@@ -1,0 +1,1 @@
+export * from './no-break-hyphen-translator.js';

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.js
@@ -1,0 +1,205 @@
+// @ts-check
+import { NodeTranslator } from '@translator';
+import { translator as wRPrNodeTranslator } from '../rpr/rpr-translator.js';
+import { translator as wHyperlinkTranslator } from '../hyperlink/hyperlink-translator.js';
+
+/** @type {import('@translator').XmlNodeName} */
+const XML_NODE_NAME = 'w:noBreakHyphen';
+
+/** @type {import('@translator').SuperDocNodeOrKeyName} */
+const SD_NODE_NAME = 'noBreakHyphen';
+
+/**
+ * Encode a <w:noBreakHyphen/> element as a SuperDoc noBreakHyphen atom inline node.
+ * Identity is preserved by the node type itself; literal U+2011 in <w:t> stays on the
+ * regular text path. The two never converge in PM state, so they never converge on export.
+ * @param {import('@translator').SCEncoderConfig} _
+ * @param {import('@translator').EncodedAttributes} [encodedAttrs] - The already encoded attributes
+ * @returns {import('@translator').SCEncoderResult}
+ */
+const encode = (_, encodedAttrs = {}) => {
+  const translated = { type: SD_NODE_NAME };
+  if (encodedAttrs && Object.keys(encodedAttrs).length > 0) {
+    translated.attrs = { ...encodedAttrs };
+  }
+  return translated;
+};
+
+/**
+ * Decode a SuperDoc noBreakHyphen node back into <w:r><w:rPr/><w:noBreakHyphen/></w:r>.
+ * Mirrors the run-wrapping pattern in tab-translator.js so inherited run-properties
+ * (bold, color, etc.) are preserved on export.
+ * @param {import('@translator').SCDecoderConfig} params
+ * @param {import('@translator').DecodedAttributes} [decodedAttrs] - The already decoded attributes
+ * @returns {import('@translator').SCDecoderResult}
+ */
+function decode(params, decodedAttrs = {}) {
+  const { node } = params || {};
+  if (!node) return;
+
+  // Hyperlinks: defer to wHyperlinkTranslator so the export emits a
+  // <w:hyperlink> wrapper and preserves the relationship. Without this, a
+  // linked noBreakHyphen (e.g. translateChildNodes groups the atom as the
+  // first link-marked child) would round-trip as plain <w:r><w:noBreakHyphen/>
+  // </w:r>, dropping the link entirely.
+  // The linkProcessed guard avoids re-entering once the hyperlink decoder
+  // strips the link mark and re-dispatches us.
+  const isLinkNode = node.marks?.some((m) => m.type === 'link');
+  if (isLinkNode && !params.extraParams?.linkProcessed) {
+    return wHyperlinkTranslator.decode(params);
+  }
+
+  // `elements: []` is required by SCDecoderResult even though <w:noBreakHyphen/>
+  // is self-closing — the typedef has no separate "void element" variant.
+  const wNoBreakHyphen = { name: 'w:noBreakHyphen', elements: [] };
+  if (decodedAttrs && Object.keys(decodedAttrs).length > 0) {
+    wNoBreakHyphen.attributes = { ...decodedAttrs };
+  }
+
+  if (params.extraParams?.skipRun) {
+    return wNoBreakHyphen;
+  }
+
+  const translated = {
+    name: 'w:r',
+    elements: [wNoBreakHyphen],
+  };
+
+  // Preserve inherited run properties and mark-derived formatting on exported atom (mirrors w:tab).
+  const { marks: nodeMarks = [] } = node;
+  const markRunProperties = decodeRunPropertiesFromMarks(nodeMarks);
+  const inheritedRunProperties = params.extraParams?.runProperties || {};
+  const mergedRunProperties = mergeRunProperties(inheritedRunProperties, markRunProperties);
+  const rPrNode = wRPrNodeTranslator.decode({
+    node: {
+      type: 'runProperties',
+      attrs: { runProperties: mergedRunProperties },
+    },
+  });
+  if (rPrNode) {
+    translated.elements.unshift(rPrNode);
+  }
+
+  return translated;
+}
+
+/**
+ * @param {Record<string, any>} base
+ * @param {Record<string, any>} override
+ */
+function mergeRunProperties(base = {}, override = {}) {
+  const merged = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    if (value && typeof value === 'object' && !Array.isArray(value) && base[key] && typeof base[key] === 'object') {
+      merged[key] = { ...base[key], ...value };
+      continue;
+    }
+    merged[key] = value;
+  }
+  return merged;
+}
+
+/**
+ * Lightweight mark -> runProperties mapper for noBreakHyphen-node export.
+ * Mirrors the subset used by tab-translator.js — duplicated to avoid the same
+ * module cycle the tab translator notes (importing exporter.js during converter bootstrap).
+ * @param {Array<any>} marks
+ */
+function decodeRunPropertiesFromMarks(marks = []) {
+  const runProperties = {};
+
+  for (const mark of marks) {
+    const type = mark?.type?.name ?? mark?.type;
+    const attrs = mark?.attrs ?? {};
+
+    switch (type) {
+      case 'bold':
+      case 'italic':
+      case 'strike':
+        runProperties[type] = attrs.value !== '0' && attrs.value !== false;
+        break;
+      case 'underline': {
+        const underlineAttrs = {};
+        if (attrs.underlineType) underlineAttrs['w:val'] = attrs.underlineType;
+        if (attrs.underlineColor) underlineAttrs['w:color'] = String(attrs.underlineColor).replace('#', '');
+        if (Object.keys(underlineAttrs).length > 0) {
+          runProperties.underline = underlineAttrs;
+        }
+        break;
+      }
+      case 'highlight':
+        if (attrs.color) {
+          runProperties.highlight =
+            String(attrs.color).toLowerCase() === 'transparent' ? { 'w:val': 'none' } : { 'w:val': attrs.color };
+        }
+        break;
+      case 'link':
+        runProperties.styleId = 'Hyperlink';
+        break;
+      case 'styleId':
+        if (attrs.styleId != null) {
+          runProperties.styleId = attrs.styleId;
+        }
+        break;
+      case 'textStyle':
+        if (attrs.styleId != null) {
+          runProperties.styleId = attrs.styleId;
+        }
+        if (attrs.textTransform != null) {
+          runProperties.textTransform = attrs.textTransform;
+        }
+        if (attrs.color != null) {
+          runProperties.color = { val: String(attrs.color).replace('#', '') };
+        }
+        if (attrs.fontSize != null) {
+          const points = Number.parseFloat(String(attrs.fontSize));
+          if (!Number.isNaN(points)) {
+            runProperties.fontSize = points * 2;
+          }
+        }
+        if (attrs.letterSpacing != null) {
+          const ptValue = Number.parseFloat(String(attrs.letterSpacing));
+          if (!Number.isNaN(ptValue)) {
+            runProperties.letterSpacing = ptValue * 20;
+          }
+        }
+        if (attrs.fontFamily != null) {
+          const cleanValue = String(attrs.fontFamily).split(',')[0].trim();
+          runProperties.fontFamily = {
+            ascii: cleanValue,
+            eastAsia: cleanValue,
+            hAnsi: cleanValue,
+            cs: cleanValue,
+          };
+        }
+        if (attrs.vertAlign != null) {
+          runProperties.vertAlign = attrs.vertAlign;
+        }
+        if (attrs.position != null) {
+          const numeric = Number.parseFloat(String(attrs.position));
+          if (!Number.isNaN(numeric)) {
+            runProperties.position = numeric * 2;
+          }
+        }
+        break;
+    }
+  }
+
+  return runProperties;
+}
+
+/** @type {import('@translator').NodeTranslatorConfig} */
+export const config = {
+  xmlName: XML_NODE_NAME,
+  sdNodeOrKeyName: SD_NODE_NAME,
+  type: NodeTranslator.translatorTypes.NODE,
+  encode,
+  decode,
+  attributes: [],
+};
+
+/**
+ * The NodeTranslator instance for the <w:noBreakHyphen/> element.
+ * @type {import('@translator').NodeTranslator}
+ */
+export const translator = NodeTranslator.from(config);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.js
@@ -2,6 +2,8 @@
 import { NodeTranslator } from '@translator';
 import { translator as wRPrNodeTranslator } from '../rpr/rpr-translator.js';
 import { translator as wHyperlinkTranslator } from '../hyperlink/hyperlink-translator.js';
+import { translator as wInsTranslator } from '../ins/index.js';
+import { translator as wDelTranslator } from '../del/index.js';
 
 /** @type {import('@translator').XmlNodeName} */
 const XML_NODE_NAME = 'w:noBreakHyphen';
@@ -36,6 +38,19 @@ const encode = (_, encodedAttrs = {}) => {
 function decode(params, decodedAttrs = {}) {
   const { node } = params || {};
   if (!node) return;
+
+  // Tracked changes: defer to ins/del so the atom exports inside <w:ins> or
+  // <w:del>. Without this, a tracked-insert noBreakHyphen would round-trip as
+  // plain <w:r><w:noBreakHyphen/></w:r> and the tracking would be silently
+  // dropped on save. Mirrors t-translator's hand-off (no `trackingProcessed`
+  // guard needed — wInsTranslator/wDelTranslator strip the tracking marks
+  // before re-dispatching, so re-entry won't re-fire this branch).
+  // Tracked-changes check runs before the link check so a linked + tracked
+  // atom composes as <w:ins><w:hyperlink>...</w:hyperlink></w:ins>.
+  const trackedMark = node.marks?.find((m) => m.type === 'trackInsert' || m.type === 'trackDelete');
+  if (trackedMark) {
+    return (trackedMark.type === 'trackInsert' ? wInsTranslator : wDelTranslator).decode(params);
+  }
 
   // Hyperlinks: defer to wHyperlinkTranslator so the export emits a
   // <w:hyperlink> wrapper and preserves the relationship. Without this, a

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.js
@@ -47,9 +47,13 @@ function decode(params, decodedAttrs = {}) {
   // before re-dispatching, so re-entry won't re-fire this branch).
   // Tracked-changes check runs before the link check so a linked + tracked
   // atom composes as <w:ins><w:hyperlink>...</w:hyperlink></w:ins>.
-  const trackedMark = node.marks?.find((m) => m.type === 'trackInsert' || m.type === 'trackDelete');
+  const trackedMark = node.marks?.find((m) => {
+    const t = m?.type?.name ?? m?.type;
+    return t === 'trackInsert' || t === 'trackDelete';
+  });
   if (trackedMark) {
-    return (trackedMark.type === 'trackInsert' ? wInsTranslator : wDelTranslator).decode(params);
+    const t = trackedMark.type?.name ?? trackedMark.type;
+    return (t === 'trackInsert' ? wInsTranslator : wDelTranslator).decode(params);
   }
 
   // Hyperlinks: defer to wHyperlinkTranslator so the export emits a
@@ -59,7 +63,7 @@ function decode(params, decodedAttrs = {}) {
   // </w:r>, dropping the link entirely.
   // The linkProcessed guard avoids re-entering once the hyperlink decoder
   // strips the link mark and re-dispatches us.
-  const isLinkNode = node.marks?.some((m) => m.type === 'link');
+  const isLinkNode = node.marks?.some((m) => (m?.type?.name ?? m?.type) === 'link');
   if (isLinkNode && !params.extraParams?.linkProcessed) {
     return wHyperlinkTranslator.decode(params);
   }

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { config } from './index.js';
+
+describe('w:noBreakHyphen translator config', () => {
+  describe('encode', () => {
+    it('encodes to a SuperDoc noBreakHyphen atom by default', () => {
+      const res = config.encode({}, undefined);
+      expect(res).toEqual({ type: 'noBreakHyphen' });
+    });
+
+    it('omits attrs when encodedAttrs is empty', () => {
+      const res = config.encode({}, {});
+      expect(res).toEqual({ type: 'noBreakHyphen' });
+      expect(res.attrs).toBeUndefined();
+    });
+
+    it('passes through provided encodedAttrs as attrs', () => {
+      const encoded = { foo: 'bar' };
+      const res = config.encode({}, encoded);
+      expect(res.type).toBe('noBreakHyphen');
+      expect(res.attrs).toEqual(encoded);
+    });
+
+    it('config exposes the expected xmlName and sdNodeOrKeyName', () => {
+      expect(config.xmlName).toBe('w:noBreakHyphen');
+      expect(config.sdNodeOrKeyName).toBe('noBreakHyphen');
+    });
+  });
+
+  describe('decode', () => {
+    it('wraps <w:noBreakHyphen/> in a <w:r> run', () => {
+      const res = config.decode({ node: { type: 'noBreakHyphen' } }, undefined);
+      expect(res).toBeTruthy();
+      expect(res.name).toBe('w:r');
+      expect(Array.isArray(res.elements)).toBe(true);
+      expect(res.elements[0]).toEqual({ name: 'w:noBreakHyphen' });
+    });
+
+    it('returns the bare element when extraParams.skipRun is set', () => {
+      const res = config.decode({ node: { type: 'noBreakHyphen' }, extraParams: { skipRun: true } }, undefined);
+      expect(res).toEqual({ name: 'w:noBreakHyphen' });
+    });
+
+    it('returns undefined when params.node is missing', () => {
+      const res = config.decode({}, {});
+      expect(res).toBeUndefined();
+    });
+
+    it('preserves decodedAttrs as element attributes', () => {
+      const decoded = { 'w:custom': 'foo' };
+      const res = config.decode({ node: { type: 'noBreakHyphen' } }, decoded);
+      expect(res.elements[0]).toEqual({ name: 'w:noBreakHyphen', attributes: decoded });
+    });
+  });
+
+  describe('decode — marks and run props', () => {
+    it('adds run props from node.marks before <w:noBreakHyphen/>', () => {
+      const res = config.decode(
+        { node: { type: 'noBreakHyphen', marks: [{ type: 'bold' }, { type: 'italic' }] } },
+        undefined,
+      );
+      expect(res.name).toBe('w:r');
+      expect(res.elements[0].name).toBe('w:rPr');
+      const childNames = res.elements[0].elements.map((el) => el.name);
+      expect(childNames).toContain('w:b');
+      expect(childNames).toContain('w:i');
+      expect(res.elements[1]).toEqual({ name: 'w:noBreakHyphen' });
+    });
+
+    it('does not add run props when node.marks is empty and no inherited rPr', () => {
+      const res = config.decode({ node: { type: 'noBreakHyphen', marks: [] } }, undefined);
+      expect(res.name).toBe('w:r');
+      expect(res.elements).toEqual([{ name: 'w:noBreakHyphen' }]);
+    });
+
+    it('inherits run properties from extraParams.runProperties', () => {
+      const res = config.decode(
+        {
+          node: { type: 'noBreakHyphen', marks: [] },
+          extraParams: { runProperties: { bold: true } },
+        },
+        undefined,
+      );
+      expect(res.elements[0].name).toBe('w:rPr');
+      const childNames = res.elements[0].elements.map((el) => el.name);
+      expect(childNames).toContain('w:b');
+    });
+
+    it('node.marks override inherited run properties on conflict', () => {
+      const res = config.decode(
+        {
+          node: { type: 'noBreakHyphen', marks: [{ type: 'bold', attrs: { value: false } }] },
+          extraParams: { runProperties: { bold: true } },
+        },
+        undefined,
+      );
+      expect(res.elements[0].name).toBe('w:rPr');
+      const wB = res.elements[0].elements.find((el) => el.name === 'w:b');
+      expect(wB?.attributes?.['w:val']).toBe('0');
+    });
+  });
+
+  describe('round-trip identity', () => {
+    it('encode then decode produces a run wrapping the original element', () => {
+      const encoded = config.encode({}, undefined);
+      expect(encoded.type).toBe('noBreakHyphen');
+      const decoded = config.decode({ node: encoded }, undefined);
+      expect(decoded.name).toBe('w:r');
+      expect(decoded.elements.find((el) => el.name === 'w:noBreakHyphen')).toBeTruthy();
+    });
+  });
+
+  describe('decode — link mark', () => {
+    // When translateChildNodes groups link-marked siblings, it dispatches the
+    // group through whichever translator owns the first node's type. A linked
+    // noBreakHyphen as the first/only child must therefore emit <w:hyperlink>
+    // — same contract as the text translator.
+    it('emits <w:hyperlink> for a noBreakHyphen carrying a link mark', () => {
+      const linkMark = {
+        type: 'link',
+        attrs: { href: 'https://example.com', rId: 'rId7', anchor: null, history: null, tooltip: null, target: null },
+      };
+      const res = config.decode({
+        node: { type: 'noBreakHyphen', marks: [linkMark] },
+        relationships: [],
+      });
+      expect(res?.name).toBe('w:hyperlink');
+      // The hyperlink wrapper should contain the run with the bare element inside.
+      const wR = res.elements.find((el) => el.name === 'w:r');
+      expect(wR).toBeTruthy();
+      expect(wR.elements.some((el) => el.name === 'w:noBreakHyphen')).toBe(true);
+    });
+
+    it('does not delegate when extraParams.linkProcessed is set (avoids loops)', () => {
+      const linkMark = {
+        type: 'link',
+        attrs: { href: 'https://example.com', rId: 'rId7', anchor: null, history: null, tooltip: null, target: null },
+      };
+      const res = config.decode({
+        node: { type: 'noBreakHyphen', marks: [linkMark] },
+        extraParams: { linkProcessed: true },
+      });
+      // With linkProcessed=true, we fall through to the normal run-wrapped output.
+      expect(res?.name).toBe('w:r');
+      expect(res.elements.some((el) => el.name === 'w:noBreakHyphen')).toBe(true);
+    });
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.test.js
@@ -145,4 +145,66 @@ describe('w:noBreakHyphen translator config', () => {
       expect(res.elements.some((el) => el.name === 'w:noBreakHyphen')).toBe(true);
     });
   });
+
+  describe('decode — tracked changes', () => {
+    // Without the hand-off, a tracked-insert noBreakHyphen exported as bare
+    // <w:r><w:noBreakHyphen/></w:r> and the tracking was silently dropped on
+    // save. The branch mirrors t-translator's tracked-changes hand-off.
+    const trackAttrs = { id: 'tc-1', sourceId: '', author: 'A', authorEmail: 'a@x', date: '2026-05-06T00:00:00Z' };
+
+    it('emits <w:ins> wrapping the run when the node carries a trackInsert mark', () => {
+      const res = config.decode({
+        node: { type: 'noBreakHyphen', marks: [{ type: 'trackInsert', attrs: trackAttrs }] },
+      });
+      expect(res?.name).toBe('w:ins');
+      expect(res.attributes['w:author']).toBe('A');
+      const wR = res.elements[0];
+      expect(wR.name).toBe('w:r');
+      expect(wR.elements.some((el) => el.name === 'w:noBreakHyphen')).toBe(true);
+    });
+
+    it('emits <w:del> wrapping the run when the node carries a trackDelete mark', () => {
+      // <w:del> only renames w:t → w:delText. Atoms like w:noBreakHyphen stay
+      // as-is — the deletion is conveyed by the wrapper alone (ECMA-376).
+      const res = config.decode({
+        node: { type: 'noBreakHyphen', marks: [{ type: 'trackDelete', attrs: trackAttrs }] },
+      });
+      expect(res?.name).toBe('w:del');
+      const wR = res.elements[0];
+      expect(wR.name).toBe('w:r');
+      expect(wR.elements.some((el) => el.name === 'w:noBreakHyphen')).toBe(true);
+      expect(wR.elements.some((el) => el.name === 'w:delText')).toBe(false);
+    });
+
+    it('composes <w:ins><w:hyperlink>...</w:hyperlink></w:ins> for a tracked + linked atom', () => {
+      // Tracked-changes branch must run before the link branch — otherwise the
+      // hyperlink wrapper would land outside the <w:ins> and Word would render
+      // the link without the change-tracking attribution.
+      const res = config.decode({
+        node: {
+          type: 'noBreakHyphen',
+          marks: [
+            { type: 'trackInsert', attrs: trackAttrs },
+            {
+              type: 'link',
+              attrs: {
+                href: 'https://example.com',
+                rId: 'rId9',
+                anchor: null,
+                history: null,
+                tooltip: null,
+                target: null,
+              },
+            },
+          ],
+        },
+        relationships: [],
+      });
+      expect(res?.name).toBe('w:ins');
+      const inner = res.elements[0];
+      expect(inner.name).toBe('w:hyperlink');
+      const wR = inner.elements.find((el) => el.name === 'w:r');
+      expect(wR.elements.some((el) => el.name === 'w:noBreakHyphen')).toBe(true);
+    });
+  });
 });

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/noBreakHyphen/no-break-hyphen-translator.test.js
@@ -33,12 +33,12 @@ describe('w:noBreakHyphen translator config', () => {
       expect(res).toBeTruthy();
       expect(res.name).toBe('w:r');
       expect(Array.isArray(res.elements)).toBe(true);
-      expect(res.elements[0]).toEqual({ name: 'w:noBreakHyphen' });
+      expect(res.elements[0]).toEqual({ name: 'w:noBreakHyphen', elements: [] });
     });
 
     it('returns the bare element when extraParams.skipRun is set', () => {
       const res = config.decode({ node: { type: 'noBreakHyphen' }, extraParams: { skipRun: true } }, undefined);
-      expect(res).toEqual({ name: 'w:noBreakHyphen' });
+      expect(res).toEqual({ name: 'w:noBreakHyphen', elements: [] });
     });
 
     it('returns undefined when params.node is missing', () => {
@@ -49,7 +49,7 @@ describe('w:noBreakHyphen translator config', () => {
     it('preserves decodedAttrs as element attributes', () => {
       const decoded = { 'w:custom': 'foo' };
       const res = config.decode({ node: { type: 'noBreakHyphen' } }, decoded);
-      expect(res.elements[0]).toEqual({ name: 'w:noBreakHyphen', attributes: decoded });
+      expect(res.elements[0]).toEqual({ name: 'w:noBreakHyphen', elements: [], attributes: decoded });
     });
   });
 
@@ -64,13 +64,13 @@ describe('w:noBreakHyphen translator config', () => {
       const childNames = res.elements[0].elements.map((el) => el.name);
       expect(childNames).toContain('w:b');
       expect(childNames).toContain('w:i');
-      expect(res.elements[1]).toEqual({ name: 'w:noBreakHyphen' });
+      expect(res.elements[1]).toEqual({ name: 'w:noBreakHyphen', elements: [] });
     });
 
     it('does not add run props when node.marks is empty and no inherited rPr', () => {
       const res = config.decode({ node: { type: 'noBreakHyphen', marks: [] } }, undefined);
       expect(res.name).toBe('w:r');
-      expect(res.elements).toEqual([{ name: 'w:noBreakHyphen' }]);
+      expect(res.elements).toEqual([{ name: 'w:noBreakHyphen', elements: [] }]);
     });
 
     it('inherits run properties from extraParams.runProperties', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/r/r-translator.no-break-hyphen.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/r/r-translator.no-break-hyphen.test.js
@@ -110,7 +110,12 @@ describe('w:r translator <w:noBreakHyphen/> round-trip', () => {
     const runs = Array.isArray(decoded) ? decoded : [decoded];
 
     const allChildren = runs.flatMap((r) => (r.elements || []).filter((el) => el.name !== 'w:rPr'));
-    expect(allChildren).toEqual([{ name: 'w:noBreakHyphen' }]);
+    // Match by intent (exactly one child, named w:noBreakHyphen) instead of
+    // strict deep-equality — the encode/decode pipeline normalizes through
+    // xml-js shapes that introduce ancillary undefined fields (`attributes`,
+    // `text`, `type`) along with the required `elements: []`.
+    expect(allChildren).toHaveLength(1);
+    expect(allChildren[0]).toMatchObject({ name: 'w:noBreakHyphen' });
     // Specifically: no <w:t> emitted in lieu of the element
     expect(allChildren.some((el) => el.name === 'w:t')).toBe(false);
   });

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/r/r-translator.no-break-hyphen.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/r/r-translator.no-break-hyphen.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { defaultNodeListHandler } from '../../../../v2/importer/docxImporter.js';
+import { translator } from './r-translator.js';
+
+describe('w:r translator <w:noBreakHyphen/> handling', () => {
+  it('encodes <w:noBreakHyphen/> as a noBreakHyphen atom inside the run', () => {
+    const runNode = {
+      name: 'w:r',
+      elements: [
+        { name: 'w:t', elements: [{ type: 'text', text: '24' }] },
+        { name: 'w:noBreakHyphen' },
+        { name: 'w:t', elements: [{ type: 'text', text: 'Apr' }] },
+        { name: 'w:noBreakHyphen' },
+        { name: 'w:t', elements: [{ type: 'text', text: '2026' }] },
+      ],
+    };
+
+    const handler = defaultNodeListHandler();
+    const result = translator.encode({ nodes: [runNode], nodeListHandler: handler, docx: {} });
+
+    expect(result).toMatchObject({ type: 'run' });
+    expect(result.content).toEqual([
+      expect.objectContaining({ type: 'text', text: '24' }),
+      expect.objectContaining({ type: 'noBreakHyphen' }),
+      expect.objectContaining({ type: 'text', text: 'Apr' }),
+      expect.objectContaining({ type: 'noBreakHyphen' }),
+      expect.objectContaining({ type: 'text', text: '2026' }),
+    ]);
+  });
+
+  it('does NOT collapse the atom into a passthroughInline (the bug)', () => {
+    const runNode = {
+      name: 'w:r',
+      elements: [{ name: 'w:noBreakHyphen' }],
+    };
+    const handler = defaultNodeListHandler();
+    const result = translator.encode({ nodes: [runNode], nodeListHandler: handler, docx: {} });
+    expect(result.content[0].type).toBe('noBreakHyphen');
+    expect(result.content[0].type).not.toBe('passthroughInline');
+  });
+
+  it('keeps literal U+2011 in <w:t> as a text node (does not promote it to the atom)', () => {
+    const runNode = {
+      name: 'w:r',
+      elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'A‑B' }] }],
+    };
+    const handler = defaultNodeListHandler();
+    const result = translator.encode({ nodes: [runNode], nodeListHandler: handler, docx: {} });
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toBe('A‑B');
+  });
+});
+
+describe('w:r translator <w:noBreakHyphen/> round-trip', () => {
+  it('encode then decode round-trips the bare <w:noBreakHyphen/> element back', () => {
+    const runNode = {
+      name: 'w:r',
+      elements: [
+        { name: 'w:t', elements: [{ type: 'text', text: '24' }] },
+        { name: 'w:noBreakHyphen' },
+        { name: 'w:t', elements: [{ type: 'text', text: 'Apr' }] },
+        { name: 'w:noBreakHyphen' },
+        { name: 'w:t', elements: [{ type: 'text', text: '2026' }] },
+      ],
+    };
+    const handler = defaultNodeListHandler();
+
+    const encoded = translator.encode({ nodes: [runNode], nodeListHandler: handler, docx: {} });
+    expect(encoded?.type).toBe('run');
+
+    const decoded = translator.decode({ node: encoded });
+    const decodedRuns = Array.isArray(decoded) ? decoded : [decoded];
+
+    // Flatten run children, ignoring rPr wrappers
+    const tokens = [];
+    for (const run of decodedRuns) {
+      for (const el of run.elements || []) {
+        if (el.name === 'w:rPr') continue;
+        if (el.name === 'w:t') {
+          const text = (el.elements || []).find((e) => e.type === 'text')?.text;
+          tokens.push({ kind: 'text', text });
+        } else if (el.name === 'w:noBreakHyphen') {
+          tokens.push({ kind: 'nbh' });
+        } else {
+          tokens.push({ kind: el.name });
+        }
+      }
+    }
+
+    // Tier 1 ordered-token contract from the plan: structural identity preserved
+    expect(tokens).toEqual([
+      { kind: 'text', text: '24' },
+      { kind: 'nbh' },
+      { kind: 'text', text: 'Apr' },
+      { kind: 'nbh' },
+      { kind: 'text', text: '2026' },
+    ]);
+  });
+
+  it('exports <w:noBreakHyphen/> as a bare element, not as <w:t>U+2011</w:t>', () => {
+    const runNode = {
+      name: 'w:r',
+      elements: [{ name: 'w:noBreakHyphen' }],
+    };
+    const handler = defaultNodeListHandler();
+
+    const encoded = translator.encode({ nodes: [runNode], nodeListHandler: handler, docx: {} });
+    const decoded = translator.decode({ node: encoded });
+    const runs = Array.isArray(decoded) ? decoded : [decoded];
+
+    const allChildren = runs.flatMap((r) => (r.elements || []).filter((el) => el.name !== 'w:rPr'));
+    expect(allChildren).toEqual([{ name: 'w:noBreakHyphen' }]);
+    // Specifically: no <w:t> emitted in lieu of the element
+    expect(allChildren.some((el) => el.name === 'w:t')).toBe(false);
+  });
+
+  it('preserves <w:hyperlink> wrapper when the run carries a link mark', () => {
+    // Reproduces the issue raised in review: a hyperlink whose only inline
+    // child is a noBreakHyphen must round-trip back as <w:hyperlink> wrapping
+    // the run, not as a bare <w:r><w:noBreakHyphen/></w:r>.
+    const linkMark = {
+      type: 'link',
+      attrs: {
+        href: 'https://example.com',
+        rId: 'rId42',
+        anchor: null,
+        history: null,
+        tooltip: null,
+        target: null,
+      },
+    };
+    // Simulate the post-import shape: a run carrying a link mark, containing
+    // the noBreakHyphen atom. The run translator's encode would propagate the
+    // link mark down to the atom too.
+    const runNode = {
+      type: 'run',
+      attrs: { runProperties: {}, runPropertiesInlineKeys: [] },
+      marks: [linkMark],
+      content: [{ type: 'noBreakHyphen', marks: [linkMark] }],
+    };
+
+    const decoded = translator.decode({ node: runNode, relationships: [] });
+    // Decoded should be a w:hyperlink wrapping a w:r with the bare element
+    expect(decoded?.name).toBe('w:hyperlink');
+    const innerRun = (decoded.elements || []).find((el) => el.name === 'w:r');
+    expect(innerRun).toBeTruthy();
+    expect((innerRun.elements || []).some((el) => el.name === 'w:noBreakHyphen')).toBe(true);
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/text-with-tabs.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/text-with-tabs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { Fragment, Schema } from 'prosemirror-model';
 import { buildTextWithTabs, parentAllowsNodeAt, textBetweenWithTabs } from './text-with-tabs.js';
 
-function makeRealSchema(options: { hasTab?: boolean } = {}) {
+function makeRealSchema(options: { hasTab?: boolean; hasNoBreakHyphen?: boolean; hasGenericLeaf?: boolean } = {}) {
   const nodes: Record<string, any> = {
     doc: { content: 'paragraph+' },
     paragraph: { group: 'block', content: 'inline*' },
@@ -12,6 +12,14 @@ function makeRealSchema(options: { hasTab?: boolean } = {}) {
     // Mirrors the real extensions/tab/tab.js shape: inline atom with `content: 'inline*'`.
     // Tab is non-leaf, which is why `textBetweenWithTabs` (not PM's built-in textBetween) is needed.
     nodes.tab = { group: 'inline', inline: true, atom: true, content: 'inline*' };
+  }
+  if (options.hasNoBreakHyphen) {
+    // Mirrors the real extensions/no-break-hyphen schema: inline leaf atom with leafText.
+    nodes.noBreakHyphen = { group: 'inline', inline: true, atom: true, leafText: () => '‑' };
+  }
+  if (options.hasGenericLeaf) {
+    // An inline leaf atom WITHOUT leafText — should fall back to leafFallback.
+    nodes.genericLeaf = { group: 'inline', inline: true, atom: true };
   }
   return new Schema({
     nodes,
@@ -142,5 +150,27 @@ describe('textBetweenWithTabs', () => {
     // Reading [2, 10) yields "ello" + tab + "wo".
     const result = textBetweenWithTabs(doc, 2, 10, '\n', '\ufffc');
     expect(result).toBe('ello\two');
+  });
+
+  it('emits the visible character for inline leaves that declare leafText (e.g. noBreakHyphen)', () => {
+    // Repro for SD-2746 follow-up: search/get-text/diff consumers must see
+    // the U+2011 glyph, not the leafFallback placeholder.
+    const schema = makeRealSchema({ hasNoBreakHyphen: true });
+    const doc = schema.nodes.doc.createAndFill({}, [
+      schema.nodes.paragraph.create({}, [schema.text('a'), schema.nodes.noBreakHyphen.create(), schema.text('b')]),
+    ])!;
+    const paragraph = doc.firstChild!;
+    const result = textBetweenWithTabs(doc, 1, 1 + paragraph.content.size, '\n', '\n');
+    expect(result).toBe('a\u2011b');
+  });
+
+  it('falls back to leafFallback for inline leaves without leafText', () => {
+    const schema = makeRealSchema({ hasGenericLeaf: true });
+    const doc = schema.nodes.doc.createAndFill({}, [
+      schema.nodes.paragraph.create({}, [schema.text('a'), schema.nodes.genericLeaf.create(), schema.text('b')]),
+    ])!;
+    const paragraph = doc.firstChild!;
+    const result = textBetweenWithTabs(doc, 1, 1 + paragraph.content.size, '\n', '\ufffc');
+    expect(result).toBe('a\ufffcb');
   });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/text-with-tabs.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/text-with-tabs.ts
@@ -120,7 +120,16 @@ export function textBetweenWithTabs(
     }
     if (node.isLeaf) {
       if (node.isInline) {
-        out += leafFallback;
+        // Honor PM's `leafText` NodeSpec contract: an inline leaf can declare
+        // its visible text representation (e.g. noBreakHyphen → U+2011) so
+        // flattened reads match the rendered glyph instead of producing the
+        // generic placeholder. Falls back to `leafFallback` when undefined.
+        const leafTextFn = node.type?.spec?.leafText;
+        if (typeof leafTextFn === 'function') {
+          out += leafTextFn(node);
+        } else {
+          out += leafFallback;
+        }
         emitted = true;
       }
       return false;

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/executor-no-break-hyphen-rewrite.integration.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/executor-no-break-hyphen-rewrite.integration.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { initTestEditor } from '@tests/helpers/helpers.js';
+import { charOffsetToDocPos } from './executor.ts';
+import { textBetweenWithTabs } from '../helpers/text-with-tabs.js';
+
+const NON_BREAKING_HYPHEN = '‑';
+
+/**
+ * Repro for the second SD-2746 review finding: text.rewrite trims
+ * `originalText` against `replacementText` using a character-offset diff,
+ * then maps the resulting offset back to a PM position via `charOffsetToDocPos`.
+ *
+ * After the leafText fix surfaces noBreakHyphen as U+2011 in `originalText`
+ * (via `textBetweenWithTabs`), the mapper must also count that character —
+ * otherwise the offset slips past the atom and any edit lands at the wrong
+ * PM position. Tab nodes have the same shape (textBetweenWithTabs emits '\t'
+ * even though tab is non-leaf), so this fix covers both.
+ */
+function makeEditorWithNoBreakHyphen() {
+  return initTestEditor({
+    loadFromSchema: true,
+    content: {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          attrs: {},
+          content: [
+            { type: 'run', attrs: {}, content: [{ type: 'text', text: 'a' }] },
+            { type: 'run', attrs: {}, content: [{ type: 'noBreakHyphen' }] },
+            { type: 'run', attrs: {}, content: [{ type: 'text', text: 'b' }] },
+          ],
+        },
+      ],
+    },
+    user: { name: 'Integration User', email: 'integration@example.com' },
+  }).editor;
+}
+
+function paragraphRange(editor: any): { from: number; to: number } {
+  let from = -1;
+  let to = -1;
+  editor.state.doc.descendants((node: any, pos: number) => {
+    if (from !== -1) return false;
+    if (node.type.name === 'paragraph') {
+      from = pos + 1;
+      to = pos + 1 + node.content.size;
+      return false;
+    }
+  });
+  return { from, to };
+}
+
+describe('charOffsetToDocPos with noBreakHyphen atoms (SD-2746)', () => {
+  let editor: any | undefined;
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = undefined;
+  });
+
+  it('originalText (textBetweenWithTabs) matches positions returned by charOffsetToDocPos', () => {
+    editor = makeEditorWithNoBreakHyphen();
+    const { from, to } = paragraphRange(editor);
+
+    // Mirror the executor's call site: blockSeparator='', leafFallback=''.
+    const originalText = textBetweenWithTabs(editor.state.doc, from, to, '', '');
+    expect(originalText).toBe(`a${NON_BREAKING_HYPHEN}b`);
+    expect(originalText.length).toBe(3);
+
+    // Each character offset (0..3) must round-trip to a coherent PM position
+    // such that subsequent text.rewrite slicing lands at the right boundary.
+    // Doc structure (positions inside the paragraph):
+    //   [1] run-1 open  [2] 'a' content  [3] run-1 close
+    //   [4] run-2 open  [5] atom         [6] run-2 close
+    //   [7] run-3 open  [8] 'b' content  [9] run-3 close
+    // The mapper resolves at the immediate post-atom boundary (pos 6) — both
+    // pos 6 and pos 7 are visually equivalent for text insertion ("between
+    // atom and 'b'") since they straddle a run boundary; the helper picks
+    // the earliest valid spot.
+    const expectedByOffset = {
+      0: 2, // before 'a'
+      1: 3, // after 'a' (boundary at run-1 close)
+      2: 6, // after the atom (boundary at run-2 close, equivalent to before 'b')
+      3: 9, // after 'b'
+    } as Record<number, number>;
+
+    for (const [offsetStr, expectedPos] of Object.entries(expectedByOffset)) {
+      const offset = Number(offsetStr);
+      expect({ offset, pos: charOffsetToDocPos(editor.state.doc, from, to, offset) }).toEqual({
+        offset,
+        pos: expectedPos,
+      });
+    }
+  });
+
+  it('common-prefix offset 2 (matching "a‑") lands AFTER the atom, not after "b"', () => {
+    // The exact regression the reviewer described: rewriting "a‑b" → "a‑c",
+    // the diff computes prefix=2. Without counting the atom in the offset
+    // mapper, charOffsetToDocPos walks past 'a' (count=1), skips the atom
+    // (count stays 1), then 'b' (count=2 ≥ 2) → returns position AFTER 'b'.
+    //
+    // With the fix, the atom contributes 1 char (count=2 after atom) so the
+    // mapper resolves the offset to the boundary right after the atom,
+    // before 'b'. The trailing 'b' is then correctly identified as the only
+    // character to replace.
+    editor = makeEditorWithNoBreakHyphen();
+    const { from, to } = paragraphRange(editor);
+
+    const prefix = 2;
+    const pos = charOffsetToDocPos(editor.state.doc, from, to, prefix);
+
+    // Resolved PM position must be at or before 'b'. After 'b' would be 9
+    // (the bug); before 'b' is 8; the run boundary just before 'b' is 7.
+    expect(pos).toBeLessThanOrEqual(8);
+  });
+
+  it('symmetric: suffix from the right side past the atom maps before "a", not before atom', () => {
+    // For rewriting "a‑b" → "z‑b", suffix=2 (matching "‑b"). The mapper is
+    // called with `origLen - suffix = 1`, which should land just after 'a'.
+    editor = makeEditorWithNoBreakHyphen();
+    const { from, to } = paragraphRange(editor);
+
+    const pos = charOffsetToDocPos(editor.state.doc, from, to, 1);
+    expect(pos).toBe(3); // immediately after 'a' inside its run
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/executor.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/executor.ts
@@ -69,24 +69,73 @@ import { getFormattingStateAtPos } from '../../core/helpers/getMarksFromSelectio
  * corresponding ProseMirror document position.  Needed because inline
  * node boundaries (run open/close) create gaps in the position space
  * that `textBetween` hides.
+ *
+ * Must mirror `textBetweenWithTabs`'s character accounting exactly — the diff
+ * loop above computes prefix/suffix offsets against that string, then asks
+ * this function to translate them back into PM positions. Any disagreement
+ * (e.g. an atom that contributed a char on one side but not the other) maps
+ * the edit to the wrong place. We count:
+ *   - text nodes by char length (the obvious case),
+ *   - `tab` nodes as 1 char (textBetweenWithTabs emits '\t'),
+ *   - inline leaves declaring `leafText` by `leafText(node).length`
+ *     (e.g. noBreakHyphen → '‑', length 1).
+ * Everything else contributes 0 — matching the executor's call site, which
+ * passes `leafFallback=''` so unknown leaves don't widen `originalText`.
+ *
+ * Atoms cannot be sliced mid-glyph, so when an offset lands strictly past an
+ * atom's first char we resolve to the position immediately after the atom.
  */
-function charOffsetToDocPos(doc: ProseMirrorNode, rangeFrom: number, rangeTo: number, charOffset: number): number {
+export function charOffsetToDocPos(
+  doc: ProseMirrorNode,
+  rangeFrom: number,
+  rangeTo: number,
+  charOffset: number,
+): number {
   let count = 0;
   let foundPos = -1;
 
+  const resolveAtom = (pos: number, nodeSize: number, len: number) => {
+    if (count + len < charOffset) return false;
+    foundPos = charOffset === count ? pos : pos + nodeSize;
+    return true;
+  };
+
   doc.nodesBetween(rangeFrom, rangeTo, (node, pos) => {
     if (foundPos >= 0) return false;
-    if (!node.isText) return true; // descend into non-text nodes
 
-    const textStart = Math.max(pos, rangeFrom);
-    const textEnd = Math.min(pos + node.nodeSize, rangeTo);
-    const textLen = textEnd - textStart;
-
-    if (count + textLen >= charOffset) {
-      foundPos = textStart + (charOffset - count);
+    if (node.isText) {
+      const textStart = Math.max(pos, rangeFrom);
+      const textEnd = Math.min(pos + node.nodeSize, rangeTo);
+      const textLen = textEnd - textStart;
+      if (count + textLen >= charOffset) {
+        foundPos = textStart + (charOffset - count);
+      }
+      count += textLen;
+      return false;
     }
-    count += textLen;
-    return false;
+
+    // tab nodes are non-leaf (content: 'inline*') but textBetweenWithTabs
+    // surfaces them as '\t', so they consume one offset slot here too.
+    if (node.type?.name === 'tab') {
+      resolveAtom(pos, node.nodeSize, 1);
+      count += 1;
+      return false;
+    }
+
+    // Inline leaves with a `leafText` spec contribute their visible text.
+    if (node.isLeaf && node.isInline) {
+      const leafTextFn = (node.type?.spec as { leafText?: (n: ProseMirrorNode) => string } | undefined)?.leafText;
+      if (typeof leafTextFn === 'function') {
+        const leafText = leafTextFn(node);
+        if (typeof leafText === 'string' && leafText.length > 0) {
+          resolveAtom(pos, node.nodeSize, leafText.length);
+          count += leafText.length;
+        }
+      }
+      return false;
+    }
+
+    return true; // descend into non-text, non-leaf nodes
   });
 
   return foundPos >= 0 ? foundPos : rangeTo;

--- a/packages/super-editor/src/editors/v1/extensions/index.js
+++ b/packages/super-editor/src/editors/v1/extensions/index.js
@@ -31,6 +31,7 @@ import { FootnoteReference } from './footnote/index.js';
 import { EndnoteReference } from './endnote/index.js';
 import { TabNode } from './tab/index.js';
 import { LineBreak, HardBreak } from './line-break/index.js';
+import { NoBreakHyphenNode } from './no-break-hyphen/index.js';
 import { Table } from './table/index.js';
 import { TableHeader } from './table-header/index.js';
 import { TableRow } from './table-row/index.js';
@@ -164,6 +165,7 @@ const getStarterExtensions = () => {
     ContextMenu,
     Strike,
     TabNode,
+    NoBreakHyphenNode,
     TableOfContents,
     TocPageNumber,
     DocumentIndex,
@@ -253,6 +255,7 @@ export {
   FootnoteReference,
   EndnoteReference,
   TabNode,
+  NoBreakHyphenNode,
   LineBreak,
   HardBreak,
   Bold,

--- a/packages/super-editor/src/editors/v1/extensions/no-break-hyphen/index.js
+++ b/packages/super-editor/src/editors/v1/extensions/no-break-hyphen/index.js
@@ -1,0 +1,1 @@
+export * from './no-break-hyphen.js';

--- a/packages/super-editor/src/editors/v1/extensions/no-break-hyphen/no-break-hyphen.js
+++ b/packages/super-editor/src/editors/v1/extensions/no-break-hyphen/no-break-hyphen.js
@@ -23,6 +23,12 @@ export const NoBreakHyphenNode = Node.create({
   selectable: false,
   atom: true,
 
+  // Tell PM the visible text representation of this leaf so flattening APIs —
+  // search, get-text, diff, accessibility readers — see U+2011 instead of a
+  // placeholder. Read by PM's built-in `Node.textBetween` and by SuperDoc's
+  // `textBetweenWithTabs`.
+  leafText: () => NON_BREAKING_HYPHEN,
+
   addOptions() {
     return {
       htmlAttributes: {

--- a/packages/super-editor/src/editors/v1/extensions/no-break-hyphen/no-break-hyphen.js
+++ b/packages/super-editor/src/editors/v1/extensions/no-break-hyphen/no-break-hyphen.js
@@ -1,0 +1,43 @@
+// @ts-nocheck
+
+import { Node } from '@core/Node.js';
+import { Attribute } from '@core/Attribute.js';
+
+const NON_BREAKING_HYPHEN = '‑';
+
+/**
+ * Configuration options for NoBreakHyphenNode
+ * @typedef {Object} NoBreakHyphenNodeOptions
+ * @category Options
+ * @property {Object} [htmlAttributes] - HTML attributes for the rendered element
+ */
+
+/**
+ * @module NoBreakHyphenNode
+ * @sidebarTitle Non-breaking Hyphen
+ */
+export const NoBreakHyphenNode = Node.create({
+  name: 'noBreakHyphen',
+  group: 'inline',
+  inline: true,
+  selectable: false,
+  atom: true,
+
+  addOptions() {
+    return {
+      htmlAttributes: {
+        class: 'sd-no-break-hyphen',
+        style: 'white-space: nowrap;',
+        contentEditable: false,
+      },
+    };
+  },
+
+  parseDOM() {
+    return [{ tag: 'span.sd-no-break-hyphen' }];
+  },
+
+  renderDOM({ htmlAttributes }) {
+    return ['span', Attribute.mergeAttributes(this.options.htmlAttributes, htmlAttributes), NON_BREAKING_HYPHEN];
+  },
+});

--- a/tests/behavior/tests/basic-commands/sd-2746-no-break-hyphen-backspace.spec.ts
+++ b/tests/behavior/tests/basic-commands/sd-2746-no-break-hyphen-backspace.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from '../../fixtures/superdoc.js';
+
+/**
+ * Repro for SD-2746 follow-up:
+ * Placing the caret right after a noBreakHyphen atom and pressing Backspace
+ * should delete the atom — same as backspacing any other atomic glyph.
+ *
+ * The atom is wrapped in its own `run` node by the run translator. So three
+ * distinct PM caret positions all correspond visually to "right after the
+ * hyphen", and all three must work:
+ *   1. Inside the atom's run, after the atom        → nodeBefore = atom
+ *   2. At paragraph level, between runs             → nodeBefore = atom-wrapper run
+ *   3. At the start of the run after the atom-run   → nodeBefore = null
+ *
+ * The first version of the fix only handled (1) because the synthetic test set
+ * the cursor via `pos + atom.nodeSize`, which lands inside the atom's run.
+ * Real-world clicks after the rendered glyph typically resolve to (2) or (3),
+ * which is what the customer hit.
+ */
+
+const setupDocWithAtom = async (superdoc: any) => {
+  await superdoc.type('abc');
+  await superdoc.waitForStable();
+  await superdoc.executeCommand('insertContent', { type: 'noBreakHyphen' });
+  await superdoc.waitForStable();
+  await superdoc.type('def');
+  await superdoc.waitForStable();
+};
+
+const countAtoms = async (superdoc: any): Promise<number> =>
+  superdoc.page.evaluate(() => {
+    const { state } = (window as any).editor;
+    let count = 0;
+    state.doc.descendants((node: any) => {
+      if (node.type.name === 'noBreakHyphen') count++;
+    });
+    return count;
+  });
+
+const collectText = async (superdoc: any): Promise<string> =>
+  superdoc.page.evaluate(() => {
+    const { state } = (window as any).editor;
+    const parts: string[] = [];
+    state.doc.descendants((n: any) => {
+      if (n.isText) parts.push(n.text ?? '');
+    });
+    return parts.join('');
+  });
+
+const findAtomPos = async (superdoc: any): Promise<number> =>
+  superdoc.page.evaluate(() => {
+    const { state } = (window as any).editor;
+    let atomPos = -1;
+    state.doc.descendants((node: any, pos: number) => {
+      if (atomPos !== -1) return false;
+      if (node.type.name === 'noBreakHyphen') {
+        atomPos = pos;
+        return false;
+      }
+    });
+    if (atomPos === -1) throw new Error('noBreakHyphen atom not found in doc');
+    return atomPos;
+  });
+
+const describeCaret = async (superdoc: any, pos: number) =>
+  superdoc.page.evaluate((p: number) => {
+    const { state } = (window as any).editor;
+    const $pos = state.doc.resolve(p);
+    return {
+      parent: $pos.parent.type.name,
+      depth: $pos.depth,
+      parentOffset: $pos.parentOffset,
+      nodeBefore: $pos.nodeBefore?.type.name ?? null,
+      nodeAfter: $pos.nodeAfter?.type.name ?? null,
+    };
+  }, pos);
+
+const collectFirstParagraphChildTypes = async (superdoc: any): Promise<string[]> =>
+  superdoc.page.evaluate(() => {
+    const { state } = (window as any).editor;
+    const types: string[] = [];
+    let firstParagraph: any = null;
+    state.doc.descendants((node: any) => {
+      if (firstParagraph) return false;
+      if (node.type.name === 'paragraph') {
+        firstParagraph = node;
+        return false;
+      }
+    });
+    if (!firstParagraph) return types;
+    firstParagraph.content.forEach((child: any) => {
+      types.push(child.type.name);
+    });
+    return types;
+  });
+
+test.describe('Backspace after a noBreakHyphen atom (SD-2746)', () => {
+  test('caret inside the atom-run, immediately after the atom (pos = atom + nodeSize)', async ({ superdoc }) => {
+    await setupDocWithAtom(superdoc);
+    expect(await countAtoms(superdoc)).toBe(1);
+
+    const atomPos = await findAtomPos(superdoc);
+    const caret = atomPos + 1; // inside atom's run, after atom
+    await superdoc.setTextSelection(caret, caret);
+    await superdoc.waitForStable();
+
+    const ctx = await describeCaret(superdoc, caret);
+    expect(ctx.parent).toBe('run');
+    expect(ctx.nodeBefore).toBe('noBreakHyphen');
+
+    await superdoc.press('Backspace');
+    await superdoc.waitForStable();
+
+    expect(await countAtoms(superdoc)).toBe(0);
+    expect(await collectText(superdoc)).toBe('abcdef');
+    // The wrapper run that held the atom must also be removed — leaving an
+    // empty run behind would be a structural leak that the text/atom counts
+    // alone wouldn't catch.
+    expect(await collectFirstParagraphChildTypes(superdoc)).toEqual(['run', 'run']);
+  });
+
+  test('caret at paragraph level between runs (pos = atom + nodeSize + 1)', async ({ superdoc }) => {
+    await setupDocWithAtom(superdoc);
+    expect(await countAtoms(superdoc)).toBe(1);
+
+    const atomPos = await findAtomPos(superdoc);
+    const caret = atomPos + 2; // step out of atom's run; paragraph-level boundary
+    await superdoc.setTextSelection(caret, caret);
+    await superdoc.waitForStable();
+
+    const ctx = await describeCaret(superdoc, caret);
+    expect(ctx.parent).toBe('paragraph');
+    expect(ctx.nodeBefore).toBe('run');
+
+    await superdoc.press('Backspace');
+    await superdoc.waitForStable();
+
+    expect(await countAtoms(superdoc)).toBe(0);
+    expect(await collectText(superdoc)).toBe('abcdef');
+    expect(await collectFirstParagraphChildTypes(superdoc)).toEqual(['run', 'run']);
+  });
+
+  test('caret at start of the run that follows the atom-run (pos = atom + nodeSize + 2)', async ({ superdoc }) => {
+    await setupDocWithAtom(superdoc);
+    expect(await countAtoms(superdoc)).toBe(1);
+
+    const atomPos = await findAtomPos(superdoc);
+    const caret = atomPos + 3; // inside the next run, at its content start
+    await superdoc.setTextSelection(caret, caret);
+    await superdoc.waitForStable();
+
+    const ctx = await describeCaret(superdoc, caret);
+    expect(ctx.parent).toBe('run');
+    expect(ctx.parentOffset).toBe(0);
+    expect(ctx.nodeBefore).toBeNull();
+
+    await superdoc.press('Backspace');
+    await superdoc.waitForStable();
+
+    expect(await countAtoms(superdoc)).toBe(0);
+    expect(await collectText(superdoc)).toBe('abcdef');
+    expect(await collectFirstParagraphChildTypes(superdoc)).toEqual(['run', 'run']);
+  });
+});

--- a/tests/behavior/tests/basic-commands/sd-2746-no-break-hyphen-deletion.spec.ts
+++ b/tests/behavior/tests/basic-commands/sd-2746-no-break-hyphen-deletion.spec.ts
@@ -23,7 +23,13 @@ const setupDocWithAtom = async (superdoc: any) => {
   await superdoc.waitForStable();
   await superdoc.executeCommand('insertContent', { type: 'noBreakHyphen' });
   await superdoc.waitForStable();
-  await superdoc.type('def');
+  // After insertContent of an atom, PM leaves the caret inside the atom's
+  // wrapper run. WebKit's contenteditable doesn't deliver subsequent keyboard
+  // input back to PM at that position (chromium/firefox do), so `type('def')`
+  // gets silently dropped. Use insertContent here — the deletion tests below
+  // are about Backspace/Delete semantics, not the typing path, and the
+  // resulting doc structure (three runs) is identical either way.
+  await superdoc.executeCommand('insertContent', 'def');
   await superdoc.waitForStable();
 };
 

--- a/tests/behavior/tests/basic-commands/sd-2746-no-break-hyphen-deletion.spec.ts
+++ b/tests/behavior/tests/basic-commands/sd-2746-no-break-hyphen-deletion.spec.ts
@@ -162,3 +162,79 @@ test.describe('Backspace after a noBreakHyphen atom (SD-2746)', () => {
     expect(await collectFirstParagraphChildTypes(superdoc)).toEqual(['run', 'run']);
   });
 });
+
+/**
+ * Symmetric coverage for forward Delete. The atom-wrapper run shape gives three
+ * "before the atom" caret positions; only the innermost (caret inside the
+ * wrapper run, with the atom as nodeAfter) is broken in the default chain
+ * because every command after `deleteSkipEmptyRun` bails on a non-run atom.
+ * The other two positions already work via `deleteNextToRun` — covered here
+ * to lock in the existing behavior.
+ */
+test.describe('Delete before a noBreakHyphen atom (SD-2746)', () => {
+  test('caret inside the atom-run, immediately before the atom', async ({ superdoc }) => {
+    await setupDocWithAtom(superdoc);
+    expect(await countAtoms(superdoc)).toBe(1);
+
+    const atomPos = await findAtomPos(superdoc);
+    const caret = atomPos; // inside atom's wrapper run, before atom (parentOffset = 0)
+    await superdoc.setTextSelection(caret, caret);
+    await superdoc.waitForStable();
+
+    const ctx = await describeCaret(superdoc, caret);
+    expect(ctx.parent).toBe('run');
+    expect(ctx.nodeAfter).toBe('noBreakHyphen');
+
+    await superdoc.press('Delete');
+    await superdoc.waitForStable();
+
+    // Without the deleteAtomAfter command, none of the chain commands fire
+    // here and the doc is unchanged. With the fix, the atom and its wrapper
+    // run are removed as one unit (matching the Backspace case-1 behavior).
+    expect(await countAtoms(superdoc)).toBe(0);
+    expect(await collectText(superdoc)).toBe('abcdef');
+    expect(await collectFirstParagraphChildTypes(superdoc)).toEqual(['run', 'run']);
+  });
+
+  test('caret at paragraph level immediately before the atom-run', async ({ superdoc }) => {
+    await setupDocWithAtom(superdoc);
+    expect(await countAtoms(superdoc)).toBe(1);
+
+    const atomPos = await findAtomPos(superdoc);
+    const caret = atomPos - 1; // paragraph-level boundary; nodeAfter = atom-wrapper run
+    await superdoc.setTextSelection(caret, caret);
+    await superdoc.waitForStable();
+
+    const ctx = await describeCaret(superdoc, caret);
+    expect(ctx.parent).toBe('paragraph');
+    expect(ctx.nodeAfter).toBe('run');
+
+    await superdoc.press('Delete');
+    await superdoc.waitForStable();
+
+    expect(await countAtoms(superdoc)).toBe(0);
+    expect(await collectText(superdoc)).toBe('abcdef');
+    expect(await collectFirstParagraphChildTypes(superdoc)).toEqual(['run', 'run']);
+  });
+
+  test('caret at end of the previous run (atom-wrapper is the next paragraph-level sibling)', async ({ superdoc }) => {
+    await setupDocWithAtom(superdoc);
+    expect(await countAtoms(superdoc)).toBe(1);
+
+    const atomPos = await findAtomPos(superdoc);
+    const caret = atomPos - 2; // inside previous run, parentOffset === content size
+    await superdoc.setTextSelection(caret, caret);
+    await superdoc.waitForStable();
+
+    const ctx = await describeCaret(superdoc, caret);
+    expect(ctx.parent).toBe('run');
+    expect(ctx.nodeAfter).toBeNull();
+
+    await superdoc.press('Delete');
+    await superdoc.waitForStable();
+
+    expect(await countAtoms(superdoc)).toBe(0);
+    expect(await collectText(superdoc)).toBe('abcdef');
+    expect(await collectFirstParagraphChildTypes(superdoc)).toEqual(['run', 'run']);
+  });
+});


### PR DESCRIPTION
## Summary
Adds full support for OOXML `<w:noBreakHyphen/>` tags so non-breaking hyphens are preserved end-to-end (import → schema → adapter → render → export) and behave like the visible U+2011 character users expect — including in search, get-text, diffing, and the document-api `text.rewrite` operation.

The atom is selectable, deletable from either side via Backspace/Delete, and round-trips back to `<w:noBreakHyphen/>` on export.

## Changes

**Schema & extension**
- New `noBreakHyphen` PM node (`atom`, inline, non-selectable) — `super-editor/src/editors/v1/extensions/no-break-hyphen/`.
- `Schema.js` surfaces PM's function-valued `leafText` NodeSpec field (without invoking it) so flattening APIs see the rendered glyph.

**Import / export**
- v2 + v3 importers translate `<w:noBreakHyphen/>` to the new node.
- v3 adds `noBreakHyphen` translator with co-located tests (translator + `r-translator` integration).
- Exporter writes the atom back as `<w:noBreakHyphen/>`.

**Layout / pm-adapter**
- New `no-break-hyphen.ts` inline converter emits a `TextRun` carrying U+2011 — DomPainter renders it through the existing text path with no painter changes.
- `paragraph.ts` wires the converter into the run pipeline.

**Editing behavior**
- `backspaceAtomBefore` command + keymap entry: handles all three caret positions around the atom (inside its run, between runs, at start of next run) on an opt-in allowlist (currently just `noBreakHyphen`) so existing `bookmarkEnd` behavior is preserved.
- `deleteAtomAfter` command + keymap entry: mirrors the above for forward-delete when the caret sits inside the atom's wrapper run.
- Without these, the keymap fell through to `backspaceAcrossRuns`, which intentionally skips non-text inline nodes and would delete the previous character instead of the hyphen.

**Document-API / text helpers**
- `textBetweenWithTabs` honors `leafText` (with a fallback for leaves that don't define one) — search/get-text/diff now see U+2011 instead of the generic placeholder.
- `plan-engine/executor.ts` `charOffsetToDocPos` now counts atomic inline leaves as `leafText(node).length` slots (and tabs as one slot), so `text.rewrite` lands edits at the correct PM position. Previously, rewriting `"a‑b"` → `"a‑c"` replaced `'a'` instead of `'b'`.
