### PR TITLE
fix(super-editor): null-safe getTrackChanges to avoid init-race crash (SD-2641)

### DIFF
--- a/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/getTrackChanges.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/getTrackChanges.js
@@ -3,12 +3,18 @@ import { findInlineNodes } from './documentHelpers.js';
 
 /**
  * Get track changes marks.
- * @param {import('prosemirror-state').EditorState} state
- * @param {string} id
+ *
+ * Tolerates a missing or partially-initialized state and returns an empty array
+ * instead of throwing. Comment-import bootstrap can call this through a
+ * setTimeout(0) before the editor's PM state is attached (SD-2641).
+ *
+ * @param {import('prosemirror-state').EditorState | null | undefined} state
+ * @param {string} [id]
  * @returns {Array} Array with track changes marks.
  */
 export const getTrackChanges = (state, id = null) => {
   const trackedChanges = [];
+  if (!state?.doc) return trackedChanges;
   const allInlineNodes = findInlineNodes(state.doc);
 
   if (!allInlineNodes.length) {

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/getTrackChanges.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/getTrackChanges.test.js
@@ -1,0 +1,26 @@
+import { describe, test, expect } from 'vitest';
+import { getTrackChanges } from './getTrackChanges.js';
+
+// SD-2641: The helper must not throw when called before the editor's PM state
+// is initialized. During DOCX comment-import bootstrap, the orchestrator schedules
+// the call via setTimeout(0) which only defers to the next tick — it does not wait
+// for editor.state to be attached. The helper is reused from 4 call sites in
+// comments-store.js, so we harden it once at the source rather than guarding each
+// caller.
+describe('getTrackChanges — null-safe input handling', () => {
+  test('returns [] when state is undefined', () => {
+    expect(getTrackChanges(undefined)).toEqual([]);
+  });
+
+  test('returns [] when state is null', () => {
+    expect(getTrackChanges(null)).toEqual([]);
+  });
+
+  test('returns [] when state has no doc property', () => {
+    expect(getTrackChanges({})).toEqual([]);
+  });
+
+  test('returns [] when state.doc is undefined', () => {
+    expect(getTrackChanges({ doc: undefined })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`createCommentForTrackChanges` is scheduled from `processLoadedDocxComments` via `setTimeout(0)`. That only defers to the next tick — it does **not** wait for the editor's PM state to be attached. When the bootstrap fires before `editor.state` exists, `getTrackChanges(editor.state)` becomes `getTrackChanges(undefined)` and crashes reading `state.doc` (the stack trace's `"reading 'doc'"`).

The same race affects **all four** call sites of `getTrackChanges` in `comments-store.js` (lines 294, 1143, 1453, 1545), so I harden the helper once rather than guarding each caller. A pure helper returning `[]` when there's no state to inspect is the semantically correct null behaviour — "no state → no tracked changes."

## Linear

- [SD-2641](https://linear.app/superdocworkspace/issue/SD-2641) — SLA breached 2026-05-08. Related: [SD-2635](https://linear.app/superdocworkspace/issue/SD-2635) (React-wrapper re-init).

## Why fix at the helper, not the caller

| | Helper-level (this PR) | Per-caller |
|---|---|---|
| Lines changed | 1 + JSDoc | 4 separate guards |
| Closes the race for all four `comments-store.js` callsites | ✅ | only one |
| Prevents future similar bugs from new callers | ✅ | ❌ |
| Changes the public contract of an exported helper | yes — documented in JSDoc | no |

Helpers in JS libraries idiomatically null-check their input. Returning `[]` from a "find tracked changes" function on a missing doc is the only sensible answer — not throwing.

## Test plan

- [x] Failing unit tests added at the same commit (TDD red): 4 cases — `undefined`, `null`, `{}`, `{ doc: undefined }`. All reproduce the bug's exact error chain (`Cannot read properties of undefined (reading 'doc')` and `Invalid "node" parameter` in `findChildren`).
- [x] After the guard: all 4 tests pass.
- [x] Full `super-editor` suite: **12,723 passed**, 13 skipped, 0 failed (+4 from baseline).
- [ ] Manual: open a document with comments in the dev app — no console error during startup.

## Out of scope

- Refactoring the `setTimeout(0)` bootstrap to wait on a `editorReady` promise. That's a deeper change (touches the editor lifecycle contract); this PR closes the user-visible crash without changing the timing model.
- The existing helper-positive path is covered by mocked integration tests in `comments-store.test.js`; not duplicating that coverage here.