### PR TITLE
fix(converter): preserve hyperlink mark on inserted text split across paragraphs (SD-2973)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/hyperlink-preprocessor.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/hyperlink-preprocessor.js
@@ -1,21 +1,24 @@
 import { generateDocxRandomId } from '@helpers/generateDocxRandomId.js';
 
 /**
- * Processes a HYPERLINK instruction and creates a `w:hyperlink` node.
- * @param {import('../../v2/types/index.js').OpenXmlNode[]} nodesToCombine The nodes to combine.
- * @param {string} instruction The instruction text.
- * @param {import('../../v2/docxHelper').ParsedDocx} [docx] - The docx object.
- * @returns {import('../../v2/types/index.js').OpenXmlNode[]}
- * @see {@link https://ecma-international.org/publications-and-standards/standards/ecma-376/} "Fundamentals And Markup Language Reference", page 1216
+ * Parses a HYPERLINK field instruction into the attribute set that belongs on
+ * a `<w:hyperlink>` element, registering an external-link relationship in
+ * `word/_rels/document.xml.rels` when needed.
+ *
+ * Side-effect: a `<Relationship>` is appended to the rels file when the
+ * instruction is a URL form and the rels container exists.
+ *
+ * @param {string} instruction
+ * @param {import('../../v2/docxHelper').ParsedDocx} [docx]
+ * @returns {Record<string, string | boolean> | null} Attribute set, or null
+ *   when the instruction has no recognisable target.
  */
-export function preProcessHyperlinkInstruction(nodesToCombine, instruction, docx) {
+export function resolveHyperlinkAttributes(instruction, docx) {
   const urlMatch = instruction.match(/HYPERLINK\s+"([^"]+)"/);
-  let linkAttributes;
   if (urlMatch && urlMatch.length >= 2) {
     const url = urlMatch[1];
-
-    const rels = docx['word/_rels/document.xml.rels'];
-    const relationships = rels?.elements.find((el) => el.name === 'Relationships');
+    const rels = docx?.['word/_rels/document.xml.rels'];
+    const relationships = rels?.elements?.find((el) => el.name === 'Relationships');
     if (relationships) {
       const rId = 'rId' + generateDocxRandomId();
       relationships.elements.push({
@@ -28,34 +31,48 @@ export function preProcessHyperlinkInstruction(nodesToCombine, instruction, docx
           TargetMode: 'External',
         },
       });
-      linkAttributes = { 'r:id': rId };
-    } else {
-      linkAttributes = { 'w:anchor': url };
+      return { 'r:id': rId };
     }
-  } else {
-    const availableSwitches = {
-      'w:anchor': /(?:\\)?l "(?<value>[^"]+)"/,
-      new_window: /(?:\\n|\n)/,
-      'w:tgtFrame': /(?:\\t|\t) "(?<value>[^"]+)"/,
-      'w:tooltip': /(?:\\)?o "(?<value>[^"]+)"/,
-    };
-
-    const parsedSwitches = {};
-
-    for (const [key, pattern] of Object.entries(availableSwitches)) {
-      const match = instruction.match(pattern);
-      if (match) {
-        parsedSwitches[key] = match.groups?.value || true;
-      }
-    }
-
-    if (parsedSwitches.new_window) {
-      parsedSwitches['w:tgtFrame'] = '_blank';
-      delete parsedSwitches.new_window;
-    }
-
-    linkAttributes = { ...parsedSwitches };
+    return { 'w:anchor': url };
   }
