### PR TITLE
docs: require checking comment-policy.md before editing comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,4 +282,6 @@ Preset theme overrides are defined in `packages/superdoc/src/assets/styles/helpe
 
 ## Comments
 
-Follow `comment-policy.md`. Short version: write comments only when they encode information the code cannot express (invariants, business rules, non-local coupling, refactor-sensitive rationale). Don't paraphrase the next line. Use `AIDEV-NOTE:` anchors for rules that must survive future agent edits. Treat stale comments as bugs.
+**Always check for `comment-policy.md` at the repo root (or any ancestor of files you're touching) before adding, removing, or rewording comments.** The policy overrides defaults. Run `/comment-audit` to validate comment changes against it before commit.
+
+Short version: write comments only when they encode information the code cannot express (invariants, business rules, non-local coupling, refactor-sensitive rationale). Don't paraphrase the next line. Use `AIDEV-NOTE:` anchors for rules that must survive future agent edits. Treat stale comments as bugs.


### PR DESCRIPTION
Strengthens the agent-facing reminder in `CLAUDE.md` (and `AGENTS.md`, which is a symlink) so agents look for `comment-policy.md` explicitly and run `/comment-audit` to validate changes, instead of relying on the bare "follow comment-policy.md" wording.

Same pattern we use for `brand.md` ("always follow brand.md when a project has one") - having the policy file is only useful if agents reliably read it before touching comments.