### PR TITLE
refactor: migrate paragraph consumers to directionContext (SD-2777)

### DIFF
--- a/packages/layout-engine/contracts/src/direction-context.test.ts
+++ b/packages/layout-engine/contracts/src/direction-context.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { getParagraphInlineDirection } from './direction-context.js';
+
+describe('getParagraphInlineDirection', () => {
+  it('returns undefined for null/undefined attrs', () => {
+    expect(getParagraphInlineDirection(undefined)).toBeUndefined();
+    expect(getParagraphInlineDirection(null)).toBeUndefined();
+  });
+
+  it('prefers directionContext.inlineDirection over legacy fields', () => {
+    const attrs = {
+      directionContext: { inlineDirection: 'rtl' as const },
+      direction: 'ltr',
+      rtl: false,
+    };
+    expect(getParagraphInlineDirection(attrs)).toBe('rtl');
+  });
+
+  it('returns undefined when directionContext is present with no inlineDirection', () => {
+    // Per resolver semantics, undefined means "no explicit w:bidi"; UAX #9 takes over.
+    const attrs = { directionContext: { inlineDirection: null }, direction: 'rtl' };
+    expect(getParagraphInlineDirection(attrs)).toBe('rtl');
+  });
+
+  it('falls back to attrs.direction', () => {
+    expect(getParagraphInlineDirection({ direction: 'rtl' })).toBe('rtl');
+    expect(getParagraphInlineDirection({ direction: 'ltr' })).toBe('ltr');
+  });
+
+  it('falls back to attrs.dir', () => {
+    expect(getParagraphInlineDirection({ dir: 'rtl' })).toBe('rtl');
+    expect(getParagraphInlineDirection({ dir: 'ltr' })).toBe('ltr');
+  });
+
+  it('falls back to attrs.rtl boolean', () => {
+    expect(getParagraphInlineDirection({ rtl: true })).toBe('rtl');
+    expect(getParagraphInlineDirection({ rtl: false })).toBe('ltr');
+  });
+
+  it('falls back to paragraphProperties.rightToLeft', () => {
+    expect(getParagraphInlineDirection({ paragraphProperties: { rightToLeft: true } })).toBe('rtl');
+    expect(getParagraphInlineDirection({ paragraphProperties: { rightToLeft: false } })).toBe('ltr');
+  });
+
+  it('returns undefined when no signal is present', () => {
+    expect(getParagraphInlineDirection({})).toBeUndefined();
+    expect(getParagraphInlineDirection({ directionContext: {} })).toBeUndefined();
+    expect(getParagraphInlineDirection({ paragraphProperties: {} })).toBeUndefined();
+  });
+});

--- a/packages/layout-engine/contracts/src/direction-context.test.ts
+++ b/packages/layout-engine/contracts/src/direction-context.test.ts
@@ -16,8 +16,9 @@ describe('getParagraphInlineDirection', () => {
     expect(getParagraphInlineDirection(attrs)).toBe('rtl');
   });
 
