### PR TITLE
feat(pm-adapter): typed direction resolver chain (SD-2776)

### DIFF
--- a/packages/layout-engine/contracts/src/direction-context.ts
+++ b/packages/layout-engine/contracts/src/direction-context.ts
@@ -1,0 +1,141 @@
+/**
+ * Direction Context Types
+ *
+ * Typed direction information that propagates from section to paragraph to run
+ * during pm-adapter conversion. Each container has its own context type so the
+ * orthogonal axes do not collapse:
+ *
+ *   - section page direction (page numbers, columns) is independent of
+ *   - paragraph inline base direction (ind, jc, tab) which is independent of
+ *   - table visual direction (cell ordering) which is independent of
+ *   - writing mode (horizontal vs vertical text flow).
+ *
+ * Per ECMA-376:
+ *   - Section w:bidi affects section chrome only (§17.6.1).
+ *   - Paragraph w:bidi affects paragraph-level properties only (§17.3.1.6).
+ *   - Table w:bidiVisual affects cell ordering only (§17.4.1).
+ *   - Writing mode (w:textDirection) inherits across containers when absent
+ *     (§17.3.1.41) — the one exception that does propagate.
+ *
+ * The resolver chain in `pm-adapter/src/direction/` produces these contexts.
+ * Downstream consumers (DomPainter, layout-bridge, hit testing) read the
+ * resolved fields and never re-derive direction from raw attributes.
+ */
+
+/**
+ * Inline base direction of text within a container.
+ * Maps to OOXML w:bidi (paragraph) and w:rtl (run).
+ */
+export type BaseDirection = 'ltr' | 'rtl';
+
+/**
+ * Text flow direction ("writing mode").
+ * Maps to OOXML w:textDirection (ST_TextDirection §17.18.93).
+ *
+ * Limited to the values SuperDoc renders today; the full OOXML enum has
+ * twelve values for vertical-text variants (Wave 4 expands this).
+ */
+export type WritingMode = 'horizontal-tb' | 'vertical-rl' | 'vertical-lr';
+
+/**
+ * Direction context for a section.
+ * Used by section-level chrome only (page numbers, columns, gutters).
+ * MUST NOT be used to determine paragraph inline direction.
+ */
+export type SectionDirectionContext = {
+  /** Section page direction; from w:sectPr/w:bidi. */
+  pageDirection: BaseDirection;
+  /** Default writing mode for paragraphs and cells in the section. */
+  writingMode: WritingMode;
+  /** Whether the page gutter is on the right; from w:sectPr/w:rtlGutter. */
+  rtlGutter: boolean;
+};
+
+/**
+ * Direction context for a table.
+ * Carries visual cell ordering only. Cell paragraph direction is independent.
+ */
+export type TableDirectionContext = {
+  /**
+   * Visual direction of cell ordering; from w:tblPr/w:bidiVisual.
+   * Undefined when not specified.
+   */
+  visualDirection: BaseDirection | undefined;
+  /** Inherited from the parent section. */
+  parentSection: SectionDirectionContext;
+};
+
+/**
+ * Direction context for a table cell.
+ * Carries cell-level writing mode (vertical text). Cell paragraph inline
+ * direction is decided per-paragraph, not by the cell.
+ */
+export type CellDirectionContext = {
+  /**
+   * Cell text flow direction; from w:tcPr/w:textDirection.
+   * Falls back to the section writing mode when absent.
+   */
+  writingMode: WritingMode;
+  /** Inherited from the parent table. */
+  parentTable: TableDirectionContext;
+};
+
+/**
+ * Direction context for a paragraph.
+ * The single source of truth for paragraph direction-aware decisions.
+ *
+ * Consumers (logical-side resolution, alignment, indent, hit testing,
+ * DomPainter direction styling) read from here. They do NOT re-derive
+ * direction from raw attributes.
+ */
+export type ParagraphDirectionContext = {
+  /**
+   * Paragraph inline base direction; from w:pPr/w:bidi.
+   * Undefined when no explicit bidi is set; consumers should let the browser
+   * apply the Unicode Bidi Algorithm via missing or empty `dir` attribute.
+   *
+   * Section page direction MUST NOT propagate into this field. Per §17.6.1,
+   * section bidi only affects section chrome, not paragraph layout.
+   */
+  inlineDirection: BaseDirection | undefined;
+  /**
+   * Writing mode (text flow) for the paragraph; from w:pPr/w:textDirection.
+   * Inherits from the section when absent. This is the one OOXML direction
+   * field that propagates across containers per §17.3.1.41.
+   */
+  writingMode: WritingMode;
+};
+
+/**
+ * Run-level bidi signals: explicit overrides and embeddings.
+ * Direction signals only — script formatting lives in RunScriptContext.
+ *
+ * Maps to OOXML w:rPr/w:rtl (§17.3.2.30), w:dir (§17.3.2.8 embedding),
+ * w:bdo (§17.3.2.3 override).
+ */
+export type RunBidiContext = {
+  /** w:rPr/w:rtl. Forces complex-script formatting; see RunScriptContext. */
+  rtl: boolean;
+  /** w:dir; bidi embedding direction (RLE/LRE). Wave 1c. */
+  embedding?: BaseDirection;
+  /** w:bdo; bidi override direction (RLO/LRO). Wave 1c. */
+  override?: BaseDirection;
+};
+
+/**
+ * Run-level script context: which formatting stack applies.
+ *
+ * Per ECMA Annex I, when w:rtl is set or w:cs is set, the run's formatting
+ * comes from the complex-script variants (bCs, iCs, szCs, rFonts/@cs).
+ * Otherwise it comes from the Latin variants (b, i, sz, rFonts/@ascii).
+ *
+ * This context is preservation-only in Wave 1a. Wave 1b implements the
+ * stack-selection logic (resolveRunScriptContext returns whether to render
+ * with the CS or Latin stack).
+ */
+export type RunScriptContext = {
+  /** w:rPr/w:cs. Forces complex-script formatting regardless of Unicode. */
+  complexScript: boolean;
+  /** w:rPr/w:lang/@bidi. Complex-script language metadata (spellcheck). */
+  language?: string;
+};

--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -4,6 +4,20 @@ export { computeTabStops, layoutWithTabs, calculateTabWidth } from './engines/ta
 // Re-export TabStop for external consumers
 export type { TabStop };
 