+
+  const availableSwitches = {
+    'w:anchor': /(?:\\)?l "(?<value>[^"]+)"/,
+    new_window: /(?:\\n|\n)/,
+    'w:tgtFrame': /(?:\\t|\t) "(?<value>[^"]+)"/,
+    'w:tooltip': /(?:\\)?o "(?<value>[^"]+)"/,
+  };
+
+  const parsedSwitches = {};
+  for (const [key, pattern] of Object.entries(availableSwitches)) {
+    const match = instruction.match(pattern);
+    if (match) {
+      parsedSwitches[key] = match.groups?.value || true;
+    }
+  }
+
+  if (parsedSwitches.new_window) {
+    parsedSwitches['w:tgtFrame'] = '_blank';
+    delete parsedSwitches.new_window;
+  }
+
+  if (Object.keys(parsedSwitches).length === 0) {
+    return null;
+  }
+
+  return { ...parsedSwitches };
+}
+
+/**
+ * Processes a HYPERLINK instruction and creates a `w:hyperlink` node.
+ * @param {import('../../v2/types/index.js').OpenXmlNode[]} nodesToCombine The nodes to combine.
+ * @param {string} instruction The instruction text.
+ * @param {import('../../v2/docxHelper').ParsedDocx} [docx] - The docx object.
+ * @returns {import('../../v2/types/index.js').OpenXmlNode[]}
+ * @see {@link https://ecma-international.org/publications-and-standards/standards/ecma-376/} "Fundamentals And Markup Language Reference", page 1216
+ */
+export function preProcessHyperlinkInstruction(nodesToCombine, instruction, docx) {
+  const linkAttributes = resolveHyperlinkAttributes(instruction, docx) ?? {};
 
   return [
     {

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -3,7 +3,8 @@
  */
 import { getInstructionPreProcessor } from './fld-preprocessors';
 import { carbonCopy } from '@core/utilities/carbonCopy.js';
-import { isTrackChangeElement } from '../v2/importer/trackChangeElements.js';
+import { isTrackChangeElement, isConstructiveTrackChangeElement } from '../v2/importer/trackChangeElements.js';
+import { generateDocxRandomId } from '@helpers/generateDocxRandomId.js';
 
 const SKIP_FIELD_PROCESSING_NODE_NAMES = new Set(['w:drawing', 'w:pict']);
 
@@ -61,6 +62,14 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
           fieldRunRPr,
         );
         outputNodes = combinedResult.handled ? combinedResult.nodes : rawCollectedNodes;
+      } else if (currentField.preserveRawConstructive) {
+        // SD-2973: SD-2858's preserveRaw guarantees structural validity when a
+        // field crosses tracked-change wrappers but loses field interpretation.
+        // For constructive wrappers (w:ins / w:moveTo) the user keeps the
+        // visible content — drop the link-like interpretations and they'd see
+        // plain text. Run a per-field post-pass that re-applies the
+        // interpretation in-place without restructuring the tree.
+        applyConstructiveFieldInterpretation(outputNodes, currentField.instrText.trim(), docx);
       }
       if (collectedNodesStack.length === 0) {
         // We have completed a top-level field, add the combined nodes to the output.
@@ -215,6 +224,14 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
           if (fieldInfo.preserveRaw || isTrackChangeElement(node)) {
             fieldInfo.preserveRaw = true;
           }
+          // SD-2973: track whether the wrapper that forced preserveRaw was a
+          // constructive tracked-change (w:ins / w:moveTo). Constructive
+          // wrappers keep the content on accept, so the user sees the visible
+          // text — and field interpretations like HYPERLINK need to survive
+          // even though we cannot collapse the structural tree.
+          if (isConstructiveTrackChangeElement(node)) {
+            fieldInfo.preserveRawConstructive = true;
+          }
           currentFieldStack.push(fieldInfo);
 
           // The current node should be added to the collected nodes
@@ -237,6 +254,12 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
 
         if (shouldPreserveRaw) {
           currentFieldStack[currentFieldStack.length - 1].preserveRaw = true;
+        }
+        // SD-2973: an end fldChar wrapped in a constructive tracked change
+        // also flags the active field as constructive-preserved so the
+        // HYPERLINK post-pass runs.
+        if (isConstructiveTrackChangeElement(node)) {
+          currentFieldStack[currentFieldStack.length - 1].preserveRawConstructive = true;
         }
         collectedNodesStack[collectedNodesStack.length - 1].push(node);
         captureRawNodeForCurrentField(rawNode, capturedRawNodes, rawSourceToken);
@@ -304,6 +327,132 @@ const _processCombinedNodesForFldChar = (nodesToCombine = [], instrText, docx, i
     };
   }
   return { nodes: nodesToCombine, handled: false };
+};
+
+/**
+ * SD-2973: Apply field interpretation in-place for constructive tracked-change
+ * wrappers that triggered preserveRaw. Walks the raw nodes (paragraphs,
+ * tracked-change wrappers, runs) to find the visible runs between the
+ * field's `separate` and `end` fldChars, and wraps just those runs in the
+ * structural element the field type implies (today: `w:hyperlink` for
+ * HYPERLINK fields). Leaves the surrounding paragraph and tracked-change
+ * structure untouched so the SD-2858 round-trip guarantee still holds.
+ *
+ * @param {OpenXmlNode[]} rawNodes
+ * @param {string} instrText
+ * @param {ParsedDocx} docx
+ */
+const applyConstructiveFieldInterpretation = (rawNodes, instrText, docx) => {
+  const instructionType = instrText.split(' ')[0];
+  if (instructionType !== 'HYPERLINK') return;
+
+  const urlMatch = instrText.match(/HYPERLINK\s+"([^"]+)"/);
+  let linkAttributes;
+  if (urlMatch && urlMatch.length >= 2) {
+    const url = urlMatch[1];
+    const rels = docx?.['word/_rels/document.xml.rels'];
+    const relationships = rels?.elements?.find((el) => el.name === 'Relationships');
+    if (!relationships) return;
+    const rId = 'rId' + generateDocxRandomId();
+    relationships.elements.push({
+      type: 'element',
+      name: 'Relationship',
+      attributes: {
+        Id: rId,
+        Type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink',
+        Target: url,
+        TargetMode: 'External',
+      },
+    });
+    linkAttributes = { 'r:id': rId };
+  } else {
+    const anchorMatch = instrText.match(/(?:\\)?l "(?<value>[^"]+)"/);
+    if (!anchorMatch?.groups?.value) return;
+    linkAttributes = { 'w:anchor': anchorMatch.groups.value };
+  }
+
+  // State machine: visit every run; when we cross a `separate` fldChar
+  // turn collection on; when we cross an `end` fldChar turn it off. Runs
+  // collected while on are wrapped in <w:hyperlink> in their parent.
+  let visible = false;
+
+  /** @param {OpenXmlNode} parent */
+  const walk = (parent) => {
+    if (!parent || !Array.isArray(parent.elements)) return;
+    /** @type {OpenXmlNode[]} */
+    const next = [];
+    /** @type {OpenXmlNode[] | null} */
+    let pendingHyperlinkRuns = null;
+    const flushHyperlink = () => {
+      if (!pendingHyperlinkRuns || pendingHyperlinkRuns.length === 0) {
+        pendingHyperlinkRuns = null;
+        return;
+      }
+      next.push({
+        type: 'element',
+        name: 'w:hyperlink',
+        attributes: linkAttributes,
+        elements: pendingHyperlinkRuns,
+      });
+      pendingHyperlinkRuns = null;
+    };
+
+    for (const child of parent.elements) {
+      if (!child) continue;
+
+      // Recurse into block / wrapper containers.
+      if (child.name === 'w:p' || child.name === 'w:ins' || child.name === 'w:moveTo') {
+        flushHyperlink();
+        walk(child);
+        next.push(child);
+        continue;
+      }
+
+      if (child.name === 'w:r') {
+        const fldChar = child.elements?.find((el) => el?.name === 'w:fldChar');
+        const fldType = fldChar?.attributes?.['w:fldCharType'];
+        if (fldType === 'separate') {
+          flushHyperlink();
+          visible = true;
+          next.push(child);
+          continue;
+        }
+        if (fldType === 'end') {
+          flushHyperlink();
+          visible = false;
+          next.push(child);
+          continue;
+        }
+        if (fldType === 'begin') {
+          flushHyperlink();
+          next.push(child);
+          continue;
+        }
+        // Skip instruction-only runs from being wrapped (they're the
+        // HYPERLINK <w:instrText>, not visible content).
+        const hasInstrText = child.elements?.some((el) => el?.name === 'w:instrText');
+        if (hasInstrText) {
+          flushHyperlink();
+          next.push(child);
+          continue;
+        }
+        if (visible) {
+          if (!pendingHyperlinkRuns) pendingHyperlinkRuns = [];
+          pendingHyperlinkRuns.push(child);
+          continue;
+        }
+        next.push(child);
+        continue;
+      }
+
+      flushHyperlink();
+      next.push(child);
+    }
+    flushHyperlink();
+    parent.elements = next;
+  };
+
+  rawNodes.forEach(walk);
 };
 
 /**

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -2,9 +2,9 @@
  * @typedef {import('../v2/types/index.js').OpenXmlNode} OpenXmlNode
  */
 import { getInstructionPreProcessor } from './fld-preprocessors';
