### PR TITLE
fix(converter): preserve tracked-change-wrapped fields during DOCX import (SD-2858)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -3,11 +3,11 @@
  */
 import { getInstructionPreProcessor } from './fld-preprocessors';
 import { carbonCopy } from '@core/utilities/carbonCopy.js';
+import { isTrackChangeElement } from '../v2/importer/trackChangeElements.js';
 
 const SKIP_FIELD_PROCESSING_NODE_NAMES = new Set(['w:drawing', 'w:pict']);
 
 const shouldSkipFieldProcessing = (node) => SKIP_FIELD_PROCESSING_NODE_NAMES.has(node?.name);
-const isTrackChangeWrapper = (node) => node?.name === 'w:del' || node?.name === 'w:ins';
 /**
  * @typedef {object} FldCharProcessResult
  * @property {OpenXmlNode[]} processedNodes - The list of nodes after processing.
@@ -212,7 +212,7 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
         // A field started in the children, so this node is part of that field.
         childResult.unpairedBegin.forEach((pendingField) => {
           const fieldInfo = { ...pendingField.fieldInfo };
-          if (fieldInfo.preserveRaw || isTrackChangeWrapper(node)) {
+          if (fieldInfo.preserveRaw || isTrackChangeElement(node)) {
             fieldInfo.preserveRaw = true;
           }
           currentFieldStack.push(fieldInfo);
@@ -226,7 +226,7 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
         });
       } else if (childResult.unpairedEnd) {
         // A field from this level or higher ended in the children.
-        const shouldPreserveRaw = childResult.unpairedEndPreserveRaw || isTrackChangeWrapper(node);
+        const shouldPreserveRaw = childResult.unpairedEndPreserveRaw || isTrackChangeElement(node);
         if (collectedNodesStack.length === 0) {
           // Preserve the original subtree; child processing may have stripped the fldChar end marker.
           processedNodes.push(rawNode);

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -227,6 +227,7 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
         // A field from this level or higher ended in the children.
         const shouldPreserveRaw = childResult.unpairedEndPreserveRaw || isTrackChangeWrapper(node);
         if (collectedNodesStack.length === 0) {
+          // Preserve the original subtree; child processing may have stripped the fldChar end marker.
           processedNodes.push(rawNode);
           unpairedEnd = true;
           if (shouldPreserveRaw) unpairedEndPreserveRaw = true;

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -228,8 +228,8 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
         // A field from this level or higher ended in the children.
         const shouldPreserveRaw = childResult.unpairedEndPreserveRaw || isTrackChangeElement(node);
         if (collectedNodesStack.length === 0) {
-          // Preserve the original subtree; child processing may have stripped the fldChar end marker.
-          processedNodes.push(rawNode);
+          // Track-change wrappers need the original field boundary; ordinary wrappers can keep processed children.
+          processedNodes.push(shouldPreserveRaw ? rawNode : node);
           unpairedEnd = true;
           if (shouldPreserveRaw) unpairedEndPreserveRaw = true;
           return;

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -13,6 +13,7 @@ const isTrackChangeWrapper = (node) => node?.name === 'w:del' || node?.name === 
  * @property {OpenXmlNode[]} processedNodes - The list of nodes after processing.
  * @property {Array<{nodes: OpenXmlNode[], fieldInfo: {instrText: string, instructionTokens?: Array<{type: string, text?: string}>, afterSeparate?: boolean, preserveRaw?: boolean}}>| null} unpairedBegin - If a field 'begin' was found without a matching 'end'. Contains the current field data.
  * @property {boolean | null} unpairedEnd - If a field 'end' was found without a matching 'begin'.
+ * @property {boolean | null} unpairedEndPreserveRaw - If an unpaired field 'end' bubbled through a tracked-change wrapper.
  */
 
 /**
@@ -36,6 +37,7 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
   let fieldRunRPrStack = [];
   let currentFieldStack = [];
   let unpairedEnd = null;
+  let unpairedEndPreserveRaw = null;
   let collecting = false;
   const rawNodeSourceTokens = new WeakMap();
 
@@ -223,12 +225,17 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
         });
       } else if (childResult.unpairedEnd) {
         // A field from this level or higher ended in the children.
+        const shouldPreserveRaw = childResult.unpairedEndPreserveRaw || isTrackChangeWrapper(node);
         if (collectedNodesStack.length === 0) {
           processedNodes.push(node);
           unpairedEnd = true;
+          if (shouldPreserveRaw) unpairedEndPreserveRaw = true;
           return;
         }
 
+        if (shouldPreserveRaw) {
+          currentFieldStack[currentFieldStack.length - 1].preserveRaw = true;
+        }
         collectedNodesStack[collectedNodesStack.length - 1].push(node);
         captureRawNodeForCurrentField(rawNode, capturedRawNodes, rawSourceToken);
         finalizeField();
@@ -272,7 +279,7 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
     }
   }
 
-  return { processedNodes, unpairedBegin, unpairedEnd };
+  return { processedNodes, unpairedBegin, unpairedEnd, unpairedEndPreserveRaw };
 };
 
 /**

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -227,7 +227,7 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
         // A field from this level or higher ended in the children.
         const shouldPreserveRaw = childResult.unpairedEndPreserveRaw || isTrackChangeWrapper(node);
         if (collectedNodesStack.length === 0) {
-          processedNodes.push(node);
+          processedNodes.push(rawNode);
           unpairedEnd = true;
           if (shouldPreserveRaw) unpairedEndPreserveRaw = true;
           return;

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -51,16 +51,17 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
       const rawCollectedNodes = rawCollectedNodesStack.pop().filter((n) => n !== null);
       const fieldRunRPr = fieldRunRPrStack.pop() ?? null;
       const currentField = currentFieldStack.pop();
-      const combinedResult = currentField.preserveRaw
-        ? { nodes: rawCollectedNodes, handled: false }
-        : _processCombinedNodesForFldChar(
-            collectedNodes,
-            currentField.instrText.trim(),
-            docx,
-            currentField.instructionTokens,
-            fieldRunRPr,
-          );
-      const outputNodes = combinedResult.handled ? combinedResult.nodes : rawCollectedNodes;
+      let outputNodes = rawCollectedNodes;
+      if (!currentField.preserveRaw) {
+        const combinedResult = _processCombinedNodesForFldChar(
+          collectedNodes,
+          currentField.instrText.trim(),
+          docx,
+          currentField.instructionTokens,
+          fieldRunRPr,
+        );
+        outputNodes = combinedResult.handled ? combinedResult.nodes : rawCollectedNodes;
+      }
       if (collectedNodesStack.length === 0) {
         // We have completed a top-level field, add the combined nodes to the output.
         processedNodes.push(...outputNodes);

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -7,10 +7,11 @@ import { carbonCopy } from '@core/utilities/carbonCopy.js';
 const SKIP_FIELD_PROCESSING_NODE_NAMES = new Set(['w:drawing', 'w:pict']);
 
 const shouldSkipFieldProcessing = (node) => SKIP_FIELD_PROCESSING_NODE_NAMES.has(node?.name);
+const isTrackChangeWrapper = (node) => node?.name === 'w:del' || node?.name === 'w:ins';
 /**
  * @typedef {object} FldCharProcessResult
  * @property {OpenXmlNode[]} processedNodes - The list of nodes after processing.
- * @property {Array<{nodes: OpenXmlNode[], fieldInfo: {instrText: string, instructionTokens?: Array<{type: string, text?: string}>}}>| null} unpairedBegin - If a field 'begin' was found without a matching 'end'. Contains the current field data.
+ * @property {Array<{nodes: OpenXmlNode[], fieldInfo: {instrText: string, instructionTokens?: Array<{type: string, text?: string}>, afterSeparate?: boolean, preserveRaw?: boolean}}>| null} unpairedBegin - If a field 'begin' was found without a matching 'end'. Contains the current field data.
  * @property {boolean | null} unpairedEnd - If a field 'end' was found without a matching 'begin'.
  */
 
