### PR TITLE
docs(collaboration): add YHub guide

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -133,8 +133,9 @@
                     "group": "Guides",
                     "pages": [
                       "guides/collaboration/liveblocks",
-                      "guides/collaboration/superdoc-yjs",
-                      "guides/collaboration/hocuspocus"
+                      "guides/collaboration/yhub",
+                      "guides/collaboration/hocuspocus",
+                      "guides/collaboration/superdoc-yjs"
                     ]
                   }
                 ]

--- a/apps/docs/editor/collaboration/overview.mdx
+++ b/apps/docs/editor/collaboration/overview.mdx
@@ -34,7 +34,7 @@ Collaboration is configured through `modules.collaboration` today, but it isn't 
 
     | Option | Best For |
     |--------|----------|
-    | [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/providers/yhub) | Advanced Yjs backend for attribution, activity, and revision-history workflows. Beta. |
+    | [YHub](/guides/collaboration/yhub) | Advanced Yjs backend for attribution, activity, and revision-history workflows. Beta. |
     | [Hocuspocus](/guides/collaboration/hocuspocus) | Mature self-hosted Yjs server with auth, persistence, and scaling hooks. |
     | [SuperDoc Yjs](/guides/collaboration/superdoc-yjs) | Minimal reference server. Not production infrastructure. |
 

--- a/apps/docs/guides/collaboration/self-hosted-overview.mdx
+++ b/apps/docs/guides/collaboration/self-hosted-overview.mdx
@@ -40,7 +40,7 @@ SuperDoc's integration contract is provider-agnostic: pass `{ ydoc, provider }` 
 
 | Option | Notes | Setup Time |
 |--------|-------|------------|
-| [YHub](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/providers/yhub) | Advanced Yjs backend for attribution, activity, and revision-history workflows. Beta; validate licensing and infrastructure requirements. | 1+ hour |
+| [YHub](/guides/collaboration/yhub) | Advanced Yjs backend for attribution, activity, and revision-history workflows. Beta; validate licensing and infrastructure requirements. | 1+ hour |
 | [Hocuspocus](/guides/collaboration/hocuspocus) | Mature self-hosted Yjs server with auth, persistence, and scaling hooks. | 30 mins |
 | [SuperDoc Yjs](/guides/collaboration/superdoc-yjs) | Minimal reference server for prototypes and local development. Not production infrastructure. | 30 mins |
 
@@ -50,7 +50,7 @@ SuperDoc's integration contract is provider-agnostic: pass `{ ydoc, provider }` 
   <Tab title="YHub">
     Advanced Yjs backend for attribution, activity, and revision-history workflows. Redis + Postgres backing. Beta; validate licensing and infrastructure requirements.
 
-    [See the example](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/providers/yhub)
+    [Setup guide](/guides/collaboration/yhub)
   </Tab>
 
   <Tab title="Hocuspocus">
