### PR TITLE
fix(converter): preserve explicit w:bidiVisual w:val="0" on export (SD-3142)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/bidiVisual/bidiVisual-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/bidiVisual/bidiVisual-translator.js
@@ -1,14 +1,15 @@
 import { NodeTranslator } from '@translator';
-import { parseBoolean } from '@converter/v3/handlers/utils';
+import { createSingleBooleanPropertyHandler } from '@converter/v3/handlers/utils';
 
 /**
  * The NodeTranslator instance for the bidiVisual element.
+ *
+ * SD-3142: use the shared boolean handler so an explicit `w:val="0"` survives
+ * the round trip as `<w:bidiVisual w:val="0"/>`. Per ECMA-376 §17.4.1 +
+ * §17.17.4, explicit-false can override a style-cascade true; dropping it on
+ * export silently flips the table visual direction on the next open.
+ *
  * @type {import('@translator').NodeTranslator}
  * @see {@link https://ecma-international.org/publications-and-standards/standards/ecma-376/} "Fundamentals And Markup Language Reference", page 373
  */
-export const translator = NodeTranslator.from({
-  xmlName: 'w:bidiVisual',
-  sdNodeOrKeyName: 'rightToLeft',
-  encode: ({ nodes }) => parseBoolean(nodes[0].attributes?.['w:val'] ?? '1'),
-  decode: ({ node }) => (node.attrs.rightToLeft ? { attributes: {} } : undefined),
-});
+export const translator = NodeTranslator.from(createSingleBooleanPropertyHandler('w:bidiVisual', 'rightToLeft'));

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/bidiVisual/bidiVisual-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/bidiVisual/bidiVisual-translator.test.js
@@ -17,13 +17,20 @@ describe('w:bidiVisual translator', () => {
   });
 
   describe('decode', () => {
-    it('creates a w:bidiVisual element if rightToLeft is true', () => {
+    it('creates a bare w:bidiVisual element when rightToLeft is true', () => {
       const { attributes: result } = translator.decode({ node: { attrs: { rightToLeft: true } } });
       expect(result).toEqual({});
     });
 
-    it('returns undefined if rightToLeft is false or missing', () => {
-      expect(translator.decode({ node: { attrs: { rightToLeft: false } } })).toBeUndefined();
+    // SD-3142: explicit false (from `<w:bidiVisual w:val="0"/>`) is a real
+    // signal per §17.4.1 + §17.17.4 and can override a style-cascade true.
+    // Drop it on export and the style cascade wins on the next open.
+    it('emits w:val="0" when rightToLeft is explicit false', () => {
+      const { attributes: result } = translator.decode({ node: { attrs: { rightToLeft: false } } });
+      expect(result).toEqual({ 'w:val': '0' });
+    });
+
+    it('returns undefined when rightToLeft is missing (omit the element)', () => {
       expect(translator.decode({ node: { attrs: {} } })).toBeUndefined();
     });
   });


### PR DESCRIPTION
Round-trip data-loss fix. Independent of SD-3141 (different layer).

`bidiVisual-translator.decode` used a one-off shape that dropped `rightToLeft: false` on export:

```js
decode: ({ node }) => (node.attrs.rightToLeft ? { attributes: {} } : undefined)
```

The paragraph `w:bidi` counterpart uses `createSingleBooleanPropertyHandler`, which distinguishes missing (omit) from explicit false (emit `w:val="0"`). This PR switches `w:bidiVisual` to the same shared handler.

**Why it matters:** per ECMA-376 §17.4.1 + §17.17.4, `<w:bidiVisual w:val="0"/>` is an explicit-false that can override a style-cascade true. A Word doc with `<w:tblStyle w:val="SomeStyleThatSetsBidiVisualTrue"/>` followed by `<w:bidiVisual w:val="0"/>` round-trips through SuperDoc and loses the override on export — the next open flips the table to RTL.

**Diff:** translator becomes a one-liner using the shared helper. Test split: `false` now asserts `w:val="0"` (new — round-trip preservation), missing still omits.

**Tests:** 6 pass. Encode coverage retained (no change to encode side; `parseBoolean` already handled `w:val="0"` correctly).

**Sibling:** SD-3141 (resolver-side fix for the same explicit-false semantic, different layer).