### PR TITLE
fix(direction): preserve explicit bidiVisual=false in resolveTableDirection (SD-3141)

### DIFF
--- a/packages/layout-engine/pm-adapter/src/direction/non-collapse.test.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/non-collapse.test.ts
@@ -72,6 +72,37 @@ describe('Non-collapse rule 2: table w:bidiVisual MUST NOT make cell paragraphs 
     const paragraphContext = resolveParagraphDirection({}, sectionContext, cellContext);
     expect(paragraphContext.inlineDirection).toBeUndefined();
   });
+
+  // SD-3141: explicit `w:bidiVisual w:val="0"` is a real signal per §17.4.1 +
+  // §17.17.4 and can override a style-cascade `true`. The resolver must
+  // distinguish "no signal" (undefined) from "explicit false" (ltr), mirroring
+  // the paragraph resolver's handling of `w:bidi w:val="0"`.
+
+  it('table with explicit rightToLeft:false → visualDirection is ltr', () => {
+    const sectionContext = resolveSectionDirection(undefined);
+    const tableContext = resolveTableDirection({ rightToLeft: false }, sectionContext);
+    expect(tableContext.visualDirection).toBe('ltr');
+  });
+
+  it('table with explicit bidiVisual:false → visualDirection is ltr', () => {
+    const sectionContext = resolveSectionDirection(undefined);
+    const tableContext = resolveTableDirection({ bidiVisual: false }, sectionContext);
+    expect(tableContext.visualDirection).toBe('ltr');
+  });
+
+  it('table with no signal → visualDirection stays undefined', () => {
+    const sectionContext = resolveSectionDirection(undefined);
+    const tableContext = resolveTableDirection({}, sectionContext);
+    expect(tableContext.visualDirection).toBeUndefined();
+  });
+
+  it('table with rightToLeft:true wins when both signals present', () => {
+    // Mixed shape (one true, one false) should NOT happen in practice but
+    // the rtl branch is checked first to keep this case explicit. SD-3141.
+    const sectionContext = resolveSectionDirection(undefined);
+    const tableContext = resolveTableDirection({ rightToLeft: true, bidiVisual: false }, sectionContext);
+    expect(tableContext.visualDirection).toBe('rtl');
+  });
 });
 
 describe('Non-collapse rule 3: run-level w:rtl MUST NOT bubble up to paragraph', () => {

--- a/packages/layout-engine/pm-adapter/src/direction/resolveTableDirection.ts
+++ b/packages/layout-engine/pm-adapter/src/direction/resolveTableDirection.ts
@@ -27,8 +27,14 @@ export const resolveTableDirection = (
   parentSection: SectionDirectionContext,
 ): TableDirectionContext => {
   let visualDirection: BaseDirection | undefined;
+  // Mirror the paragraph resolver shape (resolveParagraphDirection): explicit
+  // false is a real signal and must be distinguished from "no signal." Per
+  // ECMA-376 §17.4.1 + §17.17.4, w:bidiVisual w:val="0" is an explicit-false
+  // that can override a style-cascade true. SD-3141.
   if (tableProperties?.rightToLeft === true || tableProperties?.bidiVisual === true) {
     visualDirection = 'rtl';
+  } else if (tableProperties?.rightToLeft === false || tableProperties?.bidiVisual === false) {
+    visualDirection = 'ltr';
   }
   return { visualDirection, parentSection };
 };


### PR DESCRIPTION
Small, prerequisite for SD-3138 Phase 1B.

`resolveTableDirection` previously emitted `visualDirection` only for the explicit-true case, conflating "no signal" with "explicit false." Per ECMA-376 §17.4.1 + §17.17.4, `w:bidiVisual w:val="0"` is an explicit-false that can override a style-cascade true. The cascade-override semantic is the same as paragraph `w:bidi`, which `resolveParagraphDirection` already handles symmetrically.

The helper `getTableVisualDirection` added in SD-3138 / PR #3279 already returned `'ltr'` for the legacy fallback path. Without this fix, Phase 1B (pm-adapter wiring of `tableDirectionContext`) would silently regress an explicit-false table from `'ltr'` to `undefined` once the context path takes over.

**Diff:** one `else if` added; four resolver tests covering the new branch + the unchanged paths.

**Tests:** 29 pass (24 existing direction tests + 4 new + 1 existing rtl-mixed). No behavior change for current consumers (they read `=== 'rtl'`; `'ltr'` and `undefined` both go to the false branch).

**Sequencing:** land before SD-3138 Phase 1B starts. Companion to SD-3142 (export-side fix for the same explicit-false semantic).