### PR TITLE
fix(doc-api): use textRanges[0] instead of highlightRange for comment anchoring

### DIFF
--- a/packages/document-api/src/contract/operation-definitions.ts
+++ b/packages/document-api/src/contract/operation-definitions.ts
@@ -395,7 +395,7 @@ export const INTENT_GROUP_META: Record<string, IntentGroupMeta> = {
     toolName: 'superdoc_comment',
     description:
       'Manage document comment threads: create, read, update, and delete. ' +
-      'To create a comment, first use superdoc_search to find the target text, then pass action "create" with the comment text and a target: {kind:"text", blockId:"<blockId>", range:{start:<N>, end:<N>}} using the blockId and highlightRange from the search result. ' +
+      'To create a comment, first use superdoc_search to find the target text, then pass action "create" with the comment text and a target built from the search result: use result.items[0].context.textRanges[0] directly as the target — it is already a complete {kind:"text", blockId, range:{start,end}} block-relative address. Do NOT use result.highlightRange — it is offset relative to the snippet preview (up to 30 chars off) and will mis-anchor the comment or trigger TARGET_NOT_FOUND. ' +
       'For threaded replies, pass "parentId" with the parent comment ID. ' +
       'Action "list" returns all comments with optional pagination (limit, offset) and filtering (includeResolved:true to include resolved). ' +
       'Action "get" retrieves a single comment by ID. Action "update" changes status to "resolved" or marks as internal. Action "delete" removes a comment or reply by ID. ' +


### PR DESCRIPTION
## Summary

The `superdoc_comment` tool description instructs LLMs to build `target.range` from `result.highlightRange`. But `highlightRange` is computed relative to the **snippet preview string**, not the block — it is offset by up to `SNIPPET_PADDING = 30` characters:

```ts
// super-editor/.../find/common.ts
const snippetFrom = Math.max(0, matchFrom - SNIPPET_PADDING);
highlightRange: { start: prefix.length, end: prefix.length + matchNormalized.length }
```

Following the description literally produces silently mis-anchored comments (off by ~30 chars) or `TARGET_NOT_FOUND` errors when the offset lands past the end of the block.

The correct field is `result.items[0].context.textRanges[0]` — a complete block-relative `TextAddress` (`{kind:"text", blockId, range:{start,end}}`) that can be passed directly as `target`. The document-api's own integration test (`overview-examples.test.ts:537`) already uses this pattern.

## Changes

- `packages/document-api/src/contract/operation-definitions.ts` — one-line description fix: replace the `highlightRange` instruction with `context.textRanges[0]` and add an explicit warning not to use `highlightRange`.

The generated `apps/mcp/src/generated/catalog.ts` and `mcp-prompt.ts` will pick up the corrected wording when `pnpm run generate:all` is run.

## Test plan

- [ ] `pnpm run generate:all` — catalog and prompt regenerate cleanly.
- [ ] Manual: `superdoc_search` → use `result.items[0].context.textRanges[0]` as `target` in `superdoc_comment action:"create"` — comment anchors correctly.
- [ ] Manual (regression): verify that using `highlightRange` still mis-anchors (so the fix is needed and the warning is accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)