@@ -138,9 +138,9 @@ new SuperDoc({
 
 <CardGroup cols={2}>
   <Card
-    title="YHub example"
+    title="YHub setup"
     icon="layers"
-    href="https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/providers/yhub"
+    href="/guides/collaboration/yhub"
   >
     Attribution and revision-history workflows (beta)
   </Card>

--- a/apps/docs/guides/collaboration/yhub.mdx
+++ b/apps/docs/guides/collaboration/yhub.mdx
@@ -7,7 +7,7 @@ keywords: "yhub, yjs collaboration, revision history, attribution, self-hosted c
 [YHub](https://github.com/yjs/yhub) is a Yjs backend for teams that need attribution, activity, revision-history, or rollback workflows.
 
 <Warning>
-YHub is in beta and requires Node.js 22+. Validate licensing (AGPL or proprietary) and infrastructure requirements (Redis + Postgres) before production use. The bundled local server in our example is intentionally local-only and is not production infrastructure.
+YHub is in beta and requires Node.js 22+. Validate licensing (AGPL or proprietary) and infrastructure requirements before production use. Production YHub typically pairs Redis with Postgres and an object store (S3 or MinIO) for persisted update blobs; see [YHub's setup docs](https://github.com/yjs/yhub) for the exact architecture. The bundled local server in our example is intentionally local-only (Redis + Postgres, no object store) and is not production infrastructure.
 </Warning>
 
 ## When to choose YHub
@@ -49,9 +49,11 @@ const provider = new WebsocketProvider(
   },
 );
 
+// Guard against the `sync` event firing on reconnect after a network drop.
+let superdoc;
 provider.on("sync", (isSynced) => {
-  if (!isSynced) return;
-  new SuperDoc({
+  if (!isSynced || superdoc) return;
+  superdoc = new SuperDoc({
     selector: "#editor",
     user: { name: "User 123", email: "user-123@example.com" },
     modules: {

--- a/apps/docs/guides/collaboration/yhub.mdx
+++ b/apps/docs/guides/collaboration/yhub.mdx
@@ -24,6 +24,8 @@ For most teams without those requirements, [Hocuspocus](/guides/collaboration/ho
 
 YHub speaks the standard y-websocket protocol, so the SuperDoc client uses `WebsocketProvider` from `y-websocket`. No YHub-specific provider class is needed.
 
+The snippet below connects to the bundled local SuperDoc example server. Production YHub deployments may use a different URL and auth parameter shape (for example, yauth JWT params and `/ws/{org}/{docid}` style paths). Check your deployment's docs.
+
 ```bash
 npm install yjs y-websocket
 ```
@@ -59,7 +61,7 @@ provider.on("sync", (isSynced) => {
 });
 ```
 
-The `params.token` is the shared secret the server validates; `params.userId` is the identifier YHub records on each update for attribution.
+For the bundled local server, `params.token` is the shared secret and `params.userId` is the identifier recorded for attribution. In production, use the auth flow configured for your YHub deployment.
 
 ## Server
 

--- a/apps/docs/guides/collaboration/yhub.mdx
+++ b/apps/docs/guides/collaboration/yhub.mdx
@@ -1,0 +1,124 @@
+---
+title: YHub
+sidebarTitle: YHub
+keywords: "yhub, yjs collaboration, revision history, attribution, self-hosted collaboration"
+---
+
+[YHub](https://github.com/yjs/yhub) is a Yjs backend for teams that need attribution, activity, revision-history, or rollback workflows.
+
+<Warning>
+YHub is in beta and requires Node.js 22+. Validate licensing (AGPL or proprietary) and infrastructure requirements (Redis + Postgres) before production use. The bundled local server in our example is intentionally local-only and is not production infrastructure.
+</Warning>
+
+## When to choose YHub
+
+Reach for YHub when:
+
+- You need built-in attribution or per-update authorship tracking.
+- You need revision history, changesets, or rollback APIs as a first-class concept.
+- You're comfortable operating Redis and Postgres for collaboration state.
+
+For most teams without those requirements, [Hocuspocus](/guides/collaboration/hocuspocus) is a simpler self-hosted starting point, and [Liveblocks](/guides/collaboration/liveblocks) covers the managed path.
+
+## Client setup
+
+YHub speaks the standard y-websocket protocol, so the SuperDoc client uses `WebsocketProvider` from `y-websocket`. No YHub-specific provider class is needed.
+
+```bash
+npm install yjs y-websocket
+```
+
+```typescript
+import * as Y from "yjs";
+import { WebsocketProvider } from "y-websocket";
+import { SuperDoc } from "superdoc";
+
+const documentId = "document-123";
+const ydoc = new Y.Doc();
+const provider = new WebsocketProvider(
+  "ws://127.0.0.1:8081/v1/collaboration",
+  documentId,
+  ydoc,
+  {
+    params: {
+      token: "YOUR_PRIVATE_TOKEN",
+      userId: "user-123",
+    },
+  },
+);
+
+provider.on("sync", (isSynced) => {
+  if (!isSynced) return;
+  new SuperDoc({
+    selector: "#editor",
+    user: { name: "User 123", email: "user-123@example.com" },
+    modules: {
+      collaboration: { ydoc, provider },
+    },
+  });
+});
+```
+
+The `params.token` is the shared secret the server validates; `params.userId` is the identifier YHub records on each update for attribution.
+
+## Server
+
+Running a YHub server requires Redis and Postgres. See the [bundled local server example](https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub) for a working setup with Docker Compose. Use it as a starting point, not as a production deployment.
+
+For production, follow [YHub's own setup guide](https://github.com/yjs/yhub) and pair it with your existing auth, persistence, and ops tooling.
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card
+    title="SuperDoc + YHub example"
+    icon="github"
+    href="https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/providers/yhub"
+  >
+    Complete React + Vite client paired with the bundled local server
+  </Card>
+
+  <Card
+    title="Bundled YHub server"
+    icon="server"
+    href="https://github.com/superdoc-dev/superdoc/tree/main/examples/editor/collaboration/backends/fastapi/yjs-hub"
+  >
+    Local Node + Redis + Postgres reference for development
+  </Card>
+
+  <Card
+    title="YHub repo"
+    icon="book"
+    href="https://github.com/yjs/yhub"
+  >
+    Upstream project, setup, and licensing
+  </Card>
+
+  <Card
+    title="YHub API"
+    icon="code"
+    href="https://github.com/yjs/yhub/blob/master/API.md"
+  >
+    Attribution, activity, changesets, rollback
+  </Card>
+</CardGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Self-hosted overview"
+    icon="layers"
+    href="/guides/collaboration/self-hosted-overview"
+  >
+    Compare YHub with Hocuspocus and the SuperDoc Yjs reference server
+  </Card>
+
+  <Card
+    title="Client configuration"
+    icon="settings"
+    href="/editor/collaboration/configuration"
+  >
+    All SuperDoc collaboration options and events
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Adds a focused YHub integration guide at `apps/docs/guides/collaboration/yhub.mdx` that answers "how do I connect SuperDoc to YHub?" without duplicating YHub's own operations docs. Covers when to choose YHub (attribution / revision history / Redis+Postgres ops budget), the client snippet (`WebsocketProvider` from `y-websocket` with token + userId params), a short server note pointing at the bundled local example, and Resources cards linking out to upstream.

Warning block calls out the three production foot-guns: YHub is beta and needs Node 22+, licensing is AGPL or proprietary, and the bundled local server is intentionally local-only (not production infrastructure). Activity-stream APIs are intentionally not documented here: they're real in YHub but our local example demonstrates them only for debugging, and promising "SuperDoc owns an audit pipeline" would overstate what we ship.

Also adds the page to `docs.json` nav (collaboration order: liveblocks, yhub, hocuspocus, superdoc-yjs) and swaps the 4 docs link references that currently point at the `providers/yhub` GitHub folder to point at the new guide instead: 2 comparison-table rows (in `self-hosted-overview.mdx` and `editor/collaboration/overview.mdx`), the YHub Tab CTA, and the YHub Next-Steps card. The Resources cards inside the guide itself still link to GitHub for the actual code.

**Review**: confirm the guide doesn't overpromise (no implied production audit API), the warning hits the right caveats, the client snippet matches the bundled server's URL/auth shape, and the link swaps land cleanly.
**Verified**: `pnpm --filter @superdoc/docs run test:examples` 291 pass; `check:icons` clean; `check:imports` clean across 647 MDX files.