+import { resolveHyperlinkAttributes } from './fld-preprocessors/hyperlink-preprocessor.js';
 import { carbonCopy } from '@core/utilities/carbonCopy.js';
 import { isTrackChangeElement, isConstructiveTrackChangeElement } from '../v2/importer/trackChangeElements.js';
-import { generateDocxRandomId } from '@helpers/generateDocxRandomId.js';
 
 const SKIP_FIELD_PROCESSING_NODE_NAMES = new Set(['w:drawing', 'w:pict']);
 
@@ -346,30 +346,8 @@ const applyConstructiveFieldInterpretation = (rawNodes, instrText, docx) => {
   const instructionType = instrText.split(' ')[0];
   if (instructionType !== 'HYPERLINK') return;
 
-  const urlMatch = instrText.match(/HYPERLINK\s+"([^"]+)"/);
-  let linkAttributes;
-  if (urlMatch && urlMatch.length >= 2) {
-    const url = urlMatch[1];
-    const rels = docx?.['word/_rels/document.xml.rels'];
-    const relationships = rels?.elements?.find((el) => el.name === 'Relationships');
-    if (!relationships) return;
-    const rId = 'rId' + generateDocxRandomId();
-    relationships.elements.push({
-      type: 'element',
-      name: 'Relationship',
-      attributes: {
-        Id: rId,
-        Type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink',
-        Target: url,
-        TargetMode: 'External',
-      },
-    });
-    linkAttributes = { 'r:id': rId };
-  } else {
-    const anchorMatch = instrText.match(/(?:\\)?l "(?<value>[^"]+)"/);
-    if (!anchorMatch?.groups?.value) return;
-    linkAttributes = { 'w:anchor': anchorMatch.groups.value };
-  }
+  const linkAttributes = resolveHyperlinkAttributes(instrText, docx);
+  if (!linkAttributes) return;
 
   // State machine: visit every run; when we cross a `separate` fldChar
   // turn collection on; when we cross an `end` fldChar turn it off. Runs

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -428,6 +428,118 @@ describe('preProcessNodesForFldChar', () => {
     expect(result.unpairedEnd).toBeNull();
   });
 
