### PR TITLE
fix(document-api): align position readback with write-side offset model (SD-3109)

### DIFF
--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/bookmark-resolver.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/bookmark-resolver.ts
@@ -17,6 +17,7 @@ import { DocumentApiAdapterError } from '../errors.js';
 import { BODY_STORY_KEY, buildStoryKey } from '../story-runtime/story-key.js';
 import { resolveLiveStorySessionRuntime } from '../story-runtime/live-story-session-runtime-registry.js';
 import { enumerateEffectiveNoteEntries } from './note-entry-lookup.js';
+import { pmPositionToTextOffset } from './text-offset-resolver.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -371,7 +372,12 @@ function nodePositionToPosition(doc: ProseMirrorNode, pos: number): Position {
     const node = resolved.node(depth);
     const blockId = node.attrs?.sdBlockId as string | undefined;
     if (blockId) {
-      return { blockId, offset: pos - resolved.start(depth) };
+      // AIDEV-NOTE: Read-side offsets must match the write-side model
+      // owned by `pmPositionToTextOffset` (text-offset-resolver.ts).
+      // Raw PM arithmetic (`pos - resolved.start(depth)`) counts run
+      // and other inline wrapper tokens that the flattened model skips.
+      const blockPos = resolved.start(depth) - 1;
+      return { blockId, offset: pmPositionToTextOffset(node, blockPos, pos) };
     }
   }
   return { blockId: '', offset: pos };

--- a/packages/super-editor/src/editors/v1/document-api-adapters/permission-ranges-adapter.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/permission-ranges-adapter.ts
@@ -21,6 +21,7 @@ import { rejectTrackedMode } from './helpers/mutation-helpers.js';
 import { getRevision } from './plan-engine/revision-tracker.js';
 import { paginate } from './helpers/adapter-utils.js';
 import { resolveSelectionTarget } from './helpers/selection-target-resolver.js';
+import { pmPositionToTextOffset } from './helpers/text-offset-resolver.js';
 import { PERMISSION_MUTATION_META } from '../extensions/permission-ranges/permission-ranges.js';
 
 // ---------------------------------------------------------------------------