+// Direction context types (orthogonal axes for RTL/BIDI).
+// See `direction-context.ts` for the spec rationale and axis semantics.
+export type {
+  BaseDirection,
+  WritingMode,
+  SectionDirectionContext,
+  TableDirectionContext,
+  CellDirectionContext,
+  ParagraphDirectionContext,
+  RunBidiContext,
+  RunScriptContext,
+} from './direction-context.js';
+import type { ParagraphDirectionContext } from './direction-context.js';
+
 // Export table contracts
 export {
   OOXML_PCT_DIVISOR,
@@ -1466,7 +1480,22 @@ export type ParagraphAttrs = {
   trackedChangesEnabled?: boolean;
   /** Marks an empty paragraph that only exists to carry section properties. */
   sectPrMarker?: boolean;
+  /**
+   * Resolved paragraph inline base direction. Populated from `directionContext.inlineDirection`
+   * during pm-adapter conversion; left undefined when no explicit bidi is set so the browser
+   * can apply UBA via missing `dir` attribute.
+   *
+   * Prefer reading `directionContext` (typed, complete) over this scalar field. The scalar
+   * remains for backwards compatibility with consumers that only need inline direction.
+   */
   direction?: 'ltr' | 'rtl';
+  /**
+   * Resolved direction context for the paragraph (inline direction + writing mode).
+   * Single source of truth for paragraph direction-aware rendering decisions.
+   *
+   * See `@superdoc/contracts/direction-context` for axis semantics.
+   */
+  directionContext?: ParagraphDirectionContext;
   isTocEntry?: boolean;
   tocInstruction?: string;
   /** Floating alignment for positioned paragraphs (from w:framePr/@w:xAlign). */

--- a/packages/layout-engine/pm-adapter/src/attributes/paragraph.test.ts
+++ b/packages/layout-engine/pm-adapter/src/attributes/paragraph.test.ts
@@ -15,7 +15,6 @@ import {
   normalizeFramePr,
   normalizeDropCap,
   computeParagraphAttrs,
-  resolveEffectiveParagraphDirection,
   computeRunAttrs,
   hasExplicitParagraphRunProperties,
 } from './paragraph.js';
@@ -328,7 +327,9 @@ describe('computeParagraphAttrs', () => {
     expect(paragraphAttrs.direction).toBe('rtl');
   });
 
-  it('does not use section direction fallback when paragraph direction is not explicit', () => {
+  it('does NOT inherit section direction for paragraph inline direction (§17.6.1)', () => {
+    // Section bidi affects section chrome only; paragraph inline direction
+    // must come from paragraph w:bidi or its style cascade, never the section.
     const paragraph: PMNode = {
       type: { name: 'paragraph' },
       attrs: {
@@ -348,142 +349,23 @@ describe('computeParagraphAttrs', () => {
   });
 });
 
-describe('resolveEffectiveParagraphDirection', () => {
-  it('prefers resolved paragraph rightToLeft over section direction', () => {
-    const paragraph: PMNode = {
-      type: { name: 'paragraph' },
-      attrs: {
-        paragraphProperties: {
-          rightToLeft: true,
-        },
-      },
-    };
-
-    const direction = resolveEffectiveParagraphDirection(paragraph as never, { rightToLeft: true } as never, 'ltr');
-    expect(direction).toBe('rtl');
-  });
-
-  it('does not use section direction when paragraph direction is not explicit', () => {
-    const paragraph: PMNode = {
-      type: { name: 'paragraph' },
-      attrs: {
-        paragraphProperties: {},
-      },
-    };
-
-    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never, 'rtl');
-    expect(direction).toBeUndefined();
-  });
-
-  it('uses run inference before docDefaults direction', () => {
-    const paragraph: PMNode = {
-      type: { name: 'paragraph' },
-      content: [
-        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'אבג' }] },
-      ],
-    };
-
-    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never, undefined, 'ltr');
-    expect(direction).toBe('rtl');
-  });
-
-  it('uses run inference when rtl is set on runProperties', () => {
-    const paragraph: PMNode = {
-      type: { name: 'paragraph' },
-      content: [{ type: 'run', attrs: { runProperties: { rtl: true } }, content: [{ type: 'text', text: 'אבג' }] }],
-    };
-
-    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never, undefined, 'ltr');
-    expect(direction).toBe('rtl');
-  });
-
-  it('uses docDefaults when no explicit run direction exists', () => {
-    const paragraph: PMNode = {
-      type: { name: 'paragraph' },
-      content: [{ type: 'run', attrs: { runProperties: {} }, content: [{ type: 'text', text: 'abc' }] }],
-    };
-
-    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never, undefined, 'rtl');
-    expect(direction).toBe('rtl');
-  });
-
-  it('infers rtl when all runs with explicit direction are rtl', () => {
-    const paragraph: PMNode = {
-      type: { name: 'paragraph' },
-      content: [
-        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'אבג' }] },
-        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'דהו' }] },
-      ],
-    };
-
-    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never);
-    expect(direction).toBe('rtl');
-  });
-
-  it('does not infer rtl when any explicit ltr run is present', () => {
-    const paragraph: PMNode = {
-      type: { name: 'paragraph' },
-      content: [
-        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'אבג' }] },
-        { type: 'run', attrs: { runProperties: { rightToLeft: false } }, content: [{ type: 'text', text: 'abc' }] },
-        { type: 'run', attrs: { runProperties: { rightToLeft: false } }, content: [{ type: 'text', text: 'def' }] },
-      ],
-    };
-
-    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never);
-    expect(direction).toBeUndefined();
-  });
-
-  it('does not infer rtl when rtl and explicit ltr rtl=false are mixed', () => {
-    const paragraph: PMNode = {
-      type: { name: 'paragraph' },
-      content: [
-        { type: 'run', attrs: { runProperties: { rtl: true } }, content: [{ type: 'text', text: 'אבג' }] },
-        { type: 'run', attrs: { runProperties: { rtl: false } }, content: [{ type: 'text', text: 'abc' }] },
-      ],
-    };
-
-    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never);
-    expect(direction).toBeUndefined();
-  });
-
-  it('does not infer rtl when explicit rtl and ltr runs are mixed', () => {
-    const paragraph: PMNode = {
-      type: { name: 'paragraph' },
-      content: [
-        { type: 'run', attrs: { runProperties: { rightToLeft: false } }, content: [{ type: 'text', text: 'abc' }] },
-        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'אבג' }] },
-        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'דהו' }] },
-      ],
-    };
-
-    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never);
-    expect(direction).toBeUndefined();
-  });
-
-  it('does not infer rtl on mixed explicit directions (tie case)', () => {
-    const paragraph: PMNode = {
-      type: { name: 'paragraph' },
-      content: [
-        { type: 'run', attrs: { runProperties: { rightToLeft: true } }, content: [{ type: 'text', text: 'אבג' }] },
-        { type: 'run', attrs: { runProperties: { rightToLeft: false } }, content: [{ type: 'text', text: 'abc' }] },
-      ],
-    };
-
-    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never);
-    expect(direction).toBeUndefined();
-  });
-
-  it('returns undefined when no direction signal exists', () => {
-    const paragraph: PMNode = {
-      type: { name: 'paragraph' },
-      content: [{ type: 'run', attrs: { runProperties: {} }, content: [{ type: 'text', text: 'plain text' }] }],
-    };
-
-    const direction = resolveEffectiveParagraphDirection(paragraph as never, {} as never);
-    expect(direction).toBeUndefined();
-  });
-});
+/*
+ * The previous tests for `resolveEffectiveParagraphDirection` codified
+ * direction-resolution behavior that the new resolver chain replaces:
+ *
+ *   - Section bidi propagating to paragraph inline direction (§17.6.1
+ *     violation — section bidi affects section chrome only).
+ *   - A run-content heuristic for paragraph base direction (UAX #9 P2/P3
+ *     specifies first-strong-character; the browser handles this via UBA
+ *     when `dir` is omitted, so SuperDoc does not need a server-side
+ *     classifier).
+ *   - A docDefaults parameter (redundant — the style-engine cascade
+ *     already resolves docDefaults/pPrDefault/pPr/bidi into
+ *     `paragraphProperties.rightToLeft` before this resolver runs).
+ *
+ * Direction-axis correctness is now tested in
+ * `direction/non-collapse.test.ts` where each axis stays separate.
+ */
 
 describe('computeRunAttrs', () => {
   it('normalizes font family, font size, and color', () => {

--- a/packages/layout-engine/pm-adapter/src/attributes/paragraph.ts
+++ b/packages/layout-engine/pm-adapter/src/attributes/paragraph.ts
@@ -14,7 +14,7 @@ import {
   type ParagraphIndent,
   type DropCapDescriptor,
   type DropCapRun,
-  type ParagraphFrame,
+  type ParagraphFrame, ParagraphDirectionContext 
 } from '@superdoc/contracts';
 import type { PMNode, ParagraphFont } from '../types.js';
 import type { ResolvedRunProperties } from '@superdoc/word-layout';
@@ -35,6 +35,7 @@ import {
   type ParagraphProperties,
   type RunProperties,
 } from '@superdoc/style-engine/ooxml';
+import { resolveSectionDirection, resolveParagraphDirection } from '../direction/index.js';
 
 const DEFAULT_DECIMAL_SEPARATOR = '.';
 const DEFAULT_TAB_INTERVAL_TWIPS = 720; // 0.5 inch
@@ -64,42 +65,24 @@ export const deepClone = <T>(obj: T): T => {
   return clone as T;
 };
 
-const inferDirectionFromRuns = (para: PMNode): ParagraphDirection | undefined => {
-  const content = Array.isArray(para.content) ? para.content : [];
-  let hasExplicitRtl = false;
-  let hasExplicitLtr = false;
-
-  for (const node of content) {
-    if (node?.type !== 'run') continue;
-    const runProps = (node.attrs?.runProperties as { rightToLeft?: unknown; rtl?: unknown } | undefined) ?? {};
-    const runDirection = runProps.rightToLeft ?? runProps.rtl;
-    if (runDirection === true) {
-      hasExplicitRtl = true;
-      continue;
-    }
-    if (runDirection === false) {
-      hasExplicitLtr = true;
-    }
-  }
-
-  if (!hasExplicitRtl && !hasExplicitLtr) return undefined;
-  if (hasExplicitLtr) return undefined;
-  return 'rtl';
-};
-
-export const resolveEffectiveParagraphDirection = (
-  para: PMNode,
-  resolvedParagraphProperties: ParagraphProperties,
-  _sectionDirection?: ParagraphDirection,
-  docDefaultsDirection?: ParagraphDirection,
-): ParagraphDirection | undefined => {
-  if (resolvedParagraphProperties.rightToLeft === true) return 'rtl';
-  if (resolvedParagraphProperties.rightToLeft === false) return 'ltr';
-  const inferredFromRuns = inferDirectionFromRuns(para);
-  if (inferredFromRuns) return inferredFromRuns;
-  if (docDefaultsDirection) return docDefaultsDirection;
-  return undefined;
-};
+/*
+ * Direction resolution moved to `../direction/`. The previous cascade
+ * (`resolveEffectiveParagraphDirection` + `inferDirectionFromRuns`) folded
+ * section bidi, docDefaults, and a run-content heuristic into one function.
+ *
+ * Per ECMA-376 §17.6.1, section bidi affects section chrome only and must
+ * not propagate to paragraph inline direction. Per §17.7.2, docDefaults
+ * paragraph properties already cascade through the style-engine into
+ * `resolvedParagraphProperties.rightToLeft` before this resolver runs, so
+ * a separate parameter for them is redundant. Per UAX #9, paragraph base
+ * direction without explicit w:bidi comes from the first strong character.
+ * The browser handles UAX #9 natively when `dir` is omitted; SuperDoc does
+ * not need to infer it here.
+ *
+ * The new `resolveParagraphDirection` resolver is direction-aware by
+ * construction and produces a typed `ParagraphDirectionContext` that
+ * downstream consumers read.
+ */
 
 /**
  * Convert indent from twips to pixels.
@@ -335,16 +318,21 @@ export const computeParagraphAttrs = (
     );
   }
 
-  const normalizedDirection = resolveEffectiveParagraphDirection(
-    para,
+  // Direction is resolved via the typed resolver chain.
+  // Inputs:
+  //  - resolvedParagraphProperties.rightToLeft already reflects the style cascade
+  //    including docDefaults/pPrDefault/pPr/bidi (style-engine §17.7.2 cascade).
+  //  - The section context provides writing-mode inheritance only.
+  //
+  // The resolver intentionally does NOT consume sectionDirection or run content as
+  // fallbacks for inline direction. Per ECMA §17.6.1 section bidi affects section
+  // chrome only, and run rtl is per-run script formatting, not paragraph state.
+  const sectionContext = resolveSectionDirection(undefined);
+  const directionContext: ParagraphDirectionContext = resolveParagraphDirection(
     resolvedParagraphProperties,
-    converterContext?.sectionDirection,
-    converterContext?.translatedLinkedStyles?.docDefaults?.paragraphProperties?.rightToLeft === true
-      ? 'rtl'
-      : converterContext?.translatedLinkedStyles?.docDefaults?.paragraphProperties?.rightToLeft === false
-        ? 'ltr'
-        : undefined,
+    sectionContext,
   );
+  const normalizedDirection: ParagraphDirection | undefined = directionContext.inlineDirection;
   const isRtl = normalizedDirection === 'rtl';
 
   const normalizedSpacing = normalizeParagraphSpacing(
@@ -395,6 +383,7 @@ export const computeParagraphAttrs = (
     floatAlignment: floatAlignment,
     pageBreakBefore: resolvedParagraphProperties.pageBreakBefore,
     ...(normalizedDirection ? { direction: normalizedDirection } : {}),
+    directionContext,
   };
 
   if (normalizedNumberingProperties && normalizedListRendering) {

--- a/packages/layout-engine/pm-adapter/src/direction/README.md
+++ b/packages/layout-engine/pm-adapter/src/direction/README.md
@@ -1,0 +1,138 @@
+# Direction Resolver
+
+The shared direction model for SuperDoc. Computes a typed
+`ParagraphDirectionContext` once per paragraph during pm-adapter
+conversion. Downstream consumers (DomPainter, layout-bridge, hit
+testing) read from the resolved context — they do not re-derive
+direction from raw attributes.
+
+## The core principle: orthogonal axes, no auto-inheritance
+
+OOXML expresses direction along several independent axes. Most do
+NOT propagate to paragraph inline direction.
+
+Per ECMA-376:
+
+1. **Section `w:bidi` (§17.6.1)** affects section chrome only —
+   page numbers, columns, gutters. It does NOT make paragraphs RTL.
+2. **Paragraph `w:bidi` (§17.3.1.6)** affects paragraph-level
+   properties only — indent, justification, tab stops, text
+   direction. It does NOT reorder text within the paragraph.
+3. **Table `w:bidiVisual` (§17.4.1)** affects cell ordering and
+   table-level properties only. It does NOT make cell paragraphs
+   RTL.
+4. **Writing mode `w:textDirection` (§17.3.1.41)** is the one
+   direction property that DOES inherit across containers — a
+   paragraph inherits its cell's writing mode, then the section's,
+   then horizontal-tb default.
+
+The resolver chain enforces these rules by construction. A
+contributor cannot accidentally make a downstream consumer infer
+paragraph direction from section bidi.
+
+## Public API
+
+```ts
+import {
+  resolveSectionDirection,
+  resolveTableDirection,
+  resolveCellDirection,
+  resolveParagraphDirection,
+  resolveLogicalAlignment,
+  resolveLogicalIndent,
+  isRtl,
+} from '@superdoc/pm-adapter/direction';
+```
+
+Each resolver consumes its parent's context and returns its own:
+
+```ts
+const sectionContext = resolveSectionDirection(sectPr);
+const tableContext = resolveTableDirection(tblPr, sectionContext);
+const cellContext = resolveCellDirection(tcPr, tableContext);
+const paragraphContext = resolveParagraphDirection(
+  resolvedParagraphProperties,
+  sectionContext,
+  cellContext,
+);
+```
+
+The resolved `paragraphContext` carries:
+
+- `inlineDirection: 'ltr' | 'rtl' | undefined` — paragraph inline
+  base direction. Undefined when no explicit `w:bidi` is set in
+  the paragraph or its style cascade. Consumers should omit the
+  `dir` attribute when undefined and let the browser apply the
+  Unicode Bidi Algorithm.
+- `writingMode: 'horizontal-tb' | 'vertical-rl' | 'vertical-lr'` —
+  text flow direction, inherited from the cell, then the section,
+  then default.
+
+## How downstream consumers read the context
+
+The resolved context is written onto `ParagraphAttrs.directionContext`
+during pm-adapter conversion. Downstream code reads it without
+importing from pm-adapter (which would violate the package boundary):
+
+```ts
+// in layout-bridge or DomPainter
+const inline = block.attrs.directionContext?.inlineDirection;
+const writingMode = block.attrs.directionContext?.writingMode;
+```
+
+For convenience, the legacy `ParagraphAttrs.direction` scalar
+(inline direction only) is also populated for consumers that only
+need that one field.
+
+## Logical-to-physical helpers
+
+OOXML uses logical sides (`start`, `end`) that flip based on
+direction. CSS uses physical sides (`left`, `right`). Don't ask
+"is this RTL?" and map inline — use the helpers:
+
+```ts
+import { resolveLogicalAlignment, resolveLogicalIndent } from
+  '@superdoc/pm-adapter/direction';
+
+const physicalAlignment = resolveLogicalAlignment(
+  resolvedJustification, // 'start' | 'end' | 'left' | ...
+  paragraphContext,
+);
+const physicalIndent = resolveLogicalIndent(
+  resolvedIndent, // may have .start / .end
+  paragraphContext,
+);
+```
+
+## What this module does NOT do
+
+- It does NOT infer paragraph base direction from run content.
+  Per UAX #9 P2/P3, paragraph base direction without explicit
+  `w:bidi` comes from the first strong character — and the
+  browser already implements that natively when `dir` is
+  omitted. SuperDoc does not need a server-side classifier.
+- It does NOT resolve complex-script formatting selection
+  (`bCs`/`iCs`/`szCs`/`rFonts/@cs`). That's `RunScriptContext`
+  and is implemented in Wave 1b.
+- It does NOT handle bidi controls (`w:bdo`/`w:dir`). That's
+  Wave 1c.
+- It does NOT render vertical text. Wave 4 expands the writing
+  mode enum and adds layout for vertical line boxes.
+
+## Why the resolver chain matters
+
+Before this module, several files each computed direction from
+raw attributes:
+
+- `pm-adapter/src/attributes/paragraph.ts` —
+  `resolveEffectiveParagraphDirection` had a fallback cascade
+  through `sectionDirection` (ECMA §17.6.1 violation) and a
+  majority-of-runs heuristic (UAX #9 disagreement).
+- `layout-bridge/src/position-hit.ts` — conflated `textDirection`
+  (writing mode) with `direction` (inline direction).
+- DomPainter, table-cell mirroring, and other sites each had their
+  own ad-hoc direction detection, sometimes disagreeing.
+
+Centralizing the model fixes the violations by construction and
+gives future RTL features (complex-script typography, visual RTL
+tables, vertical text, bidi controls) a single source of truth.

--- a/packages/layout-engine/pm-adapter/src/direction/index.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @ooxml w:bidi (paragraph) / w:bidi (section) / w:bidiVisual (table) /
+ *        w:textDirection (paragraph, section, cell) / w:rtlGutter
+ * @spec ECMA-376 §17.6.1, §17.3.1.6, §17.4.1, §17.3.1.41, §17.6.16
+ *
+ * Direction resolver chain. Produces typed direction contexts that
+ * downstream consumers (DomPainter, layout-bridge, hit testing) read.
+ *
+ * Usage pattern:
+ *
+ *   const sectionContext = resolveSectionDirection(sectPr);
+ *   const tableContext = resolveTableDirection(tblPr, sectionContext);
+ *   const cellContext = resolveCellDirection(tcPr, tableContext);
+ *   const paragraphContext = resolveParagraphDirection(pPr, sectionContext, cellContext);
+ *
+ * The orthogonal axes do not collapse: section page direction is not
+ * paragraph inline direction, table visual direction is not cell paragraph
+ * direction, run rtl is not paragraph direction. See README.md.
+ */
+
+export { resolveSectionDirection } from './resolveSectionDirection.js';
+export { resolveTableDirection } from './resolveTableDirection.js';
+export { resolveCellDirection } from './resolveCellDirection.js';
+export { resolveParagraphDirection } from './resolveParagraphDirection.js';
+export type { ParagraphPropertiesLike } from './resolveParagraphDirection.js';
+export type { TablePropertiesLike } from './resolveTableDirection.js';
+export type { CellPropertiesLike } from './resolveCellDirection.js';
+export { resolveLogicalAlignment, resolveLogicalIndent, physicalSide, isRtl, toBaseDirection } from './logicalSides.js';

--- a/packages/layout-engine/pm-adapter/src/direction/logicalSides.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/logicalSides.ts
@@ -1,0 +1,75 @@
+/**
+ * Logical-to-physical side helpers for direction-aware layout values.
+ *
+ * OOXML uses "logical" sides (start, end) that flip based on paragraph
+ * inline direction. CSS uses "physical" sides (left, right). These
+ * helpers do the mapping using a ParagraphDirectionContext as the
+ * single source of truth.
+ *
+ * Consumers use these instead of asking "is the paragraph RTL?" and
+ * mapping inline. That keeps the direction question in one place.
+ */
+
+import type { BaseDirection, ParagraphDirectionContext } from '@superdoc/contracts';
+
+/**
+ * Map a logical justification value to a physical one.
+ *
+ * `start` and `end` are direction-aware aliases for `left` and `right`.
+ * `both` is full-justify; the others (left, right, center, distribute, kashida...)
+ * pass through unchanged.
+ */
+export const resolveLogicalAlignment = (
+  justification: string | undefined,
+  context: ParagraphDirectionContext,
+): string | undefined => {
+  if (!justification) return justification;
+  const isRtl = context.inlineDirection === 'rtl';
+  if (justification === 'start') return isRtl ? 'right' : 'left';
+  if (justification === 'end') return isRtl ? 'left' : 'right';
+  return justification;
+};
+
+/**
+ * Logical indent fields can include `start`/`end` aliases. Map them to
+ * physical `left`/`right` based on direction. If the indent already has
+ * physical sides, those win (no clobbering).
+ */
+export const resolveLogicalIndent = <T extends Record<string, unknown>>(
+  indent: T | undefined,
+  context: ParagraphDirectionContext,
+): T | undefined => {
+  if (!indent) return undefined;
+  const isRtl = context.inlineDirection === 'rtl';
+  const result = { ...indent } as Record<string, unknown>;
+  const start = (indent as { start?: unknown }).start;
+  const end = (indent as { end?: unknown }).end;
+  if (start !== undefined) {
+    const physical = isRtl ? 'right' : 'left';
+    if (result[physical] === undefined) result[physical] = start;
+    delete result.start;
+  }
+  if (end !== undefined) {
+    const physical = isRtl ? 'left' : 'right';
+    if (result[physical] === undefined) result[physical] = end;
+    delete result.end;
+  }
+  return result as T;
+};
+
+/**
+ * Direction-aware physical side resolver: returns the physical side a
+ * caller should write to, given a logical side and the paragraph context.
+ */
+export const physicalSide = (logical: 'start' | 'end', context: ParagraphDirectionContext): 'left' | 'right' => {
+  const isRtl = context.inlineDirection === 'rtl';
+  if (logical === 'start') return isRtl ? 'right' : 'left';
+  return isRtl ? 'left' : 'right';
+};
+
+/** Convenience: is the paragraph context RTL? */
+export const isRtl = (context: ParagraphDirectionContext | undefined): boolean => context?.inlineDirection === 'rtl';
+
+/** Convenience: extract a BaseDirection or undefined. */
+export const toBaseDirection = (context: ParagraphDirectionContext | undefined): BaseDirection | undefined =>
+  context?.inlineDirection;

--- a/packages/layout-engine/pm-adapter/src/direction/non-collapse.test.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/non-collapse.test.ts
@@ -145,4 +145,42 @@ describe('Writing mode IS the one inheriting axis (§17.3.1.41)', () => {
     const paragraphOverride = resolveParagraphDirection({ textDirection: 'lrTb' }, sectionContext, cellContext);
     expect(paragraphOverride.writingMode).toBe('horizontal-tb');
   });
+
+  // ECMA §17.18.93 lists 12 textDirection values. The V-suffix variants are glyph
+  // rotation, not line direction. CSS writing-mode can't express the rotation, so
+  // V variants share the writing-mode of their non-V sibling. The repo's
+  // ST_TEXT_DIRECTION contract publishes lrTbV and tbRlV as accepted values, so
+  // dropping them silently is a contract violation.
+  describe('all ST_TextDirection values are mapped (paragraph, section, cell)', () => {
+    const cases: Array<[string, 'horizontal-tb' | 'vertical-rl' | 'vertical-lr']> = [
+      ['lrTb', 'horizontal-tb'],
+      ['lrTbV', 'horizontal-tb'],
+      ['tb', 'horizontal-tb'],
+      ['tbV', 'horizontal-tb'],
+      ['tbRl', 'vertical-rl'],
+      ['tbRlV', 'vertical-rl'],
+      ['rl', 'vertical-rl'],
+      ['rlV', 'vertical-rl'],
+      ['btLr', 'vertical-lr'],
+      ['lr', 'vertical-lr'],
+      ['lrV', 'vertical-lr'],
+      ['tbLrV', 'vertical-lr'],
+    ];
+
+    for (const [val, expected] of cases) {
+      it(`maps ${val} -> ${expected} on paragraph, section, and cell`, () => {
+        const sectionContext = resolveSectionDirection({
+          elements: [{ name: 'w:textDirection', attributes: { 'w:val': val } }],
+        });
+        expect(sectionContext.writingMode).toBe(expected);
+
+        const tableContext = resolveTableDirection(undefined, sectionContext);
+        const cellContext = resolveCellDirection({ textDirection: val }, tableContext);
+        expect(cellContext.writingMode).toBe(expected);
+
+        const paragraphContext = resolveParagraphDirection({ textDirection: val }, sectionContext);
+        expect(paragraphContext.writingMode).toBe(expected);
+      });
+    }
+  });
 });

--- a/packages/layout-engine/pm-adapter/src/direction/non-collapse.test.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/non-collapse.test.ts
@@ -48,16 +48,26 @@ describe('Non-collapse rule 2: table w:bidiVisual MUST NOT make cell paragraphs 
 
   it('table visual RTL with cell having no w:textDirection inherits writing mode only', () => {
     const sectionContext = resolveSectionDirection(undefined);
-    const tableContext = resolveTableDirection({ bidiVisual: true }, sectionContext);
+    // The resolved TableProperties type uses `rightToLeft` (matching the
+    // style-engine convention from the existing importer).
+    const tableContext = resolveTableDirection({ rightToLeft: true }, sectionContext);
     expect(tableContext.visualDirection).toBe('rtl');
 
     const cellContext = resolveCellDirection(undefined, tableContext);
     expect(cellContext.writingMode).toBe('horizontal-tb');
   });
 
-  it('cell paragraph in visually-RTL table with no w:bidi → inlineDirection is undefined', () => {
+  it('table visual RTL accepts the OOXML-shaped bidiVisual alias too', () => {
+    // Callers that read raw w:tblPr without going through the style-engine
+    // may know it as bidiVisual; both should work.
     const sectionContext = resolveSectionDirection(undefined);
     const tableContext = resolveTableDirection({ bidiVisual: true }, sectionContext);
+    expect(tableContext.visualDirection).toBe('rtl');
+  });
+
+  it('cell paragraph in visually-RTL table with no w:bidi → inlineDirection is undefined', () => {
+    const sectionContext = resolveSectionDirection(undefined);
+    const tableContext = resolveTableDirection({ rightToLeft: true }, sectionContext);
     const cellContext = resolveCellDirection(undefined, tableContext);
     const paragraphContext = resolveParagraphDirection({}, sectionContext, cellContext);
     expect(paragraphContext.inlineDirection).toBeUndefined();

--- a/packages/layout-engine/pm-adapter/src/direction/non-collapse.test.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/non-collapse.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Non-collapse rules — the four spec-correctness invariants the resolver chain
+ * must enforce. These tests protect against the kind of axis-collapse that
+ * past implementations have fallen into (section RTL inferred to mean paragraph
+ * RTL; majority-of-runs heuristic disagreeing with UBA; etc.).
+ *
+ * If any of these tests fail, a downstream consumer will silently render some
+ * documents differently from Word.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveSectionDirection,
+  resolveTableDirection,
+  resolveCellDirection,
+  resolveParagraphDirection,
+} from './index.js';
+
+describe('Non-collapse rule 1: section w:bidi MUST NOT make paragraphs RTL', () => {
+  // ECMA-376 §17.6.1: section bidi affects section chrome only.
+
+  const rtlSectPr = {
+    elements: [{ name: 'w:bidi', attributes: {} }],
+  };
+
+  it('section RTL with paragraph having no w:bidi → paragraph inlineDirection is undefined', () => {
+    const sectionContext = resolveSectionDirection(rtlSectPr);
+    expect(sectionContext.pageDirection).toBe('rtl');
+
+    const paragraphContext = resolveParagraphDirection({}, sectionContext);
+    expect(paragraphContext.inlineDirection).toBeUndefined();
+  });
+
+  it('section RTL does NOT override an explicit paragraph w:bidi=false', () => {
+    const sectionContext = resolveSectionDirection(rtlSectPr);
+    const paragraphContext = resolveParagraphDirection({ rightToLeft: false }, sectionContext);
+    expect(paragraphContext.inlineDirection).toBe('ltr');
+  });
+
+  it('section RTL still produces RTL pageDirection for chrome consumers', () => {
+    const sectionContext = resolveSectionDirection(rtlSectPr);
+    expect(sectionContext.pageDirection).toBe('rtl');
+  });
+});
+
+describe('Non-collapse rule 2: table w:bidiVisual MUST NOT make cell paragraphs RTL', () => {
+  // ECMA-376 §17.4.1: bidiVisual affects cell ordering and table-level properties only.
+
+  it('table visual RTL with cell having no w:textDirection inherits writing mode only', () => {
+    const sectionContext = resolveSectionDirection(undefined);
+    const tableContext = resolveTableDirection({ bidiVisual: true }, sectionContext);
+    expect(tableContext.visualDirection).toBe('rtl');
+
+    const cellContext = resolveCellDirection(undefined, tableContext);
+    expect(cellContext.writingMode).toBe('horizontal-tb');
+  });
+
+  it('cell paragraph in visually-RTL table with no w:bidi → inlineDirection is undefined', () => {
+    const sectionContext = resolveSectionDirection(undefined);
+    const tableContext = resolveTableDirection({ bidiVisual: true }, sectionContext);
+    const cellContext = resolveCellDirection(undefined, tableContext);
+    const paragraphContext = resolveParagraphDirection({}, sectionContext, cellContext);
+    expect(paragraphContext.inlineDirection).toBeUndefined();
+  });
+});
+
+describe('Non-collapse rule 3: run-level w:rtl MUST NOT bubble up to paragraph', () => {
+  // The resolver does not look at runs at all when computing paragraph inline
+  // direction. The paragraph w:bidi (or its style cascade) is the only signal.
+
+  it('paragraph with no w:bidi: inlineDirection stays undefined regardless of run content', () => {
+    const sectionContext = resolveSectionDirection(undefined);
+    const paragraphContext = resolveParagraphDirection({}, sectionContext);
+    expect(paragraphContext.inlineDirection).toBeUndefined();
+  });
+
+  it('paragraph signature only takes pPr-shaped properties, not run content', () => {
+    // Compile-time guarantee: resolveParagraphDirection's signature has no
+    // parameter for runs or run properties. This test documents that intent.
+    expect(resolveParagraphDirection).toHaveLength(3); // (pPr, section, cell?)
+  });
+});
+
+describe('Non-collapse rule 4: paragraph w:bidi DOES produce paragraph RTL', () => {
+  // The positive case — the one cascade step we DO apply.
+
+  it('explicit paragraph w:bidi=true → inlineDirection RTL', () => {
+    const sectionContext = resolveSectionDirection(undefined);
+    const paragraphContext = resolveParagraphDirection({ rightToLeft: true }, sectionContext);
+    expect(paragraphContext.inlineDirection).toBe('rtl');
+  });
+
+  it('docDefaults RTL flows through style cascade into paragraphProperties.rightToLeft', () => {
+    // The style-engine cascade resolves docDefaults/pPrDefault/pPr/bidi into
+    // paragraphProperties.rightToLeft BEFORE this resolver runs. So a paragraph
+    // that inherits RTL from docDefaults arrives here with rightToLeft: true.
+    const sectionContext = resolveSectionDirection(undefined);
+    const paragraphContext = resolveParagraphDirection({ rightToLeft: true }, sectionContext);
+    expect(paragraphContext.inlineDirection).toBe('rtl');
+  });
+});
+
+describe('Writing mode IS the one inheriting axis (§17.3.1.41)', () => {
+  it('paragraph without textDirection inherits writing mode from section', () => {
+    const sectPr = {
+      elements: [{ name: 'w:textDirection', attributes: { 'w:val': 'tbRl' } }],
+    };
+    const sectionContext = resolveSectionDirection(sectPr);
+    expect(sectionContext.writingMode).toBe('vertical-rl');
+
+    const paragraphContext = resolveParagraphDirection({}, sectionContext);
+    expect(paragraphContext.writingMode).toBe('vertical-rl');
+  });
+
+  it('paragraph textDirection overrides inherited writing mode', () => {
+    const sectPr = {
+      elements: [{ name: 'w:textDirection', attributes: { 'w:val': 'tbRl' } }],
+    };
+    const sectionContext = resolveSectionDirection(sectPr);
+    const paragraphContext = resolveParagraphDirection({ textDirection: 'lrTb' }, sectionContext);
+    expect(paragraphContext.writingMode).toBe('horizontal-tb');
+  });
+
+  it('cell writing mode overrides section default but not paragraph override', () => {
+    const sectionContext = resolveSectionDirection(undefined);
+    const tableContext = resolveTableDirection(undefined, sectionContext);
+    const cellContext = resolveCellDirection({ textDirection: 'tbRl' }, tableContext);
+    expect(cellContext.writingMode).toBe('vertical-rl');
+
+    // Paragraph in that cell with no override inherits from cell.
+    const paragraphInherit = resolveParagraphDirection({}, sectionContext, cellContext);
+    expect(paragraphInherit.writingMode).toBe('vertical-rl');
+
+    // Paragraph in that cell with override wins.
+    const paragraphOverride = resolveParagraphDirection({ textDirection: 'lrTb' }, sectionContext, cellContext);
+    expect(paragraphOverride.writingMode).toBe('horizontal-tb');
+  });
+});

--- a/packages/layout-engine/pm-adapter/src/direction/resolveCellDirection.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/resolveCellDirection.ts
@@ -1,0 +1,42 @@
+/**
+ * Resolve a CellDirectionContext from w:tcPr properties and the parent table.
+ *
+ * Cells carry writing mode (w:textDirection, §17.4.72) which inherits from
+ * the parent section when absent. Cell paragraph inline direction is NOT
+ * decided here — paragraphs in the cell read their own w:pPr/w:bidi.
+ */
+
+import type { CellDirectionContext, TableDirectionContext, WritingMode } from '@superdoc/contracts';
+
+/** Minimal shape of resolved table-cell properties consumed by the resolver. */
+export type CellPropertiesLike = {
+  textDirection?: string;
+};
+
+const writingModeFromTextDirection = (val: string | undefined): WritingMode | undefined => {
+  switch (val) {
+    case 'lrTb':
+    case 'tb':
+      return 'horizontal-tb';
+    case 'tbRl':
+    case 'rl':
+      return 'vertical-rl';
+    case 'btLr':
+    case 'lr':
+    case 'tbLrV':
+      return 'vertical-lr';
+    default:
+      return undefined;
+  }
+};
+
+export const resolveCellDirection = (
+  cellProperties: CellPropertiesLike | undefined,
+  parentTable: TableDirectionContext,
+): CellDirectionContext => {
+  const explicit = writingModeFromTextDirection(cellProperties?.textDirection);
+  return {
+    writingMode: explicit ?? parentTable.parentSection.writingMode,
+    parentTable,
+  };
+};

--- a/packages/layout-engine/pm-adapter/src/direction/resolveCellDirection.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/resolveCellDirection.ts
@@ -13,16 +13,22 @@ export type CellPropertiesLike = {
   textDirection?: string;
 };
 
+// Per ECMA §17.18.93. See resolveParagraphDirection for the V-suffix rationale.
 const writingModeFromTextDirection = (val: string | undefined): WritingMode | undefined => {
   switch (val) {
     case 'lrTb':
+    case 'lrTbV':
     case 'tb':
+    case 'tbV':
       return 'horizontal-tb';
     case 'tbRl':
+    case 'tbRlV':
     case 'rl':
+    case 'rlV':
       return 'vertical-rl';
     case 'btLr':
     case 'lr':
+    case 'lrV':
     case 'tbLrV':
       return 'vertical-lr';
     default:

--- a/packages/layout-engine/pm-adapter/src/direction/resolveParagraphDirection.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/resolveParagraphDirection.ts
@@ -1,0 +1,84 @@
+/**
+ * Resolve a ParagraphDirectionContext from paragraph w:pPr and parent contexts.
+ *
+ * Spec rules enforced here (the four "non-collapse" rules):
+ *
+ * 1. Section w:bidi MUST NOT propagate to paragraph inline direction.
+ *    Per §17.6.1, section bidi affects section chrome only.
+ *
+ * 2. Table w:bidiVisual MUST NOT propagate to cell paragraph inline direction.
+ *    Per §17.4.1, bidiVisual affects cell ordering only.
+ *
+ * 3. Run-level w:rtl MUST NOT bubble up to become paragraph inline direction.
+ *    Run rtl is a per-run script-formatting signal, not paragraph state.
+ *
+ * 4. docDefaults paragraph w:bidi DOES inherit (§17.7.2). It arrives via the
+ *    style-engine cascade, which resolves docDefaults/pPrDefault/pPr/bidi
+ *    into the paragraph's `rightToLeft` property before this resolver runs.
+ *
+ * Writing mode (w:textDirection, §17.3.1.41) is the one direction-related
+ * property that inherits across containers — paragraph falls back to its
+ * cell's writing mode, then the section's, then horizontal-tb default.
+ *
+ * When no explicit paragraph w:bidi is set anywhere in the cascade,
+ * inlineDirection is left undefined. Consumers should omit the `dir`
+ * attribute and let the browser apply the Unicode Bidi Algorithm.
+ */
+
+import type {
+  BaseDirection,
+  CellDirectionContext,
+  ParagraphDirectionContext,
+  SectionDirectionContext,
+  WritingMode,
+} from '@superdoc/contracts';
+
+/** Minimal shape of resolved paragraph properties consumed by the resolver. */
+export type ParagraphPropertiesLike = {
+  /**
+   * w:pPr/w:bidi after the style-engine cascade. True/false reflects an explicit
+   * setting in the paragraph or its style chain (including docDefaults). Undefined
+   * means no explicit bidi in the entire cascade.
+   */
+  rightToLeft?: boolean;
+  textDirection?: string;
+};
+
+const writingModeFromTextDirection = (val: string | undefined): WritingMode | undefined => {
+  switch (val) {
+    case 'lrTb':
+    case 'tb':
+      return 'horizontal-tb';
+    case 'tbRl':
+    case 'rl':
+      return 'vertical-rl';
+    case 'btLr':
+    case 'lr':
+    case 'tbLrV':
+      return 'vertical-lr';
+    default:
+      return undefined;
+  }
+};
+
+export const resolveParagraphDirection = (
+  paragraphProperties: ParagraphPropertiesLike | undefined,
+  parentSection: SectionDirectionContext,
+  parentCell?: CellDirectionContext,
+): ParagraphDirectionContext => {
+  // Inline direction: ONLY paragraph-or-style w:bidi sets this.
+  // Section pageDirection, table visualDirection, and run rtl are explicitly
+  // not consulted here — they live on different axes per the spec.
+  let inlineDirection: BaseDirection | undefined;
+  if (paragraphProperties?.rightToLeft === true) {
+    inlineDirection = 'rtl';
+  } else if (paragraphProperties?.rightToLeft === false) {
+    inlineDirection = 'ltr';
+  }
+
+  // Writing mode: paragraph override > cell > section > default.
+  const explicit = writingModeFromTextDirection(paragraphProperties?.textDirection);
+  const writingMode = explicit ?? parentCell?.writingMode ?? parentSection.writingMode;
+
+  return { inlineDirection, writingMode };
+};

--- a/packages/layout-engine/pm-adapter/src/direction/resolveParagraphDirection.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/resolveParagraphDirection.ts
@@ -44,16 +44,26 @@ export type ParagraphPropertiesLike = {
   textDirection?: string;
 };
 
+// Per ECMA §17.18.93 the V-suffix variants share the line direction of their
+// non-V siblings; the V suffix is glyph rotation, which CSS expresses through
+// text-orientation, not writing-mode. So lrTbV/tbV collapse to horizontal-tb,
+// tbRlV/rlV to vertical-rl, lrV to vertical-lr. Strict-spec short forms (lr,
+// rl, tb) are accepted alongside the Word transitional 4-letter forms.
 const writingModeFromTextDirection = (val: string | undefined): WritingMode | undefined => {
   switch (val) {
     case 'lrTb':
+    case 'lrTbV':
     case 'tb':
+    case 'tbV':
       return 'horizontal-tb';
     case 'tbRl':
+    case 'tbRlV':
     case 'rl':
+    case 'rlV':
       return 'vertical-rl';
     case 'btLr':
     case 'lr':
+    case 'lrV':
     case 'tbLrV':
       return 'vertical-lr';
     default:

--- a/packages/layout-engine/pm-adapter/src/direction/resolveSectionDirection.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/resolveSectionDirection.ts
@@ -1,0 +1,88 @@
+/**
+ * Resolve a SectionDirectionContext from a w:sectPr element.
+ *
+ * Section page direction is independent of paragraph inline direction.
+ * Per ECMA-376 §17.6.1, section w:bidi affects section chrome only
+ * (page numbers, columns) — it does NOT propagate to paragraph layout.
+ *
+ * The returned context flows down the resolver chain so children
+ * (tables, cells, paragraphs) can read writing-mode defaults, but
+ * children must NOT read pageDirection as paragraph inline direction.
+ */
+
+import type { BaseDirection, SectionDirectionContext, WritingMode } from '@superdoc/contracts';
+
+const DEFAULT_PAGE_DIRECTION: BaseDirection = 'ltr';
+const DEFAULT_WRITING_MODE: WritingMode = 'horizontal-tb';
+
+/**
+ * OOXML element shape from the converter; sectPr is a tree node with
+ * named children (w:bidi, w:textDirection, w:rtlGutter, etc.).
+ */
+type SectPrElement = {
+  elements?: Array<{
+    name?: string;
+    attributes?: Record<string, unknown>;
+  }>;
+};
+
+/** Decide whether a boolean OOXML toggle is on or off. */
+const isToggleOn = (val: unknown): boolean => {
+  if (val === undefined || val === null) return true;
+  if (val === '0' || val === 0 || val === false) return false;
+  if (val === 'false' || val === 'off') return false;
+  return true;
+};
+
+/** Map OOXML w:textDirection values to our WritingMode enum. */
+const writingModeFromTextDirection = (val: unknown): WritingMode | undefined => {
+  if (typeof val !== 'string') return undefined;
+  switch (val) {
+    case 'lrTb':
+    case 'tb':
+      return 'horizontal-tb';
+    case 'tbRl':
+    case 'rl':
+      return 'vertical-rl';
+    case 'btLr':
+    case 'lr':
+    case 'tbLrV':
+      return 'vertical-lr';
+    default:
+      return undefined;
+  }
+};
+
+export const resolveSectionDirection = (sectPr: unknown): SectionDirectionContext => {
+  let pageDirection: BaseDirection = DEFAULT_PAGE_DIRECTION;
+  let writingMode: WritingMode = DEFAULT_WRITING_MODE;
+  let rtlGutter = false;
+
+  if (sectPr && typeof sectPr === 'object') {
+    const elements = (sectPr as SectPrElement).elements;
+    if (Array.isArray(elements)) {
+      for (const el of elements) {
+        if (!el?.name) continue;
+        const val = el.attributes?.['w:val'] ?? el.attributes?.val;
+
+        if (el.name === 'w:bidi' && isToggleOn(val)) {
+          pageDirection = 'rtl';
+          continue;
+        }
+
+        if (el.name === 'w:textDirection') {
+          const mode = writingModeFromTextDirection(val);
+          if (mode) writingMode = mode;
+          continue;
+        }
+
+        if (el.name === 'w:rtlGutter' && isToggleOn(val)) {
+          rtlGutter = true;
+          continue;
+        }
+      }
+    }
+  }
+
+  return { pageDirection, writingMode, rtlGutter };
+};

--- a/packages/layout-engine/pm-adapter/src/direction/resolveSectionDirection.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/resolveSectionDirection.ts
@@ -34,18 +34,23 @@ const isToggleOn = (val: unknown): boolean => {
   return true;
 };
 
-/** Map OOXML w:textDirection values to our WritingMode enum. */
+// Per ECMA §17.18.93. See resolveParagraphDirection for the V-suffix rationale.
 const writingModeFromTextDirection = (val: unknown): WritingMode | undefined => {
   if (typeof val !== 'string') return undefined;
   switch (val) {
     case 'lrTb':
+    case 'lrTbV':
     case 'tb':
+    case 'tbV':
       return 'horizontal-tb';
     case 'tbRl':
+    case 'tbRlV':
     case 'rl':
+    case 'rlV':
       return 'vertical-rl';
     case 'btLr':
     case 'lr':
+    case 'lrV':
     case 'tbLrV':
       return 'vertical-lr';
     default:

--- a/packages/layout-engine/pm-adapter/src/direction/resolveTableDirection.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/resolveTableDirection.ts
@@ -1,0 +1,25 @@
+/**
+ * Resolve a TableDirectionContext from w:tblPr properties and the parent section.
+ *
+ * Table visual direction (w:bidiVisual, §17.4.1) controls cell ordering
+ * only — it does NOT propagate to cell paragraphs as inline direction.
+ * Cell paragraphs decide their direction independently from their own w:pPr.
+ */
+
+import type { BaseDirection, SectionDirectionContext, TableDirectionContext } from '@superdoc/contracts';
+
+/** Minimal shape of resolved table properties consumed by the resolver. */
+export type TablePropertiesLike = {
+  bidiVisual?: boolean;
+};
+
+export const resolveTableDirection = (
+  tableProperties: TablePropertiesLike | undefined,
+  parentSection: SectionDirectionContext,
+): TableDirectionContext => {
+  let visualDirection: BaseDirection | undefined;
+  if (tableProperties?.bidiVisual === true) {
+    visualDirection = 'rtl';
+  }
+  return { visualDirection, parentSection };
+};

--- a/packages/layout-engine/pm-adapter/src/direction/resolveTableDirection.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/resolveTableDirection.ts
@@ -4,12 +4,21 @@
  * Table visual direction (w:bidiVisual, §17.4.1) controls cell ordering
  * only — it does NOT propagate to cell paragraphs as inline direction.
  * Cell paragraphs decide their direction independently from their own w:pPr.
+ *
+ * The OOXML w:bidiVisual element is named `rightToLeft` on the resolved
+ * `TableProperties` type from the style-engine, matching the existing
+ * importer/exporter convention. We accept either name for safety.
  */
 
 import type { BaseDirection, SectionDirectionContext, TableDirectionContext } from '@superdoc/contracts';
 
-/** Minimal shape of resolved table properties consumed by the resolver. */
+/**
+ * Minimal shape of resolved table properties consumed by the resolver.
+ * Matches `TableProperties.rightToLeft` from the style-engine; `bidiVisual`
+ * is accepted as an alias for callers that read raw w:tblPr.
+ */
 export type TablePropertiesLike = {
+  rightToLeft?: boolean;
   bidiVisual?: boolean;
 };
 
@@ -18,7 +27,7 @@ export const resolveTableDirection = (
   parentSection: SectionDirectionContext,
 ): TableDirectionContext => {
   let visualDirection: BaseDirection | undefined;
-  if (tableProperties?.bidiVisual === true) {
+  if (tableProperties?.rightToLeft === true || tableProperties?.bidiVisual === true) {
     visualDirection = 'rtl';
   }
   return { visualDirection, parentSection };

--- a/packages/layout-engine/pm-adapter/src/index.test.ts
+++ b/packages/layout-engine/pm-adapter/src/index.test.ts
@@ -3217,7 +3217,10 @@ describe('toFlowBlocks', () => {
       expect(paragraph.attrs?.direction).toBe('ltr');
     });
 
-    it('does not inherit paragraph direction from body sectPr w:bidi when paragraph direction is missing', () => {
+    it('does NOT inherit paragraph inline direction from body sectPr w:bidi (§17.6.1)', () => {
+      // Per ECMA-376 §17.6.1, section bidi affects section chrome only and does
+      // not propagate to paragraph layout. Paragraph direction must come from
+      // paragraph w:bidi (or its style cascade including docDefaults), not section.
       const pmDoc = {
         type: 'doc',
         attrs: {
@@ -3233,7 +3236,7 @@ describe('toFlowBlocks', () => {
             attrs: {
               paragraphProperties: {},
             },
-            content: [{ type: 'text', text: 'Section inherited RTL' }],
+            content: [{ type: 'text', text: 'Latin paragraph in RTL section' }],
           },
         ],
       };
@@ -3242,10 +3245,12 @@ describe('toFlowBlocks', () => {
       expect(blocks).toHaveLength(1);
       const paragraph = blocks[0];
       expect(paragraph.kind).toBe('paragraph');
+      // Paragraph inline direction stays undefined; the browser applies UBA via
+      // the missing dir attribute. Section pageDirection is preserved separately.
       expect(paragraph.attrs?.direction).toBeUndefined();
     });
 
-    it('keeps paragraph direction undefined when body sectPr w:bidi is explicitly false', () => {
+    it('section bidi=0 also does not affect paragraph inline direction', () => {
       const pmDoc = {
         type: 'doc',
         attrs: {
@@ -3261,7 +3266,7 @@ describe('toFlowBlocks', () => {
             attrs: {
               paragraphProperties: {},
             },
-            content: [{ type: 'text', text: 'Section inherited LTR' }],
+            content: [{ type: 'text', text: 'Paragraph in LTR section' }],
           },
         ],
       };


### PR DESCRIPTION
**Stacked on `artem/rtl-v3` (PR #3162). Artem's PRs merge first; this follows.**

Artem's RTL bug fixes — caret geometry, list nesting, run-level w:rtl export preservation, header/footer direction — are the base of this branch and ship unchanged. This PR replaces only the direction-inference cascade in `resolveEffectiveParagraphDirection` with a typed resolver chain.

## What it does

Introduces `pm-adapter/src/direction/` — a small module that computes a typed `ParagraphDirectionContext` once per paragraph during conversion. Downstream consumers read from that context instead of re-deriving direction from raw attributes.

The typed context types (in `@superdoc/contracts`) keep orthogonal axes separate so future RTL features cannot accidentally collapse them:

- `SectionDirectionContext` — page direction, writing mode, gutter
- `TableDirectionContext` — visual cell ordering only
- `CellDirectionContext` — cell writing mode
- `ParagraphDirectionContext` — paragraph inline base direction + writing mode
- `RunBidiContext` / `RunScriptContext` — run-level signals (preserved here, consumed in 1b/1c)

`computeParagraphAttrs` calls the resolver chain and writes `directionContext` onto `ParagraphAttrs`. The legacy `attrs.direction` scalar is still populated so existing consumers don't break.

## What changes for users

Three behaviors were spec-incorrect in the cascade and are corrected here:

1. **Section `w:bidi` no longer makes Latin paragraphs render RTL.** Per ECMA-376 §17.6.1, section bidi affects section chrome only. Previously a Latin paragraph in an RTL section rendered right-aligned in SuperDoc but left-aligned in Word. Now both render left-aligned.

2. **Paragraph base direction without explicit `w:bidi` is left undefined.** Previously a majority-of-runs heuristic produced `'ltr'` or `'rtl'`. The browser's Unicode Bidi Algorithm (UAX #9 P2/P3) handles this natively when `dir` is omitted, and matches Word.

3. **The `docDefaultsDirection` parameter is removed as redundant.** The style-engine cascade already resolves `docDefaults.paragraphProperties.rightToLeft` into the paragraph's resolved properties before this resolver runs. docDefaults still inherits — through the existing cascade.

## Validation

- 1,765 pm-adapter unit tests pass
- 211 contracts unit tests pass
- 12,374 super-editor unit tests pass (incl. Artem's `footer-run-rtl-roundtrip`)
- 12 new non-collapse tests in `direction/non-collapse.test.ts` enforce the four spec rules by construction
- **51 RTL Playwright behavior tests pass across Chromium/Firefox/WebKit** — Artem's caret geometry, list nesting, mixed-bidi click handling all work end-to-end on the resolver chain

## What it does NOT do

Explicit non-goals — separate PRs:

- Position-hit `textDirection`/`direction` conflation fix
- Feature module rename (`rtl-paragraph` → `direction`)
- Run-level cs/bCs/iCs/szCs preservation (Wave 1b)
- bidiVisual cell ordering (Wave 3)
- Vertical text rendering (Wave 4)

## Spec rationale

Full ECMA citations and design notes live in `pm-adapter/src/direction/README.md`.