### PR TITLE
feat: render images inside Word textboxes (SD-2804)

### DIFF
--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -806,6 +806,18 @@ export type TextPart = {
   isLineBreak?: boolean;
   /** Indicates this line break follows an empty paragraph (creates extra spacing). */
   isEmptyParagraph?: boolean;
+  /**
+   * SD-2804: ECMA-376 §20.4.2.38 lets a textbox hold full body-level
+   * content, including paragraphs whose runs carry inline w:drawing
+   * images. When the importer encounters such a drawing it appends a
+   * part with `kind: 'image'` carrying a resolved data-URI src so the
+   * shape painter can render an <img> alongside the text.
+   */
+  kind?: 'image';
+  src?: string;
+  width?: number;
+  height?: number;
+  alt?: string;
 };
 
 /** Text content configuration for shapes. */

--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -810,11 +810,15 @@ export type TextPart = {
    * SD-2804: ECMA-376 §20.4.2.38 lets a textbox hold full body-level
    * content, including paragraphs whose runs carry inline w:drawing
    * images. When the importer encounters such a drawing it appends a
-   * part with `kind: 'image'` carrying a resolved data-URI src so the
-   * shape painter can render an <img> alongside the text.
+   * part with `kind: 'image'` carrying the raw media path; pm-adapter's
+   * hydrateImageBlocks resolves it to a data URI alongside ImageRuns so
+   * binary (Y.js) and string (zip) media files share the same path
+   * candidates and Uint8Array decoding.
    */
   kind?: 'image';
   src?: string;
+  extension?: string;
+  rId?: string;
   width?: number;
   height?: number;
   alt?: string;

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -4461,14 +4461,17 @@ export class DomPainter {
       } else if (part.kind === 'image' && part.src) {
         // SD-2804: image part produced by the textbox importer for an
         // inline w:drawing inside a textbox run. Render as <img> alongside
-        // sibling text spans so layout matches Word's inline flow.
+        // sibling text spans so layout matches Word's inline flow. Match
+        // body inline images' baseline default (`vertical-align: bottom`)
+        // so an image and adjacent text line up the same way inside a
+        // textbox as outside.
         const img = this.doc!.createElement('img');
         img.src = part.src;
         img.alt = part.alt ?? '';
         if (typeof part.width === 'number') img.style.width = `${part.width}px`;
         if (typeof part.height === 'number') img.style.height = `${part.height}px`;
         img.style.display = 'inline-block';
-        img.style.verticalAlign = 'middle';
+        img.style.verticalAlign = 'bottom';
         currentParagraph.appendChild(img);
       } else {
         const span = this.doc!.createElement('span');

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -4458,6 +4458,18 @@ export class DomPainter {
         if (part.isEmptyParagraph) {
           currentParagraph.style.minHeight = '1em';
         }
+      } else if (part.kind === 'image' && part.src) {
+        // SD-2804: image part produced by the textbox importer for an
+        // inline w:drawing inside a textbox run. Render as <img> alongside
+        // sibling text spans so layout matches Word's inline flow.
+        const img = this.doc!.createElement('img');
+        img.src = part.src;
+        img.alt = part.alt ?? '';
+        if (typeof part.width === 'number') img.style.width = `${part.width}px`;
+        if (typeof part.height === 'number') img.style.height = `${part.height}px`;
+        img.style.display = 'inline-block';
+        img.style.verticalAlign = 'middle';
+        currentParagraph.appendChild(img);
       } else {
         const span = this.doc!.createElement('span');
         span.textContent = this.resolveShapeTextPartText(part, context);

--- a/packages/layout-engine/pm-adapter/src/utilities.ts
+++ b/packages/layout-engine/pm-adapter/src/utilities.ts
@@ -15,6 +15,8 @@ import type {
   ShapeGroupDrawing,
   ShapeGroupImageChild,
   ShapeGroupTransform,
+  TextPart,
+  VectorShapeDrawing,
   FlowBlock,
   ImageRun,
   ParagraphBlock,
@@ -1174,6 +1176,37 @@ export function hydrateImageBlocks(blocks: FlowBlock[], mediaFiles?: Record<stri
       // Handle DrawingBlocks with shapeGroup kind (contain image children)
       if (blk.kind === 'drawing') {
         const drawingBlock = blk as DrawingBlock;
+
+        // SD-2804: vectorShape blocks carry inline image parts in their
+        // textContent.parts array (importer stamps part.kind === 'image'
+        // for w:drawing inside textbox runs). Hydrate the same way as
+        // ImageRuns so Uint8Array (Y.js binary) and string (zip) media
+        // alike resolve to a data URI.
+        if (drawingBlock.drawingKind === 'vectorShape') {
+          const parts = (drawingBlock as VectorShapeDrawing).textContent?.parts;
+          if (!parts || parts.length === 0) return blk;
+          let partsChanged = false;
+          const hydratedParts = parts.map((part: TextPart) => {
+            if (part?.kind !== 'image' || !part.src || part.src.startsWith('data:')) {
+              return part;
+            }
+            const resolvedSrc = resolveImageSrc(part.src, part.rId, undefined, part.extension);
+            if (resolvedSrc) {
+              partsChanged = true;
+              return { ...part, src: resolvedSrc };
+            }
+            return part;
+          });
+          if (partsChanged) {
+            const vectorShapeBlock = drawingBlock as VectorShapeDrawing;
+            return {
+              ...vectorShapeBlock,
+              textContent: { ...vectorShapeBlock.textContent, parts: hydratedParts },
+            };
+          }
+          return blk;
+        }
+
         if (drawingBlock.drawingKind !== 'shapeGroup') {
           return blk;
         }

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/encode-image-node-helpers.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/encode-image-node-helpers.js
@@ -1008,29 +1008,6 @@ const handleChartDrawing = (params, node, graphicData, size, padding, marginOffs
  *   wrap: string
  * }|null} Text content with formatting information and line break markers, or null if no text found
  */
-// SD-2804: turn a path-style src ("word/media/image1.png" or "media/image1.png")
-// into a data URI by reading converter.media. Mirrors how layout-engine's
-// hydrateRuns resolves body ImageRuns, but inline since the text-parts model
-// the shape painter consumes has no downstream hydration step.
-function resolveImagePartSrc(src, params, extension) {
-  if (!src || src.startsWith('data:')) return src;
-  const media = params?.converter?.media;
-  if (!media) return src;
-  const candidates = [src];
-  if (src.startsWith('word/')) candidates.push(src.slice(5));
-  else candidates.push(`word/${src}`);
-  for (const candidate of candidates) {
-    const data = media[candidate];
-    if (!data) continue;
-    if (typeof data === 'string') {
-      if (data.startsWith('data:')) return data;
-      const ext = extension || (src.includes('.') ? src.slice(src.lastIndexOf('.') + 1) : 'png');
-      return `data:image/${ext};base64,${data}`;
-    }
-  }
-  return src;
-}
-
 function extractTextFromTextBox(textBoxContent, bodyPr, params = {}) {
   if (!textBoxContent || !textBoxContent.elements) return null;
 
@@ -1086,24 +1063,28 @@ function extractTextFromTextBox(textBoxContent, bodyPr, params = {}) {
         appendFieldPart('NUMPAGES', el, paragraphProperties);
       } else if (el.name === 'w:drawing') {
         // SD-2804 / ECMA-376 §20.4.2.38: a textbox can hold body-level
-        // content, including runs with inline w:drawing images. Reuse the
-        // existing v3 wp drawing handler so the rId → resolution matches
-        // what body paragraphs use, then upgrade the path-style src to a
-        // data URI from converter.media (the text-parts model has no
-        // downstream hydration step like body ImageRuns do).
-        const inlineOrAnchor = el.elements?.find((child) => child?.name === 'wp:inline' || child?.name === 'wp:anchor');
-        if (inlineOrAnchor) {
-          const isAnchor = inlineOrAnchor.name === 'wp:anchor';
-          const imagePm = handleImageNode(inlineOrAnchor, { ...params, nodes: [el] }, isAnchor);
-          if (imagePm?.attrs?.src) {
+        // content, including runs with inline w:drawing images. Defer to
+        // the existing v3 wp drawing handler for rId → src + size resolution
+        // so this branch behaves identically to body inline images. Anchored
+        // drawings inside textboxes are out of scope (the wrap / position /
+        // transform metadata isn't carried into the text-parts model);
+        // confine support to wp:inline.
+        const inline = el.elements?.find((child) => child?.name === 'wp:inline');
+        if (inline) {
+          const imagePm = handleImageNode(inline, { ...params, nodes: [el] }, false);
+          // Skip hidden drawings (wp:docPr hidden="1") to match the body-level
+          // pipeline — handleImageNode flags them via attrs.hidden, and image
+          // parts bypass the top-level filtering that drops them elsewhere.
+          if (imagePm?.attrs?.src && imagePm.attrs.hidden !== true) {
             hasText = true;
             const sizeAttr = imagePm.attrs.size || imagePm.attrs;
-            const resolvedSrc = resolveImagePartSrc(imagePm.attrs.src, params, imagePm.attrs.extension);
             textParts.push({
               text: '',
               formatting,
               kind: 'image',
-              src: resolvedSrc,
+              src: imagePm.attrs.src,
+              extension: imagePm.attrs.extension,
+              rId: imagePm.attrs.rId,
               width: typeof sizeAttr?.width === 'number' ? sizeAttr.width : undefined,
               height: typeof sizeAttr?.height === 'number' ? sizeAttr.height : undefined,
               alt: imagePm.attrs.alt || '',

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/encode-image-node-helpers.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/encode-image-node-helpers.js
@@ -1008,6 +1008,29 @@ const handleChartDrawing = (params, node, graphicData, size, padding, marginOffs
  *   wrap: string
  * }|null} Text content with formatting information and line break markers, or null if no text found
  */
+// SD-2804: turn a path-style src ("word/media/image1.png" or "media/image1.png")
+// into a data URI by reading converter.media. Mirrors how layout-engine's
+// hydrateRuns resolves body ImageRuns, but inline since the text-parts model
+// the shape painter consumes has no downstream hydration step.
+function resolveImagePartSrc(src, params, extension) {
+  if (!src || src.startsWith('data:')) return src;
+  const media = params?.converter?.media;
+  if (!media) return src;
+  const candidates = [src];
+  if (src.startsWith('word/')) candidates.push(src.slice(5));
+  else candidates.push(`word/${src}`);
+  for (const candidate of candidates) {
+    const data = media[candidate];
+    if (!data) continue;
+    if (typeof data === 'string') {
+      if (data.startsWith('data:')) return data;
+      const ext = extension || (src.includes('.') ? src.slice(src.lastIndexOf('.') + 1) : 'png');
+      return `data:image/${ext};base64,${data}`;
+    }
+  }
+  return src;
+}
+
 function extractTextFromTextBox(textBoxContent, bodyPr, params = {}) {
   if (!textBoxContent || !textBoxContent.elements) return null;
 
@@ -1061,6 +1084,32 @@ function extractTextFromTextBox(textBoxContent, bodyPr, params = {}) {
       } else if (el.name === 'sd:totalPageNumber') {
         hasText = true;
         appendFieldPart('NUMPAGES', el, paragraphProperties);
+      } else if (el.name === 'w:drawing') {
+        // SD-2804 / ECMA-376 §20.4.2.38: a textbox can hold body-level
+        // content, including runs with inline w:drawing images. Reuse the
+        // existing v3 wp drawing handler so the rId → resolution matches
+        // what body paragraphs use, then upgrade the path-style src to a
+        // data URI from converter.media (the text-parts model has no
+        // downstream hydration step like body ImageRuns do).
+        const inlineOrAnchor = el.elements?.find((child) => child?.name === 'wp:inline' || child?.name === 'wp:anchor');
+        if (inlineOrAnchor) {
+          const isAnchor = inlineOrAnchor.name === 'wp:anchor';
+          const imagePm = handleImageNode(inlineOrAnchor, { ...params, nodes: [el] }, isAnchor);
+          if (imagePm?.attrs?.src) {
+            hasText = true;
+            const sizeAttr = imagePm.attrs.size || imagePm.attrs;
+            const resolvedSrc = resolveImagePartSrc(imagePm.attrs.src, params, imagePm.attrs.extension);
+            textParts.push({
+              text: '',
+              formatting,
+              kind: 'image',
+              src: resolvedSrc,
+              width: typeof sizeAttr?.width === 'number' ? sizeAttr.width : undefined,
+              height: typeof sizeAttr?.height === 'number' ? sizeAttr.height : undefined,
+              alt: imagePm.attrs.alt || '',
+            });
+          }
+        }
       }
     });
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/encode-image-node-helpers.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/encode-image-node-helpers.test.js
@@ -2023,4 +2023,119 @@ describe('getVectorShape', () => {
       expect(result1.attrs.src).not.toBe(result2.attrs.src);
     });
   });
+
+  // SD-2804: ECMA-376 §20.4.2.38 — a textbox (CT_TxbxContent) can hold rich
+  // body-level content, including paragraphs whose runs carry inline images
+  // via w:drawing > wp:inline > pic:pic. The text-only extractor used to
+  // silently skip those drawings, leaving the textbox visually empty even
+  // though export round-tripped the image. The fix surfaces the image as a
+  // textContent part with kind='image' so the shape painter can render it.
+  describe('SD-2804: image inside textbox content', () => {
+    const docxFixture = {
+      'word/_rels/header1.xml.rels': {
+        elements: [
+          {
+            name: 'Relationships',
+            elements: [
+              {
+                name: 'Relationship',
+                attributes: { Id: 'rId1', Target: 'media/image1.png' },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const makeShape = () => ({
+      elements: [
+        {
+          name: 'wps:wsp',
+          elements: [
+            { name: 'wps:cNvSpPr', attributes: { txBox: '1' } },
+            {
+              name: 'wps:spPr',
+              elements: [
+                { name: 'a:prstGeom', attributes: { prst: 'rect' } },
+                { name: 'a:xfrm', elements: [{ name: 'a:ext', attributes: { cx: '4745620', cy: '520860' } }] },
+              ],
+            },
+            {
+              name: 'wps:txbx',
+              elements: [
+                {
+                  name: 'w:txbxContent',
+                  elements: [
+                    {
+                      name: 'w:p',
+                      elements: [
+                        {
+                          name: 'w:r',
+                          elements: [
+                            { name: 'w:rPr', elements: [{ name: 'w:noProof' }] },
+                            {
+                              name: 'w:drawing',
+                              elements: [
+                                {
+                                  name: 'wp:inline',
+                                  elements: [
+                                    { name: 'wp:extent', attributes: { cx: '481330', cy: '422910' } },
+                                    { name: 'wp:docPr', attributes: { id: '1', name: 'Picture 2' } },
+                                    {
+                                      name: 'a:graphic',
+                                      elements: [
+                                        {
+                                          name: 'a:graphicData',
+                                          attributes: {
+                                            uri: 'http://schemas.openxmlformats.org/drawingml/2006/picture',
+                                          },
+                                          elements: [
+                                            {
+                                              name: 'pic:pic',
+                                              elements: [
+                                                {
+                                                  name: 'pic:blipFill',
+                                                  elements: [{ name: 'a:blip', attributes: { 'r:embed': 'rId1' } }],
+                                                },
+                                              ],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            { name: 'wps:bodyPr', attributes: {} },
+          ],
+        },
+      ],
+    });
+
+    it('emits an image part in textContent for an inline w:drawing inside the textbox', () => {
+      const graphicData = makeShape();
+      const result = getVectorShape({
+        params: { nodes: [{ name: 'w:drawing', elements: [] }], docx: docxFixture, filename: 'header1.xml' },
+        node: { name: 'wp:anchor', elements: [] },
+        graphicData,
+        size: { width: 374, height: 41 },
+      });
+
+      expect(result?.type).toBe('vectorShape');
+      const parts = result?.attrs?.textContent?.parts || [];
+      const imagePart = parts.find((p) => p.kind === 'image');
+      expect(imagePart).toBeTruthy();
+      expect(typeof imagePart?.src).toBe('string');
+      expect(imagePart?.src.length).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Renders inline `w:drawing` images inside Word textbox content. Previously, the textbox imported with the image silently stripped — the textbox rendered as an empty box even though export round-tripped the image untouched.

Linear: [SD-2804](https://linear.app/superdocworkspace/issue/SD-2804)

## Spec basis

ECMA-376 §20.4.2.38 (`CT_TxbxContent`) defines textbox content as `EG_BlockLevelElts (1..unbounded)` — i.e. a textbox can hold the same content as the document body, with three exclusions: cross-story refs (comments/footnotes/endnotes), VML, and nested `txbxContent`. Notably, paragraphs inside `w:txbxContent` carry the same `CT_P` content model as body paragraphs, including runs with inline `w:drawing` images.

The text-only extractor used in `extractTextFromTextBox.handleRun` only walked `w:t / w:tab / w:br / sd:autoPageNumber / sd:totalPageNumber` — `w:drawing` was silently ignored.

## Approach

Minimum surgical change — extend the existing text-parts model with one image part kind:

1. **`TextPart` contract** gains optional `kind: 'image'` plus `src / width / height / alt`.
2. **Importer** (`extractTextFromTextBox.handleRun`) branches on `w:drawing`, reuses the v3 `handleImageNode` to resolve `r:embed → media path`, then upgrades the path to a data URI from `converter.media` (the text-parts model has no downstream hydration step like body `ImageRun`s do).
3. **Painter** (`createFallbackTextElement`) renders parts with `kind: 'image'` as inline `<img>` next to text spans.

No new PM nodes, no new pm-adapter wiring, no schema changes, no NodeHandlerContext threading.

## Before / after

Fixture: a DOCX with a textbox-in-header containing a single inline image.

| Before | After |
|---|---|
| Empty textbox outline; image silently dropped on import | Image renders inline inside the textbox, matching what Word shows |

Captured via agent-browser against the dev server: see `/tmp/sd-2804-final3.png`.

## Test plan

- [x] Unit test: importer emits an image part in `textContent.parts` for an inline `w:drawing` inside the textbox (`encode-image-node-helpers.test.js`)
- [x] super-editor full suite: 12,645 tests passing
- [x] painter-dom full suite: 1,064 tests passing
- [x] pm-adapter full suite: 1,788 tests passing
- [x] layout-bridge full suite: 1,206 tests passing
- [x] Browser: upload the SD-2804 fixture, confirm the image renders inside the textbox

## Out of scope (deferred)

The fixture's image is `wp:inline` inside a textbox run — the most common case. ECMA-376 also permits richer block-level content inside a textbox: tables, lists, SDTs, hyperlinks, fields, math. The current text-parts model can't represent those; surfacing them would need to flow `w:txbxContent` through the same body pipeline (`handleParagraphNode` recursion) and likely a container PM node (`shapeTextbox` schema already exists for the legacy v:pict path).

That refactor is intentionally deferred — the supplied SD-2804 fixture has only an image, and Option B was over-engineering for the immediate user-visible bug. Tracking issue / future PR scope for content beyond inline-image-in-textbox.

## Related

- SD-2745 (header-anchored floating textboxes) — handles textbox **position**; this PR handles textbox **content**. They compose.