@@ -48,13 +49,15 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
       const rawCollectedNodes = rawCollectedNodesStack.pop().filter((n) => n !== null);
       const fieldRunRPr = fieldRunRPrStack.pop() ?? null;
       const currentField = currentFieldStack.pop();
-      const combinedResult = _processCombinedNodesForFldChar(
-        collectedNodes,
-        currentField.instrText.trim(),
-        docx,
-        currentField.instructionTokens,
-        fieldRunRPr,
-      );
+      const combinedResult = currentField.preserveRaw
+        ? { nodes: rawCollectedNodes, handled: false }
+        : _processCombinedNodesForFldChar(
+            collectedNodes,
+            currentField.instrText.trim(),
+            docx,
+            currentField.instructionTokens,
+            fieldRunRPr,
+          );
       const outputNodes = combinedResult.handled ? combinedResult.nodes : rawCollectedNodes;
       if (collectedNodesStack.length === 0) {
         // We have completed a top-level field, add the combined nodes to the output.
@@ -205,7 +208,11 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
       if (childResult.unpairedBegin) {
         // A field started in the children, so this node is part of that field.
         childResult.unpairedBegin.forEach((pendingField) => {
-          currentFieldStack.push(pendingField.fieldInfo);
+          const fieldInfo = { ...pendingField.fieldInfo };
+          if (fieldInfo.preserveRaw || isTrackChangeWrapper(node)) {
+            fieldInfo.preserveRaw = true;
+          }
+          currentFieldStack.push(fieldInfo);
 
           // The current node should be added to the collected nodes
           collectedNodesStack.push([node]);
@@ -216,6 +223,12 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
         });
       } else if (childResult.unpairedEnd) {
         // A field from this level or higher ended in the children.
+        if (collectedNodesStack.length === 0) {
+          processedNodes.push(node);
+          unpairedEnd = true;
+          return;
+        }
+
         collectedNodesStack[collectedNodesStack.length - 1].push(node);
         captureRawNodeForCurrentField(rawNode, capturedRawNodes, rawSourceToken);
         finalizeField();

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -303,6 +303,62 @@ describe('preProcessNodesForFldChar', () => {
     ]);
   });
 
