### PR TITLE
feat(pm-adapter): preserve run-level bidi/script metadata on TextRun (SD-2781)

### DIFF
--- a/packages/layout-engine/contracts/src/direction-context.ts
+++ b/packages/layout-engine/contracts/src/direction-context.ts
@@ -134,8 +134,14 @@ export type RunBidiContext = {
  * with the CS or Latin stack).
  */
 export type RunScriptContext = {
-  /** w:rPr/w:cs. Forces complex-script formatting regardless of Unicode. */
-  complexScript: boolean;
+  /**
+   * w:rPr/w:cs (§17.3.2.7). Forces complex-script formatting regardless of Unicode.
+   * Per the spec, absence != false: when omitted, the value inherits from the style
+   * hierarchy and ultimately falls back to Unicode-based script detection. Only set
+   * this field when the source explicitly carries w:cs - leave undefined otherwise so
+   * downstream consumers can distinguish "not set" from "explicitly off".
+   */
+  complexScript?: boolean;
   /**
    * Per-script language metadata, kept on separate fields per ECMA §17.3.2.20
    * because each maps to a different formatting stack (Latin / CS / East Asian).

--- a/packages/layout-engine/contracts/src/direction-context.ts
+++ b/packages/layout-engine/contracts/src/direction-context.ts
@@ -136,6 +136,17 @@ export type RunBidiContext = {
 export type RunScriptContext = {
   /** w:rPr/w:cs. Forces complex-script formatting regardless of Unicode. */
   complexScript: boolean;
-  /** w:rPr/w:lang/@bidi. Complex-script language metadata (spellcheck). */
-  language?: string;
+  /**
+   * Per-script language metadata, kept on separate fields per ECMA §17.3.2.20
+   * because each maps to a different formatting stack (Latin / CS / East Asian).
+   * Wave 1b consumes these to gate spellcheck and font-stack selection.
+   */
+  language?: {
+    /** w:rPr/w:lang/@val. Default (Latin) language tag. */
+    default?: string;
+    /** w:rPr/w:lang/@bidi. Complex-script language tag. */
+    complexScript?: string;
+    /** w:rPr/w:lang/@eastAsia. East Asian language tag. */
+    eastAsian?: string;
+  };
 };

--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -315,6 +315,19 @@ export type TextRun = RunMarks & {
   };
   /** Tracked-change metadata from ProseMirror marks. */
   trackedChange?: TrackedChangeMeta;
