### PR TITLE
SD-3092 - fix: toolbar serialization for stable rendering

### DIFF
--- a/packages/template-builder/src/index.tsx
+++ b/packages/template-builder/src/index.tsx
@@ -103,7 +103,10 @@ const SuperDocTemplateBuilder = forwardRef<Types.SuperDocTemplateBuilderHandle, 
     const trigger = menu.trigger || '{{';
 
     const availableFields = fieldsRef.current.available || [];
-    const toolbarSettings = useMemo(() => resolveToolbar(toolbar), [toolbar]);
+    // Serialize so structurally-equal toolbar objects compare as equal across
+    // renders — otherwise a fresh inline `toolbar={{...}}` literal would
+    // recreate the SuperDoc instance every parent render.
+    const toolbarSettings = useMemo(() => resolveToolbar(toolbar), [JSON.stringify(toolbar)]);
     const stableTelemetry = useMemo(
       () => ({
         enabled: telemetry?.enabled ?? true,


### PR DESCRIPTION
### Issue

Passing an inline object to the `toolbar` prop caused `SuperDocTemplateBuilder` to rebuild SuperDoc on every parent re-render, looping infinitely. The reason for that is that `useMemo` compared the object dep by reference (`Object.is`), so every time the parent re-renders, this would look like the `toolbar` also changed.

### Proposed solution

Use `JSON.stringify(toolbar)` as the dep (same pattern as `stableTelemetry` in the same file).