+  it('processes known fields that end inside nested non-tracked wrappers', () => {
+    const nodes = [
+      { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'HYPERLINK "http://example.com"' }] }],
+      },
+      { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+      {
+        name: 'w:p',
+        elements: [
+          {
+            name: 'w:sdt',
+            elements: [
+              {
+                name: 'w:sdtContent',
+                elements: [
+                  { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'link text' }] }] },
+                  { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const { processedNodes } = preProcessNodesForFldChar(nodes, mockDocx);
+
+    expect(processedNodes).toEqual([
+      {
+        name: 'w:hyperlink',
+        type: 'element',
+        attributes: { 'r:id': 'rIdabc12345' },
+        elements: [
+          {
+            name: 'w:p',
+            elements: [
+              {
+                name: 'w:sdt',
+                elements: [
+                  {
+                    name: 'w:sdtContent',
+                    elements: [
+                      { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'link text' }] }] },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
   it('preserves a tracked-deletion-wrapped field split across paragraphs without throwing', () => {
     const expectedNodes = [
       {

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -372,6 +372,52 @@ describe('preProcessNodesForFldChar', () => {
     expect(result.unpairedEnd).toBeNull();
   });
 
+  it('preserves raw field nodes when an active field ends inside a tracked deletion wrapper', () => {
+    const expectedNodes = [
+      { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'HYPERLINK "http://example.com"' }] }],
+      },
+      { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+      { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'link text' }] }] },
+      {
+        name: 'w:p',
+        elements: [
+          {
+            name: 'w:del',
+            attributes: { 'w:id': '1', 'w:author': 'Repro', 'w:date': '2026-04-30T00:00:00Z' },
+            elements: [
+              { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+              {
+                name: 'w:r',
+                elements: [
+                  {
+                    name: 'w:delText',
+                    attributes: { 'xml:space': 'preserve' },
+                    elements: [{ type: 'text', text: 'deleted text after field end' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const nodes = structuredClone(expectedNodes);
+    const docx = {
+      'word/_rels/document.xml.rels': {
+        elements: [{ name: 'Relationships', elements: [] }],
+      },
+    };
+    const { processedNodes, unpairedBegin, unpairedEnd } = preProcessNodesForFldChar(nodes, docx);
+
+    expect(processedNodes).toEqual(expectedNodes);
+    expect(unpairedBegin).toBeNull();
+    expect(unpairedEnd).toBeNull();
+    expect(docx['word/_rels/document.xml.rels'].elements[0].elements).toEqual([]);
+  });
+
   it('should handle unpaired begin', () => {
     const nodes = [
       { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -303,6 +303,75 @@ describe('preProcessNodesForFldChar', () => {
     ]);
   });
 
+  it('preserves a tracked-deletion-wrapped field split across paragraphs without throwing', () => {
+    const expectedNodes = [
+      {
+        name: 'w:p',
+        elements: [
+          {
+            name: 'w:del',
+            attributes: { 'w:id': '1', 'w:author': 'Repro', 'w:date': '2026-04-30T00:00:00Z' },
+            elements: [
+              { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+              {
+                name: 'w:r',
+                elements: [
+                  {
+                    name: 'w:instrText',
+                    attributes: { 'xml:space': 'preserve' },
+                    elements: [{ type: 'text', text: ' HYPERLINK \\l "Bookmark" ' }],
+                  },
+                ],
+              },
+              { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+              {
+                name: 'w:r',
+                elements: [
+                  {
+                    name: 'w:delText',
+                    attributes: { 'xml:space': 'preserve' },
+                    elements: [{ type: 'text', text: 'deleted link text' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'w:p',
+        elements: [
+          {
+            name: 'w:del',
+            attributes: { 'w:id': '2', 'w:author': 'Repro', 'w:date': '2026-04-30T00:00:00Z' },
+            elements: [
+              { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+              {
+                name: 'w:r',
+                elements: [
+                  {
+                    name: 'w:delText',
+                    attributes: { 'xml:space': 'preserve' },
+                    elements: [{ type: 'text', text: 'deleted text after field end' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const nodes = structuredClone(expectedNodes);
+
+    let result;
+    expect(() => {
+      result = preProcessNodesForFldChar(nodes, mockDocx);
+    }).not.toThrow();
+    expect(result.processedNodes).toEqual(expectedNodes);
+    expect(result.unpairedBegin).toBeNull();
+    expect(result.unpairedEnd).toBeNull();
+  });
+
   it('should handle unpaired begin', () => {
     const nodes = [
       { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -418,6 +418,38 @@ describe('preProcessNodesForFldChar', () => {
     expect(docx['word/_rels/document.xml.rels'].elements[0].elements).toEqual([]);
   });
 
+  it('preserves raw child nodes when an unpaired end bubbles through a non-collecting wrapper', () => {
+    const expectedNodes = [
+      { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'CUSTOMFIELD foo' }] }],
+      },
+      { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+      { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'value' }] }] },
+      {
+        name: 'w:p',
+        elements: [
+          {
+            name: 'w:sdt',
+            elements: [
+              {
+                name: 'w:sdtContent',
+                elements: [{ name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const nodes = structuredClone(expectedNodes);
+    const { processedNodes, unpairedBegin, unpairedEnd } = preProcessNodesForFldChar(nodes, mockDocx);
+
+    expect(processedNodes).toEqual(expectedNodes);
+    expect(unpairedBegin).toBeNull();
+    expect(unpairedEnd).toBeNull();
+  });
+
   it('should handle unpaired begin', () => {
     const nodes = [
       { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -418,6 +418,52 @@ describe('preProcessNodesForFldChar', () => {
     expect(docx['word/_rels/document.xml.rels'].elements[0].elements).toEqual([]);
   });
 
+  it('preserves raw field nodes when an active field ends inside a tracked move wrapper', () => {
+    const expectedNodes = [
+      { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'HYPERLINK "http://example.com"' }] }],
+      },
+      { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+      { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'link text' }] }] },
+      {
+        name: 'w:p',
+        elements: [
+          {
+            name: 'w:moveFrom',
+            attributes: { 'w:id': '1', 'w:author': 'Repro', 'w:date': '2026-04-30T00:00:00Z' },
+            elements: [
+              { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+              {
+                name: 'w:r',
+                elements: [
+                  {
+                    name: 'w:t',
+                    attributes: { 'xml:space': 'preserve' },
+                    elements: [{ type: 'text', text: 'moved text after field end' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const nodes = structuredClone(expectedNodes);
+    const docx = {
+      'word/_rels/document.xml.rels': {
+        elements: [{ name: 'Relationships', elements: [] }],
+      },
+    };
+    const { processedNodes, unpairedBegin, unpairedEnd } = preProcessNodesForFldChar(nodes, docx);
+
+    expect(processedNodes).toEqual(expectedNodes);
+    expect(unpairedBegin).toBeNull();
+    expect(unpairedEnd).toBeNull();
+    expect(docx['word/_rels/document.xml.rels'].elements[0].elements).toEqual([]);
+  });
+
   it('preserves raw child nodes when an unpaired end bubbles through a non-collecting wrapper', () => {
     const expectedNodes = [
       { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
@@ -680,7 +680,7 @@ export function addDefaultStylesIfMissing(styles) {
  */
 const importHeadersFooters = (docx, converter, mainEditor, numbering, translatedNumbering, translatedLinkedStyles) => {
   const rels = docx['word/_rels/document.xml.rels'];
-  const relationships = rels?.elements.find((el) => el.name === 'Relationships');
+  const relationships = rels?.elements?.find((el) => el.name === 'Relationships');
   const elements = relationships?.elements ?? [];
 
   const headerType = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header';

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
@@ -681,12 +681,12 @@ export function addDefaultStylesIfMissing(styles) {
 const importHeadersFooters = (docx, converter, mainEditor, numbering, translatedNumbering, translatedLinkedStyles) => {
   const rels = docx['word/_rels/document.xml.rels'];
   const relationships = rels?.elements.find((el) => el.name === 'Relationships');
-  const { elements } = relationships || { elements: [] };
+  const elements = relationships?.elements ?? [];
 
   const headerType = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header';
   const footerType = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer';
-  const headers = elements.filter((el) => el.attributes['Type'] === headerType);
-  const footers = elements.filter((el) => el.attributes['Type'] === footerType);
+  const headers = elements.filter((el) => el.attributes?.['Type'] === headerType);
+  const footers = elements.filter((el) => el.attributes?.['Type'] === footerType);
 
   const sectPr = findSectPr(docx['word/document.xml']) || [];
   const allSectPrElements = sectPr.flatMap((el) => el.elements);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/trackChangeElements.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/trackChangeElements.js
@@ -1,0 +1,5 @@
+const TRACK_CHANGE_ELEMENT_NAMES = new Set(['w:del', 'w:ins', 'w:moveFrom', 'w:moveTo']);
+const TRANSLATED_TRACK_CHANGE_ELEMENT_NAMES = new Set(['w:del', 'w:ins']);
+
+export const isTrackChangeElement = (node) => TRACK_CHANGE_ELEMENT_NAMES.has(node?.name);
+export const isTranslatedTrackChangeElement = (node) => TRANSLATED_TRACK_CHANGE_ELEMENT_NAMES.has(node?.name);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/trackChangesImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/trackChangesImporter.js
@@ -1,14 +1,13 @@
 import { translator as wDelTranslator } from '@converter/v3/handlers/w/del';
 import { translator as wInsTranslator } from '@converter/v3/handlers/w/ins';
-
-const isTrackChangeElement = (node) => node?.name === 'w:del' || node?.name === 'w:ins';
+import { isTranslatedTrackChangeElement } from './trackChangeElements.js';
 
 const unwrapTrackChangeNode = (node) => {
   if (!node) {
     return null;
   }
 
-  if (isTrackChangeElement(node)) {
+  if (isTranslatedTrackChangeElement(node)) {
     return node;
   }
 


### PR DESCRIPTION
## Summary

Fixes DOCX import handling for fields wrapped in tracked changes when the field spans multiple nodes or paragraphs.

This preserves the original raw OOXML for tracked-change-wrapped fields instead of trying to collapse/process them as normal field references. That avoids import failures fordocuments where a field begins inside one tracked deletion/insertion wrapper and ends inside another.

Also makes header/footer relationship filtering more defensive by tolerating missing relationship elements or relationship nodes without attributes.

## Changes

- Preserve raw field nodes when field processing crosses `w:del` or `w:ins` wrappers.
- Handle unpaired field ends bubbling up from child nodes without throwing.
- Add regression coverage for a tracked-deletion-wrapped hyperlink field split across paragraphs.
- Guard header/footer relationship lookup against missing `elements` or `attributes`.