+  /**
+   * Run-level bidi signals preserved from the source DOCX (run rtl flag,
+   * embedding/override directions). Direction-only - script formatting lives
+   * on `script`. Populated by pm-adapter from raw run properties; not yet
+   * rendered (Wave 1c consumes embedding/override).
+   */
+  bidi?: RunBidiContext;
+  /**
+   * Run-level script context preserved from the source DOCX (complex-script
+   * flag, per-script language metadata). Wave 1b uses `complexScript` to gate
+   * the formatting-stack selection (Latin variants vs CS variants).
+   */
+  script?: RunScriptContext;
 };
 
 export type TabRun = RunMarks & {

--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -16,7 +16,7 @@ export type {
   RunBidiContext,
   RunScriptContext,
 } from './direction-context.js';
-import type { ParagraphDirectionContext } from './direction-context.js';
+import type { ParagraphDirectionContext, RunBidiContext, RunScriptContext } from './direction-context.js';
 
 // Export table contracts
 export {

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/bookmark-start.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/bookmark-start.ts
@@ -20,8 +20,17 @@ import { type InlineConverterParams } from './common.js';
  * into any content inside the bookmark span but emits no visual output.
  */
 export function bookmarkStartNodeToBlocks(params: InlineConverterParams): TextRun | void {
-  const { node, positions, bookmarks, visitNode, inheritedMarks, sdtMetadata, runProperties, converterContext } =
-    params;
+  const {
+    node,
+    positions,
+    bookmarks,
+    visitNode,
+    inheritedMarks,
+    sdtMetadata,
+    runProperties,
+    inlineRunProperties,
+    converterContext,
+  } = params;
   const nodeAttrs =
     typeof node.attrs === 'object' && node.attrs !== null ? (node.attrs as Record<string, unknown>) : {};
   const bookmarkName = typeof nodeAttrs.name === 'string' ? nodeAttrs.name : undefined;
@@ -61,7 +70,11 @@ export function bookmarkStartNodeToBlocks(params: InlineConverterParams): TextRu
   }
 
   if (Array.isArray(node.content)) {
-    node.content.forEach((child) => visitNode(child, inheritedMarks, sdtMetadata, runProperties));
+    // SD-2781: forward inlineRunProperties so text inside the bookmark span
+    // preserves run-level bidi/script metadata from the enclosing run wrapper.
+    node.content.forEach((child) =>
+      visitNode(child, inheritedMarks, sdtMetadata, runProperties, false, inlineRunProperties),
+    );
   }
 
   return run;

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.test.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.test.ts
@@ -121,32 +121,31 @@ describe('applyInlineRunProperties', () => {
   // Wave 1a preserves these signals; nothing renders them yet.
   describe('SD-2781 bidi/script preservation', () => {
     it('does not attach bidi or script when no relevant signals are set', () => {
-      const result = applyInlineRunProperties(baseRun, { bold: true });
+      const result = applyInlineRunProperties(baseRun, { bold: true }, undefined, { bold: true });
       expect(result.bidi).toBeUndefined();
       expect(result.script).toBeUndefined();
     });
 
     it('preserves run rtl on TextRun.bidi (does not affect script)', () => {
-      const result = applyInlineRunProperties(baseRun, { rtl: true });
+      const result = applyInlineRunProperties(baseRun, { rtl: true }, undefined, { rtl: true });
       expect(result.bidi).toEqual({ rtl: true });
       expect(result.script).toBeUndefined();
     });
 
     it('preserves explicit rtl=false (a meaningful override of inherited rtl)', () => {
-      const result = applyInlineRunProperties(baseRun, { rtl: false });
+      const result = applyInlineRunProperties(baseRun, { rtl: false }, undefined, { rtl: false });
       expect(result.bidi).toEqual({ rtl: false });
     });
 
     it('preserves complex-script flag on TextRun.script (does not affect bidi)', () => {
-      const result = applyInlineRunProperties(baseRun, { cs: true });
+      const result = applyInlineRunProperties(baseRun, { cs: true }, undefined, { cs: true });
       expect(result.script).toEqual({ complexScript: true });
       expect(result.bidi).toBeUndefined();
     });
 
     it('preserves the three lang tags on separate fields per ECMA §17.3.2.20', () => {
-      const result = applyInlineRunProperties(baseRun, {
-        lang: { val: 'en-US', bidi: 'ar-SA', eastAsia: 'ja-JP' },
-      });
+      const lang = { val: 'en-US', bidi: 'ar-SA', eastAsia: 'ja-JP' };
+      const result = applyInlineRunProperties(baseRun, { lang }, undefined, { lang });
       expect(result.script?.language).toEqual({
         default: 'en-US',
         complexScript: 'ar-SA',
@@ -155,18 +154,47 @@ describe('applyInlineRunProperties', () => {
     });
 
     it('partial lang attrs only fill the fields that were set', () => {
-      const result = applyInlineRunProperties(baseRun, { lang: { bidi: 'he-IL' } });
+      const lang = { bidi: 'he-IL' };
+      const result = applyInlineRunProperties(baseRun, { lang }, undefined, { lang });
       expect(result.script?.language).toEqual({ complexScript: 'he-IL' });
     });
 
     it('keeps rtl and cs on separate axes (axis non-collapse)', () => {
-      const result = applyInlineRunProperties(baseRun, { rtl: true, cs: true });
+      const props = { rtl: true, cs: true };
+      const result = applyInlineRunProperties(baseRun, props, undefined, props);
       // rtl goes to bidi only; cs goes to script only
       expect(result.bidi).toEqual({ rtl: true });
       expect(result.script).toEqual({ complexScript: true });
       // cs must NOT leak into bidi, and rtl must NOT leak into script
       expect(result.bidi).not.toHaveProperty('complexScript');
       expect(result.script).not.toHaveProperty('rtl');
+    });
+
+    // Cascade-leak guard: when the cascade-resolved runProperties has rtl/cs/lang
+    // but the raw inline runProperties does NOT, the metadata must not appear.
+    // Otherwise every style-inherited run gets false bidi/script signals.
+    it('does NOT populate bidi/script from cascade-resolved props alone', () => {
+      const cascadedProps = { rtl: true, cs: true, lang: { bidi: 'ar-SA' } };
+      const inlineProps = {}; // No inline rtl/cs/lang on the source run
+      const result = applyInlineRunProperties(baseRun, cascadedProps, undefined, inlineProps);
+      expect(result.bidi).toBeUndefined();
+      expect(result.script).toBeUndefined();
+    });
+
+    it('does NOT populate bidi/script when caller omits inlineRunProperties', () => {
+      // Default safety: callers that don't opt in to metadata get nothing.
+      const result = applyInlineRunProperties(baseRun, { rtl: true, cs: true });
+      expect(result.bidi).toBeUndefined();
+      expect(result.script).toBeUndefined();
+    });
+
+    it('inline overrides survive even when cascade-resolved props differ', () => {
+      // User explicitly set rtl=true inline; cascade may also resolve to true.
+      // Either way, inline is the source of truth for preservation.
+      const cascaded = { rtl: true, fontSize: 12 };
+      const inline = { rtl: true };
+      const result = applyInlineRunProperties(baseRun, cascaded, undefined, inline);
+      expect(result.bidi).toEqual({ rtl: true });
     });
   });
 });

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.test.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.test.ts
@@ -118,8 +118,7 @@ describe('applyInlineRunProperties', () => {
     expect(result.bold).toBe(false);
   });
 
-  // SD-2781: TextRun.bidi and TextRun.script preserve run-level direction and
-  // script signals from raw run properties. Wave 1a does not render either.
+  // Wave 1a preserves these signals; nothing renders them yet.
   describe('SD-2781 bidi/script preservation', () => {
     it('does not attach bidi or script when no relevant signals are set', () => {
       const result = applyInlineRunProperties(baseRun, { bold: true });

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.test.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.test.ts
@@ -117,4 +117,57 @@ describe('applyInlineRunProperties', () => {
 
     expect(result.bold).toBe(false);
   });
+
+  // SD-2781: TextRun.bidi and TextRun.script preserve run-level direction and
+  // script signals from raw run properties. Wave 1a does not render either.
+  describe('SD-2781 bidi/script preservation', () => {
+    it('does not attach bidi or script when no relevant signals are set', () => {
+      const result = applyInlineRunProperties(baseRun, { bold: true });
+      expect(result.bidi).toBeUndefined();
+      expect(result.script).toBeUndefined();
+    });
+
+    it('preserves run rtl on TextRun.bidi (does not affect script)', () => {
+      const result = applyInlineRunProperties(baseRun, { rtl: true });
+      expect(result.bidi).toEqual({ rtl: true });
+      expect(result.script).toBeUndefined();
+    });
+
+    it('preserves explicit rtl=false (a meaningful override of inherited rtl)', () => {
+      const result = applyInlineRunProperties(baseRun, { rtl: false });
+      expect(result.bidi).toEqual({ rtl: false });
+    });
+
+    it('preserves complex-script flag on TextRun.script (does not affect bidi)', () => {
+      const result = applyInlineRunProperties(baseRun, { cs: true });
+      expect(result.script).toEqual({ complexScript: true });
+      expect(result.bidi).toBeUndefined();
+    });
+
+    it('preserves the three lang tags on separate fields per ECMA §17.3.2.20', () => {
+      const result = applyInlineRunProperties(baseRun, {
+        lang: { val: 'en-US', bidi: 'ar-SA', eastAsia: 'ja-JP' },
+      });
+      expect(result.script?.language).toEqual({
+        default: 'en-US',
+        complexScript: 'ar-SA',
+        eastAsian: 'ja-JP',
+      });
+    });
+
+    it('partial lang attrs only fill the fields that were set', () => {
+      const result = applyInlineRunProperties(baseRun, { lang: { bidi: 'he-IL' } });
+      expect(result.script?.language).toEqual({ complexScript: 'he-IL' });
+    });
+
+    it('keeps rtl and cs on separate axes (axis non-collapse)', () => {
+      const result = applyInlineRunProperties(baseRun, { rtl: true, cs: true });
+      // rtl goes to bidi only; cs goes to script only
+      expect(result.bidi).toEqual({ rtl: true });
+      expect(result.script).toEqual({ complexScript: true });
+      // cs must NOT leak into bidi, and rtl must NOT leak into script
+      expect(result.bidi).not.toHaveProperty('complexScript');
+      expect(result.script).not.toHaveProperty('rtl');
+    });
+  });
 });

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.test.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.test.ts
@@ -159,6 +159,22 @@ describe('applyInlineRunProperties', () => {
       expect(result.script?.language).toEqual({ complexScript: 'he-IL' });
     });
 
+    // Per ECMA §17.3.2.7, w:cs absent != false. Absence inherits from the style
+    // hierarchy and ultimately falls back to Unicode-based detection. Only set
+    // complexScript when the source explicitly carries w:cs.
+    it('omits complexScript when only lang is set (no explicit w:cs)', () => {
+      const lang = { bidi: 'he-IL' };
+      const result = applyInlineRunProperties(baseRun, { lang }, undefined, { lang });
+      expect(result.script).toBeDefined();
+      expect(result.script).not.toHaveProperty('complexScript');
+      expect(result.script?.language).toEqual({ complexScript: 'he-IL' });
+    });
+
+    it('preserves explicit cs=false (a meaningful toggle-off of inherited cs)', () => {
+      const result = applyInlineRunProperties(baseRun, { cs: false }, undefined, { cs: false });
+      expect(result.script).toEqual({ complexScript: false });
+    });
+
     it('keeps rtl and cs on separate axes (axis non-collapse)', () => {
       const props = { rtl: true, cs: true };
       const result = applyInlineRunProperties(baseRun, props, undefined, props);

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.ts
@@ -109,7 +109,12 @@ const buildScriptContext = (runProperties: RunProperties): RunScriptContext | un
   const hasLang = lang != null && (lang.val != null || lang.bidi != null || lang.eastAsia != null);
   if (cs == null && !hasLang) return undefined;
 
-  const ctx: RunScriptContext = { complexScript: cs === true };
+  // Per ECMA §17.3.2.7, cs absent != false. Only set complexScript when the source
+  // explicitly carries w:cs (true OR false - both are meaningful toggle states per
+  // §17.17.4). Leaving undefined lets consumers distinguish "not set" from "explicitly
+  // off" and fall back to Unicode-based script detection.
+  const ctx: RunScriptContext = {};
+  if (cs != null) ctx.complexScript = cs === true;
   if (hasLang) {
     const language: NonNullable<RunScriptContext['language']> = {};
     if (lang.val != null) language.default = lang.val;

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.ts
@@ -1,5 +1,12 @@
 import type { RunProperties, ParagraphProperties } from '@superdoc/style-engine/ooxml';
-import type { FlowBlock, SdtMetadata, TextRun, ParagraphAttrs } from '@superdoc/contracts';
+import type {
+  FlowBlock,
+  RunBidiContext,
+  RunScriptContext,
+  SdtMetadata,
+  TextRun,
+  ParagraphAttrs,
+} from '@superdoc/contracts';
 import {
   HyperlinkConfig,
   NodeHandlerContext,
@@ -73,6 +80,38 @@ export type BlockConverterOptions = {
   paragraphAttrs: ParagraphAttrs;
 };
 
+/**
+ * Build a RunBidiContext from raw run properties when any direction signal is set.
+ * Returns undefined when nothing to preserve, so empty contexts don't bloat the
+ * layout tree. Wave 1c will populate `embedding` (w:dir) and `override` (w:bdo).
+ */
+const buildBidiContext = (runProperties: RunProperties): RunBidiContext | undefined => {
+  if (runProperties.rtl == null) return undefined;
+  return { rtl: runProperties.rtl === true };
+};
+
+/**
+ * Build a RunScriptContext from raw run properties when any script signal is set.
+ * Per ECMA §17.3.2.20, w:lang carries three independent language tags - default
+ * (Latin), bidi (complex-script), eastAsia - mapped here to one structured field.
+ */
+const buildScriptContext = (runProperties: RunProperties): RunScriptContext | undefined => {
+  const cs = runProperties.cs;
+  const lang = runProperties.lang;
+  const hasLang = lang != null && (lang.val != null || lang.bidi != null || lang.eastAsia != null);
+  if (cs == null && !hasLang) return undefined;
+
+  const ctx: RunScriptContext = { complexScript: cs === true };
+  if (hasLang) {
+    const language: NonNullable<RunScriptContext['language']> = {};
+    if (lang.val != null) language.default = lang.val;
+    if (lang.bidi != null) language.complexScript = lang.bidi;
+    if (lang.eastAsia != null) language.eastAsian = lang.eastAsia;
+    ctx.language = language;
+  }
+  return ctx;
+};
+
 export const applyInlineRunProperties = (
   run: TextRun,
   runProperties: RunProperties | undefined,
@@ -90,5 +129,12 @@ export const applyInlineRunProperties = (
       (merged as Record<string, unknown>)[key] = runAttrs[key];
     }
   }
+  // SD-2781: preserve run-level bidi/script metadata. Wave 1a stops at preservation;
+  // Wave 1b consumes script.complexScript to gate CS formatting, Wave 1c consumes
+  // bidi.embedding and bidi.override.
+  const bidi = buildBidiContext(runProperties);
+  if (bidi) merged.bidi = bidi;
+  const script = buildScriptContext(runProperties);
+  if (script) merged.script = script;
   return merged;
 };

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/common.ts
@@ -26,6 +26,7 @@ type VisitNodeFn = (
   activeSdt: SdtMetadata | undefined,
   activeRunProperties: RunProperties | undefined,
   activeHidden?: boolean,
+  activeInlineRunProperties?: RunProperties,
 ) => void;
 
 export class HiddenByVanishError extends Error {
@@ -53,6 +54,13 @@ export type InlineConverterParams = {
   hyperlinkConfig: HyperlinkConfig;
   themeColors: ThemeColorPalette | undefined;
   runProperties: RunProperties | undefined;
+  /**
+   * The raw inline w:rPr from the run wrapper, BEFORE the style cascade. Used by
+   * preservation-only metadata (TextRun.bidi / TextRun.script in SD-2781) so
+   * style-inherited values don't surface as if they were direct formatting.
+   * Undefined for callers outside a run wrapper.
+   */
+  inlineRunProperties: RunProperties | undefined;
   paragraphProperties: ParagraphProperties | undefined;
   converterContext: ConverterContext;
   enableComments: boolean;
@@ -116,6 +124,7 @@ export const applyInlineRunProperties = (
   run: TextRun,
   runProperties: RunProperties | undefined,
   converterContext?: ConverterContext,
+  inlineRunProperties?: RunProperties,
 ): TextRun => {
   if (!runProperties) {
     return run;
@@ -129,12 +138,16 @@ export const applyInlineRunProperties = (
       (merged as Record<string, unknown>)[key] = runAttrs[key];
     }
   }
-  // SD-2781: preserve run-level bidi/script metadata. Wave 1a stops at preservation;
-  // Wave 1b consumes script.complexScript to gate CS formatting, Wave 1c consumes
-  // bidi.embedding and bidi.override.
-  const bidi = buildBidiContext(runProperties);
-  if (bidi) merged.bidi = bidi;
-  const script = buildScriptContext(runProperties);
-  if (script) merged.script = script;
+  // SD-2781: preserve run-level bidi/script metadata. Read from `inlineRunProperties`
+  // (the raw inline w:rPr, before the style cascade) so style-inherited runs don't
+  // get false metadata - per ECMA the metadata categories track what the source
+  // document encoded, not what the cascade resolved to. When the caller doesn't
+  // supply inline properties, no metadata is populated.
+  if (inlineRunProperties) {
+    const bidi = buildBidiContext(inlineRunProperties);
+    if (bidi) merged.bidi = bidi;
+    const script = buildScriptContext(inlineRunProperties);
+    if (script) merged.script = script;
+  }
   return merged;
 };

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/generic-token.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/generic-token.ts
@@ -27,6 +27,7 @@ export function tokenNodeToRun({
   themeColors,
   sdtMetadata,
   runProperties,
+  inlineRunProperties,
   converterContext,
 }: InlineConverterParams): TextRun | null {
   const token = TOKEN_INLINE_TYPES.get(node.type);
@@ -35,7 +36,7 @@ export function tokenNodeToRun({
   }
 
   // Tokens carry a placeholder character so measurers reserve width; painters will replace it with the real value.
-  const run: TextRun = {
+  let run: TextRun = {
     text: '0',
     token,
     fontFamily: defaultFont,
@@ -61,7 +62,10 @@ export function tokenNodeToRun({
   const marks = [...effectiveMarks, ...(inheritedMarks ?? [])];
   applyMarksToRun(run, marks, hyperlinkConfig, themeColors, undefined, true, storyKey);
 
-  applyInlineRunProperties(run, runProperties, converterContext);
+  // Reassign the return value: applyInlineRunProperties returns a new object
+  // via spread, so the merged fields (including SD-2781 bidi/script metadata)
+  // are dropped if we don't capture them here.
+  run = applyInlineRunProperties(run, runProperties, converterContext, inlineRunProperties);
 
   // If marksAsAttrs carried font styling, mark the run so downstream defaults don't overwrite it.
   if (marksAsAttrs.length > 0) {

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/no-break-hyphen.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/no-break-hyphen.ts
@@ -24,6 +24,7 @@ export function noBreakHyphenNodeToRun({
   themeColors,
   enableComments,
   runProperties,
+  inlineRunProperties,
   converterContext,
 }: InlineConverterParams): TextRun {
   let run: TextRun = {
@@ -52,7 +53,7 @@ export function noBreakHyphenNodeToRun({
     run.sdt = sdtMetadata;
   }
 
-  run = applyInlineRunProperties(run, runProperties, converterContext);
+  run = applyInlineRunProperties(run, runProperties, converterContext, inlineRunProperties);
 
   return run;
 }

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/page-reference.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/page-reference.ts
@@ -7,7 +7,16 @@ import { buildFlowRunLink } from '../../marks/links.js';
 import { type RunProperties, resolveRunProperties } from '@superdoc/style-engine/ooxml';
 
 export function pageReferenceNodeToBlock(params: InlineConverterParams): TextRun | void {
-  const { node, inheritedMarks, visitNode, sdtMetadata, positions, converterContext, paragraphProperties } = params;
+  const {
+    node,
+    inheritedMarks,
+    visitNode,
+    sdtMetadata,
+    positions,
+    converterContext,
+    paragraphProperties,
+    inlineRunProperties: parentInlineRunProperties,
+  } = params;
   // Create pageReference token run for dynamic resolution
   const instruction = getNodeInstruction(node) || '';
   const nodeAttrs =
@@ -57,6 +66,10 @@ export function pageReferenceNodeToBlock(params: InlineConverterParams): TextRun
       node: { type: 'text', text: fallbackText } as PMNode,
       inheritedMarks: mergedMarks,
       runProperties: resolvedRunProperties,
+      // SD-2781: pass the raw inline runProperties scanned from the <run> child
+      // above (not the cascade-resolved version) so the token run preserves
+      // bidi/script only when the source explicitly carried those signals.
+      inlineRunProperties: runProperties,
     });
 
     // Copy PM positions from parent pageReference node
@@ -83,7 +96,12 @@ export function pageReferenceNodeToBlock(params: InlineConverterParams): TextRun
     }
     return tokenRun;
   } else if (Array.isArray(node.content)) {
-    // No bookmark found, fall back to treating as transparent container
-    node.content.forEach((child) => visitNode(child, mergedMarks, sdtMetadata, runProperties));
+    // No bookmark found, fall back to treating as transparent container.
+    // SD-2781: forward the parent's inlineRunProperties (this node didn't introduce
+    // a new run boundary), and pass the locally-collected runProperties as the
+    // resolved/active properties for children.
+    node.content.forEach((child) =>
+      visitNode(child, mergedMarks, sdtMetadata, runProperties, false, parentInlineRunProperties),
+    );
   }
 }

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/run.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/run.ts
@@ -22,5 +22,10 @@ export function runNodeChildrenToRuns({
     false,
     false,
   );
-  node.content?.forEach((child) => visitNode(child, mergedMarks, sdtMetadata, resolvedRunProperties, false));
+  // Pass the RAW inline runProperties alongside the resolved cascade. SD-2781's
+  // bidi/script preservation must read from inline only - cascade-resolved
+  // values would tag every style-inherited run with metadata it didn't have.
+  node.content?.forEach((child) =>
+    visitNode(child, mergedMarks, sdtMetadata, resolvedRunProperties, false, runProperties),
+  );
 }

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/structured-content.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/structured-content.ts
@@ -8,8 +8,14 @@ export function structuredContentNodeToBlocks({
   sdtMetadata,
   visitNode,
   runProperties,
+  inlineRunProperties,
 }: InlineConverterParams): void {
   const inlineMetadata = resolveNodeSdtMetadata(node, 'structuredContent');
   const nextSdt = inlineMetadata ?? sdtMetadata;
-  node.content?.forEach((child) => visitNode(child, inheritedMarks, nextSdt, runProperties, false));
+  // SD-2781: forward inlineRunProperties so children inside this SDT wrapper
+  // preserve run-level bidi/script metadata. The SDT itself doesn't introduce a
+  // new run boundary, so the parent run's inline source still applies.
+  node.content?.forEach((child) =>
+    visitNode(child, inheritedMarks, nextSdt, runProperties, false, inlineRunProperties),
+  );
 }

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/text-run.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/text-run.ts
@@ -37,6 +37,7 @@ export function textNodeToRun({
   themeColors,
   enableComments,
   runProperties,
+  inlineRunProperties,
   converterContext,
 }: InlineConverterParams): TextRun {
   let run: TextRun = {
@@ -65,7 +66,7 @@ export function textNodeToRun({
   if (sdtMetadata) {
     run.sdt = sdtMetadata;
   }
-  run = applyInlineRunProperties(run, runProperties, converterContext);
+  run = applyInlineRunProperties(run, runProperties, converterContext, inlineRunProperties);
 
   return run;
 }

--- a/packages/layout-engine/pm-adapter/src/converters/paragraph.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/paragraph.ts
@@ -744,6 +744,7 @@ export function paragraphToFlowBlocks({
     activeSdt?: SdtMetadata,
     activeRunProperties?: RunProperties,
     activeHidden = false,
+    activeInlineRunProperties?: RunProperties,
   ) => {
     if (activeHidden && node.type !== 'run') {
       suppressedByVanish = true;
@@ -765,6 +766,7 @@ export function paragraphToFlowBlocks({
       themeColors,
       enableComments,
       runProperties: activeRunProperties,
+      inlineRunProperties: activeInlineRunProperties,
       paragraphProperties: resolvedParagraphProperties,
       converterContext,
       visitNode,

--- a/packages/layout-engine/pm-adapter/src/integration.test.ts
+++ b/packages/layout-engine/pm-adapter/src/integration.test.ts
@@ -1075,4 +1075,39 @@ describe('page break integration tests', () => {
     expect(tokenRun?.bidi).toEqual({ rtl: true });
     expect(tokenRun?.script).toEqual({ complexScript: true });
   });
+
+  // SD-2781 round-3 (codex finding): nested inline converters (bookmark-start,
+  // structuredContent, page-reference) used to drop the activeInlineRunProperties
+  // arg when forwarding to visitNode, so children inside an SDT/bookmark wrapper
+  // lost run-level bidi/script. These tests pin the pass-through.
+  it('preserves bidi/script on text inside a structuredContent wrapper', () => {
+    const pmDoc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'run',
+              attrs: { runProperties: { rtl: true, cs: true } },
+              content: [
+                {
+                  type: 'structuredContent',
+                  content: [{ type: 'text', text: 'sdt-wrapped rtl text' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { blocks } = toFlowBlocks(pmDoc);
+    const paragraph = blocks.find((block) => block.kind === 'paragraph');
+    if (paragraph?.kind !== 'paragraph') return;
+    const textRun = paragraph.runs.find((run) => 'text' in run && run.text === 'sdt-wrapped rtl text');
+    expect(textRun, 'text run inside SDT should be present').toBeDefined();
+    expect(textRun?.bidi).toEqual({ rtl: true });
+    expect(textRun?.script).toEqual({ complexScript: true });
+  });
 });

--- a/packages/layout-engine/pm-adapter/src/integration.test.ts
+++ b/packages/layout-engine/pm-adapter/src/integration.test.ts
@@ -982,4 +982,65 @@ describe('page break integration tests', () => {
     expect(exhibitPageIndex).toBe(1);
     expect(layout.pages[1].fragments.length).toBeGreaterThan(0);
   });
+
+  // SD-2781: end-to-end check that runs the unmocked applyInlineRunProperties
+  // pipeline. The unit tests in common.test.ts mock computeRunAttrs, so they
+  // can't catch type-shape regressions in the contracts package. This test
+  // exercises the full PM -> FlowBlock conversion with raw runProperties on
+  // a real run-wrapper node, mirroring how the importer emits them.
+  it('preserves run-level rtl, cs, and lang on TextRun.bidi / TextRun.script', () => {
+    const pmDoc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'run',
+              attrs: {
+                runProperties: {
+                  rtl: true,
+                  cs: true,
+                  lang: { val: 'en-US', bidi: 'ar-SA', eastAsia: 'ja-JP' },
+                },
+              },
+              content: [{ type: 'text', text: 'mixed-script run' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { blocks } = toFlowBlocks(pmDoc);
+    const paragraph = blocks.find((block) => block.kind === 'paragraph');
+    expect(paragraph).toBeDefined();
+    if (paragraph?.kind !== 'paragraph') return;
+
+    const textRun = paragraph.runs.find((run) => 'text' in run && run.text === 'mixed-script run');
+    expect(textRun).toBeDefined();
+    expect(textRun?.bidi).toEqual({ rtl: true });
+    expect(textRun?.script).toEqual({
+      complexScript: true,
+      language: { default: 'en-US', complexScript: 'ar-SA', eastAsian: 'ja-JP' },
+    });
+  });
+
+  it('omits bidi and script on TextRun when no signals are set (no bloat)', () => {
+    const pmDoc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'plain Latin text' }],
+        },
+      ],
+    };
+
+    const { blocks } = toFlowBlocks(pmDoc);
+    const paragraph = blocks.find((block) => block.kind === 'paragraph');
+    if (paragraph?.kind !== 'paragraph') return;
+    const textRun = paragraph.runs.find((run) => 'text' in run && run.text === 'plain Latin text');
+    expect(textRun?.bidi).toBeUndefined();
+    expect(textRun?.script).toBeUndefined();
+  });
 });

--- a/packages/layout-engine/pm-adapter/src/integration.test.ts
+++ b/packages/layout-engine/pm-adapter/src/integration.test.ts
@@ -1043,4 +1043,36 @@ describe('page break integration tests', () => {
     expect(textRun?.bidi).toBeUndefined();
     expect(textRun?.script).toBeUndefined();
   });
+
+  // SD-2781 round 2 (codex finding): generic-token.ts:64 calls
+  // applyInlineRunProperties without reassigning the return value, so token
+  // runs (page numbers, total page counts) lose run-level bidi/script metadata
+  // even when wrapped in a run that explicitly sets rtl/cs/lang.
+  it('preserves bidi/script on page-number token TextRuns inside an rtl run', () => {
+    const pmDoc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'run',
+              attrs: { runProperties: { rtl: true, cs: true } },
+              content: [{ type: 'page-number' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { blocks } = toFlowBlocks(pmDoc);
+    const paragraph = blocks.find((block) => block.kind === 'paragraph');
+    if (paragraph?.kind !== 'paragraph') return;
+    const tokenRun = paragraph.runs.find(
+      (run) => 'token' in run && (run.token === 'pageNumber' || run.token === 'totalPageCount'),
+    );
+    expect(tokenRun, 'token run should be present').toBeDefined();
+    expect(tokenRun?.bidi).toEqual({ rtl: true });
+    expect(tokenRun?.script).toEqual({ complexScript: true });
+  });
 });

--- a/packages/layout-engine/pm-adapter/src/integration.test.ts
+++ b/packages/layout-engine/pm-adapter/src/integration.test.ts
@@ -1076,10 +1076,10 @@ describe('page break integration tests', () => {
     expect(tokenRun?.script).toEqual({ complexScript: true });
   });
 
-  // SD-2781 round-3 (codex finding): nested inline converters (bookmark-start,
-  // structuredContent, page-reference) used to drop the activeInlineRunProperties
-  // arg when forwarding to visitNode, so children inside an SDT/bookmark wrapper
-  // lost run-level bidi/script. These tests pin the pass-through.
+  // SD-2781: nested inline converters (bookmark-start, structuredContent,
+  // page-reference) must forward activeInlineRunProperties when calling
+  // visitNode - otherwise children inside an SDT/bookmark wrapper lose
+  // run-level bidi/script. These tests pin the pass-through.
   it('preserves bidi/script on text inside a structuredContent wrapper', () => {
     const pmDoc = {
       type: 'doc',


### PR DESCRIPTION
Adds preservation-only run-level direction and script metadata to the layout text-run contract, kept on separate axes per ECMA's own categorization.

## What changes

Two fields on \`TextRun\`:

- **\`bidi: RunBidiContext\`** - direction signals only. Carries the run rtl flag now (§17.3.2.30); space reserved for w:dir embedding and w:bdo override in Wave 1c.
- **\`script: RunScriptContext\`** - complex-script context. Carries the cs flag (§17.3.2.7) and per-script language tags (default / complexScript / eastAsian per §17.3.2.20).

Both populated by pm-adapter in \`applyInlineRunProperties\` from raw \`RunProperties\` when present. Empty contexts are not attached, so the layout tree doesn't bloat for runs with no signals.

## Why typed split

ECMA-376 puts direction (\`rtl\`, \`dir\`, \`bdo\`) and script formatting (\`cs\`, \`lang/@bidi\`) in different categories.

- Direction signals control reading order and embedding levels.
- Script signals control which formatting stack applies (Latin variants vs CS variants vs East Asian).

Lumping them under one \`bidi\` field would collapse the axes and lie about the schema. The non-collapse test exercises this directly: setting \`rtl: true, cs: true\` produces \`bidi.rtl === true\` and \`script.complexScript === true\` with no leakage.

## Why now

Wave 1b will consume \`script.complexScript\` to gate the formatting-stack selection; Wave 1c will consume \`bidi.embedding\` and \`bidi.override\`. Adding the data path now means each wave doesn't have to introduce both the data and the rendering at once.

## Type shape change

\`RunScriptContext.language\` expanded from \`string\` to \`{ default?, complexScript?, eastAsian? }\`. No production consumer reads the field yet (preservation-only since #3184), so the change is safe.

## What this PR does NOT do

- DomPainter does not render anything based on either field.
- Round-trip is unaffected (preservation-only, no behavior change).
- Wave 1c's \`w:dir\` / \`w:bdo\` import isn't done yet - the type has slots for those signals, but the importer doesn't populate them.

## Validation

- 1,794 pm-adapter tests pass (+7 new tests covering the preservation, partial lang attrs, and axis non-collapse)
- 12,644 super-editor tests pass
- 1,201 layout-bridge tests pass
