### PR TITLE
fix(super-editor): recurse into nested marks in TOC sanitizer

### DIFF
--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/toc-wrappers.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/toc-wrappers.test.ts
@@ -25,6 +25,7 @@ vi.mock('./plan-wrappers.js', () => ({
 
 import {
   createTableOfContentsWrapper,
+  sanitizeTocContentForSchema,
   tocConfigureWrapper,
   tocListWrapper,
   tocRemoveWrapper,
@@ -442,5 +443,112 @@ describe('toc wrappers', () => {
         expect(result.failure.code).toBe('CAPABILITY_UNAVAILABLE');
       }
     });
+  });
+});
+
+describe('sanitizeTocContentForSchema', () => {
+  // buildTocEntryParagraphs wraps the page-number text inside a `run` node,
+  // so the `tocPageNumber` mark lives one level below the paragraph's direct
+  // children. The sanitizer exists to support headless/test schemas that
+  // omit `tocPageNumber`; if it doesn't recurse, the unknown mark survives
+  // and ProseMirror's nodeFromJSON throws when rebuilding the TOC entry.
+  function makeEditorWithoutTocMark(): Editor {
+    return {
+      state: { schema: { marks: {} } },
+      schema: { marks: {} },
+    } as unknown as Editor;
+  }
+
+  function makeEditorWithTocMark(): Editor {
+    return {
+      state: { schema: { marks: { tocPageNumber: {} } } },
+      schema: { marks: { tocPageNumber: {} } },
+    } as unknown as Editor;
+  }
+
+  it('strips tocPageNumber marks nested inside a run when the schema omits the mark', () => {
+    const paragraph = {
+      type: 'paragraph',
+      content: [
+        { type: 'run', content: [{ type: 'text', text: 'Heading 1' }] },
+        { type: 'run', content: [{ type: 'tab' }] },
+        {
+          type: 'run',
+          content: [{ type: 'text', text: '0', marks: [{ type: 'tocPageNumber' }] }],
+        },
+      ],
+    };
+
+    const [sanitized] = sanitizeTocContentForSchema(
+      [paragraph] as unknown as Parameters<typeof sanitizeTocContentForSchema>[0],
+      makeEditorWithoutTocMark(),
+    );
+
+    const sanitizedJson = sanitized as unknown as { content: Array<{ content: Array<{ marks?: unknown }> }> };
+    const pageNumberRun = sanitizedJson.content[2];
+    const pageNumberText = pageNumberRun.content[0];
+    expect(pageNumberText.marks).toBeUndefined();
+  });
+
+  it('leaves coexisting non-tocPageNumber marks intact when stripping', () => {
+    const paragraph = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'run',
+          content: [
+            {
+              type: 'text',
+              text: '0',
+              marks: [{ type: 'bold' }, { type: 'tocPageNumber' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const [sanitized] = sanitizeTocContentForSchema(
+      [paragraph] as unknown as Parameters<typeof sanitizeTocContentForSchema>[0],
+      makeEditorWithoutTocMark(),
+    );
+
+    const sanitizedJson = sanitized as unknown as {
+      content: Array<{ content: Array<{ marks?: Array<{ type: string }> }> }>;
+    };
+    expect(sanitizedJson.content[0].content[0].marks).toEqual([{ type: 'bold' }]);
+  });
+
+  it('returns content unchanged when the schema defines tocPageNumber', () => {
+    const paragraph = {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'run',
+          content: [{ type: 'text', text: '0', marks: [{ type: 'tocPageNumber' }] }],
+        },
+      ],
+    };
+
+    const result = sanitizeTocContentForSchema(
+      [paragraph] as unknown as Parameters<typeof sanitizeTocContentForSchema>[0],
+      makeEditorWithTocMark(),
+    );
+
+    // Same reference: no rewrite when the mark is supported.
+    expect(result[0]).toBe(paragraph);
+  });
+
+  it('returns paragraph unchanged when no tocPageNumber marks are present anywhere', () => {
+    const paragraph = {
+      type: 'paragraph',
+      content: [{ type: 'run', content: [{ type: 'text', text: 'Plain entry' }] }],
+    };
+
+    const [sanitized] = sanitizeTocContentForSchema(
+      [paragraph] as unknown as Parameters<typeof sanitizeTocContentForSchema>[0],
+      makeEditorWithoutTocMark(),
+    );
+
+    expect(sanitized).toBe(paragraph);
   });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/toc-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/toc-wrappers.ts
@@ -221,11 +221,53 @@ function withRightAlign(config: TocSwitchConfig, rightAlignPageNumbers: boolean 
 }
 
 /**
+ * Strips `tocPageNumber` marks anywhere in a node subtree. Returns the
+ * possibly-rewritten node and whether anything changed. Required because
+ * buildTocEntryParagraphs wraps the page-number text in a `run`, so the
+ * mark lives one level below the paragraph's direct children.
+ */
+function stripTocPageNumberFromNode<T>(node: T): { node: T; changed: boolean } {
+  if (!node || typeof node !== 'object') return { node, changed: false };
+
+  const typedNode = node as { marks?: Array<{ type?: string }>; content?: unknown[] };
+  let changed = false;
+  let next: typeof typedNode = typedNode;
+
+  if (Array.isArray(typedNode.marks)) {
+    const filtered = typedNode.marks.filter((mark) => mark?.type !== 'tocPageNumber');
+    if (filtered.length !== typedNode.marks.length) {
+      changed = true;
+      if (filtered.length === 0) {
+        const { marks: _removed, ...rest } = next;
+        next = rest as typeof typedNode;
+      } else {
+        next = { ...next, marks: filtered };
+      }
+    }
+  }
+
+  if (Array.isArray(typedNode.content)) {
+    let childChanged = false;
+    const nextChildren = typedNode.content.map((child) => {
+      const result = stripTocPageNumberFromNode(child);
+      if (result.changed) childChanged = true;
+      return result.node;
+    });
+    if (childChanged) {
+      changed = true;
+      next = { ...next, content: nextChildren };
+    }
+  }
+
+  return { node: next as unknown as T, changed };
+}
+
+/**
  * Removes tocPageNumber marks when the active schema doesn't define that mark.
  * Some headless/test schemas omit TOC-specific marks, and nodeFromJSON fails if
  * unknown marks are present in generated TOC paragraph content.
  */
-function sanitizeTocContentForSchema(content: EntryParagraphJson[], editor: Editor): EntryParagraphJson[] {
+export function sanitizeTocContentForSchema(content: EntryParagraphJson[], editor: Editor): EntryParagraphJson[] {
   if (editor.state.schema?.marks?.tocPageNumber) return content;
 
   return content.map((paragraph) => {
@@ -234,19 +276,9 @@ function sanitizeTocContentForSchema(content: EntryParagraphJson[], editor: Edit
 
     let changed = false;
     const sanitizedContent = paragraphContent.map((node) => {
-      if (!node || typeof node !== 'object') return node;
-      const typedNode = node as { marks?: Array<{ type?: string }> };
-      const marks = typedNode.marks;
-      if (!Array.isArray(marks)) return node;
-      const filteredMarks = marks.filter((mark) => mark?.type !== 'tocPageNumber');
-      if (filteredMarks.length === marks.length) return node;
-
-      changed = true;
-      if (filteredMarks.length === 0) {
-        const { marks: _removed, ...rest } = typedNode;
-        return rest as typeof node;
-      }
-      return { ...typedNode, marks: filteredMarks } as typeof node;
+      const result = stripTocPageNumberFromNode(node);
+      if (result.changed) changed = true;
+      return result.node;
     });
 
     return changed ? ({ ...paragraph, content: sanitizedContent } as EntryParagraphJson) : paragraph;


### PR DESCRIPTION
\`buildTocEntryParagraphs\` wraps the page-number text inside a \`run\`, so the \`tocPageNumber\` mark lives one level below the paragraph's direct children. \`sanitizeTocContentForSchema\` only filtered marks on direct children, so any schema that omits \`tocPageNumber\` (the exact case the sanitizer exists to support) would still receive the unknown nested mark and \`nodeFromJSON\` would fail when rebuilding the TOC.

Extracts per-node mark-stripping into a recursive helper that walks \`content\` arrays, so the sanitizer works regardless of how deep \`buildTocEntryParagraphs\` nests the run wrapper.

Flagged by chatgpt-codex-connector in #3228.

**Verified**: \`pnpm --filter @superdoc/super-editor exec vitest run src/editors/v1/document-api-adapters/plan-engine/toc-wrappers.test.ts\` → 9/9 pass. \`pnpm run type-check\` → clean.