### PR TITLE
fix: cap text right indentation to prevent overflow from the editor

### DIFF
--- a/packages/super-editor/src/editors/v1/core/commands/textIndent.js
+++ b/packages/super-editor/src/editors/v1/core/commands/textIndent.js
@@ -2,6 +2,7 @@ import { getResolvedParagraphProperties } from '@extensions/paragraph/resolvedPr
 import { ptToTwips } from '@converter/helpers';
 
 const defaultIncrementPoints = 36;
+const maxIndentPoints = 9360; // 6.5 inches
 
 /**
  * Increase text indentation
@@ -62,6 +63,10 @@ function calculateNewIndentation(node, delta) {
     left = increment;
   } else {
     left += increment;
+  }
+
+  if (left > maxIndentPoints) {
+    left = maxIndentPoints;
   }
 
   if (left <= 0) {

--- a/packages/super-editor/src/editors/v1/core/commands/textIndent.test.js
+++ b/packages/super-editor/src/editors/v1/core/commands/textIndent.test.js
@@ -90,4 +90,16 @@ describe('text indent commands', () => {
     const finalNode = afterUnset.doc.firstChild;
     expect(finalNode.attrs.paragraphProperties.indent).toBeUndefined();
   });
+
+  it('increaseTextIndent caps at maximum indent (9360 points)', () => {
+    const nearMaxIndent = 9000;
+    const state = createState({ paragraphProperties: { indent: { left: nearMaxIndent } } });
+    getResolvedParagraphProperties.mockReturnValueOnce({ indent: { left: nearMaxIndent } });
+
+    const { dispatched, nextState } = runCommand(increaseTextIndent(), state);
+
+    expect(dispatched).toBe(true);
+    const updated = nextState.doc.firstChild;
+    expect(updated.attrs.paragraphProperties.indent.left).toBe(9360);
+  });
 });


### PR DESCRIPTION
## Summary
Adds a maximum limit to paragraph text indentation to prevent values from exceeding 6.5 inches (9360 points). This ensures indentation stays within reasonable bounds and matches common word processor constraints, and not overflows the editor.

### Before

https://github.com/user-attachments/assets/aab0c75f-9550-4194-9dec-1ff618931d65

### After

https://github.com/user-attachments/assets/fb4bca9e-e7bd-4d38-ba92-5eb7bd7d682e


## Changes
* Add `maxIndentPoints` constant (9360 points / 6.5 inches) to define the maximum allowed indentation
* Add validation in `calculateNewIndentation` to clamp left indent values at the maximum threshold
* Add test case to verify `increaseTextIndent()` properly caps at 9360 points when near the maximum
* Prevents `increaseTextIndent()` from creating excessively large indentation values through repeated increments

**Technical Details:** The fix is applied in the `calculateNewIndentation` function after computing the new indent value but before the zero-check, ensuring the maximum is enforced for both initial indents and incremental changes.

**Test coverage:** New test verifies that when starting from 9000 points (near max), calling `increaseTextIndent()` caps the result at exactly 9360 points instead of allowing it to exceed the limit.