### PR TITLE
fix(mcp): rename wire fields to contract names before dispatch

### DIFF
--- a/apps/mcp/src/__tests__/intent-param-renames.test.ts
+++ b/apps/mcp/src/__tests__/intent-param-renames.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'bun:test';
+import { applyParamRenames } from '../tools/param-renames.js';
+
+describe('applyParamRenames', () => {
+  it('renames id → commentId for comments.delete', () => {
+    expect(applyParamRenames('comments.delete', { id: 'c1' })).toEqual({ commentId: 'c1' });
+  });
+
+  it('renames id → commentId for comments.get', () => {
+    expect(applyParamRenames('comments.get', { id: 'c1' })).toEqual({ commentId: 'c1' });
+  });
+
+  it('renames id → commentId for comments.patch and preserves other fields', () => {
+    expect(applyParamRenames('comments.patch', { id: 'c1', text: 'updated', isInternal: true })).toEqual({
+      commentId: 'c1',
+      text: 'updated',
+      isInternal: true,
+    });
+  });
+
+  it('renames parentId → parentCommentId for comments.create', () => {
+    expect(applyParamRenames('comments.create', { text: 'reply', parentId: 'c1' })).toEqual({
+      text: 'reply',
+      parentCommentId: 'c1',
+    });
+  });
+
+  it('renames id → nodeId for getNodeById', () => {
+    expect(applyParamRenames('getNodeById', { id: 'n1' })).toEqual({ nodeId: 'n1' });
+  });
+
+  it('passes through unchanged for operations with no renames', () => {
+    expect(applyParamRenames('comments.list', { limit: 10 })).toEqual({ limit: 10 });
+    expect(applyParamRenames('getText', {})).toEqual({});
+  });
+
+  it('does not strip non-renamed keys when a rename map exists', () => {
+    expect(applyParamRenames('comments.create', { text: 'top-level' })).toEqual({ text: 'top-level' });
+  });
+});

