### PR TITLE
fix(workflows): point homepage notify at stable orchestrator

### DIFF
--- a/.github/workflows/notify-homepage-superdoc-release.yml
+++ b/.github/workflows/notify-homepage-superdoc-release.yml
@@ -1,16 +1,24 @@
 # Fires repository_dispatch to superdoc-dev/homepage when a stable SuperDoc
 # release ships, so the homepage can auto-bump its superdoc dependency.
-# Same trigger and tag-diff pattern as promote-stable-docs.yml.
+#
+# Trigger matches promote-stable-docs.yml: stable superdoc releases now run
+# through the orchestrator (release-stable.yml), not release-superdoc.yml.
+# Accept both success and failure conclusions because the orchestrator runs
+# chains independently - a tools-chain failure that follows a successful
+# superdoc release should still notify. The npm verification is the source
+# of truth for whether the release actually shipped.
 name: 📨 Notify homepage of SuperDoc release
 
 on:
   workflow_run:
-    workflows: ["📦 Release superdoc"]
+    workflows: ["📦 Release stable tooling (CLI/SDK/MCP)"]
     types: [completed]
 
 jobs:
   notify:
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'stable'
+    if: |
+      github.event.workflow_run.head_branch == 'stable' &&
+      (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -41,11 +49,25 @@ jobs:
             | sort -V | tail -n1)
 
           if [ -z "$new_tag" ]; then
-            echo "No new stable v* tag — release-superdoc was a no-op."
+            echo "No new stable v* tag — orchestrator superdoc step was a no-op."
             exit 0
           fi
 
+          # Tag alone is not sufficient. @semantic-release/git pushes the v*
+          # tag during prepare, before publish-superdoc.cjs runs. If publish
+          # failed and recovery did not republish, the tag exists without
+          # corresponding npm tarballs. Verify both unscoped and scoped
+          # publishes match what promote-stable-docs.yml verifies.
           version="${new_tag#v}"
+          if ! npm view "superdoc@${version}" version >/dev/null 2>&1; then
+            echo "Tag ${new_tag} exists but superdoc@${version} is not on npm — orchestrator publish did not complete; not notifying homepage."
+            exit 0
+          fi
+          if ! npm view "@harbour-enterprises/superdoc@${version}" version >/dev/null 2>&1; then
+            echo "Tag ${new_tag} exists but @harbour-enterprises/superdoc@${version} is not on npm — orchestrator publish did not complete; not notifying homepage."
+            exit 0
+          fi
+
           echo "Dispatching superdoc@$version to superdoc-dev/homepage"
           gh api -X POST repos/superdoc-dev/homepage/dispatches \
             -f event_type=superdoc-stable-release \


### PR DESCRIPTION
Stable superdoc releases now ship via \`release-stable.yml\` (the orchestrator from #3204/#3221/#3222), so listening to \`📦 Release superdoc\` on \`workflow_run\` silently stopped firing for stable releases. The homepage auto-bump would just stop working.

Mirrors the trigger change already in place on \`promote-stable-docs.yml\`:

- workflow_run listens to the orchestrator (\`📦 Release stable tooling (CLI/SDK/MCP)\`).
- Accept conclusion \`failure\` too: a tools-chain failure that follows a successful superdoc release should still notify (chain-independent orchestrator semantics).
- Verify both \`superdoc\` and \`@harbour-enterprises/superdoc\` on npm before dispatching; \`@semantic-release/git\`'s prepare phase pushes the v* tag before publish runs, so a tag-without-publish failure would otherwise notify on an unpublished version.

Flagged by chatgpt-codex-connector in #3228.