### PR TITLE
chore(ci): add contract-templates to demos smoke matrix

### DIFF
--- a/.github/workflows/ci-demos.yml
+++ b/.github/workflows/ci-demos.yml
@@ -56,6 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         demo:
+          - contract-templates
           - custom-ui
           - docx-from-html
           - docxtemplater


### PR DESCRIPTION
The contract-templates demo was added in #3267 but never wired into `ci-demos.yml`, so it would only get exercised by local dev. Adds it to the matrix - same generic smoke (loads `/`, fails on console errors), Vite default port, no portMap entry needed.

Follow-up to #3267.