--- a/apps/mcp/src/tools/intent.ts
+++ b/apps/mcp/src/tools/intent.ts
@@ -122,6 +122,11 @@ function buildZodSchema(tool: CatalogTool): Record<string, z.ZodTypeAny> {
 function executeOperation(api: DocumentApi, operationId: string, input: Record<string, unknown>): unknown {
   // Generated dispatch uses 'doc.' prefix (e.g. 'doc.query.match'); strip it for DocumentApi.invoke()
   const opId = operationId.startsWith('doc.') ? operationId.slice(4) : operationId;
+  // AIDEV-NOTE: renames are applied on input only. The contract response uses
+  // canonical names (e.g. commentId), which is fine — agents can use either
+  // name on subsequent calls (canonical names pass through unchanged; short
+  // names are renamed here). Inverting on output would add complexity for no
+  // practical benefit.
   return api.invoke({ operationId: opId, input: applyParamRenames(opId, input) } as DynamicInvokeRequest);
 }
 

--- a/apps/mcp/src/tools/intent.ts
+++ b/apps/mcp/src/tools/intent.ts
@@ -122,11 +122,13 @@ function buildZodSchema(tool: CatalogTool): Record<string, z.ZodTypeAny> {
 function executeOperation(api: DocumentApi, operationId: string, input: Record<string, unknown>): unknown {
   // Generated dispatch uses 'doc.' prefix (e.g. 'doc.query.match'); strip it for DocumentApi.invoke()
   const opId = operationId.startsWith('doc.') ? operationId.slice(4) : operationId;
-  // AIDEV-NOTE: renames are applied on input only. The contract response uses
-  // canonical names (e.g. commentId), which is fine — agents can use either
-  // name on subsequent calls (canonical names pass through unchanged; short
-  // names are renamed here). Inverting on output would add complexity for no
-  // practical benefit.
+  // AIDEV-NOTE: renames are applied on input only — output is not inverted.
+  // This is incidental rather than deliberate: the fix only needed to address
+  // the input path. The asymmetry is harmless: the contract response uses
+  // canonical names (e.g. commentId), and agents can use either name on
+  // subsequent calls (canonical names pass through PARAM_RENAMES unchanged;
+  // short names are renamed here). A follow-up could invert on output for
+  // symmetry, but it is not load-bearing.
   return api.invoke({ operationId: opId, input: applyParamRenames(opId, input) } as DynamicInvokeRequest);
 }
 

--- a/apps/mcp/src/tools/intent.ts
+++ b/apps/mcp/src/tools/intent.ts
@@ -12,6 +12,7 @@ import type { SessionManager } from '../session-manager.js';
 import type { DocumentApi, DynamicInvokeRequest } from '@superdoc/document-api';
 import { MCP_TOOL_CATALOG } from '../generated/catalog.js';
 import { dispatchIntentTool } from '../generated/intent-dispatch.generated.js';
+import { applyParamRenames } from './param-renames.js';
 
 // ---------------------------------------------------------------------------
 // Types for the generated catalog
@@ -121,7 +122,7 @@ function buildZodSchema(tool: CatalogTool): Record<string, z.ZodTypeAny> {
 function executeOperation(api: DocumentApi, operationId: string, input: Record<string, unknown>): unknown {
   // Generated dispatch uses 'doc.' prefix (e.g. 'doc.query.match'); strip it for DocumentApi.invoke()
   const opId = operationId.startsWith('doc.') ? operationId.slice(4) : operationId;
-  return api.invoke({ operationId: opId, input } as DynamicInvokeRequest);
+  return api.invoke({ operationId: opId, input: applyParamRenames(opId, input) } as DynamicInvokeRequest);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mcp/src/tools/param-renames.ts
+++ b/apps/mcp/src/tools/param-renames.ts
@@ -11,9 +11,9 @@
  *
  * The CLI applies the inverse rename in extractInvokeInput()
  * (apps/cli/src/lib/invoke-input.ts PARAM_RENAMES). This module is the MCP
- * mirror — kept in lockstep by hand. Three operations are affected today
- * (comments.delete, comments.get, comments.patch, plus comments.create's
- * parentId and getNodeById's id), so duplication is small.
+ * mirror, kept in lockstep by hand. Five operations are affected today
+ * (comments.delete, comments.get, comments.patch, comments.create's
+ * parentId, and getNodeById's id), so duplication is small.
  *
  * Keys are bare operation IDs (no `doc.` prefix) to match the form
  * executeOperation passes to api.invoke().

--- a/apps/mcp/src/tools/param-renames.ts
+++ b/apps/mcp/src/tools/param-renames.ts
@@ -1,0 +1,37 @@
+/**
+ * Wire → contract field-name renames for intent tool dispatch.
+ *
+ * The MCP wire schema (apps/mcp/src/generated/catalog.ts) is generated from
+ * apps/cli/src/cli/operation-params.ts, where PARAM_FLAG_OVERRIDES rewrites
+ * a handful of contract field names to shorter CLI flag names (e.g.
+ * `commentId` → `id`, `parentCommentId` → `parentId`). The same renamed
+ * names end up in the MCP wire schema. Without an inverse translation at
+ * dispatch time, the contract validator rejects the input because it expects
+ * the canonical field names.
+ *
+ * The CLI applies the inverse rename in extractInvokeInput()
+ * (apps/cli/src/lib/invoke-input.ts PARAM_RENAMES). This module is the MCP
+ * mirror — kept in lockstep by hand. Three operations are affected today
+ * (comments.delete, comments.get, comments.patch, plus comments.create's
+ * parentId and getNodeById's id), so duplication is small.
+ *
+ * Keys are bare operation IDs (no `doc.` prefix) to match the form
+ * executeOperation passes to api.invoke().
+ */
+const PARAM_RENAMES: Record<string, Record<string, string>> = {
+  getNodeById: { id: 'nodeId' },
+  'comments.create': { parentId: 'parentCommentId' },
+  'comments.patch': { id: 'commentId' },
+  'comments.delete': { id: 'commentId' },
+  'comments.get': { id: 'commentId' },
+};
+
+export function applyParamRenames(opId: string, input: Record<string, unknown>): Record<string, unknown> {
+  const renames = PARAM_RENAMES[opId];
+  if (!renames) return input;
+  const renamed: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    renamed[renames[key] ?? key] = value;
+  }
+  return renamed;
+}


### PR DESCRIPTION
## Summary

The MCP wire schema (generated from `apps/cli` operation params) exposes the `PARAM_FLAG_OVERRIDES` renames `commentId` → `id` and `parentCommentId` → `parentId`. The contract validator on the receiving side still expects the canonical names, but the MCP dispatch path passes args through raw with no inverse rename — so `superdoc_comment` actions `delete` / `get` / `update` fail with `comments.<action> commentId must be a non-empty string` even when callers follow the documented schema.

The CLI handles this in `extractInvokeInput()` (`apps/cli/src/lib/invoke-input.ts` `PARAM_RENAMES`). This PR mirrors that translation for the MCP path: a small `applyParamRenames` helper in a standalone module, applied in `executeOperation` right before `api.invoke`.

## Repro (before this fix)

1. Open a doc with at least one comment via `superdoc_open`.
2. `superdoc_comment action:"list"` — returns comments with valid `id`s.
3. `superdoc_comment action:"delete" id:"<that-id>"` — fails with `comments.delete commentId must be a non-empty string.`

`action:"create"` and `action:"list"` are unaffected (they don't take a comment id).

## Affected operations

| Operation | Wire field | Contract field |
|---|---|---|
| `comments.create` | `parentId` | `parentCommentId` |
| `comments.patch` (update) | `id` | `commentId` |
| `comments.delete` | `id` | `commentId` |
| `comments.get` | `id` | `commentId` |
| `getNodeById` | `id` | `nodeId` |

## Changes

- New `apps/mcp/src/tools/param-renames.ts` — rename map + `applyParamRenames` helper. Mirrors the CLI's `PARAM_RENAMES`; comment in the file points to it.
- `apps/mcp/src/tools/intent.ts` — `executeOperation` now wraps `input` with `applyParamRenames(opId, input)` before `api.invoke`.
- New `apps/mcp/src/__tests__/intent-param-renames.test.ts` — 7 unit tests.

## Test plan

- [x] `bun test apps/mcp/src/__tests__/intent-param-renames.test.ts` — 7 pass / 0 fail.
- [x] `bun build apps/mcp/src/tools/param-renames.ts --target=node` — transpiles clean.
- [ ] CI to type-check the full MCP app.
- [ ] Manual end-to-end: `superdoc_comment action:"delete"` against a doc that round-trips through `list`.

## Notes

- The duplication between this module and the CLI's `PARAM_RENAMES` is intentional for now — the rename table is small (5 entries across 4 operations) and stable. A follow-up could promote it to a shared location, ideally driven by codegen so both the wire schema and the inverse map come from a single source.
- Alternative considered: change the wire schema to use the canonical contract names (`commentId`, `parentCommentId`, `nodeId`) directly. Cleaner but a breaking change for any caller relying on the current short names.