### PR TITLE
fix(converter): preserve CommentReference rStyle on comment anchor runs (SD-2910)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/commentRange/comment-range-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/commentRange/comment-range-translator.js
@@ -51,9 +51,16 @@ const decode = (params) => {
   let commentSchema = getCommentSchema(type, commentIndex);
 
   if (type === 'commentRangeEnd') {
+    // SD-2910: Word marks comment-anchor runs with w:rStyle="CommentReference" so the
+    // marker renders with the expected appearance. The importer drops the source w:rPr
+    // (commentReference is consumed by the comments-list import), so we synthesize the
+    // canonical rStyle here on every round-trip.
     const commentReference = {
       name: 'w:r',
-      elements: [{ name: 'w:commentReference', attributes: { 'w:id': String(commentIndex) } }],
+      elements: [
+        { name: 'w:rPr', elements: [{ name: 'w:rStyle', attributes: { 'w:val': 'CommentReference' } }] },
+        { name: 'w:commentReference', attributes: { 'w:id': String(commentIndex) } },
+      ],
     };
     commentSchema = [commentSchema, commentReference];
   }

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/commentRange/comment-range-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/commentRange/comment-range-translator.test.js
@@ -100,7 +100,7 @@ describe('w:commentRangeStart and w:commentRangeEnd', () => {
   });
 
   describe('decode:commentRangeEndTranslator', () => {
-    test('returns comment schema', () => {
+    test('returns comment schema with CommentReference rStyle on the synthesized anchor run (SD-2910)', () => {
       expect(
         commentRangeEndTranslator.decode({
           node: { type: 'commentRangeEnd', attrs: { 'w:id': 'id1' } },
@@ -111,15 +111,14 @@ describe('w:commentRangeStart and w:commentRangeEnd', () => {
       ).toStrictEqual([
         { attributes: { 'w:id': '0' }, name: 'w:commentRangeEnd' },
         {
+          name: 'w:r',
           elements: [
             {
-              attributes: {
-                'w:id': '0',
-              },
-              name: 'w:commentReference',
+              name: 'w:rPr',
+              elements: [{ name: 'w:rStyle', attributes: { 'w:val': 'CommentReference' } }],
             },
+            { name: 'w:commentReference', attributes: { 'w:id': '0' } },
           ],
-          name: 'w:r',
         },
       ]);
     });
@@ -180,12 +179,19 @@ describe('w:commentRangeStart and w:commentRangeEnd', () => {
         commentsExportType: 'external',
       });
 
-      // Should return bare comment markers, not wrapped in w:del
+      // Should return bare comment markers, not wrapped in w:del.
+      // The synthesized anchor run must carry the CommentReference rStyle (SD-2910).
       expect(result).toStrictEqual([
         { name: 'w:commentRangeEnd', attributes: { 'w:id': '0' } },
         {
           name: 'w:r',
-          elements: [{ name: 'w:commentReference', attributes: { 'w:id': '0' } }],
+          elements: [
+            {
+              name: 'w:rPr',
+              elements: [{ name: 'w:rStyle', attributes: { 'w:val': 'CommentReference' } }],
+            },
+            { name: 'w:commentReference', attributes: { 'w:id': '0' } },
+          ],
         },
       ]);
     });


### PR DESCRIPTION
## Summary

- The exporter synthesized a fresh `<w:r>` for the inline `<w:commentReference/>` marker after each `commentRangeEnd` but emitted no `w:rPr`, dropping Word's `<w:rStyle w:val="CommentReference"/>` on round-trip (11 → 0 on the customer fixture).
- The importer cannot carry the source `w:rPr` through (the `commentReference` element is consumed by comments-list import), so we synthesize the canonical rStyle on export.
- Touched files: `comment-range-translator.{js,test.js}`. +22 / −9.

## Linear

- [SD-2910](https://linear.app/superdocworkspace/issue/SD-2910) — Athenaintelligence (Enterprise tier)
- SLA breached 2026-05-08; closes the regression for commented documents.

## Why this fix and not "preserve the source value"

`CommentReference` is the canonical Word style name for comment-anchor runs and is universally defined in any DOCX that contains comments. The customer's repro and Word's default output both use this literal. Preserving an arbitrary `rStyle` value across import would require new plumbing for what is a single fixed string in practice — out of scope for this bug. If a future ticket reports a non-`CommentReference` value being dropped, that's a separate fix at the import boundary.

## Test plan

- [x] Failing unit test added at the same commit (TDD red): both existing assertions in `decode:commentRangeEndTranslator` and `does NOT wrap range markers when trackDelete mark is present` now require the rStyle structure
- [x] `pnpm --filter super-editor test -- --run comment-range-translator` — 2 failures pre-fix, 0 failures post-fix
- [x] Full `super-editor` suite: **12,719 passed**, 13 skipped, 0 failed
- [ ] Manual round-trip with customer fixture (`input.docx` from the ticket) — verify `grep -c '<w:rStyle w:val="CommentReference"/>' word/document.xml` returns 11 on the export

## Notes

- `commentRangeStart` is unaffected — Word never synthesizes an anchor run there.
- Tracked-change wrappers (`<w:ins>`/`<w:del>`) inherit the new child structure automatically; the SD-1519 bare-marker behavior for marked range nodes is preserved.
- ECMA-376 §17.3.2 requires `w:rPr` to be the first child of `w:r` — the change respects ordering.