### PR TITLE
feat(demos/custom-ui): color pickers for tracked changes and comments

### DIFF
--- a/demos/custom-ui/src/App.tsx
+++ b/demos/custom-ui/src/App.tsx
@@ -57,7 +57,9 @@ function AppInner() {
               <Toolbar onComposeComment={openComposer} />
             </div>
             <div className="editor-shell">
-              <EditorMount />
+              <div className="editor-canvas">
+                <EditorMount />
+              </div>
             </div>
             <SelectionPopover onComposeComment={openComposer} />
             <ContextMenu />

--- a/demos/custom-ui/src/components/DisplaySettings.tsx
+++ b/demos/custom-ui/src/components/DisplaySettings.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Two color swatches that re-theme tracked changes and comment highlights
+ * by writing the public `--sd-*` CSS custom properties on `:root`. Stays
+ * consistent with the demo's "no UI kit" posture: native `<input
+ * type='color'>` hidden behind a styled label, written into `document
+ * .documentElement.style` so the variables cascade into the editor's
+ * shadow boundary the same way a consumer override would.
+ *
+ * The hex inputs are normalized to lowercase and combined with alpha
+ * suffixes (`22`, `40`, `66`) to match the shipped fade / active / focused
+ * variants in `variables.css`.
+ */
+
+const DEFAULTS = {
+  trackedChanges: '#00853d',
+  comments: '#b1124b',
+};
+
+export function DisplaySettings() {
+  const [trackedChanges, setTrackedChanges] = useState(DEFAULTS.trackedChanges);
+  const [comments, setComments] = useState(DEFAULTS.comments);
+
+  useEffect(() => {
+    const root = document.documentElement.style;
+    root.setProperty('--sd-track-insert-border', trackedChanges);
+    root.setProperty('--sd-track-insert-bg', `${trackedChanges}22`);
+    root.setProperty('--sd-tracked-changes-insert-background-focused', `${trackedChanges}44`);
+  }, [trackedChanges]);
+
+  useEffect(() => {
+    const root = document.documentElement.style;
+    root.setProperty('--sd-comments-highlight-external-base', comments);
+    root.setProperty('--sd-comment-highlight-external', `${comments}40`);
+    root.setProperty('--sd-comments-highlight-external-active', `${comments}66`);
+    root.setProperty('--sd-comments-highlight-external-faded', `${comments}20`);
+  }, [comments]);
+
+  return (
+    <>
+      <ColorSwatch
+        label="Tracked-change color"
+        value={trackedChanges}
+        onChange={setTrackedChanges}
+        icon={<TrackChangeIcon />}
+      />
+      <ColorSwatch
+        label="Comment color"
+        value={comments}
+        onChange={setComments}
+        icon={<CommentIcon />}
+      />
+    </>
+  );
+}
+
+function ColorSwatch({
+  label,
+  value,
+  onChange,
+  icon,
+}: {
+  label: string;
+  value: string;
+  onChange(next: string): void;
+  icon: React.ReactNode;
+}) {
+  return (
+    <label className="tb-btn color-swatch" title={label} style={{ backgroundColor: value }}>
+      <span className="color-swatch-icon" aria-hidden>
+        {icon}
+      </span>
+      <input
+        type="color"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={label}
+      />
+    </label>
+  );
+}
+
+const ICON_PROPS = {
+  width: 14,
+  height: 14,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 2.25,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+};
+
+function TrackChangeIcon() {
+  return (
+    <svg {...ICON_PROPS}>
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
+    </svg>
+  );
+}
+
+function CommentIcon() {
+  return (
+    <svg {...ICON_PROPS}>
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </svg>
+  );
+}

--- a/demos/custom-ui/src/components/Toolbar.tsx
+++ b/demos/custom-ui/src/components/Toolbar.tsx
@@ -7,6 +7,7 @@ import {
   useSuperDocDocument,
 } from 'superdoc/ui/react';
 import { InsertClauseButton } from './InsertClauseButton';
+import { DisplaySettings } from './DisplaySettings';
 
 interface ToolbarProps {
   /** Called when the user clicks the comment button to start composing. */
@@ -96,6 +97,10 @@ export function Toolbar({ onComposeComment }: ToolbarProps) {
 
       <div className="toolbar-group">
         <ModeToggle />
+      </div>
+
+      <div className="toolbar-group">
+        <DisplaySettings />
       </div>
 
       <div className="toolbar-group" style={{ marginLeft: 'auto' }}>

--- a/demos/custom-ui/src/styles.css
+++ b/demos/custom-ui/src/styles.css
@@ -80,6 +80,14 @@ button {
 .editor-area .editor-shell {
   flex: 1;
   overflow: auto;
+  display: flex;
+  justify-content: center;
+}
+
+.editor-canvas {
+  width: 100%;
+  max-width: 880px;
+  height: 100%;
 }
 
 .sidebar {
@@ -250,6 +258,44 @@ button {
 .tb-btn.export-btn:hover:not(:disabled) {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+/* Color swatch (DisplaySettings) — native <input type="color"> hidden
+   behind a styled label so the swatch matches `.tb-btn` sizing. */
+
+.color-swatch {
+  position: relative;
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid var(--border);
+}
+
+.color-swatch:hover {
+  border-color: var(--text-muted);
+}
+
+.color-swatch input[type='color'] {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.color-swatch-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  /* Difference flips against any picked color so the icon stays readable
+     across the full hue range without per-color contrast logic. */
+  color: #fff;
+  mix-blend-mode: difference;
 }
 
 /* Sidebar cards */


### PR DESCRIPTION
Adds two color swatches to the custom-ui demo toolbar that re-theme tracked changes and comment highlights by writing the public `--sd-*` CSS variables on `:root`, and centers the editor in its column with a max-width wrapper.

- Native `<input type="color">` hidden behind a `tb-btn` label keeps the no-UI-kit posture of the demo.
- Icons inside each swatch use `mix-blend-mode: difference` so they stay legible across any picked color.
- The editor sits inside an `.editor-canvas` wrapper (max-width 880px, margin auto) so the document is centered between the toolbar and the activity sidebar.