### PR TITLE
feat: enhance block variable styling and add tests for structured con…

### DIFF
--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -12595,7 +12595,7 @@ describe('applyRunDataAttributes', () => {
               type: 'structuredContent',
               scope: 'block',
               id: 'scb-block-1',
-              tag: 'dropdown',
+              tag: '{"fieldType":"signer"}',
               alias: 'Block Content Control',
             },
           },
@@ -12652,10 +12652,12 @@ describe('applyRunDataAttributes', () => {
         expect(fragment.dataset.sdtType).toBe('structuredContent');
         expect(fragment.dataset.sdtScope).toBe('block');
         expect(fragment.dataset.sdtId).toBe('scb-block-1');
+        expect(fragment.dataset.sdtTag).toBe('{"fieldType":"signer"}');
 
         // Should have the label element
         const label = fragment.querySelector('.superdoc-structured-content__label') as HTMLElement;
         expect(label).toBeTruthy();
+        expect(label.classList.contains('superdoc-structured-content-block__label')).toBe(true);
         expect(label.textContent).toBe('Block Content Control');
 
         // Should have container boundary markers

--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -15,6 +15,16 @@ describe('lineStyles', () => {
 });
 
 describe('ensureSdtContainerStyles', () => {
+  it('exposes hover border tokens for structured content overrides', () => {
+    ensureSdtContainerStyles(document);
+
+    const styleEl = document.querySelector('[data-superdoc-sdt-container-styles="true"]');
+    const cssText = styleEl?.textContent ?? '';
+
+    expect(cssText).toContain('border-color: var(--sd-content-controls-block-hover-border, transparent);');
+    expect(cssText).toContain('border-color: var(--sd-content-controls-inline-hover-border, transparent);');
+  });
+
   it('suppresses structured-content hover backgrounds in viewing mode, including grouped hover', () => {
     ensureSdtContainerStyles(document);
 

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -506,13 +506,13 @@ const SDT_CONTAINER_STYLES = `
 
 .superdoc-structured-content-block:not(.ProseMirror-selectednode):hover {
   background-color: var(--sd-content-controls-block-hover-bg, #f2f2f2);
-  border-color: transparent;
+  border-color: var(--sd-content-controls-block-hover-border, transparent);
 }
 
 /* Group hover (JavaScript-coordinated via PresentationEditor) */
 .superdoc-structured-content-block.sdt-group-hover:not(.ProseMirror-selectednode) {
   background-color: var(--sd-content-controls-block-hover-bg, #f2f2f2);
-  border-color: transparent;
+  border-color: var(--sd-content-controls-block-hover-border, transparent);
 }
 
 .superdoc-structured-content-block.ProseMirror-selectednode {
@@ -606,7 +606,7 @@ const SDT_CONTAINER_STYLES = `
 /* Hover effect for inline structured content */
 .superdoc-structured-content-inline:not(.ProseMirror-selectednode):hover {
   background-color: var(--sd-content-controls-inline-hover-bg, #f2f2f2);
-  border-color: transparent;
+  border-color: var(--sd-content-controls-inline-hover-border, transparent);
 }
 
 .superdoc-structured-content-inline.ProseMirror-selectednode {

--- a/packages/layout-engine/painters/dom/src/utils/sdt-helpers.ts
+++ b/packages/layout-engine/painters/dom/src/utils/sdt-helpers.ts
@@ -99,7 +99,7 @@ export function getSdtContainerConfig(sdt: SdtMetadata | null | undefined): SdtC
     return {
       className: 'superdoc-structured-content-block',
       labelText: sdt.alias ?? 'Structured content',
-      labelClassName: 'superdoc-structured-content__label',
+      labelClassName: 'superdoc-structured-content__label superdoc-structured-content-block__label',
       isStart: true,
       isEnd: true,
     };

--- a/packages/superdoc/src/assets/styles/helpers/variables.css
+++ b/packages/superdoc/src/assets/styles/helpers/variables.css
@@ -197,8 +197,10 @@
 
   /* Styles: content controls (SDT) — blue accent, intentionally standalone */
   --sd-content-controls-block-border: #629be7;
+  --sd-content-controls-block-hover-border: transparent;
   --sd-content-controls-block-hover-bg: var(--sd-ui-hover-bg);
   --sd-content-controls-inline-border: #629be7;
+  --sd-content-controls-inline-hover-border: transparent;
   --sd-content-controls-inline-hover-bg: var(--sd-ui-hover-bg);
   --sd-content-controls-label-border: #629be7;
   --sd-content-controls-label-bg: #629be7ee;

--- a/packages/template-builder/src/styles/field-types.css
+++ b/packages/template-builder/src/styles/field-types.css
@@ -1,26 +1,52 @@
 .superdoc-structured-content-inline.superdoc-structured-content-inline,
 .superdoc-structured-content-block.superdoc-structured-content-block {
   border-color: var(--superdoc-field-owner-color, #629be7);
+  --sd-content-controls-inline-border: var(--superdoc-field-owner-color, #629be7);
+  --sd-content-controls-inline-hover-border: var(--superdoc-field-owner-color, #629be7);
+  --sd-content-controls-inline-hover-bg: color-mix(in srgb, var(--superdoc-field-owner-color, #629be7) 8%, transparent);
+  --sd-content-controls-block-border: var(--superdoc-field-owner-color, #629be7);
+  --sd-content-controls-block-hover-border: var(--superdoc-field-owner-color, #629be7);
+  --sd-content-controls-block-hover-bg: color-mix(in srgb, var(--superdoc-field-owner-color, #629be7) 8%, transparent);
+  --sd-content-controls-lock-hover-bg: color-mix(in srgb, var(--superdoc-field-owner-color, #629be7) 8%, transparent);
+  --sd-content-controls-label-border: var(--superdoc-field-owner-color, #629be7);
+  --sd-content-controls-label-bg: color-mix(in srgb, var(--superdoc-field-owner-color, #629be7) 87%, transparent);
 }
 .superdoc-structured-content-inline.superdoc-structured-content-inline:hover,
 .superdoc-structured-content-block.superdoc-structured-content-block:hover {
   border-color: var(--superdoc-field-owner-color, #629be7);
 }
 .superdoc-structured-content-inline.superdoc-structured-content-inline .superdoc-structured-content-inline__label,
-.superdoc-structured-content-block.superdoc-structured-content-block .superdoc-structured-content-block__label {
+.superdoc-structured-content-block.superdoc-structured-content-block .superdoc-structured-content-block__label,
+.superdoc-structured-content-block.superdoc-structured-content-block .superdoc-structured-content__label {
   border-color: var(--superdoc-field-owner-color, #629be7);
   background-color: color-mix(in srgb, var(--superdoc-field-owner-color, #629be7) 87%, transparent);
+  color: var(--sd-content-controls-label-text, #ffffff);
 }
 .superdoc-structured-content-inline[data-sdt-tag*='"fieldType":"signer"'],
 .superdoc-structured-content-block[data-sdt-tag*='"fieldType":"signer"'] {
   border-color: var(--superdoc-field-signer-color, #d97706);
+  --sd-content-controls-inline-border: var(--superdoc-field-signer-color, #d97706);
+  --sd-content-controls-inline-hover-border: var(--superdoc-field-signer-color, #d97706);
+  --sd-content-controls-inline-hover-bg: color-mix(
+    in srgb,
+    var(--superdoc-field-signer-color, #d97706) 8%,
+    transparent
+  );
+  --sd-content-controls-block-border: var(--superdoc-field-signer-color, #d97706);
+  --sd-content-controls-block-hover-border: var(--superdoc-field-signer-color, #d97706);
+  --sd-content-controls-block-hover-bg: color-mix(in srgb, var(--superdoc-field-signer-color, #d97706) 8%, transparent);
+  --sd-content-controls-lock-hover-bg: color-mix(in srgb, var(--superdoc-field-signer-color, #d97706) 8%, transparent);
+  --sd-content-controls-label-border: var(--superdoc-field-signer-color, #d97706);
+  --sd-content-controls-label-bg: color-mix(in srgb, var(--superdoc-field-signer-color, #d97706) 87%, transparent);
 }
 .superdoc-structured-content-inline[data-sdt-tag*='"fieldType":"signer"']:hover,
 .superdoc-structured-content-block[data-sdt-tag*='"fieldType":"signer"']:hover {
   border-color: var(--superdoc-field-signer-color, #d97706);
 }
 .superdoc-structured-content-inline[data-sdt-tag*='"fieldType":"signer"'] .superdoc-structured-content-inline__label,
-.superdoc-structured-content-block[data-sdt-tag*='"fieldType":"signer"'] .superdoc-structured-content-block__label {
+.superdoc-structured-content-block[data-sdt-tag*='"fieldType":"signer"'] .superdoc-structured-content-block__label,
+.superdoc-structured-content-block[data-sdt-tag*='"fieldType":"signer"'] .superdoc-structured-content__label {
   border-color: var(--superdoc-field-signer-color, #d97706);
   background-color: color-mix(in srgb, var(--superdoc-field-signer-color, #d97706) 87%, transparent);
+  color: var(--sd-content-controls-label-text, #ffffff);
 }

--- a/packages/template-builder/src/tests/utils.test.ts
+++ b/packages/template-builder/src/tests/utils.test.ts
@@ -225,13 +225,35 @@ describe('generateFieldColorCSS', () => {
   it('uses correct label selectors for inline and block', () => {
     const css = generateFieldColorCSS({ owner: '#629be7' }, '.scope');
     expect(css).toContain('.superdoc-structured-content-inline__label');
+    expect(css).toContain('.superdoc-structured-content-block__label');
     expect(css).toContain('.superdoc-structured-content__label');
-    // Should NOT contain the wrong block label class
-    expect(css).not.toContain('.superdoc-structured-content-block__label');
   });
 
   it('uses color-mix for label backgrounds', () => {
     const css = generateFieldColorCSS({ owner: '#629be7' }, '.scope');
     expect(css).toContain('color-mix(in srgb, #629be7 87%, transparent)');
+  });
+
+  it('sets block styling variables from field colors', () => {
+    const css = generateFieldColorCSS({ signer: '#d97706' }, '.scope');
+
+    expect(css).toContain('--sd-content-controls-block-border: #d97706;');
+    expect(css).toContain('--sd-content-controls-block-hover-border: #d97706;');
+    expect(css).toContain('--sd-content-controls-block-hover-bg: color-mix(in srgb, #d97706 8%, transparent);');
+    expect(css).toContain('--sd-content-controls-lock-hover-bg: color-mix(in srgb, #d97706 8%, transparent);');
+  });
+
+  it('keeps label text color configurable through the content control token', () => {
+    const css = generateFieldColorCSS({ owner: '#629be7' }, '.scope');
+
+    expect(css).toContain('color: var(--sd-content-controls-label-text, #ffffff);');
+  });
+
+  it('includes selected block border rules for field colors', () => {
+    const css = generateFieldColorCSS({ signer: '#d97706' }, '.scope');
+
+    expect(css).toContain(
+      '.scope .superdoc-structured-content-block[data-sdt-tag*=\'"fieldType":"signer"\'].ProseMirror-selectednode',
+    );
   });
 });

--- a/packages/template-builder/src/utils.ts
+++ b/packages/template-builder/src/utils.ts
@@ -82,22 +82,42 @@ export const getFieldTypeStyle = (fieldType: string, fieldColors?: Record<string
 const SDT_INLINE = '.superdoc-structured-content-inline';
 const SDT_BLOCK = '.superdoc-structured-content-block';
 const INLINE_LABEL = '.superdoc-structured-content-inline__label';
-const BLOCK_LABEL = '.superdoc-structured-content__label';
+const BLOCK_LABEL = '.superdoc-structured-content-block__label';
+// Keep legacy selector support while we align the structured-content label API.
+const LEGACY_BLOCK_LABEL = '.superdoc-structured-content__label';
 
 function buildColorRules(scope: string, selector: string, color: string): string {
+  const hoverFill = `color-mix(in srgb, ${color} 8%, transparent)`;
+  const labelFill = `color-mix(in srgb, ${color} 87%, transparent)`;
+
   return `
 ${scope} ${SDT_INLINE}${selector},
 ${scope} ${SDT_BLOCK}${selector} {
   border-color: ${color};
+  --sd-content-controls-inline-border: ${color};
+  --sd-content-controls-inline-hover-border: ${color};
+  --sd-content-controls-inline-hover-bg: ${hoverFill};
+  --sd-content-controls-block-border: ${color};
+  --sd-content-controls-block-hover-border: ${color};
+  --sd-content-controls-block-hover-bg: ${hoverFill};
+  --sd-content-controls-lock-hover-bg: ${hoverFill};
+  --sd-content-controls-label-border: ${color};
+  --sd-content-controls-label-bg: ${labelFill};
 }
 ${scope} ${SDT_INLINE}${selector}:hover,
 ${scope} ${SDT_BLOCK}${selector}:hover {
   border-color: ${color};
 }
-${scope} ${SDT_INLINE}${selector} ${INLINE_LABEL},
-${scope} ${SDT_BLOCK}${selector} ${BLOCK_LABEL} {
+${scope} ${SDT_INLINE}${selector}.ProseMirror-selectednode,
+${scope} ${SDT_BLOCK}${selector}.ProseMirror-selectednode {
   border-color: ${color};
-  background-color: color-mix(in srgb, ${color} 87%, transparent);
+}
+${scope} ${SDT_INLINE}${selector} ${INLINE_LABEL},
+${scope} ${SDT_BLOCK}${selector} ${BLOCK_LABEL},
+${scope} ${SDT_BLOCK}${selector} ${LEGACY_BLOCK_LABEL} {
+  border-color: ${color};
+  background-color: ${labelFill};
+  color: var(--sd-content-controls-label-text, #ffffff);
 }`;
 }
 

--- a/tests/visual/tests/behavior/template-builder-block-field-styling.spec.ts
+++ b/tests/visual/tests/behavior/template-builder-block-field-styling.spec.ts
@@ -1,0 +1,155 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '../fixtures/superdoc.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../../..');
+const fieldTypesCss = fs.readFileSync(
+  path.join(repoRoot, 'packages/template-builder/src/styles/field-types.css'),
+  'utf8',
+);
+
+test('inline and block structured content field chrome use Template Builder field styles', async ({ superdoc }) => {
+  await superdoc.page.addStyleTag({
+    content: `
+      :root {
+        --superdoc-field-owner-color: rgb(37, 99, 235);
+        --superdoc-field-signer-color: rgb(220, 38, 38);
+        --sd-content-controls-label-text: rgb(255, 255, 0);
+      }
+      ${fieldTypesCss}
+    `,
+  });
+
+  await superdoc.page.evaluate(() => {
+    const fieldAttrs = (id: string, alias: string, fieldType: 'owner' | 'signer') => ({
+      id,
+      alias,
+      tag: `{"fieldType":"${fieldType}"}`,
+    });
+
+    const inlineField = (id: string, alias: string, fieldType: 'owner' | 'signer', text: string) => ({
+      type: 'paragraph',
+      content: [
+        {
+          type: 'structuredContent',
+          attrs: fieldAttrs(id, alias, fieldType),
+          content: [{ type: 'text', text }],
+        },
+      ],
+    });
+
+    const blockField = (id: string, alias: string, fieldType: 'owner' | 'signer', text: string) => ({
+      type: 'structuredContentBlock',
+      attrs: fieldAttrs(id, alias, fieldType),
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text }],
+        },
+      ],
+    });
+
+    const spacer = () => ({ type: 'paragraph', content: [{ type: 'text', text: ' ' }] });
+
+    const editor = (window as any).editor;
+    const doc = editor.schema.nodeFromJSON({
+      type: 'doc',
+      content: [
+        inlineField('1', 'Signer Inline', 'signer', 'Signer inline value'),
+        spacer(),
+        spacer(),
+        blockField('2', 'Signer Block', 'signer', 'Signature area'),
+        spacer(),
+        spacer(),
+        inlineField('3', 'Owner Inline', 'owner', 'Owner inline value'),
+        spacer(),
+        spacer(),
+        blockField('4', 'Owner Block', 'owner', 'Owner approval area'),
+      ],
+    });
+    editor.view.dispatch(editor.state.tr.replaceWith(0, editor.state.doc.content.size, doc.content));
+  });
+  await superdoc.waitForStable();
+
+  const renderedPage = superdoc.page.locator('.superdoc-page').first();
+  const getInline = (fieldType: 'owner' | 'signer') =>
+    renderedPage.locator(`.superdoc-structured-content-inline[data-sdt-tag*='"fieldType":"${fieldType}"']`).first();
+  const getBlock = (fieldType: 'owner' | 'signer') =>
+    renderedPage.locator(`.superdoc-structured-content-block[data-sdt-tag*='"fieldType":"${fieldType}"']`).first();
+
+  const showInlineLabel = async (fieldType: 'owner' | 'signer') => {
+    const inline = getInline(fieldType);
+    await inline.evaluate((el) => el.classList.add('ProseMirror-selectednode'));
+    return inline;
+  };
+
+  const showBlockLabel = async (fieldType: 'owner' | 'signer') => {
+    const block = getBlock(fieldType);
+    await block.evaluate((el) => {
+      el.classList.remove('sdt-group-hover');
+      el.classList.add('ProseMirror-selectednode');
+    });
+    return block;
+  };
+
+  const expectHoverBackgroundParity = async (fieldType: 'owner' | 'signer') => {
+    const inline = getInline(fieldType);
+    const block = getBlock(fieldType);
+
+    await inline.evaluate((el) => el.classList.remove('ProseMirror-selectednode'));
+    await inline.hover();
+    const inlineHoverBackground = await inline.evaluate((el) => getComputedStyle(el).backgroundColor);
+
+    await block.evaluate((el) => {
+      el.classList.remove('ProseMirror-selectednode');
+      el.classList.add('sdt-group-hover');
+    });
+    await expect
+      .poll(async () => block.evaluate((el) => getComputedStyle(el).backgroundColor))
+      .toBe(inlineHoverBackground);
+
+    await inline.evaluate((el) => el.classList.add('ProseMirror-selectednode'));
+    await block.evaluate((el) => {
+      el.classList.remove('sdt-group-hover');
+      el.classList.add('ProseMirror-selectednode');
+    });
+  };
+
+  const signerInline = await showInlineLabel('signer');
+  await expect(signerInline).toBeVisible();
+  await expect(signerInline).toHaveCSS('border-color', 'rgb(220, 38, 38)');
+
+  const signerInlineLabel = signerInline.locator('.superdoc-structured-content-inline__label');
+  await expect(signerInlineLabel).toHaveCSS('color', 'rgb(255, 255, 0)');
+  await expect(signerInlineLabel).toHaveCSS('border-color', 'rgb(220, 38, 38)');
+
+  const signerBlock = await showBlockLabel('signer');
+  await expect(signerBlock).toBeVisible();
+  await expect(signerBlock).toHaveCSS('border-top-color', 'rgb(220, 38, 38)');
+
+  const signerBlockLabel = signerBlock.locator('.superdoc-structured-content-block__label');
+  await expect(signerBlockLabel).toHaveCSS('color', 'rgb(255, 255, 0)');
+  await expect(signerBlockLabel).toHaveCSS('border-color', 'rgb(220, 38, 38)');
+  await expectHoverBackgroundParity('signer');
+
+  const ownerInline = await showInlineLabel('owner');
+  await expect(ownerInline).toBeVisible();
+  await expect(ownerInline).toHaveCSS('border-color', 'rgb(37, 99, 235)');
+
+  const ownerInlineLabel = ownerInline.locator('.superdoc-structured-content-inline__label');
+  await expect(ownerInlineLabel).toHaveCSS('color', 'rgb(255, 255, 0)');
+  await expect(ownerInlineLabel).toHaveCSS('border-color', 'rgb(37, 99, 235)');
+
+  const ownerBlock = await showBlockLabel('owner');
+  await expect(ownerBlock).toBeVisible();
+  await expect(ownerBlock).toHaveCSS('border-top-color', 'rgb(37, 99, 235)');
+
+  const ownerBlockLabel = ownerBlock.locator('.superdoc-structured-content-block__label');
+  await expect(ownerBlockLabel).toHaveCSS('color', 'rgb(255, 255, 0)');
+  await expect(ownerBlockLabel).toHaveCSS('border-color', 'rgb(37, 99, 235)');
+  await expectHoverBackgroundParity('owner');
+
+  await superdoc.screenshot('template-builder-owner-and-signer-inline-and-block-field-styling');
+});


### PR DESCRIPTION
- Added block field styling parity with inline fields for label, border, hover, selection, and background customization.
- Introduced matching block class names while preserving existing legacy selectors for backwards compatibility.
- Added unit and visual coverage for owner/signer inline and block field styling.

Example:
<img width="1280" height="1093" alt="SDtest" src="https://github.com/user-attachments/assets/5a0980e4-b777-4010-ade2-373733409de4" />
