### PR TITLE
chore(ci): install pnpm in demos smoke-test job

### DIFF
--- a/.github/workflows/ci-demos.yml
+++ b/.github/workflows/ci-demos.yml
@@ -78,6 +78,8 @@ jobs:
             ~/.cache/ms-playwright
           key: demos-workspace-${{ github.sha }}
 
+      - uses: pnpm/action-setup@v4
+
       - name: Run smoke test
         working-directory: demos/__tests__
         run: DEMO=${{ matrix.demo }} npx playwright test


### PR DESCRIPTION
The contract-templates demo has a `predev` script (`pnpm --filter superdoc build`) which the smoke-test runner invokes via `npm run dev`. Without pnpm on PATH the predev hook fails with `sh: 1: pnpm: not found` and the demo never starts; playwright then reports `Process from config.webServer was not able to start. Exit code: 127`.

This blocks every PR that triggers the demos workflow (i.e. anything touching `demos/**` or shared packages like `super-editor`, `layout-engine`, `superdoc`, `react`). Example: #3272.

The `build` job already uses `pnpm/action-setup@v4`. Mirroring it in `smoke-test` keeps the local dev UX intact (the predev hook still does its job) and unblocks the matrix. Two-line change.

Verified locally by reading the failing job logs at https://github.com/superdoc-dev/superdoc/actions/runs/25828093178/job/75886653390 and confirming the predev script in `demos/contract-templates/package.json:6` is the unique demo carrying this hook.