### PR TITLE
fix(content-controls): default newly-created controls to richText, not unknown (SD-3139)

### DIFF
--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.test.ts
@@ -1095,6 +1095,52 @@ describe('create.contentControl default sdtPr seeding', () => {
     expect(dateEl?.elements?.some((el) => el.name === 'w:storeMappedDataAs')).toBe(true);
     expect(dateEl?.elements?.some((el) => el.name === 'w:calendar')).toBe(true);
   });
+
+  it('defaults newly-created controls without controlType to richText', () => {
+    const editor = makeSdtEditor();
+    const adapter = createContentControlsAdapter(editor);
+
+    const result = adapter.create({ kind: 'inline' }, { changeMode: 'direct' });
+    expect(result.success).toBe(true);
+
+    const insertInline = editor.commands!.insertStructuredContentInline as ReturnType<typeof vi.fn>;
+    const attrs = insertInline.mock.calls[0][0].attrs as Record<string, unknown>;
+    expect(attrs.controlType).toBe('richText');
+    expect(attrs.type).toBe('richText');
+    const sdtPr = attrs.sdtPr as { elements?: Array<{ name: string }> };
+    expect(sdtPr.elements?.some((el) => el.name === 'w:richText')).toBe(true);
+  });
+
+  it('seeds explicit richText controls with w:richText in sdtPr', () => {
+    const editor = makeSdtEditor();
+    const adapter = createContentControlsAdapter(editor);
+
+    const result = adapter.create({ kind: 'inline', controlType: 'richText' }, { changeMode: 'direct' });
+    expect(result.success).toBe(true);
+
+    const insertInline = editor.commands!.insertStructuredContentInline as ReturnType<typeof vi.fn>;
+    const attrs = insertInline.mock.calls[0][0].attrs as Record<string, unknown>;
+    expect(attrs.controlType).toBe('richText');
+    const sdtPr = attrs.sdtPr as { elements?: Array<{ name: string }> };
+    expect(sdtPr.elements?.some((el) => el.name === 'w:richText')).toBe(true);
+  });
+});
+
+describe('contentControls.wrap default classification', () => {
+  it('sets wrapper controlType to richText and seeds w:richText in sdtPr', () => {
+    const editor = makeSdtEditor();
+    const adapter = createContentControlsAdapter(editor);
+
+    adapter.wrap({ target: SDT_TARGET, kind: 'block' }, { changeMode: 'direct' });
+
+    const createFn = editor.schema.nodes.structuredContentBlock.create as ReturnType<typeof vi.fn>;
+    expect(createFn).toHaveBeenCalledTimes(1);
+    const [attrs] = createFn.mock.calls[0];
+    expect(attrs.controlType).toBe('richText');
+    expect(attrs.type).toBe('richText');
+    const sdtPr = attrs.sdtPr as { elements?: Array<{ name: string }> };
+    expect(sdtPr.elements?.some((el) => el.name === 'w:richText')).toBe(true);
+  });
 });
 
 describe('contentControls.setType default sdtPr seeding', () => {

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.ts
@@ -493,8 +493,18 @@ function wrapWrapper(
     const nodeType = editor.schema.nodes[nodeTypeName];
     if (!nodeType) return false;
 
+    // ECMA-376 §17.5.2.26: typeless sdtPr resolves to richText. Default here so
+    // the wrapper classifies the same in-session and after reimport.
     const wrapperNode = nodeType.create(
-      { id, tag: input.tag, alias: input.alias, lockMode: input.lockMode ?? 'unlocked' },
+      {
+        id,
+        tag: input.tag,
+        alias: input.alias,
+        lockMode: input.lockMode ?? 'unlocked',
+        controlType: 'richText',
+        type: 'richText',
+        sdtPr: buildDefaultSdtPr('richText'),
+      },
       resolved.node,
     );
     const { tr } = editor.state;
@@ -1809,15 +1819,18 @@ function createWrapper(
   }
 
   return executeSdtMutation(editor, target, options, () => {
+    // ECMA-376 §17.5.2.26: typeless sdtPr resolves to richText. 'unknown' is for
+    // unsupported/unrecognized type children, not a default for new controls.
+    const controlType = input.controlType ?? 'richText';
     const attrs: Record<string, unknown> = {
       id,
       tag: input.tag,
       alias: input.alias,
       lockMode: input.lockMode ?? 'unlocked',
-      controlType: input.controlType ?? 'unknown',
-      type: input.controlType ?? 'unknown',
+      controlType,
+      type: controlType,
     };
-    const defaultSdtPr = buildDefaultSdtPr(input.controlType ?? 'unknown');
+    const defaultSdtPr = buildDefaultSdtPr(controlType);
     const isDateCreate = input.controlType === 'date' && input.content == null;
     const dateDefaults = isDateCreate ? buildDateControlDefaults() : null;
     const sdtPrWithDateDefaults = dateDefaults ? applyDateDefaultsToSdtPr(defaultSdtPr, dateDefaults) : defaultSdtPr;


### PR DESCRIPTION
Follow-up to SD-3131 (#3275). After that PR, imported typeless `w:sdtPr` correctly resolves to `controlType: 'richText'` per ECMA-376 §17.5.2.26, but newly created controls via `create.contentControl` (with `controlType` omitted) and `contentControls.wrap` still defaulted to `'unknown'`. Customers filtering `contentControls.list()` by type saw different results before vs after save/reopen — the same typeless OOXML round-tripped from `'unknown'` to `'richText'`.

| Path | In-memory | After save → reimport |
|---|---|---|
| `create.contentControl({ kind })` | `'unknown'` | `'richText'` |
| `contentControls.wrap` | `'unknown'` (resolveControlType fallback) | `'richText'` |

- `createWrapper`: collapse three `?? 'unknown'` into a single `?? 'richText'` local.
- `wrapWrapper`: explicitly seed `controlType`, `type`, and a default `sdtPr` with `<w:richText/>` on the wrapper attrs (previously `controlType` was unset entirely, leaving `resolveControlType` to fall back to `'unknown'`).

Newly created controls now emit explicit `<w:richText/>` in `sdtPr` for unambiguous engine state and exported markup. Imported typeless Word-authored SDTs preserve their original raw `sdtPr` (import path unchanged).

Per the SD-3131 design, `'unknown'` keeps its meaning of "unsupported or unrecognized type" — it's no longer the default for new controls.

**Tests**: 3 new — default-create → richText, explicit-richText-create seeds `<w:richText/>`, wrap → richText + seeds `<w:richText/>`. 42 wrappers + 1189 conformance + 1398 document-api pass. Zero new TypeScript errors.

**Non-blocking follow-up**: `create.contentControl` and `setType` still accept explicit `controlType: 'unknown'` because `'unknown'` is in the shared read/write enum. That can produce stable-but-deliberately-unknown controls, which is a separate API-shape question — worth tightening mutation validation if `'unknown'` should be read-only. Not blocking this PR.

Related: SD-3131.