### PR TITLE
fix: suppress top spacing after manual page breaks

### DIFF
--- a/packages/layout-engine/layout-engine/src/index.test.ts
+++ b/packages/layout-engine/layout-engine/src/index.test.ts
@@ -472,6 +472,37 @@ describe('layoutDocument', () => {
     expect(layout.pages.length).toBe(1);
   });
 
+  it('suppresses spacingBefore for a paragraph after an explicit page break', () => {
+    const introBlock: FlowBlock = {
+      kind: 'paragraph',
+      id: 'intro-on-page-one',
+      runs: [],
+    };
+    const pageBreak: FlowBlock = {
+      kind: 'pageBreak',
+      id: 'manual-page-break',
+    } as PageBreakBlock;
+    const headingBlock: FlowBlock = {
+      kind: 'paragraph',
+      id: 'heading-at-page-start',
+      runs: [],
+      attrs: {
+        spacing: { before: 24, after: 8 },
+      },
+    };
+
+    const layout = layoutDocument(
+      [introBlock, pageBreak, headingBlock],
+      [makeMeasure([20]), { kind: 'pageBreak' }, makeMeasure([20])],
+      DEFAULT_OPTIONS,
+    );
+
+    expect(layout.pages).toHaveLength(2);
+    expect(layout.pages[0].fragments).toHaveLength(1);
+    expect(layout.pages[1].fragments).toHaveLength(1);
+    expect(layout.pages[1].fragments[0].y).toBe(DEFAULT_OPTIONS.margins!.top);
+  });
+
   it('handles spacingBefore equal to content area height (boundary condition)', () => {
     // Edge case: spacingBefore exactly equals the content area height.
     // This triggers the infinite loop guard after advancing to a new page.
@@ -2258,7 +2289,7 @@ describe('layoutDocument', () => {
         { kind: 'paragraph', id: 'p1', runs: [] },
         { kind: 'sectionBreak', id: 'sb-next', type: 'nextPage', margins: {} } as SectionBreakBlock,
         { kind: 'pageBreak', id: 'pb-before-exhibit', attrs: { source: 'pageBreakBefore' } } as PageBreakBlock,
-        { kind: 'paragraph', id: 'p2', runs: [] },
+        { kind: 'paragraph', id: 'p2', runs: [], attrs: { spacing: { before: 24 } } },
       ];
 
       const measures: Measure[] = [
@@ -2273,6 +2304,120 @@ describe('layoutDocument', () => {
       expect(layout.pages).toHaveLength(2);
       expect(pageContainsBlock(layout.pages[1], 'p2')).toBe(true);
       expect(layout.pages[1].fragments).toHaveLength(1);
+      expect(layout.pages[1].fragments[0].y).toBe(pageBreakBoundaryOptions.margins!.top + 24);
+    });
+
+    it('preserves spacingBefore after pageBreakBefore', () => {
+      const blocks: FlowBlock[] = [
+        { kind: 'paragraph', id: 'p1', runs: [] },
+        { kind: 'pageBreak', id: 'pb-before-exhibit', attrs: { source: 'pageBreakBefore' } } as PageBreakBlock,
+        { kind: 'paragraph', id: 'p2', runs: [], attrs: { spacing: { before: 24 } } },
+      ];
+
+      const measures: Measure[] = [makeMeasure([40]), { kind: 'pageBreak' }, makeMeasure([40])];
+
+      const layout = layoutDocument(blocks, measures, pageBreakBoundaryOptions);
+
+      expect(layout.pages).toHaveLength(2);
+      expect(pageContainsBlock(layout.pages[1], 'p2')).toBe(true);
+      expect(layout.pages[1].fragments[0].y).toBe(pageBreakBoundaryOptions.margins!.top + 24);
+    });
+
+    it('suppresses spacingBefore after a manual page break when an anchored image precedes the paragraph', () => {
+      const anchoredImage: ImageBlock = {
+        kind: 'image',
+        id: 'anchored-image',
+        src: 'data:image/png;base64,xxx',
+        anchor: {
+          isAnchored: true,
+          hRelativeFrom: 'column',
+          vRelativeFrom: 'paragraph',
+          offsetH: 0,
+          offsetV: 0,
+        },
+        wrap: {
+          type: 'Square',
+          wrapText: 'right',
+        },
+        attrs: {
+          anchorParagraphId: 'p2',
+        },
+      };
+      const imageMeasure: ImageMeasure = {
+        kind: 'image',
+        width: 40,
+        height: 40,
+      };
+      const blocks: FlowBlock[] = [
+        { kind: 'paragraph', id: 'p1', runs: [] },
+        { kind: 'pageBreak', id: 'pb-manual', attrs: { lineBreakType: 'page' } } as PageBreakBlock,
+        anchoredImage,
+        { kind: 'paragraph', id: 'p2', runs: [], attrs: { spacing: { before: 24 } } },
+      ];
+
+      const measures: Measure[] = [makeMeasure([40]), { kind: 'pageBreak' }, imageMeasure, makeMeasure([40])];
+
+      const layout = layoutDocument(blocks, measures, pageBreakBoundaryOptions);
+      const para = layout.pages[1].fragments.find((fragment) => fragment.blockId === 'p2') as ParaFragment;
+
+      expect(para).toBeTruthy();
+      expect(para.y).toBe(pageBreakBoundaryOptions.margins!.top);
+    });
+
+    it('suppresses spacingBefore and wraps after a manual page break when a margin-relative anchored image precedes the paragraph', () => {
+      const anchoredImage: ImageBlock = {
+        kind: 'image',
+        id: 'margin-relative-anchored-image',
+        src: 'data:image/png;base64,xxx',
+        anchor: {
+          isAnchored: true,
+          hRelativeFrom: 'column',
+          vRelativeFrom: 'margin',
+          offsetH: 0,
+          offsetV: 0,
+        },
+        wrap: {
+          type: 'Square',
+          wrapText: 'right',
+        },
+        attrs: {
+          anchorParagraphId: 'p2',
+        },
+      };
+      const imageMeasure: ImageMeasure = {
+        kind: 'image',
+        width: 120,
+        height: 40,
+      };
+      const remeasureWidths: number[] = [];
+      const remeasureParagraph: NonNullable<LayoutOptions['remeasureParagraph']> = (_block, maxWidth) => {
+        remeasureWidths.push(maxWidth);
+        return makeMeasure([40]);
+      };
+      const blocks: FlowBlock[] = [
+        { kind: 'paragraph', id: 'p1', runs: [] },
+        { kind: 'pageBreak', id: 'pb-manual', attrs: { lineBreakType: 'page' } } as PageBreakBlock,
+        anchoredImage,
+        { kind: 'paragraph', id: 'p2', runs: [], attrs: { spacing: { before: 24 } } },
+      ];
+
+      const measures: Measure[] = [makeMeasure([40]), { kind: 'pageBreak' }, imageMeasure, makeMeasure([40])];
+
+      const layout = layoutDocument(blocks, measures, {
+        ...pageBreakBoundaryOptions,
+        remeasureParagraph,
+      });
+      const para = layout.pages[1].fragments.find((fragment) => fragment.blockId === 'p2') as ParaFragment;
+
+      expect(para).toBeTruthy();
+      expect(para.y).toBe(pageBreakBoundaryOptions.margins!.top);
+      expect(para.x).toBe(pageBreakBoundaryOptions.margins!.left + imageMeasure.width);
+      expect(remeasureWidths).toContain(
+        pageBreakBoundaryOptions.pageSize!.w -
+          pageBreakBoundaryOptions.margins!.left -
+          pageBreakBoundaryOptions.margins!.right -
+          imageMeasure.width,
+      );
     });
 
     it('still honors manual page breaks after a fresh page boundary', () => {

--- a/packages/layout-engine/layout-engine/src/index.ts
+++ b/packages/layout-engine/layout-engine/src/index.ts
@@ -36,7 +36,6 @@ import {
   scheduleSectionBreak as scheduleSectionBreakExport,
   type SectionState,
   applyPendingToActive,
-  SINGLE_COLUMN_DEFAULT,
 } from './section-breaks.js';
 import { layoutParagraphBlock } from './layout-paragraph.js';
 import { layoutImageBlock } from './layout-image.js';
@@ -632,6 +631,32 @@ const shouldSkipRedundantPageBreakBefore = (block: PageBreakBlock, state: PageSt
     Math.abs(state.cursorY - state.topMargin) <= PAGE_START_EPSILON;
 
   return isAtTopOfFreshPage;
+};
+
+const isManualPageBreak = (block: FlowBlock | undefined): block is PageBreakBlock => {
+  return block?.kind === 'pageBreak' && block.attrs?.source !== 'pageBreakBefore';
+};
+
+const hasManualPageBreakBeforeParagraph = (
+  blocks: FlowBlock[],
+  paragraphIndex: number,
+  anchorsForPara?: { block: ImageBlock | DrawingBlock }[],
+): boolean => {
+  if (isManualPageBreak(blocks[paragraphIndex - 1])) return true;
+
+  const anchorIds = new Set(anchorsForPara?.map((entry) => entry.block.id) ?? []);
+  for (let index = paragraphIndex - 1; index >= 0; index -= 1) {
+    const block = blocks[index];
+    if (
+      (block.kind === 'image' || block.kind === 'drawing') &&
+      (anchorIds.has(block.id) || (block.anchor?.isAnchored === true && isPageRelativeAnchor(block)))
+    ) {
+      continue;
+    }
+    return isManualPageBreak(block);
+  }
+
+  return false;
 };
 
 const hasOnlySectionBreakBlocks = (blocks: readonly FlowBlock[]): boolean => {
@@ -1718,7 +1743,10 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
 
   // Map to store pre-computed positions for page-relative anchors (for fragment creation later).
   // Page placement is resolved at encounter time so anchors follow pagination (e.g., after page breaks).
-  const preRegisteredPositions = new Map<string, { anchorX: number; anchorY: number }>();
+  const preRegisteredPositions = new Map<
+    string,
+    { anchorX: number; anchorY: number; columnIndex: number; pageNumber: number }
+  >();
 
   const resolveParagraphlessAnchoredTableY = (block: TableBlock, measure: TableMeasure, state: PageState): number => {
     const contentTop = state.topMargin;
@@ -1823,7 +1851,12 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
     floatManager.registerDrawing(entry.block, entry.measure, anchorY, state.columnIndex, state.page.number);
 
     // Store pre-computed position for later use when creating the fragment.
-    preRegisteredPositions.set(entry.block.id, { anchorX, anchorY });
+    preRegisteredPositions.set(entry.block.id, {
+      anchorX,
+      anchorY,
+      columnIndex: state.columnIndex,
+      pageNumber: state.page.number,
+    });
   }
 
   // Pre-compute keepNext chains for correct pagination grouping.
@@ -2365,6 +2398,7 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
           floatManager,
           remeasureParagraph: options.remeasureParagraph,
           overrideSpacingAfter,
+          suppressSpacingBeforeAtPageTop: hasManualPageBreakBeforeParagraph(blocks, index, anchorsForPara),
         },
         anchorsForPara
           ? {
@@ -2433,6 +2467,9 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
         const state = paginator.ensurePage();
         const imgBlock = block as ImageBlock;
         const imgMeasure = measure as ImageMeasure;
+        if (preRegPos.pageNumber !== state.page.number || preRegPos.columnIndex !== state.columnIndex) {
+          floatManager.registerDrawing(imgBlock, imgMeasure, preRegPos.anchorY, state.columnIndex, state.page.number);
+        }
 
         const pageContentHeight = Math.max(0, state.contentBottom - state.topMargin);
         const relativeFrom = imgBlock.anchor?.hRelativeFrom ?? 'column';
@@ -2505,6 +2542,9 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
         const state = paginator.ensurePage();
         const drawBlock = block as DrawingBlock;
         const drawMeasure = measure as DrawingMeasure;
+        if (preRegPos.pageNumber !== state.page.number || preRegPos.columnIndex !== state.columnIndex) {
+          floatManager.registerDrawing(drawBlock, drawMeasure, preRegPos.anchorY, state.columnIndex, state.page.number);
+        }
 
         const fragment: DrawingFragment = {
           kind: 'drawing',

--- a/packages/layout-engine/layout-engine/src/layout-paragraph.test.ts
+++ b/packages/layout-engine/layout-engine/src/layout-paragraph.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock } from 'bun:test';
-import type { ParagraphBlock, ParagraphMeasure, Line } from '@superdoc/contracts';
+import type { ImageBlock, ImageMeasure, ParagraphBlock, ParagraphMeasure, Line } from '@superdoc/contracts';
 import { layoutParagraphBlock, type ParagraphLayoutContext } from './layout-paragraph.js';
 import type { PageState } from './paginator.js';
 import type { FloatingObjectManager } from './floating-objects.js';
@@ -549,6 +549,133 @@ describe('layoutParagraphBlock - remeasurement with list markers', () => {
       layoutParagraphBlock(ctx);
 
       expect(remeasureParagraph).toHaveBeenCalledWith(block, 120, 24);
+    });
+
+    it('suppresses manual page-break top spacing before float remeasurement', () => {
+      const pageState = makePageState();
+      const ensurePage = mock(() => pageState);
+      const remeasureParagraph = mock((block, maxWidth, firstLineIndent) => {
+        if (maxWidth === 120) {
+          expect(firstLineIndent).toBe(0);
+        }
+        return makeMeasure([{ width: 100, lineHeight: 20, maxWidth }]);
+      });
+
+      const scannedLineYs: number[] = [];
+      const floatManager = makeFloatManager();
+      floatManager.computeAvailableWidth = mock((lineY, lineHeight, columnWidth) => {
+        scannedLineYs.push(lineY);
+        if (lineY === pageState.topMargin) {
+          return { width: 120, offsetX: 10 };
+        }
+        return { width: columnWidth, offsetX: 0 };
+      });
+
+      const block: ParagraphBlock = {
+        kind: 'paragraph',
+        id: 'test-block',
+        runs: [{ text: 'Test', fontFamily: 'Arial', fontSize: 12 }],
+        attrs: {
+          spacing: {
+            before: 30,
+          },
+        },
+      };
+
+      const measure = makeMeasure([{ width: 100, lineHeight: 20, maxWidth: 150 }]);
+
+      const ctx: ParagraphLayoutContext = {
+        block,
+        measure,
+        columnWidth: 150,
+        ensurePage,
+        advanceColumn: mock((state) => state),
+        columnX: mock(() => 50),
+        floatManager,
+        remeasureParagraph,
+        suppressSpacingBeforeAtPageTop: true,
+      };
+
+      layoutParagraphBlock(ctx);
+
+      expect(scannedLineYs[0]).toBe(pageState.topMargin);
+      expect(remeasureParagraph).toHaveBeenCalledWith(block, 120, 0);
+    });
+
+    it('keeps manual page-break top spacing suppressed when placing an anchored image first', () => {
+      const pageState = makePageState();
+      const ensurePage = mock(() => pageState);
+      const remeasureParagraph = mock((block, maxWidth, firstLineIndent) => {
+        if (maxWidth === 120) {
+          expect(firstLineIndent).toBe(0);
+        }
+        return makeMeasure([{ width: 100, lineHeight: 20, maxWidth }]);
+      });
+
+      const scannedLineYs: number[] = [];
+      const floatManager = makeFloatManager();
+      floatManager.computeAvailableWidth = mock((lineY, lineHeight, columnWidth) => {
+        scannedLineYs.push(lineY);
+        if (lineY === pageState.topMargin) {
+          return { width: 120, offsetX: 10 };
+        }
+        return { width: columnWidth, offsetX: 0 };
+      });
+
+      const block: ParagraphBlock = {
+        kind: 'paragraph',
+        id: 'test-block',
+        runs: [{ text: 'Test', fontFamily: 'Arial', fontSize: 12 }],
+        attrs: {
+          spacing: {
+            before: 30,
+          },
+        },
+      };
+      const anchoredImage: ImageBlock = {
+        kind: 'image',
+        id: 'anchored-image',
+        src: 'data:image/png;base64,xxx',
+        anchor: {
+          isAnchored: true,
+          hRelativeFrom: 'column',
+          vRelativeFrom: 'paragraph',
+          offsetH: 0,
+          offsetV: 0,
+        },
+        wrap: {
+          type: 'Square',
+          wrapText: 'right',
+        },
+      };
+      const imageMeasure: ImageMeasure = {
+        kind: 'image',
+        width: 40,
+        height: 40,
+      };
+
+      const ctx: ParagraphLayoutContext = {
+        block,
+        measure: makeMeasure([{ width: 100, lineHeight: 20, maxWidth: 150 }]),
+        columnWidth: 150,
+        ensurePage,
+        advanceColumn: mock((state) => state),
+        columnX: mock(() => 50),
+        floatManager,
+        remeasureParagraph,
+        suppressSpacingBeforeAtPageTop: true,
+      };
+
+      layoutParagraphBlock(ctx, {
+        anchoredDrawings: [{ block: anchoredImage, measure: imageMeasure }],
+        pageWidth: 300,
+        pageMargins: { top: 50, right: 50, bottom: 50, left: 50 },
+        columns: { width: 150, gap: 0, count: 1 },
+        placedAnchoredIds: new Set(),
+      });
+
+      expect(scannedLineYs[0]).toBe(pageState.topMargin);
+      expect(remeasureParagraph).toHaveBeenCalledWith(block, 120, 0);
     });
   });
 });

--- a/packages/layout-engine/layout-engine/src/layout-paragraph.ts
+++ b/packages/layout-engine/layout-engine/src/layout-paragraph.ts
@@ -9,6 +9,7 @@ import type {
   ImageMeasure,
   ImageFragment,
   ImageFragmentMetadata,
+  Fragment,
   DrawingBlock,
   DrawingMeasure,
   DrawingFragment,
@@ -29,6 +30,7 @@ import { getFragmentZIndex } from '@superdoc/contracts';
 const PX_PER_PT = 96 / 72;
 
 const spacingDebugEnabled = false;
+const PAGE_START_EPSILON = 0.0001;
 /**
  * Type definition for Word layout attributes attached to paragraph blocks.
  * This is a subset of the WordParagraphLayoutOutput from @superdoc/word-layout.
@@ -99,6 +101,18 @@ type ParagraphBlockAttrs = {
 
 const spacingDebugLog = (..._args: unknown[]): void => {
   if (!spacingDebugEnabled) return;
+};
+
+const hasFlowFragments = (fragments: Fragment[]): boolean => {
+  return fragments.some((fragment) => (fragment as { isAnchored?: boolean }).isAnchored !== true);
+};
+
+const isAtTopOfFreshPage = (state: PageState): boolean => {
+  return (
+    !hasFlowFragments(state.page.fragments) &&
+    state.columnIndex === 0 &&
+    Math.abs(state.cursorY - state.topMargin) <= PAGE_START_EPSILON
+  );
 };
 
 /**
@@ -293,6 +307,8 @@ export type ParagraphLayoutContext = {
    * When undefined, uses the value from block.attrs.spacing.after.
    */
   overrideSpacingAfter?: number;
+  /** Suppress spacing-before when this paragraph starts a fresh page after an explicit page break. */
+  suppressSpacingBeforeAtPageTop?: boolean;
 };
 
 export type AnchoredDrawingEntry = {
@@ -314,6 +330,8 @@ export function layoutParagraphBlock(ctx: ParagraphLayoutContext, anchors?: Para
 
   const blockAttrs = getParagraphAttrs(block);
   const frame = blockAttrs?.frame;
+  const suppressSpacingBeforeAtPageTop =
+    ctx.suppressSpacingBeforeAtPageTop === true && isAtTopOfFreshPage(ensurePage());
 
   if (anchors?.anchoredDrawings?.length) {
     for (const entry of anchors.anchoredDrawings) {
@@ -513,6 +531,9 @@ export function layoutParagraphBlock(ctx: ParagraphLayoutContext, anchors?: Para
     if (!spacingExplicit.before) spacingBefore = 0;
     if (!spacingExplicit.after) spacingAfter = 0;
   }
+  if (suppressSpacingBeforeAtPageTop) {
+    spacingBefore = 0;
+  }
   /** Original spacing before value, preserved for blank page calculations where no trailing collapse occurs. */
   const baseSpacingBefore = spacingBefore;
   let appliedSpacingBefore = spacingBefore === 0;
@@ -687,7 +708,6 @@ export function layoutParagraphBlock(ctx: ParagraphLayoutContext, anchors?: Para
         state.trailingSpacing = 0;
       }
     }
-
     /**
      * Keep Lines Together (OOXML w:keepLines)
      *

--- a/packages/layout-engine/pm-adapter/src/converters/paragraph.test.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/paragraph.test.ts
@@ -2668,7 +2668,8 @@ describe('paragraph converters', () => {
 
         const blocks = paragraphToFlowBlocks(para, nextBlockId, positions, 'Arial', 16);
 
-        expect(blocks.some((b) => b.kind === 'columnBreak')).toBe(true);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toMatchObject({ kind: 'columnBreak' });
       });
 
       it('should ignore lineBreak without column break type', () => {
@@ -3098,9 +3099,7 @@ describe('paragraph converters', () => {
     });
 
     describe('Edge cases', () => {
-      it('should create empty paragraph when all content is block nodes', () => {
-        // hardBreak without pageBreakType defaults to line break (inline)
-        // so we use pageBreakType: 'page' to make it a block node
+      it('does not create an empty paragraph when content is only a page break', () => {
         const para: PMNode = {
           type: 'paragraph',
           content: [{ type: 'hardBreak', attrs: { pageBreakType: 'page' } }],
@@ -3108,10 +3107,8 @@ describe('paragraph converters', () => {
 
         const blocks = paragraphToFlowBlocks(para, nextBlockId, positions, 'Arial', 16);
 
-        expect(blocks.some((b) => b.kind === 'paragraph')).toBe(true);
-        const paraBlock = blocks.find((b) => b.kind === 'paragraph') as ParagraphBlock;
-        expect(paraBlock.runs).toHaveLength(1);
-        expect(paraBlock.runs[0].text).toBe('');
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toMatchObject({ kind: 'pageBreak' });
       });
 
       it('should handle mixed inline and block content', () => {

--- a/packages/layout-engine/pm-adapter/src/converters/paragraph.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/paragraph.ts
@@ -853,7 +853,9 @@ export function paragraphToFlowBlocks({
   flushParagraph();
 
   const hasParagraphBlock = blocks.some((block) => block.kind === 'paragraph');
-  if (!hasParagraphBlock && !suppressedByVanish && !paragraphProps.runProperties?.vanish) {
+  const hasOnlyBreakBlocks =
+    blocks.length > 0 && blocks.every((block) => block.kind === 'pageBreak' || block.kind === 'columnBreak');
+  if (!hasParagraphBlock && !hasOnlyBreakBlocks && !suppressedByVanish && !paragraphProps.runProperties?.vanish) {
     blocks.push({
       kind: 'paragraph',
       id: baseBlockId,

--- a/packages/layout-engine/pm-adapter/src/index.test.ts
+++ b/packages/layout-engine/pm-adapter/src/index.test.ts
@@ -3404,6 +3404,39 @@ describe('toFlowBlocks', () => {
 
       const pageBreakBlocks = blocks.filter((b) => b.kind === 'pageBreak');
       expect(pageBreakBlocks).toHaveLength(1);
+      expect(blocks.filter((b) => b.kind === 'paragraph' && b.runs.length === 1 && b.runs[0].text === '')).toHaveLength(
+        1,
+      );
+      expect(blocks.findIndex((b) => b.kind === 'pageBreak')).toBeLessThan(
+        blocks.findIndex((b) => b.kind === 'paragraph' && b.runs[0].text === 'Page 2'),
+      );
+    });
+
+    it('does not synthesize an empty paragraph for a page-break-only paragraph', () => {
+      const pmDoc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Page 1' }],
+          },
+          {
+            type: 'paragraph',
+            content: [{ type: 'hardBreak', attrs: { pageBreakType: 'page' } }],
+          },
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Page 2' }],
+          },
+        ],
+      };
+
+      const { blocks } = toFlowBlocks(pmDoc);
+
+      expect(blocks.filter((b) => b.kind === 'pageBreak')).toHaveLength(1);
+      expect(blocks.filter((b) => b.kind === 'paragraph')).toHaveLength(2);
+      expect(blocks.findIndex((b) => b.kind === 'pageBreak')).toBe(1);
+      expect((blocks[2] as ParagraphBlock).runs[0].text).toBe('Page 2');
     });
 
     it('handles hardBreak with marks and formatting', () => {


### PR DESCRIPTION
## Summary

Fixes a DOCX layout fidelity issue where the first paragraph after an explicit manual page break could render lower than it does in Word.

In the attached `DC_Template_Descricao_Cargo.docx` fixture, the heading `01 MISSAO DO CARGO` starts at the top of page 2 in Word, but SuperDoc rendered an extra vertical gap above it.

## Root Cause

The issue was a combination of PM-to-layout conversion and page-top paragraph layout behavior:

1. A paragraph containing only an explicit break, such as `w:br w:type="page"`, was converted into both a `pageBreak` block and a synthetic empty paragraph block.
2. The first real paragraph after that manual page break still applied its `spacingBefore`, even though Word suppresses that spacing when the paragraph starts at the top of the new page.
3. The spacing suppression needed to happen before float remeasurement. Otherwise, anchored objects could be measured against the wrong Y position.
4. Anchored images/drawings between the manual page break and the paragraph needed to be treated as non-flow content for this page-top decision.

## Fix

This PR keeps the fix scoped to the layout pipeline:

- `pm-adapter`: Do not synthesize an empty paragraph when a paragraph contributes only explicit break blocks.
- `layout-engine`: Suppress `spacingBefore` only when a paragraph starts a fresh page after an explicit manual `pageBreak`.
- Preserve `pageBreakBefore` behavior so paragraph-level page-break formatting still keeps its own spacing.
- Compute the page-top suppression decision before placing paragraph-anchored images/drawings and before float remeasurement.
- Treat anchored fragments as non-flow content when checking whether a page is still at the top of its body flow.
- Re-register page/margin-relative pre-registered anchors on their actual pagination page when encountered later, so following paragraphs wrap against the correct page's float exclusions.

## Tests

Added or updated coverage for:

- page-break-only paragraphs emitting only a `pageBreak`
- mixed paragraph content around page breaks still producing paragraph blocks
- top-of-page spacing suppression after explicit manual page breaks
- preserving `spacingBefore` for `pageBreakBefore`
- float remeasurement using the suppressed page-top Y
- paragraph-relative anchored images before the first paragraph after a manual page break
- margin-relative pre-registered anchored images before the first paragraph after a manual page break, including wrapping/re-measurement on the actual page

## Local Validation

Passed:

```bash
pnpm --dir packages/layout-engine/layout-engine test -- index.test.ts layout-paragraph.test.ts
pnpm --dir packages/layout-engine/pm-adapter test -- src/converters/paragraph.test.ts src/index.test.ts
pnpm run test:superdoc
pnpm run lint
```

Notes:

- `pnpm run lint` completed with `0 errors` and existing warnings.
- `pnpm run test:editor` completed `1007/1008` files and timed out in an unrelated encrypted document lifecycle test. Re-running that exact test in isolation with a longer timeout passed:

```bash
pnpm --prefix packages/super-editor exec vitest run src/editors/v1/core/Editor.lifecycle.test.ts --testNamePattern "should open an encrypted file with the correct password" --testTimeout 120000
```

## Fixture

[DC_Template_Descricao_Cargo.docx](https://github.com/user-attachments/files/27622449/DC_Template_Descricao_Cargo.docx)
