### PR TITLE
docs(collaboration): tighten YHub/Hocuspocus framing (follow-up to #3277)

### DIFF
--- a/apps/docs/editor/collaboration/overview.mdx
+++ b/apps/docs/editor/collaboration/overview.mdx
@@ -34,7 +34,7 @@ Collaboration is configured through `modules.collaboration` today, but it isn't 
 
     | Option | Best For |
     |--------|----------|
-    | [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub) | Advanced Yjs backend for attribution, activity, and revision-history workflows. Beta. |
+    | YHub | Advanced Yjs backend for attribution, activity, and revision-history workflows. Beta. |
     | [Hocuspocus](/guides/collaboration/hocuspocus) | Mature self-hosted Yjs server with auth, persistence, and scaling hooks. |
     | [SuperDoc Yjs](/guides/collaboration/superdoc-yjs) | Minimal reference server. Not production infrastructure. |
 

--- a/apps/docs/editor/collaboration/overview.mdx
+++ b/apps/docs/editor/collaboration/overview.mdx
@@ -34,8 +34,8 @@ Collaboration is configured through `modules.collaboration` today, but it isn't 
 
     | Option | Best For |
     |--------|----------|
-    | [Hocuspocus](/guides/collaboration/hocuspocus) | Production self-hosted default. Mature, MIT, documented hooks and scaling. |
-    | [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub) | Advanced: attribution and revision history. Beta, Node 22+, AGPL/proprietary. |
+    | [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub) | Advanced Yjs backend for attribution, activity, and revision-history workflows. Beta. |
+    | [Hocuspocus](/guides/collaboration/hocuspocus) | Mature self-hosted Yjs server with auth, persistence, and scaling hooks. |
     | [SuperDoc Yjs](/guides/collaboration/superdoc-yjs) | Minimal reference server. Not production infrastructure. |
 
   </Tab>

--- a/apps/docs/editor/collaboration/quickstart.mdx
+++ b/apps/docs/editor/collaboration/quickstart.mdx
@@ -255,11 +255,11 @@ const client = createClient({
   </Card>
 
   <Card
-    title="Self-Hosted Option"
+    title="Self-Hosted Options"
     icon="server"
-    href="/guides/collaboration/hocuspocus"
+    href="/guides/collaboration/self-hosted-overview"
   >
-    Run your own collaboration server with Hocuspocus
+    Compare self-hosted Yjs server options
   </Card>
 
   <Card

--- a/apps/docs/guides/collaboration/self-hosted-overview.mdx
+++ b/apps/docs/guides/collaboration/self-hosted-overview.mdx
@@ -36,53 +36,41 @@ flowchart TB
 
 ## Choose your approach
 
-SuperDoc's collaboration is provider-agnostic: pass `{ ydoc, provider }` to `modules.collaboration` and the server choice is yours. We recommend established Yjs infrastructure for production deployments.
+SuperDoc's integration contract is provider-agnostic: pass `{ ydoc, provider }` to `modules.collaboration` and the server choice is yours. Any Yjs-compatible server works.
 
-| Option | Best For | Setup Time |
-|--------|----------|------------|
-| [Hocuspocus](/guides/collaboration/hocuspocus) | Production self-hosted default. Mature, MIT-licensed, with documented auth, persistence, and Redis scaling. | 30 mins |
-| [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub) | Advanced self-hosted. YHub supports attribution, activity, revision history, and Redis+Postgres scaling. Beta, Node 22+, AGPL or proprietary licensing. | 1+ hour |
-| [SuperDoc Yjs](/guides/collaboration/superdoc-yjs) | Minimal reference server for prototypes and local dev. Not production infrastructure. | 30 mins |
+| Option | Notes | Setup Time |
+|--------|-------|------------|
+| [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub) | Advanced Yjs backend for attribution, activity, and revision-history workflows. Beta; validate licensing and infrastructure requirements. | 1+ hour |
+| [Hocuspocus](/guides/collaboration/hocuspocus) | Mature self-hosted Yjs server with auth, persistence, and scaling hooks. | 30 mins |
+| [SuperDoc Yjs](/guides/collaboration/superdoc-yjs) | Minimal reference server for prototypes and local development. Not production infrastructure. | 30 mins |
 
-## Quick comparison
+## At a glance
 
 <Tabs>
-  <Tab title="Hocuspocus">
-    **Production self-hosted default**
+  <Tab title="YHub">
+    Advanced Yjs backend for attribution, activity, and revision-history workflows. Redis + Postgres backing. Beta; validate licensing and infrastructure requirements.
 
-    - Mature, MIT-licensed
-    - Documented auth, persistence, Redis scaling
-    - Rich extension ecosystem
+    [See the example](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub)
+  </Tab>
+
+  <Tab title="Hocuspocus">
+    Mature self-hosted Yjs server with auth, persistence, and scaling hooks.
 
     ```bash
     npm install @hocuspocus/server @hocuspocus/provider
     ```
 
-    [Get Started](/guides/collaboration/hocuspocus)
-  </Tab>
-
-  <Tab title="YHub">
-    **Advanced: attribution and revision history**
-
-    - Built-in attribution, activity stream, changesets, rollback
-    - Redis + Postgres backing
-    - Beta, Node 22+, AGPL or proprietary
-
-    Reach for YHub when revision history and identity attribution are central to your product. Validate license and beta status before committing.
-
-    [See the example](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub)
+    [Setup guide](/guides/collaboration/hocuspocus)
   </Tab>
 
   <Tab title="SuperDoc Yjs">
-    **Minimal reference server**
-
-    A small Yjs WebSocket server we ship for prototypes and local development. Not production infrastructure: no built-in auth, persistence, scaling, or observability. For production, use Hocuspocus or YHub.
+    A small Yjs WebSocket server we ship for prototypes and local development. Not production infrastructure: no built-in auth, persistence, scaling, or observability.
 
     ```bash
     npm install @superdoc-dev/superdoc-yjs-collaboration
     ```
 
-    [See the reference](/guides/collaboration/superdoc-yjs)
+    [Reference](/guides/collaboration/superdoc-yjs)
   </Tab>
 
   </Tabs>
@@ -150,27 +138,27 @@ new SuperDoc({
 
 <CardGroup cols={2}>
   <Card
-    title="Hocuspocus"
-    icon="server"
-    href="/guides/collaboration/hocuspocus"
-  >
-    Production self-hosted default
-  </Card>
-
-  <Card
     title="YHub example"
     icon="layers"
     href="https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub"
   >
-    Advanced: attribution and revision history (beta)
+    Attribution and revision-history workflows (beta)
   </Card>
 
   <Card
-    title="SuperDoc Yjs"
+    title="Hocuspocus setup"
+    icon="server"
+    href="/guides/collaboration/hocuspocus"
+  >
+    Mature self-hosted Yjs server
+  </Card>
+
+  <Card
+    title="SuperDoc Yjs reference"
     icon="flask-conical"
     href="/guides/collaboration/superdoc-yjs"
   >
-    Minimal reference server for dev and prototypes
+    Minimal server for prototypes and local development
   </Card>
 
   <Card

--- a/apps/docs/guides/collaboration/self-hosted-overview.mdx
+++ b/apps/docs/guides/collaboration/self-hosted-overview.mdx
@@ -40,19 +40,13 @@ SuperDoc's integration contract is provider-agnostic: pass `{ ydoc, provider }` 
 
 | Option | Notes | Setup Time |
 |--------|-------|------------|
-| [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub) | Advanced Yjs backend for attribution, activity, and revision-history workflows. Beta; validate licensing and infrastructure requirements. | 1+ hour |
+| YHub | Advanced Yjs backend for attribution, activity, and revision-history workflows. Beta; validate licensing and infrastructure requirements. | 1+ hour |
 | [Hocuspocus](/guides/collaboration/hocuspocus) | Mature self-hosted Yjs server with auth, persistence, and scaling hooks. | 30 mins |
 | [SuperDoc Yjs](/guides/collaboration/superdoc-yjs) | Minimal reference server for prototypes and local development. Not production infrastructure. | 30 mins |
 
 ## At a glance
 
 <Tabs>
-  <Tab title="YHub">
-    Advanced Yjs backend for attribution, activity, and revision-history workflows. Redis + Postgres backing. Beta; validate licensing and infrastructure requirements.
-
-    [See the example](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub)
-  </Tab>
-
   <Tab title="Hocuspocus">
     Mature self-hosted Yjs server with auth, persistence, and scaling hooks.
 
@@ -137,14 +131,6 @@ new SuperDoc({
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card
-    title="YHub example"
-    icon="layers"
-    href="https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub"
-  >
-    Attribution and revision-history workflows (beta)
-  </Card>
-
   <Card
     title="Hocuspocus setup"
     icon="server"

--- a/apps/docs/guides/collaboration/superdoc-yjs.mdx
+++ b/apps/docs/guides/collaboration/superdoc-yjs.mdx
@@ -7,7 +7,11 @@ keywords: "superdoc collaboration server, yjs server, self-hosted, websocket"
 A minimal Yjs WebSocket server we ship as a reference implementation for prototypes and local development.
 
 <Warning>
-This package is not production infrastructure. It has no built-in auth, persistence, scaling, or observability beyond what you wire into the hooks. For production self-hosted collaboration, use [Hocuspocus](/guides/collaboration/hocuspocus) (recommended default) or [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub) (when attribution and revision history are central). SuperDoc's collaboration contract is provider-agnostic: pass `{ ydoc, provider }` to `modules.collaboration` and the server choice is yours.
+Use this package for prototypes and local development. It does not include production auth, persistence, scaling, or observability.
+
+For production self-hosted collaboration, [compare the available Yjs servers](/guides/collaboration/self-hosted-overview). YHub is worth a look if you need attribution or revision history.
+
+SuperDoc only needs a Yjs document and provider: pass `{ ydoc, provider }` to `modules.collaboration`.
 </Warning>
 
 ## Installation

--- a/apps/docs/llms-full.txt
+++ b/apps/docs/llms-full.txt
@@ -253,10 +253,10 @@ Three preset themes included: Google Docs, Microsoft Word, and Blueprint.
 
 ## Collaboration
 
-Real-time multiplayer editing using Yjs (CRDT). The supported integration contract is provider-agnostic: pass `{ ydoc, provider }` to `modules.collaboration` on the client. Server options:
-- Liveblocks (cloud)
-- Hocuspocus (recommended self-hosted default)
-- YHub (advanced self-hosted; beta; attribution and revision history use cases)
+Real-time multiplayer editing using Yjs (CRDT). The integration contract is provider-agnostic: pass `{ ydoc, provider }` to `modules.collaboration` on the client. Any Yjs-compatible server works. Examples:
+- YHub (advanced Yjs backend for attribution, activity, and revision-history workflows; beta)
+- Hocuspocus (mature self-hosted Yjs server)
+- Liveblocks (managed cloud service)
 - SuperDoc Yjs (minimal reference server, not production infrastructure)
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -77,10 +77,10 @@ Realtime providers and backend setups for Yjs-based collaboration.
 
 | Example | Description |
 |---------|-------------|
-| [providers/hocuspocus](./editor/collaboration/providers/hocuspocus) | Hocuspocus provider (recommended self-hosted default) |
+| [backends/fastapi/yjs-hub](./editor/collaboration/backends/fastapi/yjs-hub) | YHub server (advanced Yjs backend for attribution and revision-history workflows; beta) |
+| [providers/hocuspocus](./editor/collaboration/providers/hocuspocus) | Hocuspocus provider (mature self-hosted Yjs server) |
 | [providers/liveblocks](./editor/collaboration/providers/liveblocks) | Liveblocks managed service |
 | [providers/superdoc-yjs](./editor/collaboration/providers/superdoc-yjs) | SuperDoc Yjs minimal reference server (not production infrastructure) |
-| [backends/fastapi/yjs-hub](./editor/collaboration/backends/fastapi/yjs-hub) | YHub server with attribution and activity stream (beta) |
 | [backends/node-sdk](./editor/collaboration/backends/node-sdk) | Server-side document operations alongside the realtime layer |
 | [backends/fastapi](./editor/collaboration/backends/fastapi) | Python FastAPI backend |
 

--- a/packages/collaboration-yjs/README.md
+++ b/packages/collaboration-yjs/README.md
@@ -29,9 +29,9 @@ It provides:
 
 ## Examples
 
-Please see a [quick start example here](https://github.com/superdoc-dev/superdoc/tree/develop/examples/collaboration/fastify-server)
+Please see a [quick start example here](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/providers/superdoc-yjs).
 
-For more collaboration examples, see the [collaboration examples folder](https://github.com/superdoc-dev/superdoc/tree/develop/examples/collaboration)
+For more collaboration examples, see the [collaboration examples folder](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration).
 
 ## Installation
 
@@ -97,7 +97,7 @@ app.get('/collaboration/:documentId', { websocket: true }, (socket, request) => 
 app.listen({ port: 3000 });
 ```
 
-See [examples/collaboration/fastify-server](https://github.com/superdoc-dev/superdoc/tree/develop/examples/collaboration/fastify-server) for more details
+See [examples/editor/collaboration/providers/superdoc-yjs](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/providers/superdoc-yjs) for more details.
 
 ---
 

--- a/packages/collaboration-yjs/README.md
+++ b/packages/collaboration-yjs/README.md
@@ -2,7 +2,9 @@
 
 `@superdoc-dev/superdoc-yjs-collaboration` is a minimal Yjs WebSocket server for SuperDoc, shipped as a reference implementation for prototypes and local development.
 
-> **Not production infrastructure.** No built-in auth, persistence, scaling, or observability beyond what you wire into the hooks. For production self-hosted collaboration, use [Hocuspocus](https://tiptap.dev/docs/hocuspocus) (recommended default) or [YHub](https://github.com/yjs/yhub) (when attribution and revision history are central). SuperDoc's collaboration contract is provider-agnostic: pass `{ ydoc, provider }` to `modules.collaboration` on the client and the server choice is yours.
+> **Use this package for prototypes and local development.** It does not include production auth, persistence, scaling, or observability.
+>
+> SuperDoc works with any Yjs-compatible server. For self-hosted, see [YHub](https://github.com/yjs/yhub) (advanced; attribution and revision history; beta) or [Hocuspocus](https://tiptap.dev/docs/hocuspocus) (mature). For managed, see [Liveblocks](https://liveblocks.io/). SuperDoc's integration contract is provider-agnostic: pass `{ ydoc, provider }` to `modules.collaboration` on the client.
 
 It provides:
 


### PR DESCRIPTION
Follow-up to #3277, which merged before the dial-back review feedback could be applied.

Drops "recommended self-hosted default" framing for Hocuspocus and any "official package" framing for SuperDoc Yjs. Describes each Yjs server option in trade-off terms instead of endorsing one over another: Hocuspocus is described as "mature self-hosted Yjs server" (no "recommended/default" language), YHub leads the self-hosted comparison as the advanced backend for attribution and revision-history workflows (with beta and licensing caveats), and SuperDoc Yjs stays as the minimal reference server. Also tightens the warning copy in `superdoc-yjs.mdx` and `packages/collaboration-yjs/README.md` to short sentences per the brand voice rules.

Also strips the YHub Tab and the YHub Next-Steps card from the public docs. The only YHub example we have today is the local FastAPI `yjs-hub` backend (server-only, Redis+Postgres setup). A reader landing there from a "YHub example" link would get something mismatched with the implied promise. A first-class SuperDoc+YHub provider example will land in a separate PR once it has been verified end-to-end against a live YHub server.

**Review**: check no docs still imply Hocuspocus is SuperDoc's endorsed default, no public docs link points at something that doesn't match the implied promise, and the warning copy reads as short clear sentences.
**Verified**: `pnpm --filter @superdoc/docs run test:examples` 291 pass; grep confirms no docs link points at `providers/yhub` or any unreleased path.