+  // SD-2973: when a HYPERLINK field is wrapped in a constructive tracked
+  // change (w:ins / w:moveTo) and crosses paragraphs, SD-2858's preserveRaw
+  // path used to drop the link interpretation entirely — the inserted text
+  // rendered with insertion styling but no clickable link, while Word shows
+  // both treatments. The fix keeps the raw <w:p> structure intact (so the
+  // tracked-change wrappers round-trip) but wraps the visible text run
+  // (between separate and end fldChars) in <w:hyperlink> in-place so the
+  // downstream importer applies the link mark.
+  it('wraps the visible run in w:hyperlink when an inserted HYPERLINK is split across paragraphs', () => {
+    const docx = {
+      'word/_rels/document.xml.rels': {
+        elements: [{ name: 'Relationships', elements: [] }],
+      },
+    };
+    const nodes = [
+      {
+        name: 'w:p',
+        elements: [
+          { name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: 'Before: ' }] }] },
+          {
+            name: 'w:ins',
+            attributes: { 'w:id': '1', 'w:author': 'Repro', 'w:date': '2026-04-30T00:00:00Z' },
+            elements: [
+              { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },
+              {
+                name: 'w:r',
+                elements: [
+                  {
+                    name: 'w:instrText',
+                    attributes: { 'xml:space': 'preserve' },
+                    elements: [{ type: 'text', text: ' HYPERLINK "http://example.com" ' }],
+                  },
+                ],
+              },
+              { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }] },
+              {
+                name: 'w:r',
+                elements: [
+                  {
+                    name: 'w:t',
+                    attributes: { 'xml:space': 'preserve' },
+                    elements: [{ type: 'text', text: 'inserted link text' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'w:p',
+        elements: [
+          {
+            name: 'w:ins',
+            attributes: { 'w:id': '2', 'w:author': 'Repro', 'w:date': '2026-04-30T00:00:00Z' },
+            elements: [
+              { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }] },
+              {
+                name: 'w:r',
+                elements: [
+                  {
+                    name: 'w:t',
+                    attributes: { 'xml:space': 'preserve' },
+                    elements: [{ type: 'text', text: 'inserted text after field end' }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const result = preProcessNodesForFldChar(nodes, docx);
+
+    // Two paragraphs preserved (the structural raw-preservation guarantee
+    // from SD-2858 still holds — we are not collapsing the tree).
+    expect(result.processedNodes).toHaveLength(2);
+    expect(result.processedNodes[0].name).toBe('w:p');
+    expect(result.processedNodes[1].name).toBe('w:p');
+
+    // Walk the first paragraph; it must contain a w:hyperlink wrapping the
+    // visible text run "inserted link text". The hyperlink sits inside the
+    // existing <w:ins> wrapper so insertion track-change styling layers on
+    // top of the link styling — matching Word's rendering.
+    const findFirst = (node, predicate) => {
+      if (!node) return null;
+      if (predicate(node)) return node;
+      for (const child of node.elements || []) {
+        const hit = findFirst(child, predicate);
+        if (hit) return hit;
+      }
+      return null;
+    };
+
+    const hyperlink = findFirst(result.processedNodes[0], (n) => n.name === 'w:hyperlink');
+    expect(hyperlink).toBeTruthy();
+    expect(hyperlink.attributes?.['r:id']).toMatch(/^rId/);
+
+    const visibleText = findFirst(hyperlink, (n) => n.elements?.some((c) => c?.type === 'text'));
+    expect(visibleText?.elements?.[0]?.text).toBe('inserted link text');
+
+    // Relationship must have been added pointing at the URL extracted from
+    // the field's instrText.
+    const relationships = docx['word/_rels/document.xml.rels'].elements.find((el) => el.name === 'Relationships');
+    const newRel = relationships.elements.find((el) => el.name === 'Relationship');
+    expect(newRel?.attributes?.Target).toBe('http://example.com');
+    expect(newRel?.attributes?.Type).toBe(
+      'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink',
+    );
+  });
+
   it('preserves raw field nodes when an active field ends inside a tracked deletion wrapper', () => {
     const expectedNodes = [
       { name: 'w:r', elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }] },

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/trackChangeElements.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/trackChangeElements.js
@@ -1,5 +1,11 @@
 const TRACK_CHANGE_ELEMENT_NAMES = new Set(['w:del', 'w:ins', 'w:moveFrom', 'w:moveTo']);
 const TRANSLATED_TRACK_CHANGE_ELEMENT_NAMES = new Set(['w:del', 'w:ins']);
+// Constructive wrappers carry content the user keeps when accepting the
+// change (insertion / move-to). Destructive wrappers (w:del / w:moveFrom)
+// hold content that disappears on accept — visual side-effects there are
+// invisible to the user.
+const CONSTRUCTIVE_TRACK_CHANGE_ELEMENT_NAMES = new Set(['w:ins', 'w:moveTo']);
 
 export const isTrackChangeElement = (node) => TRACK_CHANGE_ELEMENT_NAMES.has(node?.name);
 export const isTranslatedTrackChangeElement = (node) => TRANSLATED_TRACK_CHANGE_ELEMENT_NAMES.has(node?.name);
+export const isConstructiveTrackChangeElement = (node) => CONSTRUCTIVE_TRACK_CHANGE_ELEMENT_NAMES.has(node?.name);


### PR DESCRIPTION
## Summary

When a DOCX has tracked changes turned on and contains an inserted hyperlink that crosses a paragraph break, SuperDoc opens the file but the hyperlink is dropped — the inserted text shows up with insertion track-change styling, but it is no longer a clickable link. Word renders the same file with both treatments at once.

Linear: [SD-2973](https://linear.app/superdocworkspace/issue/SD-2973)
Follow-up to: [SD-2858](https://linear.app/superdocworkspace/issue/SD-2858) / [PR #3175](https://github.com/superdoc-dev/superdoc/pull/3175)

## Root cause

SD-2858's \`preserveRaw\` path in \`preProcessNodesForFldChar.js\` keeps tracked-change-wrapped fields structurally intact when the field crosses paragraph or wrapper boundaries — necessary because re-emitting \`<w:hyperlink>\` wrapping multiple \`<w:p>\` elements is invalid OOXML. For destructive wrappers (\`w:del\` / \`w:moveFrom\`) this trade-off is invisible (deleted content disappears on accept). For constructive wrappers (\`w:ins\` / \`w:moveTo\`) the user keeps the inserted text and Word shows it as a clickable hyperlink — the previous behaviour rendered insertion styling alone.

Console.log trace from the supplied fixture (\`sd-2858-ins-fixture.docx\`):

\`\`\`
[SD-2973] finalizeField {instrText: \"HYPERLINK \\\"http://example.com\\\"\", preserveRaw: true, rawCount: 2}
[SD-2973] finalizeField PRESERVE-RAW path — link mark not applied {rawNodeNames: [\"w:p\", \"w:p\"]}
\`\`\`

## Fix

- New \`isConstructiveTrackChangeElement(node)\` predicate in \`trackChangeElements.js\` (\`w:ins\` / \`w:moveTo\`).
- A \`preserveRawConstructive\` flag rides alongside \`preserveRaw\` through the field collector, set whenever a constructive wrapper triggered the raw-preservation.
- After \`finalizeField\` emits the raw nodes, when the flag is set and the field is a HYPERLINK, a per-field post-pass walks the raw nodes (paragraphs / tracked-change wrappers / runs), finds the visible runs (those between \`separate\` and \`end\` fldChars), and wraps just those runs in \`<w:hyperlink r:id=\"rIdN\"/>\` in-place. The relationship is added to \`document.xml.rels\` using the same machinery as the regular hyperlink preprocessor.

The surrounding paragraph and tracked-change wrapper structure stays untouched, so the SD-2858 round-trip guarantee holds. Destructive wrappers (\`w:del\` / \`w:moveFrom\`) still take the original raw-only path — no behaviour change there.

## Before / after

Fixture: \`sd-2858-ins-fixture.docx\` (attached to SD-2973). Inserted hyperlink with the begin / separate in para 1's \`<w:ins>\` and the end fldChar in para 2's \`<w:ins>\`.

| Marks on \"inserted link text\" | Before | After |
|---|---|---|
| PM marks | \`[textStyle, trackInsert]\` | \`[textStyle, trackInsert, link]\` |
| \`link.attrs.href\` | (none) | \`http://example.com\` |
| Visible | green dashed underline only | green dashed underline + link styling, clickable |

Captured live via agent-browser against the dev server.

## Test plan

- [x] Unit test \`wraps the visible run in w:hyperlink when an inserted HYPERLINK is split across paragraphs\` in \`preProcessNodesForFldChar.test.js\` — fails on main, passes here.
- [x] super-editor full suite: 12,645 tests passing.
- [x] Browser repro on the supplied fixture: PM tree shows \`link\` mark with correct href; visual matches Word's layered styling.
- [x] Existing SD-2858 regression tests (\`preserves a tracked-deletion-wrapped field split across paragraphs\`, \`preserves raw field nodes when an active field ends inside a tracked deletion wrapper\`, the \`moveFrom\` variant) still pass — destructive path is unchanged.

## Out of scope

- Other field types (REF, PAGE, SEQ, etc.) wrapped in inserts split across paragraphs would have analogous issues with different visible symptoms. Each needs its own preprocessor wiring; HYPERLINK is the highest-impact case (clickable link is a user-facing feature). Other field types can be added by extending \`applyConstructiveFieldInterpretation\` as fixtures surface them.
- Restructuring \`_processCombinedNodesForFldChar\` to emit valid paragraph-crossing structures for the non-tracked-change case is a separate refactor.