@@ -51,7 +52,12 @@ function pmPosToPosition(doc: ProseMirrorNode, pos: number): Position {
     const node = resolved.node(depth);
     const blockId = node.attrs?.sdBlockId as string | undefined;
     if (blockId) {
-      return { blockId, offset: pos - resolved.start(depth) };
+      // AIDEV-NOTE: Read-side offsets must match the write-side model
+      // owned by `pmPositionToTextOffset` (text-offset-resolver.ts).
+      // Raw PM arithmetic (`pos - resolved.start(depth)`) counts run
+      // and other inline wrapper tokens that the flattened model skips.
+      const blockPos = resolved.start(depth) - 1;
+      return { blockId, offset: pmPositionToTextOffset(node, blockPos, pos) };
     }
   }
   return { blockId: '', offset: pos };

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/bookmark-readback-position.regression.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/bookmark-readback-position.regression.test.ts
@@ -1,0 +1,84 @@
+/* @vitest-environment jsdom */
+
+/**
+ * Regression coverage for `editor.doc.bookmarks.list()` Position
+ * readback offsets.
+ *
+ * Locks in the round-trip invariant: bookmarks written at flattened
+ * text offsets must read back at the same offsets. The write side
+ * (`bookmarks.insert`) takes a `TextTarget` with `range.start`/`end`
+ * in the flattened text-offset model; the read side must return the
+ * same model.
+ *
+ * Originated from SD-3109, where readback used raw PM arithmetic and
+ * drifted by the number of inline wrapper tokens (`run` etc.) in the
+ * targeted block.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { initTestEditor, loadTestDataForEditorTests } from '@tests/helpers/helpers.js';
+
+const HOST = 'The court ruled in Alpha Corp v. SEC today.';
+const PHRASE = 'Alpha Corp v. SEC';
+
+function resolveBlockId(receipt: unknown): string | null {
+  if (!receipt || typeof receipt !== 'object') return null;
+  const v = receipt as {
+    target?: { blockId?: unknown };
+    resolution?: { target?: { blockId?: unknown } };
+  };
+  if (typeof v.target?.blockId === 'string' && v.target.blockId) return v.target.blockId;
+  if (typeof v.resolution?.target?.blockId === 'string' && v.resolution.target.blockId) {
+    return v.resolution.target.blockId;
+  }
+  return null;
+}
+
+describe('bookmark readback position (regression — SD-3109)', () => {
+  it('returns offsets that round-trip to the write-side offset model', async () => {
+    const docData = await loadTestDataForEditorTests('blank-doc.docx');
+    const { editor } = initTestEditor({
+      content: docData.docx,
+      media: docData.media,
+      mediaFiles: docData.mediaFiles,
+      fonts: docData.fonts,
+      useImmediateSetTimeout: false,
+      isHeadless: true,
+      user: { name: 'Test', email: 'test@example.com' },
+    });
+
+    const seed = await Promise.resolve(editor.doc.insert({ value: HOST }));
+    const blockId = resolveBlockId(seed);
+    expect(blockId).toBeTruthy();
+    if (!blockId) return;
+
+    const phraseStart = HOST.indexOf(PHRASE);
+    const phraseEnd = phraseStart + PHRASE.length;
+
+    // Write the bookmark at the flattened text offsets we expect.
+    const insertResult = await Promise.resolve(
+      editor.doc.bookmarks.insert({
+        name: 'sd3109_marker',
+        at: {
+          kind: 'text',
+          segments: [{ blockId, range: { start: phraseStart, end: phraseEnd } }],
+        },
+      }),
+    );
+    expect((insertResult as { success?: boolean }).success ?? true).not.toBe(false);
+
+    // Read the bookmark back.
+    const list = editor.doc.bookmarks.list();
+    const recovered = list.items.find((b: { name: string }) => b.name === 'sd3109_marker') as
+      | { range: { from: { blockId: string; offset: number }; to: { blockId: string; offset: number } } }
+      | undefined;
+    expect(recovered).toBeTruthy();
+    if (!recovered) return;
+
+    // Round-trip invariant: readback offsets equal the offsets written.
+    expect(recovered.range.from.offset, 'from.offset').toBe(phraseStart);
+    expect(recovered.range.to.offset, 'to.offset').toBe(phraseEnd);
+
+    editor.destroy();
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.regression.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.regression.test.ts
@@ -1,0 +1,155 @@
+/* @vitest-environment jsdom */
+
+/**
+ * Regression coverage for `editor.doc.create.contentControl({ at })`
+ * wrapping by explicit text offsets.
+ *
+ * Locks in two behaviors:
+ *   1. A single wrap targets the exact offsets passed in.
+ *   2. Multiple wraps inserted in reverse position order (the pattern
+ *      AI-driven citation tooling uses to anchor several phrases in one
+ *      paragraph) each land on the correct phrase.
+ *
+ * Originated from SD-3108, which reported an off-by-one shift on the
+ * harvey-anchor-experiment branch. The bug did not reproduce on main;
+ * these tests stay to guard against a regression.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { initTestEditor, loadTestDataForEditorTests } from '@tests/helpers/helpers.js';
+
+const HOST = 'The court ruled in Alpha Corp v. SEC today.';
+const PHRASE = 'Alpha Corp v. SEC';
+
+function resolveBlockId(receipt: unknown): string | null {
+  if (!receipt || typeof receipt !== 'object') return null;
+  const v = receipt as {
+    target?: { blockId?: unknown };
+    resolution?: { target?: { blockId?: unknown } };
+  };
+  if (typeof v.target?.blockId === 'string' && v.target.blockId) return v.target.blockId;
+  if (typeof v.resolution?.target?.blockId === 'string' && v.resolution.target.blockId) {
+    return v.resolution.target.blockId;
+  }
+  return null;
+}
+
+describe('content control wrap by text offset (regression)', () => {
+  it('wraps exactly the phrase indicated by the start/end offsets', async () => {
+    const docData = await loadTestDataForEditorTests('blank-doc.docx');
+    const { editor } = initTestEditor({
+      content: docData.docx,
+      media: docData.media,
+      mediaFiles: docData.mediaFiles,
+      fonts: docData.fonts,
+      useImmediateSetTimeout: false,
+      isHeadless: true,
+      user: { name: 'Test', email: 'test@example.com' },
+    });
+
+    const seed = await Promise.resolve(editor.doc.insert({ value: HOST }));
+    const blockId = resolveBlockId(seed);
+    expect(blockId).toBeTruthy();
+    if (!blockId) return;
+
+    const start = HOST.indexOf(PHRASE);
+    const end = start + PHRASE.length;
+    expect(HOST.slice(start, end)).toBe(PHRASE);
+
+    const result = await Promise.resolve(
+      editor.doc.create.contentControl({
+        kind: 'inline',
+        controlType: 'text',
+        at: {
+          kind: 'selection',
+          start: { kind: 'text', blockId, offset: start },
+          end: { kind: 'text', blockId, offset: end },
+        },
+        tag: '_sd_test_wrap',
+        alias: 'Test wrap',
+      }),
+    );
+    expect(result.success).toBe(true);
+
+    // Inspect what the SDT actually wraps. Walk the PM tree for the SDT
+    // with our tag and read its text content.
+    let wrappedText: string | null = null;
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'structuredContent' && node.attrs?.tag === '_sd_test_wrap') {
+        wrappedText = node.textContent;
+        return false;
+      }
+      return true;
+    });
+
+    expect(wrappedText).toBe(PHRASE);
+
+    editor.destroy();
+  });
+
+  it('wraps the correct text when multiple SDTs are inserted into the same paragraph', async () => {
+    // Mirrors the Harvey demo: three citations in one paragraph, wrapped
+    // in reverse position order (so earlier offsets stay valid as wraps
+    // accumulate). Each wrap should land on its phrase exactly.
+    const HOST_MULTI =
+      'The court in Alpha Corp v. SEC established the standard for ' +
+      'disclosure obligations. Our standard indemnification clause governs ' +
+      'allocation of risks.';
+    const PHRASES = ['Alpha Corp v. SEC', 'standard indemnification clause'];
+
+    const docData = await loadTestDataForEditorTests('blank-doc.docx');
+    const { editor } = initTestEditor({
+      content: docData.docx,
+      media: docData.media,
+      mediaFiles: docData.mediaFiles,
+      fonts: docData.fonts,
+      useImmediateSetTimeout: false,
+      isHeadless: true,
+      user: { name: 'Test', email: 'test@example.com' },
+    });
+
+    const seed = await Promise.resolve(editor.doc.insert({ value: HOST_MULTI }));
+    const blockId = resolveBlockId(seed);
+    expect(blockId).toBeTruthy();
+    if (!blockId) return;
+
+    const insertionOrder = PHRASES.map((phrase, i) => ({
+      phrase,
+      tag: `_sd_multi_${i}`,
+      start: HOST_MULTI.indexOf(phrase),
+      end: HOST_MULTI.indexOf(phrase) + phrase.length,
+    })).sort((a, b) => b.start - a.start);
+
+    for (const { phrase, tag, start, end } of insertionOrder) {
+      const result = await Promise.resolve(
+        editor.doc.create.contentControl({
+          kind: 'inline',
+          controlType: 'text',
+          at: {
+            kind: 'selection',
+            start: { kind: 'text', blockId, offset: start },
+            end: { kind: 'text', blockId, offset: end },
+          },
+          tag,
+          alias: 'Test multi wrap',
+        }),
+      );
+      expect(result.success, `wrap for "${phrase}"`).toBe(true);
+    }
+
+    const wrappedTexts = new Map<string, string>();
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'structuredContent' && typeof node.attrs?.tag === 'string') {
+        const tag = node.attrs.tag as string;
+        if (tag.startsWith('_sd_multi_')) wrappedTexts.set(tag, node.textContent);
+      }
+      return true;
+    });
+
+    for (const { phrase, tag } of insertionOrder) {
+      expect(wrappedTexts.get(tag), `tag ${tag} should wrap "${phrase}"`).toBe(phrase);
+    }
+
+    editor.destroy();
+  });
+});


### PR DESCRIPTION
Position readback (`bookmarks.list`, and a sibling helper in the permission-ranges adapter) was using raw PM arithmetic — `pos - resolved.start(depth)` — which counts the inline wrapper boundary tokens (`run`, etc.) that the write side's flattened text-offset model intentionally skips. So a bookmark inserted at flattened offset 19 read back at offset 22 in a doc with `run`-wrapped text. Fix routes the read path through `pmPositionToTextOffset` so write and read share one offset model.

- Two regression tests, both integration-shaped: the SD-3109 one writes a bookmark via the public API and asserts the readback round-trips; the SD-3108 one is a guardrail set for content-control wrap by text offset (SD-3108 did not reproduce on main, so the tests stay as guardrails rather than a fix).
- Verified at three layers: vitest (full document-api-adapters suite, 3373/3373), unit (24 bookmark-resolver tests, 33 bookmark-wrappers tests), and the dev app + Chrome DevTools (round-trip works for both a freshly-inserted block and a paragraph 410 chars deep in the Memorandum fixture).
- The duplicated readback helper in `permission-ranges-adapter.ts` is a separate cleanup target — sharing one implementation between the two adapters would obsolete the cross-reference comment naturally. Leaving that for a later pass to keep this PR scoped to the readback fix.

**Review**: confirm the AIDEV-NOTE wording is the right anchor — it has to survive future "simplify" passes that might revert to the naive arithmetic.