### PR TITLE
docs(collaboration): reposition self-hosted guidance

### DIFF
--- a/apps/docs/editor/collaboration/overview.mdx
+++ b/apps/docs/editor/collaboration/overview.mdx
@@ -34,8 +34,9 @@ Collaboration is configured through `modules.collaboration` today, but it isn't 
 
     | Option | Best For |
     |--------|----------|
-    | [SuperDoc Yjs](/guides/collaboration/superdoc-yjs) | Recommended: the official package |
-    | [Hocuspocus](/guides/collaboration/hocuspocus) | TipTap ecosystem users |
+    | [Hocuspocus](/guides/collaboration/hocuspocus) | Production self-hosted default. Mature, MIT, documented hooks and scaling. |
+    | [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub) | Advanced: attribution and revision history. Beta, Node 22+, AGPL/proprietary. |
+    | [SuperDoc Yjs](/guides/collaboration/superdoc-yjs) | Minimal reference server. Not production infrastructure. |
 
   </Tab>
 </Tabs>

--- a/apps/docs/editor/collaboration/quickstart.mdx
+++ b/apps/docs/editor/collaboration/quickstart.mdx
@@ -257,9 +257,9 @@ const client = createClient({
   <Card
     title="Self-Hosted Option"
     icon="server"
-    href="/guides/collaboration/superdoc-yjs"
+    href="/guides/collaboration/hocuspocus"
   >
-    Run your own collaboration server
+    Run your own collaboration server with Hocuspocus
   </Card>
 
   <Card

--- a/apps/docs/guides/collaboration/hocuspocus.mdx
+++ b/apps/docs/guides/collaboration/hocuspocus.mdx
@@ -287,18 +287,18 @@ Server.configure({
 
 <CardGroup cols={2}>
   <Card
-    title="SuperDoc Yjs"
-    icon="rocket"
-    href="/guides/collaboration/superdoc-yjs"
-  >
-    Try the official collaboration package
-  </Card>
-
-  <Card
     title="Client Configuration"
     icon="settings"
     href="/editor/collaboration/configuration"
   >
     All SuperDoc collaboration options
+  </Card>
+
+  <Card
+    title="Self-hosted overview"
+    icon="server"
+    href="/guides/collaboration/self-hosted-overview"
+  >
+    Compare Hocuspocus, YHub, and the SuperDoc Yjs reference server
   </Card>
 </CardGroup>

--- a/apps/docs/guides/collaboration/self-hosted-overview.mdx
+++ b/apps/docs/guides/collaboration/self-hosted-overview.mdx
@@ -36,68 +36,62 @@ flowchart TB
 
 ## Choose your approach
 
+SuperDoc's collaboration is provider-agnostic: pass `{ ydoc, provider }` to `modules.collaboration` and the server choice is yours. We recommend established Yjs infrastructure for production deployments.
+
 | Option | Best For | Setup Time |
 |--------|----------|------------|
-| [SuperDoc Yjs](/guides/collaboration/superdoc-yjs) | New projects, recommended | 30 mins |
-| [Hocuspocus](/guides/collaboration/hocuspocus) | TipTap ecosystem users | 30 mins |
+| [Hocuspocus](/guides/collaboration/hocuspocus) | Production self-hosted default. Mature, MIT-licensed, with documented auth, persistence, and Redis scaling. | 30 mins |
+| [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub) | Advanced self-hosted. YHub supports attribution, activity, revision history, and Redis+Postgres scaling. Beta, Node 22+, AGPL or proprietary licensing. | 1+ hour |
+| [SuperDoc Yjs](/guides/collaboration/superdoc-yjs) | Minimal reference server for prototypes and local dev. Not production infrastructure. | 30 mins |
 
 ## Quick comparison
 
 <Tabs>
-  <Tab title="SuperDoc Yjs">
-    **The official collaboration package**
+  <Tab title="Hocuspocus">
+    **Production self-hosted default**
 
-    - Purpose-built for SuperDoc
-    - Builder pattern API
-    - Auto-save with debounce
-    - Memory management
+    - Mature, MIT-licensed
+    - Documented auth, persistence, Redis scaling
+    - Rich extension ecosystem
+
+    ```bash
+    npm install @hocuspocus/server @hocuspocus/provider
+    ```
+
+    [Get Started](/guides/collaboration/hocuspocus)
+  </Tab>
+
+  <Tab title="YHub">
+    **Advanced: attribution and revision history**
+
+    - Built-in attribution, activity stream, changesets, rollback
+    - Redis + Postgres backing
+    - Beta, Node 22+, AGPL or proprietary
+
+    Reach for YHub when revision history and identity attribution are central to your product. Validate license and beta status before committing.
+
+    [See the example](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub)
+  </Tab>
+
+  <Tab title="SuperDoc Yjs">
+    **Minimal reference server**
+
+    A small Yjs WebSocket server we ship for prototypes and local development. Not production infrastructure: no built-in auth, persistence, scaling, or observability. For production, use Hocuspocus or YHub.
 
     ```bash
     npm install @superdoc-dev/superdoc-yjs-collaboration
     ```
 
-    [Get Started](/guides/collaboration/superdoc-yjs)
-  </Tab>
-
-  <Tab title="Hocuspocus">
-    **TipTap's Yjs server**
-
-    - Mature, battle-tested
-    - Rich extension ecosystem
-    - Good if already using TipTap
-
-    ```bash
-    npm install @hocuspocus/server
-    ```
-
-    [Get Started](/guides/collaboration/hocuspocus)
+    [See the reference](/guides/collaboration/superdoc-yjs)
   </Tab>
 
   </Tabs>
 
 ## Client connection options
 
-When self-hosting, you have two ways to connect SuperDoc:
+The supported contract is provider-agnostic: you create the Yjs provider, SuperDoc plugs into it.
 
-### Option 1: URL-based (SuperDoc manages provider)
-
-SuperDoc creates and manages the WebSocket connection:
-
-```javascript
-new SuperDoc({
-  selector: '#editor',
-  modules: {
-    collaboration: {
-      url: 'wss://your-server.com/doc',
-      token: 'auth-token'
-    }
-  }
-});
-```
-
-### Option 2: Provider-agnostic (You manage provider)
-
-You create the Yjs provider yourself:
+### Provider-agnostic (recommended)
 
 ```javascript
 import { HocuspocusProvider } from '@hocuspocus/provider';
@@ -118,9 +112,25 @@ new SuperDoc({
 });
 ```
 
-<Note>
-The provider-agnostic approach gives you more control but requires managing the provider lifecycle yourself.
-</Note>
+This shape works with any Yjs provider: `HocuspocusProvider`, `WebsocketProvider` from `y-websocket` (compatible with YHub and SuperDoc Yjs), `LiveblocksYjsProvider`, or your own.
+
+### URL-based (deprecated)
+
+<Warning>
+This path is deprecated. SuperDoc creates the provider internally and emits a console warning. Use the provider-agnostic shape above for new code.
+</Warning>
+
+```javascript
+new SuperDoc({
+  selector: '#editor',
+  modules: {
+    collaboration: {
+      url: 'wss://your-server.com/doc',
+      token: 'auth-token'
+    }
+  }
+});
+```
 
 ## Requirements
 
@@ -140,19 +150,27 @@ The provider-agnostic approach gives you more control but requires managing the 
 
 <CardGroup cols={2}>
   <Card
-    title="SuperDoc Yjs"
-    icon="rocket"
-    href="/guides/collaboration/superdoc-yjs"
-  >
-    Recommended - the official package
-  </Card>
-
-  <Card
     title="Hocuspocus"
     icon="server"
     href="/guides/collaboration/hocuspocus"
   >
-    Alternative using TipTap's server
+    Production self-hosted default
+  </Card>
+
+  <Card
+    title="YHub example"
+    icon="layers"
+    href="https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub"
+  >
+    Advanced: attribution and revision history (beta)
+  </Card>
+
+  <Card
+    title="SuperDoc Yjs"
+    icon="flask-conical"
+    href="/guides/collaboration/superdoc-yjs"
+  >
+    Minimal reference server for dev and prototypes
   </Card>
 
   <Card

--- a/apps/docs/guides/collaboration/superdoc-yjs.mdx
+++ b/apps/docs/guides/collaboration/superdoc-yjs.mdx
@@ -4,7 +4,11 @@ sidebarTitle: SuperDoc Yjs
 keywords: "superdoc collaboration server, yjs server, self-hosted, websocket"
 ---
 
-The official collaboration package for self-hosted deployments. Purpose-built for SuperDoc with a builder API.
+A minimal Yjs WebSocket server we ship as a reference implementation for prototypes and local development.
+
+<Warning>
+This package is not production infrastructure. It has no built-in auth, persistence, scaling, or observability beyond what you wire into the hooks. For production self-hosted collaboration, use [Hocuspocus](/guides/collaboration/hocuspocus) (recommended default) or [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub) (when attribution and revision history are central). SuperDoc's collaboration contract is provider-agnostic: pass `{ ydoc, provider }` to `modules.collaboration` and the server choice is yours.
+</Warning>
 
 ## Installation
 
@@ -320,11 +324,7 @@ DATABASE_URL=postgres://user:pass@localhost/db
 
 ```typescript
 fastify.get('/health', (request, reply) => {
-  reply.send({
-    status: 'healthy',
-    documents: collaboration.getActiveDocumentCount(),
-    connections: collaboration.getConnectionCount()
-  });
+  reply.send({ status: 'healthy' });
 });
 ```
 

--- a/apps/docs/llms-full.txt
+++ b/apps/docs/llms-full.txt
@@ -253,10 +253,11 @@ Three preset themes included: Google Docs, Microsoft Word, and Blueprint.
 
 ## Collaboration
 
-Real-time multiplayer editing using Yjs (CRDT). Providers supported:
+Real-time multiplayer editing using Yjs (CRDT). The supported integration contract is provider-agnostic: pass `{ ydoc, provider }` to `modules.collaboration` on the client. Server options:
 - Liveblocks (cloud)
-- SuperDoc Yjs server (self-hosted)
-- Hocuspocus (self-hosted)
+- Hocuspocus (recommended self-hosted default)
+- YHub (advanced self-hosted; beta; attribution and revision history use cases)
+- SuperDoc Yjs (minimal reference server, not production infrastructure)
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -77,9 +77,10 @@ Realtime providers and backend setups for Yjs-based collaboration.
 
 | Example | Description |
 |---------|-------------|
-| [providers/superdoc-yjs](./editor/collaboration/providers/superdoc-yjs) | Self-hosted Yjs server (recommended) |
-| [providers/hocuspocus](./editor/collaboration/providers/hocuspocus) | Hocuspocus provider setup |
+| [providers/hocuspocus](./editor/collaboration/providers/hocuspocus) | Hocuspocus provider (recommended self-hosted default) |
 | [providers/liveblocks](./editor/collaboration/providers/liveblocks) | Liveblocks managed service |
+| [providers/superdoc-yjs](./editor/collaboration/providers/superdoc-yjs) | SuperDoc Yjs minimal reference server (not production infrastructure) |
+| [backends/fastapi/yjs-hub](./editor/collaboration/backends/fastapi/yjs-hub) | YHub server with attribution and activity stream (beta) |
 | [backends/node-sdk](./editor/collaboration/backends/node-sdk) | Server-side document operations alongside the realtime layer |
 | [backends/fastapi](./editor/collaboration/backends/fastapi) | Python FastAPI backend |
 

--- a/packages/collaboration-yjs/README.md
+++ b/packages/collaboration-yjs/README.md
@@ -1,6 +1,8 @@
 # SuperDoc Yjs collaboration library
 
-`@superdoc-dev/superdoc-yjs-collaboration` is a library for integrating Yjs-based real-time collaborative editing into any Node.js WebSocket-enabled server framework. It is designed to work out-of-the-box for **SuperDoc**.
+`@superdoc-dev/superdoc-yjs-collaboration` is a minimal Yjs WebSocket server for SuperDoc, shipped as a reference implementation for prototypes and local development.
+
+> **Not production infrastructure.** No built-in auth, persistence, scaling, or observability beyond what you wire into the hooks. For production self-hosted collaboration, use [Hocuspocus](https://tiptap.dev/docs/hocuspocus) (recommended default) or [YHub](https://github.com/yjs/yhub) (when attribution and revision history are central). SuperDoc's collaboration contract is provider-agnostic: pass `{ ydoc, provider }` to `modules.collaboration` on the client and the server choice is yours.
 
 It provides:
 
@@ -66,7 +68,7 @@ Below is an example using Fastify, but you can adapt it to any server framework.
 import Fastify from 'fastify';
 import websocket from '@fastify/websocket';
 import { v4 as uuidv4 } from 'uuid';
-import SuperDocCollaboration from '@superdoc-dev/superdoc-yjs-collaboration';
+import { CollaborationBuilder } from '@superdoc-dev/superdoc-yjs-collaboration';
 
 const app = Fastify();
 app.register(websocket);
@@ -79,7 +81,7 @@ const onLoad = (params) => {}; // Load your document from persistence (ie: S3)
 const onAutoSave = (params) => {}; // Debounced onChange hook based on 'withDebounce' setting. Save to persistence.
 const onChange = (params) => {}; // On change hook. This gets triggered a lot!
 
-const service = new SuperDocCollaboration()
+const service = new CollaborationBuilder()
   .withName(`sdc-${uuidv4()}`)
   .withDebounce(500)
   .onAuthenticate(onAuthenticate)


### PR DESCRIPTION
Repositions self-hosted collaboration guidance around SuperDoc's supported `{ ydoc, provider }` contract. Hocuspocus becomes the recommended self-hosted default, YHub joins as the advanced attribution/history path with beta and licensing caveats, and SuperDoc Yjs moves to a minimal reference-server position. Also fixes broken SuperDoc Yjs README usage (default import on a named-only export, wrong class name), removes the fictional health-check methods the docs reference, drops the Hocuspocus page card that funnelled users back to SuperDoc Yjs, and refreshes examples/README.md and llms-full.txt so stale guidance doesn't keep pointing users at SuperDoc Yjs as the production path.

**Review**: check positioning is accurate and no docs still imply SuperDoc Yjs is the production recommendation; flag if YHub caveats need to be stronger given the local example is barebones.
**Verified**: `check:imports` ok; `check:icons` ok; `superdoc build:dev` ok; `test:examples` 291 pass; `git diff --check HEAD` clean.