### PR TITLE
chore(docs-stable): sync stable into docs-stable

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdoc-dev/mcp",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "engines": {
     "node": ">=20"

--- a/apps/vscode-ext/package.json
+++ b/apps/vscode-ext/package.json
@@ -2,7 +2,7 @@
   "name": "superdoc-vscode-ext",
   "displayName": "SuperDoc - Word Document Editor",
   "description": "Open and edit Word documents (.docx) directly in VS Code using SuperDoc",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "publisher": "superdoc-dev",
   "icon": "logo.png",
   "homepage": "https://superdoc.dev",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdoc-dev/react",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Official React wrapper for the SuperDoc document editor",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/template-builder/package.json
+++ b/packages/template-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdoc-dev/template-builder",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "React template builder component for SuperDoc",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Fast-forwards `docs-stable` to the current tip of `stable` ahead of a docs update. Picks up the 4 release-bump commits since the last sync (template-builder 1.10.0, vscode 2.4.0, react 1.3.0, mcp 0.4.0).

- Clean fast-forward, no conflicts
- No code changes outside published version bumps