-  it('returns undefined when directionContext is present with no inlineDirection', () => {
-    // Per resolver semantics, undefined means "no explicit w:bidi"; UAX #9 takes over.
+  it('falls back past directionContext when inlineDirection is null', () => {
+    // Per resolver semantics, inlineDirection=null/undefined means "no explicit
+    // w:bidi"; the legacy `direction` field is the next fallback in the chain.
     const attrs = { directionContext: { inlineDirection: null }, direction: 'rtl' };
     expect(getParagraphInlineDirection(attrs)).toBe('rtl');
   });

--- a/packages/layout-engine/contracts/src/direction-context.ts
+++ b/packages/layout-engine/contracts/src/direction-context.ts
@@ -182,7 +182,8 @@ export function getParagraphInlineDirection(
 ): BaseDirection | undefined {
   const fromContext = attrs?.directionContext?.inlineDirection;
   if (fromContext != null) return fromContext;
-  // compat-fallback: legacy duplicates of inlineDirection. SD-2778 collapses these.
+  // AIDEV-NOTE: compat-fallback - used when ParagraphAttrs.directionContext.inlineDirection is absent.
+  // Retire once SD-2778 collapses the duplicate scalar fields onto directionContext.
   const ppRtl = attrs?.paragraphProperties?.rightToLeft;
   if (attrs?.direction === 'rtl' || attrs?.dir === 'rtl' || attrs?.rtl === true || ppRtl === true) {
     return 'rtl';

--- a/packages/layout-engine/contracts/src/direction-context.ts
+++ b/packages/layout-engine/contracts/src/direction-context.ts
@@ -156,3 +156,39 @@ export type RunScriptContext = {
     eastAsian?: string;
   };
 };
+
+/**
+ * Read a paragraph's inline base direction from its attributes.
+ *
+ * Prefers the resolved {@link ParagraphDirectionContext} (SD-2776) when
+ * present, then falls back to the legacy scalar fields (`direction`,
+ * `dir`, `rtl`, `paragraphProperties.rightToLeft`) for compatibility
+ * until SD-2778 collapses the duplicates.
+ *
+ * Consumers should call this instead of inspecting attrs ad hoc so the
+ * direction source check stays in one place.
+ */
+export function getParagraphInlineDirection(
+  attrs:
+    | {
+        directionContext?: { inlineDirection?: BaseDirection | null } | null;
+        direction?: string | null;
+        dir?: string | null;
+        rtl?: boolean | null;
+        paragraphProperties?: { rightToLeft?: boolean | null } | null;
+      }
+    | null
+    | undefined,
+): BaseDirection | undefined {
+  const fromContext = attrs?.directionContext?.inlineDirection;
+  if (fromContext != null) return fromContext;
+  // compat-fallback: legacy duplicates of inlineDirection. SD-2778 collapses these.
+  const ppRtl = attrs?.paragraphProperties?.rightToLeft;
+  if (attrs?.direction === 'rtl' || attrs?.dir === 'rtl' || attrs?.rtl === true || ppRtl === true) {
+    return 'rtl';
+  }
+  if (attrs?.direction === 'ltr' || attrs?.dir === 'ltr' || attrs?.rtl === false || ppRtl === false) {
+    return 'ltr';
+  }
+  return undefined;
+}

--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -16,6 +16,7 @@ export type {
   RunBidiContext,
   RunScriptContext,
 } from './direction-context.js';
+export { getParagraphInlineDirection } from './direction-context.js';
 import type { ParagraphDirectionContext, RunBidiContext, RunScriptContext } from './direction-context.js';
 
 // Export table contracts

--- a/packages/layout-engine/layout-bridge/src/cache.ts
+++ b/packages/layout-engine/layout-bridge/src/cache.ts
@@ -1,16 +1,17 @@
-import type {
-  DrawingBlock,
-  FlowBlock,
-  ImageBlock,
-  ImageRun,
-  ListBlock,
-  TableBlock,
-  ParagraphBlock,
-  ParagraphAttrs,
-  ParagraphFrame,
-  TableAttrs,
-  TableCellAttrs,
-  Run,
+import {
+  getParagraphInlineDirection,
+  type DrawingBlock,
+  type FlowBlock,
+  type ImageBlock,
+  type ImageRun,
+  type ListBlock,
+  type TableBlock,
+  type ParagraphBlock,
+  type ParagraphAttrs,
+  type ParagraphFrame,
+  type TableAttrs,
+  type TableCellAttrs,
+  type Run,
 } from '@superdoc/contracts';
 import { fieldAnnotationKey } from './field-annotation-key.js';
 import { hasTrackedChange, resolveTrackedChangesEnabled } from './tracked-changes-utils.js';
@@ -391,8 +392,9 @@ const hashRuns = (block: FlowBlock): string => {
               if (sh.color) parts.push(`shc:${sh.color}`);
             }
 
-            // Direction
-            if (attrs.direction) parts.push(`dir:${attrs.direction}`);
+            // Direction (reads directionContext first; legacy attrs.direction as fallback)
+            const cellDir = getParagraphInlineDirection(attrs);
+            if (cellDir) parts.push(`dir:${cellDir}`);
 
             if (parts.length > 0) {
               cellHashes.push(`pa:${parts.join(':')}`);
@@ -546,8 +548,9 @@ const hashRuns = (block: FlowBlock): string => {
       parts.push(`tb:${tabsHash}`);
     }
 
-    // Direction
-    if (attrs.direction) parts.push(`dir:${attrs.direction}`);
+    // Direction (reads directionContext first; legacy attrs.direction as fallback)
+    const dir = getParagraphInlineDirection(attrs);
+    if (dir) parts.push(`dir:${dir}`);
 
     // Pagination properties
     if (attrs.keepNext) parts.push('kn');

--- a/packages/layout-engine/layout-bridge/src/cache.ts
+++ b/packages/layout-engine/layout-bridge/src/cache.ts
@@ -392,7 +392,7 @@ const hashRuns = (block: FlowBlock): string => {
               if (sh.color) parts.push(`shc:${sh.color}`);
             }
 
-            // Direction (reads directionContext first; legacy attrs.direction as fallback)
+            // Direction
             const cellDir = getParagraphInlineDirection(attrs);
             if (cellDir) parts.push(`dir:${cellDir}`);
 
@@ -548,7 +548,7 @@ const hashRuns = (block: FlowBlock): string => {
       parts.push(`tb:${tabsHash}`);
     }
 
-    // Direction (reads directionContext first; legacy attrs.direction as fallback)
+    // Direction
     const dir = getParagraphInlineDirection(attrs);
     if (dir) parts.push(`dir:${dir}`);
 

--- a/packages/layout-engine/layout-bridge/src/paragraph-hash-utils.ts
+++ b/packages/layout-engine/layout-bridge/src/paragraph-hash-utils.ts
@@ -1,12 +1,13 @@
-import type {
-  ParagraphAttrs,
-  ParagraphBorders,
-  ParagraphBorder,
-  Run,
-  TableBorders,
-  TableBorderValue,
-  CellBorders,
-  BorderSpec,
+import {
+  getParagraphInlineDirection,
+  type ParagraphAttrs,
+  type ParagraphBorders,
+  type ParagraphBorder,
+  type Run,
+  type TableBorders,
+  type TableBorderValue,
+  type CellBorders,
+  type BorderSpec,
 } from '@superdoc/contracts';
 
 /**
@@ -201,8 +202,9 @@ export const hashParagraphAttrs = (attrs: ParagraphAttrs | undefined): string =>
     if (sh.color) parts.push(`shc:${sh.color}`);
   }
 
-  // Direction
-  if (attrs.direction) parts.push(`dir:${attrs.direction}`);
+  // Direction (reads directionContext first; legacy attrs.direction as fallback)
+  const dir = getParagraphInlineDirection(attrs);
+  if (dir) parts.push(`dir:${dir}`);
 
   return parts.join(':');
 };

--- a/packages/layout-engine/layout-bridge/src/paragraph-hash-utils.ts
+++ b/packages/layout-engine/layout-bridge/src/paragraph-hash-utils.ts
@@ -202,7 +202,7 @@ export const hashParagraphAttrs = (attrs: ParagraphAttrs | undefined): string =>
     if (sh.color) parts.push(`shc:${sh.color}`);
   }
 
-  // Direction (reads directionContext first; legacy attrs.direction as fallback)
+  // Direction
   const dir = getParagraphInlineDirection(attrs);
   if (dir) parts.push(`dir:${dir}`);
 

--- a/packages/layout-engine/layout-resolved/src/versionSignature.ts
+++ b/packages/layout-engine/layout-resolved/src/versionSignature.ts
@@ -1,21 +1,22 @@
-import type {
-  DrawingBlock,
-  FieldAnnotationRun,
-  FlowBlock,
-  Fragment,
-  ImageBlock,
-  ImageDrawing,
-  ImageRun,
-  ParagraphAttrs,
-  ParagraphBlock,
-  SdtMetadata,
-  ShapeGroupDrawing,
-  SourceAnchor,
-  TableAttrs,
-  TableBlock,
-  TableCellAttrs,
-  TextRun,
-  VectorShapeDrawing,
+import {
+  getParagraphInlineDirection,
+  type DrawingBlock,
+  type FieldAnnotationRun,
+  type FlowBlock,
+  type Fragment,
+  type ImageBlock,
+  type ImageDrawing,
+  type ImageRun,
+  type ParagraphAttrs,
+  type ParagraphBlock,
+  type SdtMetadata,
+  type ShapeGroupDrawing,
+  type SourceAnchor,
+  type TableAttrs,
+  type TableBlock,
+  type TableCellAttrs,
+  type TextRun,
+  type VectorShapeDrawing,
 } from '@superdoc/contracts';
 import { hashParagraphBorders } from './paragraphBorderHash.js';
 import {
@@ -293,7 +294,7 @@ export const deriveBlockVersion = (block: FlowBlock): string => {
           attrs.borders ? hashParagraphBorders(attrs.borders) : '',
           attrs.shading?.fill ?? '',
           attrs.shading?.color ?? '',
-          attrs.direction ?? '',
+          getParagraphInlineDirection(attrs) ?? '',
           attrs.tabs?.length ? JSON.stringify(attrs.tabs) : '',
         ].join(':')
       : '';
@@ -437,7 +438,7 @@ export const deriveBlockVersion = (block: FlowBlock): string => {
               hash = hashNumber(hash, attrs.indent?.hanging ?? 0);
               hash = hashString(hash, attrs.shading?.fill ?? '');
               hash = hashString(hash, attrs.shading?.color ?? '');
-              hash = hashString(hash, attrs.direction ?? '');
+              hash = hashString(hash, getParagraphInlineDirection(attrs) ?? '');
               if (attrs.borders) {
                 hash = hashString(hash, hashParagraphBorders(attrs.borders));
               }

--- a/packages/layout-engine/painters/dom/src/features/rtl-paragraph/rtl-styles.ts
+++ b/packages/layout-engine/painters/dom/src/features/rtl-paragraph/rtl-styles.ts
@@ -7,12 +7,13 @@
  * @ooxml w:pPr/w:bidi — paragraph bidirectional flag
  * @spec  ECMA-376 §17.3.1.1 (bidi)
  */
-import type { ParagraphAttrs } from '@superdoc/contracts';
+import { getParagraphInlineDirection, type ParagraphAttrs } from '@superdoc/contracts';
 
 /**
  * Returns true when the paragraph attributes indicate right-to-left direction.
  */
-export const isRtlParagraph = (attrs: ParagraphAttrs | undefined): boolean => attrs?.direction === 'rtl';
+export const isRtlParagraph = (attrs: ParagraphAttrs | undefined): boolean =>
+  getParagraphInlineDirection(attrs) === 'rtl';
 
 /**
  * Compute the effective CSS text-align for a paragraph.

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -3179,7 +3179,7 @@ export class DomPainter {
             fragment.markerTextWidth,
             resolvedLine.indentOffset,
           );
-          const isRtl = block.attrs?.direction === 'rtl';
+          const isRtl = getParagraphInlineDirection(block.attrs) === 'rtl';
           const lineEl = this.renderLine(
             block,
             resolvedLine.line,
@@ -3286,7 +3286,7 @@ export class DomPainter {
         const paraIndent = block.attrs?.indent;
         const paraIndentLeft = paraIndent?.left ?? 0;
         const paraIndentRight = paraIndent?.right ?? 0;
-        const isRtl = block.attrs?.direction === 'rtl';
+        const isRtl = getParagraphInlineDirection(block.attrs) === 'rtl';
         const {
           anchorIndentPx: paraMarkerAnchorIndent,
           firstLinePx: markerFirstLine,

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -61,6 +61,7 @@ import {
   computeLinePmRange,
   expandRunsForInlineNewlines,
   getCellSpacingPx,
+  getParagraphInlineDirection,
   normalizeColumnLayout,
   normalizeBaselineShift,
   resolveBaseFontSizeForVerticalText,
@@ -7774,7 +7775,7 @@ const deriveBlockVersion = (block: FlowBlock): string => {
           attrs.borders ? hashParagraphBorders(attrs.borders) : '',
           attrs.shading?.fill ?? '',
           attrs.shading?.color ?? '',
-          attrs.direction ?? '',
+          getParagraphInlineDirection(attrs) ?? '',
           attrs.tabs?.length ? JSON.stringify(attrs.tabs) : '',
         ].join(':')
       : '';
@@ -7960,7 +7961,7 @@ const deriveBlockVersion = (block: FlowBlock): string => {
               hash = hashNumber(hash, attrs.indent?.hanging ?? 0);
               hash = hashString(hash, attrs.shading?.fill ?? '');
               hash = hashString(hash, attrs.shading?.color ?? '');
-              hash = hashString(hash, attrs.direction ?? '');
+              hash = hashString(hash, getParagraphInlineDirection(attrs) ?? '');
               if (attrs.borders) {
                 hash = hashString(hash, hashParagraphBorders(attrs.borders));
               }

--- a/packages/layout-engine/pm-adapter/src/attributes/paragraph.test.ts
+++ b/packages/layout-engine/pm-adapter/src/attributes/paragraph.test.ts
@@ -348,6 +348,37 @@ describe('computeParagraphAttrs', () => {
     expect(paragraphAttrs.direction).toBeUndefined();
   });
 
+  // SD-2777 invariant: pm-adapter must keep `direction` and
+  // `directionContext.inlineDirection` aligned (or both absent). This is the
+  // load-bearing property that lets `getParagraphInlineDirection` produce a
+  // hash byte-identical to the legacy `attrs.direction` read across the
+  // entire R2 corpus. If this breaks, the helper-based hash sites in
+  // layout-bridge / layout-resolved / painter-dom will drift from the
+  // pre-migration output.
+  describe('SD-2777: direction and directionContext.inlineDirection are paired', () => {
+    const cases: Array<{ name: string; rightToLeft: boolean | undefined; expected: 'rtl' | 'ltr' | undefined }> = [
+      { name: 'rightToLeft=true', rightToLeft: true, expected: 'rtl' },
+      { name: 'rightToLeft=false', rightToLeft: false, expected: 'ltr' },
+      { name: 'rightToLeft=undefined', rightToLeft: undefined, expected: undefined },
+    ];
+
+    for (const { name, rightToLeft, expected } of cases) {
+      it(`${name}: attrs.direction === directionContext.inlineDirection (${String(expected)})`, () => {
+        const paragraph: PMNode = {
+          type: { name: 'paragraph' },
+          attrs: {
+            paragraphProperties: rightToLeft === undefined ? {} : { rightToLeft },
+          },
+        };
+
+        const { paragraphAttrs } = computeParagraphAttrs(paragraph as never);
+
+        expect(paragraphAttrs.direction).toBe(expected);
+        expect(paragraphAttrs.directionContext?.inlineDirection).toBe(expected);
+      });
+    }
+  });
+
   it('inherits writing mode from body section context (§17.3.1.41)', () => {
     // When the paragraph omits w:textDirection, it should pick up writing-mode
     // from the section. This test feeds a pre-resolved sectionDirectionContext

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/selection/CaretGeometry.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/selection/CaretGeometry.ts
@@ -8,15 +8,16 @@ import {
   pmPosToCharOffset,
   extractParagraphIndent,
 } from '@superdoc/layout-bridge';
-import type {
-  FlowBlock,
-  Layout,
-  Line,
-  Measure,
-  ParaFragment,
-  TableBlock,
-  TableFragment,
-  TableMeasure,
+import {
+  getParagraphInlineDirection,
+  type FlowBlock,
+  type Layout,
+  type Line,
+  type Measure,
+  type ParaFragment,
+  type TableBlock,
+  type TableFragment,
+  type TableMeasure,
 } from '@superdoc/contracts';
 import { computeTableCaretLayoutRectFromDom } from '../tables/TableCaretDomGeometry.js';
 import { getPageElementByIndex } from '../../../dom-observer/PageDom.js';
@@ -196,7 +197,7 @@ export function computeCaretLayoutRectGeometry(
 
   const availableWidth = Math.max(0, fragment.width - (indentAdjust + indent.right));
   const charX = measureCharacterX(block, line, pmOffset, availableWidth);
-  const isRtlParagraph = block.attrs?.direction === 'rtl';
+  const isRtlParagraph = getParagraphInlineDirection(block.attrs) === 'rtl';
   const resolvedCharX = isRtlParagraph ? Math.max(0, availableWidth - charX) : charX;
   const localX = fragment.x + indentAdjust + resolvedCharX;
   const lineOffset = lineHeightBeforeIndex(measure.lines, fragment.fromLine, index);

--- a/packages/super-editor/src/editors/v1/extensions/paragraph/listBoundaryNavigationPlugin.js
+++ b/packages/super-editor/src/editors/v1/extensions/paragraph/listBoundaryNavigationPlugin.js
@@ -1,4 +1,5 @@
 import { Plugin, TextSelection } from 'prosemirror-state';
+import { getParagraphInlineDirection } from '@superdoc/contracts';
 
 function isListParagraph(node) {
   return (
@@ -9,11 +10,7 @@ function isListParagraph(node) {
 }
 
 function isRtlParagraph(node) {
-  return (
-    node?.attrs?.paragraphProperties?.rightToLeft === true ||
-    node?.attrs?.direction === 'rtl' ||
-    node?.attrs?.rtl === true
-  );
+  return getParagraphInlineDirection(node?.attrs) === 'rtl';
 }
 
 function getParagraphContext($pos) {


### PR DESCRIPTION
Phase A of SD-2777. Migrates paragraph-axis consumers onto Wave 1a's resolver context (SD-2776) - paragraph hash sites in layout-bridge, layout-resolved, painter-dom, plus the list-boundary navigation plugin in super-editor.

Adds `getParagraphInlineDirection` in `@superdoc/contracts` that reads `directionContext.inlineDirection` first and falls back to the legacy `attrs.direction` / `dir` / `rtl` / `paragraphProperties.rightToLeft` until SD-2778 collapses the duplicates. Behavior is unchanged because pm-adapter still mirrors `directionContext.inlineDirection` onto the legacy fields - hash output stays identical.

Table-axis consumers (`renderTableFragment` / `renderTableCell` / `renderTableRow`) are intentionally untouched. PR #3227 is active and overlaps those files; Phase B will migrate them after #3227 settles. SD-2779 (DomPainter feature folder rename) and the `ParagraphNodeView.inferParagraphRtlFromRuns` cleanup also stay separate to keep this diff tight.

**Verified**: 15,389 unit tests pass across `@superdoc/contracts` (+8 new), `layout-bridge`, `layout-resolved`, `painter-dom`, and `super-editor`. Lint + format clean (4 pre-existing warnings, unrelated). Layout-compare against the R2 corpus is pending; PR stays draft until that confirms pixel-identical.

**Review**: focus on the helper's fallback chain and the hash-site call signatures. The helper is intentionally tolerant of all five legacy shapes so JS consumers can call it without typing gymnastics. Compat-fallback is annotated to retire under SD-2778.