### PR TITLE
feat(types): public facade policy + generator (SD-2966)

### DIFF
--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -154,6 +154,13 @@ jobs:
         # ESM, missing CDN files, unpublished `source` paths.
         run: node tests/consumer-typecheck/package-shape-gate.mjs
 
+      - name: Public facade doc drift (SD-2966)
+        # docs/architecture/public-type-facade.md is generated from
+        # tests/consumer-typecheck/public-facade-policy.json. The policy
+        # is the source of truth; this step fails if the committed doc
+        # drifts from what the renderer produces.
+        run: node tests/consumer-typecheck/render-facade-doc.mjs --check
+
   unit-tests:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Package shape gates
         run: node tests/consumer-typecheck/package-shape-gate.mjs
 
+      - name: Public facade doc drift (SD-2966)
+        run: node tests/consumer-typecheck/render-facade-doc.mjs --check
+
       - name: Release stable packages (orchestrator)
         id: stable_release
         env:

--- a/.github/workflows/release-superdoc.yml
+++ b/.github/workflows/release-superdoc.yml
@@ -139,6 +139,10 @@ jobs:
         # the packed tarball. Same step as PR CI.
         run: node tests/consumer-typecheck/package-shape-gate.mjs
 
+      - name: Public facade doc drift (SD-2966)
+        # Same gate as PR CI. Catches releases that bypass PR CI.
+        run: node tests/consumer-typecheck/render-facade-doc.mjs --check
+
       # PR preview: publish with pr-<number> dist-tag
       - name: Publish PR preview
         if: inputs.pr_number

--- a/docs/architecture/package-boundaries.md
+++ b/docs/architecture/package-boundaries.md
@@ -12,6 +12,8 @@ The fix is not "convert the whole repo to TypeScript." Recent spike work (SD-283
 
 This document is that taxonomy.
 
+Related follow-up: [SuperDoc Public Type Facade](./public-type-facade.md) (SD-2966) defines the explicit facade the package should implement before retrying declaration rollup.
+
 ## Tier definitions
 
 Every workspace package and every `superdoc` subpath export sits in exactly one of these tiers.
@@ -223,7 +225,7 @@ The order in which the work lands matters. The RFC and the gate tickets are usef
 **Future work:**
 
 4. **Folder reorganization** (SD-2835). The structural change becomes lower risk after step 3 because the gates catch any regression that the move might introduce. See SD-2835 for the proposed shape.
-5. **Surgical TypeScript migration** of the public contract files: configuration, command surfaces, toolbar/UI types, the supported `superdoc/super-editor` facade. Do not start with a 1,800-file repo-wide migration; that is expensive and would not on its own guarantee the published artifact works.
+5. **Surgical TypeScript migration** of the public contract files: configuration, command surfaces, toolbar/UI types, and the legacy `superdoc/super-editor` compatibility facade (classified under Decision 1; see also the [Public Type Facade design](./public-type-facade.md) (SD-2966) for the per-symbol policy). Do not start with a 1,800-file repo-wide migration; that is expensive and would not on its own guarantee the published artifact works.
 6. **Long-tail TypeScript migration** opportunistically, where new work touches a file or `checkJs` surfaces real drift between JSDoc and implementation.
 
 Step 4 should wait for at least one release running with strict gates, so the team has confidence the boundary holds before moving files. Steps 5-6 run on their own cadence, evidence-driven rather than calendar-driven.

--- a/docs/architecture/public-type-facade.md
+++ b/docs/architecture/public-type-facade.md
@@ -55,22 +55,34 @@ Source annotations are normalized in a follow-up PR. The policy tier remains the
 | legacy-root | @deprecated replaceWith=<target> removeIn=<version> or compat-indefinitely | `legacy-root` is a policy tier, not a TSDoc tag. Source annotations use the repository deprecation convention from comment-policy.md. |
 | internal | @internal | Not part of the supported customer contract. This is a real TSDoc release tag. |
 
+## Classification status
+
+Each `import_paths[]` entry carries a `classification_status` that bounds how the audit may use `symbols[]`.
+
+| Status | Meaning |
+| --- | --- |
+| fully-classified | Every export through this path appears in `symbols[]`. Strict audit may treat `symbols[]` as the closed contract for this path. |
+| partially-classified | Path is public, but `symbols[]` covers only a subset of exports. Strict audit must NOT treat missing symbols as policy gaps until the path is promoted to `fully-classified`. |
+| pending-classification | Path is public but no symbols are enumerated yet. Same audit posture as `partially-classified`. Tracks intent to enumerate in a follow-up. |
+| legacy-frozen | Legacy compatibility path. Existing consumers keep compiling; `symbols[]` intentionally does not enumerate the full surface. Future enforcement is a no-growth export snapshot, not deep per-symbol classification. Strict audit must NOT interpret missing symbols as policy gaps. |
+| asset | Non-code asset entry (e.g. CSS). No symbol policy applies. |
+
 ## Import Path Policy
 
-| Import path | Kind | Tier for new exports | Decision |
-| --- | --- | --- | --- |
-| `superdoc` | canonical-facade | public | Canonical entry. New docs and support guidance point here. New runtime values and types are added through this facade unless they belong to a dedicated subpath. |
-| `superdoc/types` | type-only-facade | public | Type-only entry for extension/schema authors. No runtime values. |
-| `superdoc/ui` | public-subpath | public | Browser UI controller surface. Owns UI controller types; root re-exports only what top-level consumers need. |
-| `superdoc/ui/react` | public-subpath | public | React bindings for `superdoc/ui`. |
-| `superdoc/headless-toolbar` | public-subpath | public | Headless toolbar controller; owns toolbar contract types. |
-| `superdoc/headless-toolbar/react` | public-subpath | public | React helper for the headless toolbar. |
-| `superdoc/headless-toolbar/vue` | public-subpath | public | Vue helper for the headless toolbar. |
-| `superdoc/style.css` | asset | public | Asset export. No type contract. |
-| `superdoc/super-editor` | legacy-compat-subpath | legacy-root | Legacy public compatibility surface per `package-boundaries.md` Decision 1. Keep compiling. No new exports added here. Migration target for new code is `superdoc`. |
-| `superdoc/converter` | legacy-compat-subpath | legacy-root | Legacy compatibility after SD-2953. Migrate to `SuperConverter` from `superdoc`. |
-| `superdoc/docx-zipper` | legacy-compat-subpath | legacy-root | Legacy compatibility after SD-2953. Migrate to `DocxZipper` from `superdoc`. |
-| `superdoc/file-zipper` | legacy-compat-subpath | legacy-root | Legacy compatibility after SD-2953. Migrate to `createZip` from `superdoc`. |
+| Import path | Kind | Tier for new exports | Classification status | Decision |
+| --- | --- | --- | --- | --- |
+| `superdoc` | canonical-facade | public | partially-classified | Canonical entry. New docs and support guidance point here. New runtime values and types are added through this facade unless they belong to a dedicated subpath. |
+| `superdoc/types` | type-only-facade | public | partially-classified | Type-only entry for extension/schema authors. No runtime values. `symbols[]` covers the headline schema-helper types; the full re-export from `@superdoc/super-editor/types` is not yet enumerated. |
+| `superdoc/ui` | public-subpath | public | partially-classified | Browser UI controller surface. Owns UI controller types; root re-exports only what top-level consumers need. `symbols[]` covers the controller headline types; ~60 supporting types from `@superdoc/super-editor/ui` are not yet enumerated. |
+| `superdoc/ui/react` | public-subpath | public | pending-classification | React bindings for `superdoc/ui`. Eleven hooks/components exported; none yet enumerated in `symbols[]`. |
+| `superdoc/headless-toolbar` | public-subpath | public | partially-classified | Headless toolbar controller; owns toolbar contract types. `symbols[]` covers the headline controller types; the full 16-name surface is not yet enumerated. |
+| `superdoc/headless-toolbar/react` | public-subpath | public | pending-classification | React helper for the headless toolbar (`useHeadlessToolbar`). Not yet enumerated in `symbols[]`. |
+| `superdoc/headless-toolbar/vue` | public-subpath | public | pending-classification | Vue helper for the headless toolbar (`useHeadlessToolbar`). Not yet enumerated in `symbols[]`. |
+| `superdoc/style.css` | asset | public | asset | Asset export. No type contract. |
+| `superdoc/super-editor` | legacy-compat-subpath | legacy-root | legacy-frozen | Legacy public compatibility surface per `package-boundaries.md` Decision 1. Keep compiling. No new exports added here. Migration target for new code is `superdoc`. |
+| `superdoc/converter` | legacy-compat-subpath | legacy-root | legacy-frozen | Legacy compatibility after SD-2953. Migrate to `SuperConverter` from `superdoc`. |
+| `superdoc/docx-zipper` | legacy-compat-subpath | legacy-root | legacy-frozen | Legacy compatibility after SD-2953. Migrate to `DocxZipper` from `superdoc`. |
+| `superdoc/file-zipper` | legacy-compat-subpath | legacy-root | legacy-frozen | Legacy compatibility after SD-2953. Migrate to `createZip` from `superdoc`. |
 
 No other `superdoc/*` subpath should be added without updating `public-facade-policy.json`, `package.json` exports, the export-coverage audit, and the consumer matrix in the same PR.
 
@@ -83,21 +95,20 @@ No other `superdoc/*` subpath should be added without updating `public-facade-po
 | Import and export | `SuperConverter`, `DocxZipper`, `createZip`, `BlankDOCX`, `DOCX`, `PDF`, `HTML`, `getFileObject` | Imported from `superdoc`. |
 | Extension authoring | `Extensions`, `getStarterExtensions`, `getRichTextExtensions`, `defineNode`, `defineMark`, `isNodeType`, `assertNodeType`, `isMarkType` | Imported from `superdoc`. |
 | Theming | `createTheme`, `buildTheme` | Imported from `superdoc`. |
-| UI components | `SuperEditor`, `Toolbar`, `ContextMenu`, `AIWriter` | Imported from `superdoc`. |
-| UI components | `SuperToolbar` | Imported from `superdoc`. `SuperToolbar` - Supported direct-instantiation surface; keep in the root facade with real constructor/config types. |
+| UI components | `SuperEditor`, `Toolbar`, `ContextMenu`, `AIWriter`, `SuperToolbar` | Imported from `superdoc`. `SuperToolbar` - Supported direct-instantiation surface; keep in the root facade with real constructor/config types. |
 
 ## Legacy and internal runtime values
 
 These currently appear or are reachable but are not part of the supported contract.
 
-| Group | Tier | Names | Migration / evidence |
+| Group | Tier | Names | Migration / evidence / removal |
 | --- | --- | --- | --- |
-| UI components | legacy-root | `SlashMenu` | Migration target: ContextMenu from `superdoc`. |
-| Helpers | legacy-root | `fieldAnnotationHelpers`, `trackChangesHelpers`, `SectionHelpers`, `superEditorHelpers` | Migration target: superdoc Document API or dedicated helper subpath (TBD) |
-| Plugin keys | legacy-root | `TrackChangesBasePluginKey`, `CommentsPluginKey` | Migration target: Document API or UI controller (Comments/TrackChanges slices) |
-| Low-level editor helpers | legacy-root | `getMarksFromSelection`, `getActiveFormatting`, `getAllowedImageDimensions` | Migration target: Document API |
-| Converter internals | internal | `registeredHandlers` | Currently reachable; not documented; no known consumer use case. |
-| Annotator helpers | legacy-root | `AnnotatorHelpers` | Migration target: Document API or Annotator-specific subpath (TBD) |
+| UI components | legacy-root | `SlashMenu` | Migration target: ContextMenu from `superdoc`. `SlashMenu` - Deprecated alias; do not advertise in new docs. Removal: compat-indefinitely until a major release with migration notes. |
+| Helpers | legacy-root | `fieldAnnotationHelpers`, `trackChangesHelpers`, `SectionHelpers`, `superEditorHelpers` | Migration target: superdoc Document API or dedicated helper subpath (TBD) Removal: compat-indefinitely (pending Open Decision 3) |
+| Plugin keys | legacy-root | `TrackChangesBasePluginKey`, `CommentsPluginKey` | Migration target: Document API or UI controller (Comments/TrackChanges slices) `TrackChangesBasePluginKey` - ProseMirror integration escape hatch.; `CommentsPluginKey` - ProseMirror integration escape hatch. Removal: compat-indefinitely |
+| Low-level editor helpers | legacy-root | `getMarksFromSelection`, `getActiveFormatting`, `getAllowedImageDimensions` | Migration target: Document API Removal: compat-indefinitely |
+| Converter internals | internal | `registeredHandlers` | Currently reachable; not documented; no known consumer use case. `registeredHandlers` - Move behind facade unless an existing consumer is identified (Open Decision 4). |
+| Annotator helpers | legacy-root | `AnnotatorHelpers` | Migration target: Document API or Annotator-specific subpath (TBD) `AnnotatorHelpers` - Avoid new docs. Removal: compat-indefinitely |
 
 ## Public type groups
 
@@ -119,18 +130,18 @@ Public types are named from the customer workflow they support, not from the int
 
 Exported for compatibility or reachable as implementation detail. Not part of the supported contract.
 
-| Group | Tier | Names | Migration / evidence |
+| Group | Tier | Names | Migration / evidence / removal |
 | --- | --- | --- | --- |
-| ProseMirror primitives | legacy-root | `EditorState`, `Transaction`, `Schema`, `EditorView`, `ProseMirrorJSON` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
-| Command internals | legacy-root | `EditorCommands`, `CommandProps`, `Command`, `ChainedCommand`, `CoreCommandMap`, `ExtensionCommandMap` | Migration target: Document API or UI command controller |
-| Layout internals | internal | `FlowBlock`, `Layout`, `LayoutPage`, `LayoutFragment`, `Measure`, `SectionMetadata`, `PaintSnapshot`, `PositionHit` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
-| Plugin key types | legacy-root | `TrackChangesBasePluginKey`, `CommentsPluginKey` | Migration target: Document API or UI controller |
+| ProseMirror primitives | legacy-root | `EditorState`, `Transaction`, `Schema`, `EditorView`, `ProseMirrorJSON` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. Removal: compat-indefinitely while advanced consumers depend on them |
+| Command internals | legacy-root | `EditorCommands`, `CommandProps`, `Command`, `ChainedCommand`, `CoreCommandMap`, `ExtensionCommandMap` | Migration target: Document API or UI command controller Removal: compat-indefinitely |
+| Layout internals | internal | `FlowBlock`, `Layout`, `LayoutPage`, `LayoutFragment`, `Measure`, `SectionMetadata`, `PaintSnapshot`, `PositionHit` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. `FlowBlock` - Open Decision 2: keep as inspection/debug type or promote to public. |
+| Plugin key types | legacy-root | `TrackChangesBasePluginKey`, `CommentsPluginKey` | Migration target: Document API or UI controller Removal: compat-indefinitely (paired with the value re-exports) |
 
 ## Symbol policy
 
-This flat list is the machine-readable contract the audit will consume. Grouped sections above are for review ergonomics.
+This flat list is the machine-readable record reviewed in this PR. **Strict audit may consume `symbols[]` only for `import_paths` whose `classification_status` is `fully-classified`.** For partial paths, the table records reviewed symbols and known direction; it cannot drive strict gating until the path is promoted. Grouped sections above are for review ergonomics.
 
-| Symbol | Kind | Group | Tier | Import path | Migration / evidence |
+| Symbol | Kind | Group | Tier | Import path | Migration / evidence / removal |
 | --- | --- | --- | --- | --- | --- |
 | `SuperDoc` | runtime_value | Core document UI | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
 | `Editor` | runtime_value | Headless editor | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
@@ -156,20 +167,20 @@ This flat list is the machine-readable contract the audit will consume. Grouped 
 | `SuperEditor` | runtime_value | UI components | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
 | `Toolbar` | runtime_value | UI components | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
 | `ContextMenu` | runtime_value | UI components | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
-| `SlashMenu` | runtime_value | UI components | legacy-root | `superdoc` | Migration target: ContextMenu from `superdoc`. |
+| `SlashMenu` | runtime_value | UI components | legacy-root | `superdoc` | Migration target: ContextMenu from `superdoc`. Removal: compat-indefinitely until a major release with migration notes. |
 | `AIWriter` | runtime_value | UI components | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
 | `SuperToolbar` | runtime_value | UI components | public | `superdoc` | Direct consumer fixture instantiates `new SuperToolbar(...)` in tests/consumer-typecheck/src/customer-scenario.ts:661 and asserts assignability at line 671. |
-| `fieldAnnotationHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) |
-| `trackChangesHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) |
-| `SectionHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) |
-| `superEditorHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) |
-| `TrackChangesBasePluginKey` | runtime_value | Plugin keys | legacy-root | `superdoc` | Migration target: Document API or UI controller (Comments/TrackChanges slices) |
-| `CommentsPluginKey` | runtime_value | Plugin keys | legacy-root | `superdoc` | Migration target: Document API or UI controller (Comments/TrackChanges slices) |
-| `getMarksFromSelection` | runtime_value | Low-level editor helpers | legacy-root | `superdoc` | Migration target: Document API |
-| `getActiveFormatting` | runtime_value | Low-level editor helpers | legacy-root | `superdoc` | Migration target: Document API |
-| `getAllowedImageDimensions` | runtime_value | Low-level editor helpers | legacy-root | `superdoc` | Migration target: Document API |
+| `fieldAnnotationHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) Removal: compat-indefinitely (pending Open Decision 3). |
+| `trackChangesHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) Removal: compat-indefinitely (pending Open Decision 3). |
+| `SectionHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) Removal: compat-indefinitely (pending Open Decision 3). |
+| `superEditorHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) Removal: compat-indefinitely (pending Open Decision 3). |
+| `TrackChangesBasePluginKey` | runtime_value | Plugin keys | legacy-root | `superdoc` | Migration target: Document API or UI controller (Comments/TrackChanges slices) Removal: compat-indefinitely. |
+| `CommentsPluginKey` | runtime_value | Plugin keys | legacy-root | `superdoc` | Migration target: Document API or UI controller (Comments/TrackChanges slices) Removal: compat-indefinitely. |
+| `getMarksFromSelection` | runtime_value | Low-level editor helpers | legacy-root | `superdoc` | Migration target: Document API Removal: compat-indefinitely. |
+| `getActiveFormatting` | runtime_value | Low-level editor helpers | legacy-root | `superdoc` | Migration target: Document API Removal: compat-indefinitely. |
+| `getAllowedImageDimensions` | runtime_value | Low-level editor helpers | legacy-root | `superdoc` | Migration target: Document API Removal: compat-indefinitely. |
 | `registeredHandlers` | runtime_value | Converter internals | internal | `superdoc` | Currently reachable; not documented; no known consumer use case. |
-| `AnnotatorHelpers` | runtime_value | Annotator helpers | legacy-root | `superdoc` | Migration target: Document API or Annotator-specific subpath (TBD) |
+| `AnnotatorHelpers` | runtime_value | Annotator helpers | legacy-root | `superdoc` | Migration target: Document API or Annotator-specific subpath (TBD) Removal: compat-indefinitely. |
 | `Config` | type | Configuration | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
 | `Modules` | type | Configuration | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
 | `User` | type | Configuration | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
@@ -223,17 +234,17 @@ This flat list is the machine-readable contract the audit will consume. Grouped 
 | `NodeAttrs` | type | Extension authoring (types) | public | `superdoc/types` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
 | `MarkName` | type | Extension authoring (types) | public | `superdoc/types` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
 | `MarkAttrs` | type | Extension authoring (types) | public | `superdoc/types` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
-| `EditorState` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
-| `Transaction` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
-| `Schema` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
-| `EditorView` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
-| `ProseMirrorJSON` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
-| `EditorCommands` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
-| `CommandProps` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
-| `Command` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
-| `ChainedCommand` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
-| `CoreCommandMap` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
-| `ExtensionCommandMap` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
+| `EditorState` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. Removal: compat-indefinitely while advanced consumers depend on them. |
+| `Transaction` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. Removal: compat-indefinitely while advanced consumers depend on them. |
+| `Schema` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. Removal: compat-indefinitely while advanced consumers depend on them. |
+| `EditorView` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. Removal: compat-indefinitely while advanced consumers depend on them. |
+| `ProseMirrorJSON` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. Removal: compat-indefinitely while advanced consumers depend on them. |
+| `EditorCommands` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller Removal: compat-indefinitely. |
+| `CommandProps` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller Removal: compat-indefinitely. |
+| `Command` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller Removal: compat-indefinitely. |
+| `ChainedCommand` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller Removal: compat-indefinitely. |
+| `CoreCommandMap` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller Removal: compat-indefinitely. |
+| `ExtensionCommandMap` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller Removal: compat-indefinitely. |
 | `FlowBlock` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
 | `Layout` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
 | `LayoutPage` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
@@ -242,8 +253,8 @@ This flat list is the machine-readable contract the audit will consume. Grouped 
 | `SectionMetadata` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
 | `PaintSnapshot` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
 | `PositionHit` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
-| `TrackChangesBasePluginKey` | type | Plugin key types | legacy-root | `superdoc` | Migration target: Document API or UI controller |
-| `CommentsPluginKey` | type | Plugin key types | legacy-root | `superdoc` | Migration target: Document API or UI controller |
+| `TrackChangesBasePluginKey` | type | Plugin key types | legacy-root | `superdoc` | Migration target: Document API or UI controller Removal: compat-indefinitely (paired with the value re-exports). |
+| `CommentsPluginKey` | type | Plugin key types | legacy-root | `superdoc` | Migration target: Document API or UI controller Removal: compat-indefinitely (paired with the value re-exports). |
 
 ## Legacy `superdoc/super-editor` facade
 
@@ -287,18 +298,20 @@ packages/superdoc/src/public/
 
 ## Audit consumption
 
-The audit (`deep-type-audit.mjs`) reads `public-facade-policy.json` as the authoritative classification source. Source JSDoc tags are normalized in PR 2 but are not the contract.
+The audit (`deep-type-audit.mjs`) reads `public-facade-policy.json` as the authoritative classification source. Strict gating applies only to `import_paths` whose `classification_status` is `fully-classified`. For partial paths, `symbols[]` records reviewed names but cannot drive enforcement.
 
 **Rationale.**
 
 - TSDoc release tags (`@public`, `@beta`, `@internal`) do not survive `.d.ts` emission in our current pipeline. The audit walks emitted declarations and cannot recover tags from them.
 - Source files today carry malformed JSDoc (multi-typedef blocks, missing `replaceWith`/`removeIn` on `@deprecated`). Treating source as the authority would freeze that malformed shape into CI.
 - JSON is reviewable in a single PR, diffable, and exposes intent. Source annotations follow in PR 2 once the policy is the established contract.
+- `classification_status` keeps the audit honest about partial coverage. Marking a path `partially-classified` records intent without falsely advertising completeness; the audit treats missing symbols on those paths as out-of-scope rather than as policy gaps.
 
 **Future state.**
 
+- Promote `superdoc/ui`, `superdoc/ui/react`, `superdoc/headless-toolbar`, `/react`, `/vue`, and `superdoc/types` from partial/pending to `fully-classified` (tracked as a follow-up; blocks SD-3046 strict gate).
 - PR 2 normalizes source JSDoc to match the policy.
-- PR 3 wires `deep-type-audit.mjs` to read the policy: each tier gets a strict gate appropriate to its level (public must not collapse to `any`; legacy-root tolerated; internal must not be reachable from a public path).
+- PR 3 wires `deep-type-audit.mjs` to read the policy: each tier gets a strict gate appropriate to its level (public must not collapse to `any`; legacy-root tolerated; internal must not be reachable from a public path). Strict mode keys on `classification_status: fully-classified`.
 - If API Extractor or a similar tool starts preserving TSDoc tags in emitted declarations later, the audit can prefer source tags and use the JSON only for legacy-root and internal classifications.
 
 ## CI gates after the facade exists

--- a/docs/architecture/public-type-facade.md
+++ b/docs/architecture/public-type-facade.md
@@ -1,0 +1,352 @@
+# SuperDoc Public Type Facade
+
+**Status:** Draft (SD-2966)  
+**Owner:** Caio Pizzol  
+**Last updated:** 2026-05-14
+
+<!--
+This file is generated from tests/consumer-typecheck/public-facade-policy.json.
+Do not edit by hand. Run `node tests/consumer-typecheck/render-facade-doc.mjs --write` to regenerate.
+CI runs `node tests/consumer-typecheck/render-facade-doc.mjs --check` to fail on drift.
+-->
+
+## Purpose
+
+SD-2828 made the published TypeScript surface compile for consumers. The remaining problem is that the surface is still implicit: public types are whatever the current entry barrels re-export, plus whatever those types reference transitively.
+
+That implicit surface is why declaration rollup failed in SD-2965. Both tested bundlers could close the graph, but API Extractor surfaced forgotten exports, mixed local and exported declarations, and unresolved public names. The package is bundleable in principle; it is not yet curated enough to bundle safely.
+
+This document, generated from `tests/consumer-typecheck/public-facade-policy.json`, defines the facade that should exist before retrying declaration rollup or doing broad TypeScript migration.
+
+## Goals
+
+- Make `superdoc` the canonical import path for new customer code.
+- Keep legacy public paths compiling without growing them.
+- Give every supported public type a stable name and owner.
+- Stop treating internal implementation types as public just because they are reachable.
+- Make future declaration rollup a packaging change, not an API discovery exercise.
+
+## Non-goals
+
+- Removing `superdoc/super-editor` now.
+- Publishing internal packages like `@superdoc/contracts`.
+- Migrating the whole repository to TypeScript.
+- Hiding existing legacy names in a patch or minor release.
+
+## Visibility tiers
+
+These are policy tiers, not necessarily source-code annotation tags.
+
+| Policy tier | Meaning |
+| --- | --- |
+| public | Supported and documented. Stable contract; breaking changes require a deprecation window and a major or signposted minor release. |
+| beta | Available from a public path but explicitly scoped to evolve. May change shape or be removed with notice; not yet documented as a stable contract. |
+| legacy-root | Re-exported from the root `superdoc` facade for backward compatibility. Migration target exists. Not advertised in new docs. No-growth: new exports are not added through this classification. |
+| internal | Reachable through some path today but not part of the contract. Must move behind the facade or be excluded from emitted declarations before strict gates can turn on. |
+
+## Source annotation mapping
+
+Source annotations are normalized in a follow-up PR. The policy tier remains the audit source of truth.
+
+| Policy tier | Source annotation form | Notes |
+| --- | --- | --- |
+| public | @public | Supported stable contract. This is a real TSDoc release tag. |
+| beta | @beta | Supported preview contract. This is a real TSDoc release tag. |
+| legacy-root | @deprecated replaceWith=<target> removeIn=<version> or compat-indefinitely | `legacy-root` is a policy tier, not a TSDoc tag. Source annotations use the repository deprecation convention from comment-policy.md. |
+| internal | @internal | Not part of the supported customer contract. This is a real TSDoc release tag. |
+
+## Import Path Policy
+
+| Import path | Kind | Tier for new exports | Decision |
+| --- | --- | --- | --- |
+| `superdoc` | canonical-facade | public | Canonical entry. New docs and support guidance point here. New runtime values and types are added through this facade unless they belong to a dedicated subpath. |
+| `superdoc/types` | type-only-facade | public | Type-only entry for extension/schema authors. No runtime values. |
+| `superdoc/ui` | public-subpath | public | Browser UI controller surface. Owns UI controller types; root re-exports only what top-level consumers need. |
+| `superdoc/ui/react` | public-subpath | public | React bindings for `superdoc/ui`. |
+| `superdoc/headless-toolbar` | public-subpath | public | Headless toolbar controller; owns toolbar contract types. |
+| `superdoc/headless-toolbar/react` | public-subpath | public | React helper for the headless toolbar. |
+| `superdoc/headless-toolbar/vue` | public-subpath | public | Vue helper for the headless toolbar. |
+| `superdoc/style.css` | asset | public | Asset export. No type contract. |
+| `superdoc/super-editor` | legacy-compat-subpath | legacy-root | Legacy public compatibility surface per `package-boundaries.md` Decision 1. Keep compiling. No new exports added here. Migration target for new code is `superdoc`. |
+| `superdoc/converter` | legacy-compat-subpath | legacy-root | Legacy compatibility after SD-2953. Migrate to `SuperConverter` from `superdoc`. |
+| `superdoc/docx-zipper` | legacy-compat-subpath | legacy-root | Legacy compatibility after SD-2953. Migrate to `DocxZipper` from `superdoc`. |
+| `superdoc/file-zipper` | legacy-compat-subpath | legacy-root | Legacy compatibility after SD-2953. Migrate to `createZip` from `superdoc`. |
+
+No other `superdoc/*` subpath should be added without updating `public-facade-policy.json`, `package.json` exports, the export-coverage audit, and the consumer matrix in the same PR.
+
+## Supported runtime values
+
+| Group | Names | Notes |
+| --- | --- | --- |
+| Core document UI | `SuperDoc` | Imported from `superdoc`. `SuperDoc` - Primary browser editor entry. |
+| Headless editor | `Editor`, `PresentationEditor` | Imported from `superdoc`. `Editor` - Headless and server-side workflows. Prefer Document API for state mutation.; `PresentationEditor` - Bridges editor events into layout/paint state. |
+| Import and export | `SuperConverter`, `DocxZipper`, `createZip`, `BlankDOCX`, `DOCX`, `PDF`, `HTML`, `getFileObject` | Imported from `superdoc`. |
+| Extension authoring | `Extensions`, `getStarterExtensions`, `getRichTextExtensions`, `defineNode`, `defineMark`, `isNodeType`, `assertNodeType`, `isMarkType` | Imported from `superdoc`. |
+| Theming | `createTheme`, `buildTheme` | Imported from `superdoc`. |
+| UI components | `SuperEditor`, `Toolbar`, `ContextMenu`, `AIWriter` | Imported from `superdoc`. |
+| UI components | `SuperToolbar` | Imported from `superdoc`. `SuperToolbar` - Supported direct-instantiation surface; keep in the root facade with real constructor/config types. |
+
+## Legacy and internal runtime values
+
+These currently appear or are reachable but are not part of the supported contract.
+
+| Group | Tier | Names | Migration / evidence |
+| --- | --- | --- | --- |
+| UI components | legacy-root | `SlashMenu` | Migration target: ContextMenu from `superdoc`. |
+| Helpers | legacy-root | `fieldAnnotationHelpers`, `trackChangesHelpers`, `SectionHelpers`, `superEditorHelpers` | Migration target: superdoc Document API or dedicated helper subpath (TBD) |
+| Plugin keys | legacy-root | `TrackChangesBasePluginKey`, `CommentsPluginKey` | Migration target: Document API or UI controller (Comments/TrackChanges slices) |
+| Low-level editor helpers | legacy-root | `getMarksFromSelection`, `getActiveFormatting`, `getAllowedImageDimensions` | Migration target: Document API |
+| Converter internals | internal | `registeredHandlers` | Currently reachable; not documented; no known consumer use case. |
+| Annotator helpers | legacy-root | `AnnotatorHelpers` | Migration target: Document API or Annotator-specific subpath (TBD) |
+
+## Public type groups
+
+Public types are named from the customer workflow they support, not from the internal package that happens to define them.
+
+| Group | Names | Notes |
+| --- | --- | --- |
+| Configuration | `Config`, `Modules`, `User`, `Document`, `CollaborationConfig`, `SuperDocTelemetryConfig`, `AwarenessState` | Imported from `superdoc`. `AwarenessState` - Added in SD-2834. |
+| Document API | `DocumentApi`, `SelectionApi`, `SelectionInfo`, `TextTarget`, `TextAddress`, `EntityAddress`, `BlocksListResult`, `BookmarkInfo` | Imported from `superdoc`. |
+| Editor lifecycle | `EditorOptions`, `EditorLifecycleState`, `OpenOptions`, `SaveOptions`, `ExportOptions`, `ExportDocxParams`, `EditorEventMap`, `EditorTransactionEvent` | Imported from `superdoc`. `EditorTransactionEvent` - Transaction field narrowed to real `Transaction` in SD-2834. |
+| Comments and track changes | `Comment`, `CommentElement`, `CommentsPayload`, `TrackChangesModuleConfig` | Imported from `superdoc`. |
+| UI controller | `SuperDocUI`, `SuperDocUIOptions`, `SuperDocUIState`, `SelectionSlice`, `CommentsSlice`, `TrackChangesSlice`, `ViewportHandle`, `DocumentHandle` | Imported from `superdoc/ui`. |
+| Toolbar | `CreateHeadlessToolbarOptions`, `HeadlessToolbarController`, `PublicToolbarItemId`, `ToolbarSnapshot` | Imported from `superdoc/headless-toolbar`. |
+| Proofing | `ProofingProvider`, `ProofingCheckRequest`, `ProofingCheckResult`, `ProofingIssue`, `ProofingConfig`, `ProofingError` | Imported from `superdoc`. `ProofingError` - `cause` field narrowed from `any` to `unknown` in SD-2834. |
+| Theming and surfaces | `ContextMenuConfig`, `SurfaceResolver`, `SurfaceHandle` | Imported from `superdoc`. |
+| Extension authoring (types) | `EditorExtension`, `NodeName`, `NodeAttrs`, `MarkName`, `MarkAttrs` | Imported from `superdoc/types`. |
+
+## Legacy and internal type groups
+
+Exported for compatibility or reachable as implementation detail. Not part of the supported contract.
+
+| Group | Tier | Names | Migration / evidence |
+| --- | --- | --- | --- |
+| ProseMirror primitives | legacy-root | `EditorState`, `Transaction`, `Schema`, `EditorView`, `ProseMirrorJSON` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
+| Command internals | legacy-root | `EditorCommands`, `CommandProps`, `Command`, `ChainedCommand`, `CoreCommandMap`, `ExtensionCommandMap` | Migration target: Document API or UI command controller |
+| Layout internals | internal | `FlowBlock`, `Layout`, `LayoutPage`, `LayoutFragment`, `Measure`, `SectionMetadata`, `PaintSnapshot`, `PositionHit` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
+| Plugin key types | legacy-root | `TrackChangesBasePluginKey`, `CommentsPluginKey` | Migration target: Document API or UI controller |
+
+## Symbol policy
+
+This flat list is the machine-readable contract the audit will consume. Grouped sections above are for review ergonomics.
+
+| Symbol | Kind | Group | Tier | Import path | Migration / evidence |
+| --- | --- | --- | --- | --- | --- |
+| `SuperDoc` | runtime_value | Core document UI | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `Editor` | runtime_value | Headless editor | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `PresentationEditor` | runtime_value | Headless editor | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SuperConverter` | runtime_value | Import and export | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `DocxZipper` | runtime_value | Import and export | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `createZip` | runtime_value | Import and export | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `BlankDOCX` | runtime_value | Import and export | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `DOCX` | runtime_value | Import and export | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `PDF` | runtime_value | Import and export | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `HTML` | runtime_value | Import and export | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `getFileObject` | runtime_value | Import and export | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `Extensions` | runtime_value | Extension authoring | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `getStarterExtensions` | runtime_value | Extension authoring | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `getRichTextExtensions` | runtime_value | Extension authoring | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `defineNode` | runtime_value | Extension authoring | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `defineMark` | runtime_value | Extension authoring | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `isNodeType` | runtime_value | Extension authoring | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `assertNodeType` | runtime_value | Extension authoring | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `isMarkType` | runtime_value | Extension authoring | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `createTheme` | runtime_value | Theming | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `buildTheme` | runtime_value | Theming | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SuperEditor` | runtime_value | UI components | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `Toolbar` | runtime_value | UI components | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ContextMenu` | runtime_value | UI components | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SlashMenu` | runtime_value | UI components | legacy-root | `superdoc` | Migration target: ContextMenu from `superdoc`. |
+| `AIWriter` | runtime_value | UI components | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SuperToolbar` | runtime_value | UI components | public | `superdoc` | Direct consumer fixture instantiates `new SuperToolbar(...)` in tests/consumer-typecheck/src/customer-scenario.ts:661 and asserts assignability at line 671. |
+| `fieldAnnotationHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) |
+| `trackChangesHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) |
+| `SectionHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) |
+| `superEditorHelpers` | runtime_value | Helpers | legacy-root | `superdoc` | Migration target: superdoc Document API or dedicated helper subpath (TBD) |
+| `TrackChangesBasePluginKey` | runtime_value | Plugin keys | legacy-root | `superdoc` | Migration target: Document API or UI controller (Comments/TrackChanges slices) |
+| `CommentsPluginKey` | runtime_value | Plugin keys | legacy-root | `superdoc` | Migration target: Document API or UI controller (Comments/TrackChanges slices) |
+| `getMarksFromSelection` | runtime_value | Low-level editor helpers | legacy-root | `superdoc` | Migration target: Document API |
+| `getActiveFormatting` | runtime_value | Low-level editor helpers | legacy-root | `superdoc` | Migration target: Document API |
+| `getAllowedImageDimensions` | runtime_value | Low-level editor helpers | legacy-root | `superdoc` | Migration target: Document API |
+| `registeredHandlers` | runtime_value | Converter internals | internal | `superdoc` | Currently reachable; not documented; no known consumer use case. |
+| `AnnotatorHelpers` | runtime_value | Annotator helpers | legacy-root | `superdoc` | Migration target: Document API or Annotator-specific subpath (TBD) |
+| `Config` | type | Configuration | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `Modules` | type | Configuration | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `User` | type | Configuration | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `Document` | type | Configuration | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `CollaborationConfig` | type | Configuration | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SuperDocTelemetryConfig` | type | Configuration | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `AwarenessState` | type | Configuration | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `DocumentApi` | type | Document API | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SelectionApi` | type | Document API | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SelectionInfo` | type | Document API | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `TextTarget` | type | Document API | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `TextAddress` | type | Document API | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `EntityAddress` | type | Document API | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `BlocksListResult` | type | Document API | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `BookmarkInfo` | type | Document API | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `EditorOptions` | type | Editor lifecycle | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `EditorLifecycleState` | type | Editor lifecycle | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `OpenOptions` | type | Editor lifecycle | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SaveOptions` | type | Editor lifecycle | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ExportOptions` | type | Editor lifecycle | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ExportDocxParams` | type | Editor lifecycle | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `EditorEventMap` | type | Editor lifecycle | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `EditorTransactionEvent` | type | Editor lifecycle | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `Comment` | type | Comments and track changes | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `CommentElement` | type | Comments and track changes | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `CommentsPayload` | type | Comments and track changes | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `TrackChangesModuleConfig` | type | Comments and track changes | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SuperDocUI` | type | UI controller | public | `superdoc/ui` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SuperDocUIOptions` | type | UI controller | public | `superdoc/ui` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SuperDocUIState` | type | UI controller | public | `superdoc/ui` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SelectionSlice` | type | UI controller | public | `superdoc/ui` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `CommentsSlice` | type | UI controller | public | `superdoc/ui` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `TrackChangesSlice` | type | UI controller | public | `superdoc/ui` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ViewportHandle` | type | UI controller | public | `superdoc/ui` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `DocumentHandle` | type | UI controller | public | `superdoc/ui` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `CreateHeadlessToolbarOptions` | type | Toolbar | public | `superdoc/headless-toolbar` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `HeadlessToolbarController` | type | Toolbar | public | `superdoc/headless-toolbar` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `PublicToolbarItemId` | type | Toolbar | public | `superdoc/headless-toolbar` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ToolbarSnapshot` | type | Toolbar | public | `superdoc/headless-toolbar` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ProofingProvider` | type | Proofing | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ProofingCheckRequest` | type | Proofing | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ProofingCheckResult` | type | Proofing | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ProofingIssue` | type | Proofing | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ProofingConfig` | type | Proofing | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ProofingError` | type | Proofing | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `ContextMenuConfig` | type | Theming and surfaces | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SurfaceResolver` | type | Theming and surfaces | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `SurfaceHandle` | type | Theming and surfaces | public | `superdoc` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `EditorExtension` | type | Extension authoring (types) | public | `superdoc/types` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `NodeName` | type | Extension authoring (types) | public | `superdoc/types` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `NodeAttrs` | type | Extension authoring (types) | public | `superdoc/types` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `MarkName` | type | Extension authoring (types) | public | `superdoc/types` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `MarkAttrs` | type | Extension authoring (types) | public | `superdoc/types` | Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy. |
+| `EditorState` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
+| `Transaction` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
+| `Schema` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
+| `EditorView` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
+| `ProseMirrorJSON` | type | ProseMirror primitives | legacy-root | `superdoc` | Migration target: Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them. |
+| `EditorCommands` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
+| `CommandProps` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
+| `Command` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
+| `ChainedCommand` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
+| `CoreCommandMap` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
+| `ExtensionCommandMap` | type | Command internals | legacy-root | `superdoc` | Migration target: Document API or UI command controller |
+| `FlowBlock` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
+| `Layout` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
+| `LayoutPage` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
+| `LayoutFragment` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
+| `Measure` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
+| `SectionMetadata` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
+| `PaintSnapshot` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
+| `PositionHit` | type | Layout internals | internal | `superdoc` | Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`. |
+| `TrackChangesBasePluginKey` | type | Plugin key types | legacy-root | `superdoc` | Migration target: Document API or UI controller |
+| `CommentsPluginKey` | type | Plugin key types | legacy-root | `superdoc` | Migration target: Document API or UI controller |
+
+## Legacy `superdoc/super-editor` facade
+
+`superdoc/super-editor` is a compatibility facade. Rules:
+
+- Existing exports keep compiling.
+- No new export is added through `superdoc/super-editor` unless there is no supported replacement.
+- New docs avoid this path except migration and advanced pages.
+- Each symbol kept here has a migration target: usually `superdoc`, `superdoc/ui`, or Document API.
+- A no-growth audit (future) snapshots this subpath; new names appearing on it fail CI.
+
+Known symbols and their migration decisions:
+
+| Symbols | Current use | Proposed target |
+| --- | --- | --- |
+| `Editor`, `PresentationEditor`, `SuperConverter`, `DocxZipper`, `createZip` | Headless and conversion workflows. | Already available from `superdoc`. |
+| `getStarterExtensions`, `getRichTextExtensions`, `Extensions`, `defineNode`, `defineMark`, `isNodeType`, `assertNodeType`, `isMarkType` | Extension authoring. | Already available from `superdoc`. |
+| `Extension`, `Node`, `Mark`, `Attribute`, `Plugin`, `PluginKey` | Advanced custom extension docs. | Decide whether to promote to `superdoc` or keep legacy-only (Open Decision 1). |
+| `resolveSelectionTarget`, `resolveDefaultInsertTarget` | CLI and internal Document API bridge. | Keep internal or expose a documented Document API helper home. |
+| `trackChangesHelpers`, `fieldAnnotationHelpers`, `SectionHelpers` | Existing advanced integrations. | Keep typed as legacy-supported. Do not expand. |
+
+## Implementation shape
+
+Recommended source layout:
+
+```text
+packages/superdoc/src/public/
+  index.ts                 # canonical top-level value + type facade
+  types.ts                 # type-only facade for superdoc/types
+  super-editor-compat.ts   # legacy compatibility facade
+  ui.ts                    # superdoc/ui facade
+  ui-react.ts              # superdoc/ui/react facade
+  headless-toolbar.ts      # toolbar facade
+  headless-toolbar-react.ts
+  headless-toolbar-vue.ts
+```
+
+- Existing entry files can stay as thin wrappers during migration.
+- Public exports are explicit lists, not `export *` from implementation barrels.
+- Each exported name carries one tier classification recorded in `public-facade-policy.json`. Source-side annotations (TSDoc tags) are normalized in PR 2 to match the policy.
+
+## Audit consumption
+
+The audit (`deep-type-audit.mjs`) reads `public-facade-policy.json` as the authoritative classification source. Source JSDoc tags are normalized in PR 2 but are not the contract.
+
+**Rationale.**
+
+- TSDoc release tags (`@public`, `@beta`, `@internal`) do not survive `.d.ts` emission in our current pipeline. The audit walks emitted declarations and cannot recover tags from them.
+- Source files today carry malformed JSDoc (multi-typedef blocks, missing `replaceWith`/`removeIn` on `@deprecated`). Treating source as the authority would freeze that malformed shape into CI.
+- JSON is reviewable in a single PR, diffable, and exposes intent. Source annotations follow in PR 2 once the policy is the established contract.
+
+**Future state.**
+
+- PR 2 normalizes source JSDoc to match the policy.
+- PR 3 wires `deep-type-audit.mjs` to read the policy: each tier gets a strict gate appropriate to its level (public must not collapse to `any`; legacy-root tolerated; internal must not be reachable from a public path).
+- If API Extractor or a similar tool starts preserving TSDoc tags in emitted declarations later, the audit can prefer source tags and use the JSON only for legacy-root and internal classifications.
+
+## CI gates after the facade exists
+
+Existing SD-2828 gates stay. Add these once the facade is implemented:
+
+| # | Gate | Description |
+| --- | --- | --- |
+| 1 | No wildcard public re-exports | Files under `packages/superdoc/src/public/**` must not use `export *`. Compatibility files (`super-editor-compat.ts`) are explicitly allowlisted. |
+| 2 | No-growth snapshot for `superdoc/super-editor` | Snapshot of names exported through the legacy subpath. New names appearing fail CI. |
+| 3 | Public type snapshot | Top-level `superdoc` supported names tracked against a snapshot. Additions are intentional (PR adds the row to the policy). |
+| 4 | Reachability ratio gate | After rollup or curated-emit path is in place: emitted declarations reachable only through declared public paths. |
+| 5 | Consumer matrix authoritative | Pack-and-install consumer typecheck across `bundler`, `node16`, `nodenext` with `skipLibCheck: false`. Unchanged from SD-2828. |
+
+## Sequencing
+
+1. Land this policy + renderer + reconciled RFC (PR 1).
+2. Normalize source JSDoc to match the policy: split multi-typedef blocks, standard tags only, complete `@deprecated replaceWith=X removeIn=Y` per `comment-policy.md` (PR 2).
+3. Implement explicit facade files under `packages/superdoc/src/public/` without changing runtime behavior.
+4. Update docs and examples to point new code at `superdoc`, `superdoc/ui`, and `superdoc/headless-toolbar`.
+5. Wire the audit to read the policy JSON; turn on per-tier strict gates (PR 3, sibling of SD-3046).
+6. Retry declaration rollup against the facade input.
+7. Migrate public-contract files to TypeScript only where the facade or rollup still needs cleaner input.
+
+## Open decisions
+
+| # | Question | Default if unresolved |
+| --- | --- | --- |
+| 1 | Promote `Extension`, `Node`, `Mark`, `Attribute` classes to top-level `superdoc` extension-authoring surface? | Keep legacy-only. Extension authoring proceeds through the existing factory functions. |
+| 2 | Are layout types (`FlowBlock`, `Layout`, `PaintSnapshot`) customer-supported, or internal/debug-only? | Internal. Layout is owned by `layout-engine/` and is not part of the public contract today. |
+| 3 | Promote helper namespaces (`superEditorHelpers`, `trackChangesHelpers`, `fieldAnnotationHelpers`, `SectionHelpers`) to documented stable, or keep as legacy? | Legacy-root. Keep typed; do not expand. Document API is the strategic path. |
+| 4 | Should `registeredHandlers` remain exported at all? | Internal. Move behind the facade unless a consumer surfaces a real use case. |
+| 5 | Deprecation window length for `superdoc/super-editor` once migration docs are complete? | Compat-indefinitely. Per `package-boundaries.md` Decision 1: keep compiling, do not advertise. No removal date until usage data justifies one. |
+
+## RFC reconciliation
+
+### 1. `docs/architecture/package-boundaries.md` near line 228
+
+**Issue.** Calls `superdoc/super-editor` a 'supported facade'; Decision 1 (line 144) classifies it as legacy public compatibility surface.
+
+**Current text.**
+
+> Surgical TypeScript migration of the public contract files: configuration, command surfaces, toolbar/UI types, the supported `superdoc/super-editor` facade.
+
+**Proposed text.**
+
+> Surgical TypeScript migration of the public contract files: configuration, command surfaces, toolbar/UI types, and the legacy `superdoc/super-editor` compatibility facade.
+
+**Rationale.** Decision 1 is the single source of truth for the classification. The migration item should describe the facade by its actual tier so the policy in this document and the RFC say the same thing.
+
+**Source of truth.** package-boundaries.md Decision 1 (line 144-148).

--- a/tests/consumer-typecheck/package.json
+++ b/tests/consumer-typecheck/package.json
@@ -6,7 +6,9 @@
     "typecheck": "tsc --noEmit",
     "typecheck:matrix": "node typecheck-matrix.mjs",
     "check:types": "node check-public-types.mjs",
-    "check:types:write": "node check-public-types.mjs --write"
+    "check:types:write": "node check-public-types.mjs --write",
+    "check:facade-doc": "node render-facade-doc.mjs --check",
+    "check:facade-doc:write": "node render-facade-doc.mjs --write"
   },
   "dependencies": {
     "superdoc": "file:../../packages/superdoc/superdoc.tgz"

--- a/tests/consumer-typecheck/package.json
+++ b/tests/consumer-typecheck/package.json
@@ -6,9 +6,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:matrix": "node typecheck-matrix.mjs",
     "check:types": "node check-public-types.mjs",
-    "check:types:write": "node check-public-types.mjs --write",
-    "check:facade-doc": "node render-facade-doc.mjs --check",
-    "check:facade-doc:write": "node render-facade-doc.mjs --write"
+    "check:types:write": "node check-public-types.mjs --write"
   },
   "dependencies": {
     "superdoc": "file:../../packages/superdoc/superdoc.tgz"

--- a/tests/consumer-typecheck/public-facade-policy.json
+++ b/tests/consumer-typecheck/public-facade-policy.json
@@ -28,77 +28,112 @@
       "summary": "Reachable through some path today but not part of the contract. Must move behind the facade or be excluded from emitted declarations before strict gates can turn on."
     }
   ],
+  "classification_statuses": [
+    {
+      "id": "fully-classified",
+      "summary": "Every export through this path appears in `symbols[]`. Strict audit may treat `symbols[]` as the closed contract for this path."
+    },
+    {
+      "id": "partially-classified",
+      "summary": "Path is public, but `symbols[]` covers only a subset of exports. Strict audit must NOT treat missing symbols as policy gaps until the path is promoted to `fully-classified`."
+    },
+    {
+      "id": "pending-classification",
+      "summary": "Path is public but no symbols are enumerated yet. Same audit posture as `partially-classified`. Tracks intent to enumerate in a follow-up."
+    },
+    {
+      "id": "legacy-frozen",
+      "summary": "Legacy compatibility path. Existing consumers keep compiling; `symbols[]` intentionally does not enumerate the full surface. Future enforcement is a no-growth export snapshot, not deep per-symbol classification. Strict audit must NOT interpret missing symbols as policy gaps."
+    },
+    {
+      "id": "asset",
+      "summary": "Non-code asset entry (e.g. CSS). No symbol policy applies."
+    }
+  ],
+
   "import_paths": [
     {
       "path": "superdoc",
       "kind": "canonical-facade",
       "tier_for_new_exports": "public",
+      "classification_status": "partially-classified",
       "decision": "Canonical entry. New docs and support guidance point here. New runtime values and types are added through this facade unless they belong to a dedicated subpath."
     },
     {
       "path": "superdoc/types",
       "kind": "type-only-facade",
       "tier_for_new_exports": "public",
-      "decision": "Type-only entry for extension/schema authors. No runtime values."
+      "classification_status": "partially-classified",
+      "decision": "Type-only entry for extension/schema authors. No runtime values. `symbols[]` covers the headline schema-helper types; the full re-export from `@superdoc/super-editor/types` is not yet enumerated."
     },
     {
       "path": "superdoc/ui",
       "kind": "public-subpath",
       "tier_for_new_exports": "public",
-      "decision": "Browser UI controller surface. Owns UI controller types; root re-exports only what top-level consumers need."
+      "classification_status": "partially-classified",
+      "decision": "Browser UI controller surface. Owns UI controller types; root re-exports only what top-level consumers need. `symbols[]` covers the controller headline types; ~60 supporting types from `@superdoc/super-editor/ui` are not yet enumerated."
     },
     {
       "path": "superdoc/ui/react",
       "kind": "public-subpath",
       "tier_for_new_exports": "public",
-      "decision": "React bindings for `superdoc/ui`."
+      "classification_status": "pending-classification",
+      "decision": "React bindings for `superdoc/ui`. Eleven hooks/components exported; none yet enumerated in `symbols[]`."
     },
     {
       "path": "superdoc/headless-toolbar",
       "kind": "public-subpath",
       "tier_for_new_exports": "public",
-      "decision": "Headless toolbar controller; owns toolbar contract types."
+      "classification_status": "partially-classified",
+      "decision": "Headless toolbar controller; owns toolbar contract types. `symbols[]` covers the headline controller types; the full 16-name surface is not yet enumerated."
     },
     {
       "path": "superdoc/headless-toolbar/react",
       "kind": "public-subpath",
       "tier_for_new_exports": "public",
-      "decision": "React helper for the headless toolbar."
+      "classification_status": "pending-classification",
+      "decision": "React helper for the headless toolbar (`useHeadlessToolbar`). Not yet enumerated in `symbols[]`."
     },
     {
       "path": "superdoc/headless-toolbar/vue",
       "kind": "public-subpath",
       "tier_for_new_exports": "public",
-      "decision": "Vue helper for the headless toolbar."
+      "classification_status": "pending-classification",
+      "decision": "Vue helper for the headless toolbar (`useHeadlessToolbar`). Not yet enumerated in `symbols[]`."
     },
     {
       "path": "superdoc/style.css",
       "kind": "asset",
       "tier_for_new_exports": "public",
+      "classification_status": "asset",
       "decision": "Asset export. No type contract."
     },
     {
       "path": "superdoc/super-editor",
       "kind": "legacy-compat-subpath",
       "tier_for_new_exports": "legacy-root",
+      "classification_status": "legacy-frozen",
       "decision": "Legacy public compatibility surface per `package-boundaries.md` Decision 1. Keep compiling. No new exports added here. Migration target for new code is `superdoc`."
     },
     {
       "path": "superdoc/converter",
       "kind": "legacy-compat-subpath",
       "tier_for_new_exports": "legacy-root",
+      "classification_status": "legacy-frozen",
       "decision": "Legacy compatibility after SD-2953. Migrate to `SuperConverter` from `superdoc`."
     },
     {
       "path": "superdoc/docx-zipper",
       "kind": "legacy-compat-subpath",
       "tier_for_new_exports": "legacy-root",
+      "classification_status": "legacy-frozen",
       "decision": "Legacy compatibility after SD-2953. Migrate to `DocxZipper` from `superdoc`."
     },
     {
       "path": "superdoc/file-zipper",
       "kind": "legacy-compat-subpath",
       "tier_for_new_exports": "legacy-root",
+      "classification_status": "legacy-frozen",
       "decision": "Legacy compatibility after SD-2953. Migrate to `createZip` from `superdoc`."
     }
   ],
@@ -166,15 +201,17 @@
     ]
   },
   "audit_consumption": {
-    "summary": "The audit (`deep-type-audit.mjs`) reads `public-facade-policy.json` as the authoritative classification source. Source JSDoc tags are normalized in PR 2 but are not the contract.",
+    "summary": "The audit (`deep-type-audit.mjs`) reads `public-facade-policy.json` as the authoritative classification source. Strict gating applies only to `import_paths` whose `classification_status` is `fully-classified`. For partial paths, `symbols[]` records reviewed names but cannot drive enforcement.",
     "rationale": [
       "TSDoc release tags (`@public`, `@beta`, `@internal`) do not survive `.d.ts` emission in our current pipeline. The audit walks emitted declarations and cannot recover tags from them.",
       "Source files today carry malformed JSDoc (multi-typedef blocks, missing `replaceWith`/`removeIn` on `@deprecated`). Treating source as the authority would freeze that malformed shape into CI.",
-      "JSON is reviewable in a single PR, diffable, and exposes intent. Source annotations follow in PR 2 once the policy is the established contract."
+      "JSON is reviewable in a single PR, diffable, and exposes intent. Source annotations follow in PR 2 once the policy is the established contract.",
+      "`classification_status` keeps the audit honest about partial coverage. Marking a path `partially-classified` records intent without falsely advertising completeness; the audit treats missing symbols on those paths as out-of-scope rather than as policy gaps."
     ],
     "future_state": [
+      "Promote `superdoc/ui`, `superdoc/ui/react`, `superdoc/headless-toolbar`, `/react`, `/vue`, and `superdoc/types` from partial/pending to `fully-classified` (tracked as a follow-up; blocks SD-3046 strict gate).",
       "PR 2 normalizes source JSDoc to match the policy.",
-      "PR 3 wires `deep-type-audit.mjs` to read the policy: each tier gets a strict gate appropriate to its level (public must not collapse to `any`; legacy-root tolerated; internal must not be reachable from a public path).",
+      "PR 3 wires `deep-type-audit.mjs` to read the policy: each tier gets a strict gate appropriate to its level (public must not collapse to `any`; legacy-root tolerated; internal must not be reachable from a public path). Strict mode keys on `classification_status: fully-classified`.",
       "If API Extractor or a similar tool starts preserving TSDoc tags in emitted declarations later, the audit can prefer source tags and use the JSON only for legacy-root and internal classifications."
     ]
   },

--- a/tests/consumer-typecheck/public-facade-policy.json
+++ b/tests/consumer-typecheck/public-facade-policy.json
@@ -1,0 +1,1233 @@
+{
+  "$schema_version": "1",
+  "metadata": {
+    "ticket": "SD-2966",
+    "status": "Draft",
+    "owner": "Caio Pizzol",
+    "last_updated": "2026-05-14"
+  },
+  "tiers": [
+    {
+      "id": "public",
+      "label": "public",
+      "summary": "Supported and documented. Stable contract; breaking changes require a deprecation window and a major or signposted minor release."
+    },
+    {
+      "id": "beta",
+      "label": "beta",
+      "summary": "Available from a public path but explicitly scoped to evolve. May change shape or be removed with notice; not yet documented as a stable contract."
+    },
+    {
+      "id": "legacy-root",
+      "label": "legacy-root",
+      "summary": "Re-exported from the root `superdoc` facade for backward compatibility. Migration target exists. Not advertised in new docs. No-growth: new exports are not added through this classification."
+    },
+    {
+      "id": "internal",
+      "label": "internal",
+      "summary": "Reachable through some path today but not part of the contract. Must move behind the facade or be excluded from emitted declarations before strict gates can turn on."
+    }
+  ],
+  "import_paths": [
+    {
+      "path": "superdoc",
+      "kind": "canonical-facade",
+      "tier_for_new_exports": "public",
+      "decision": "Canonical entry. New docs and support guidance point here. New runtime values and types are added through this facade unless they belong to a dedicated subpath."
+    },
+    {
+      "path": "superdoc/types",
+      "kind": "type-only-facade",
+      "tier_for_new_exports": "public",
+      "decision": "Type-only entry for extension/schema authors. No runtime values."
+    },
+    {
+      "path": "superdoc/ui",
+      "kind": "public-subpath",
+      "tier_for_new_exports": "public",
+      "decision": "Browser UI controller surface. Owns UI controller types; root re-exports only what top-level consumers need."
+    },
+    {
+      "path": "superdoc/ui/react",
+      "kind": "public-subpath",
+      "tier_for_new_exports": "public",
+      "decision": "React bindings for `superdoc/ui`."
+    },
+    {
+      "path": "superdoc/headless-toolbar",
+      "kind": "public-subpath",
+      "tier_for_new_exports": "public",
+      "decision": "Headless toolbar controller; owns toolbar contract types."
+    },
+    {
+      "path": "superdoc/headless-toolbar/react",
+      "kind": "public-subpath",
+      "tier_for_new_exports": "public",
+      "decision": "React helper for the headless toolbar."
+    },
+    {
+      "path": "superdoc/headless-toolbar/vue",
+      "kind": "public-subpath",
+      "tier_for_new_exports": "public",
+      "decision": "Vue helper for the headless toolbar."
+    },
+    {
+      "path": "superdoc/style.css",
+      "kind": "asset",
+      "tier_for_new_exports": "public",
+      "decision": "Asset export. No type contract."
+    },
+    {
+      "path": "superdoc/super-editor",
+      "kind": "legacy-compat-subpath",
+      "tier_for_new_exports": "legacy-root",
+      "decision": "Legacy public compatibility surface per `package-boundaries.md` Decision 1. Keep compiling. No new exports added here. Migration target for new code is `superdoc`."
+    },
+    {
+      "path": "superdoc/converter",
+      "kind": "legacy-compat-subpath",
+      "tier_for_new_exports": "legacy-root",
+      "decision": "Legacy compatibility after SD-2953. Migrate to `SuperConverter` from `superdoc`."
+    },
+    {
+      "path": "superdoc/docx-zipper",
+      "kind": "legacy-compat-subpath",
+      "tier_for_new_exports": "legacy-root",
+      "decision": "Legacy compatibility after SD-2953. Migrate to `DocxZipper` from `superdoc`."
+    },
+    {
+      "path": "superdoc/file-zipper",
+      "kind": "legacy-compat-subpath",
+      "tier_for_new_exports": "legacy-root",
+      "decision": "Legacy compatibility after SD-2953. Migrate to `createZip` from `superdoc`."
+    }
+  ],
+  "legacy_super_editor_facade": {
+    "rules": [
+      "Existing exports keep compiling.",
+      "No new export is added through `superdoc/super-editor` unless there is no supported replacement.",
+      "New docs avoid this path except migration and advanced pages.",
+      "Each symbol kept here has a migration target: usually `superdoc`, `superdoc/ui`, or Document API.",
+      "A no-growth audit (future) snapshots this subpath; new names appearing on it fail CI."
+    ],
+    "known_symbol_decisions": [
+      {
+        "symbols": ["Editor", "PresentationEditor", "SuperConverter", "DocxZipper", "createZip"],
+        "current_use": "Headless and conversion workflows.",
+        "proposed_target": "Already available from `superdoc`."
+      },
+      {
+        "symbols": [
+          "getStarterExtensions",
+          "getRichTextExtensions",
+          "Extensions",
+          "defineNode",
+          "defineMark",
+          "isNodeType",
+          "assertNodeType",
+          "isMarkType"
+        ],
+        "current_use": "Extension authoring.",
+        "proposed_target": "Already available from `superdoc`."
+      },
+      {
+        "symbols": ["Extension", "Node", "Mark", "Attribute", "Plugin", "PluginKey"],
+        "current_use": "Advanced custom extension docs.",
+        "proposed_target": "Decide whether to promote to `superdoc` or keep legacy-only (Open Decision 1)."
+      },
+      {
+        "symbols": ["resolveSelectionTarget", "resolveDefaultInsertTarget"],
+        "current_use": "CLI and internal Document API bridge.",
+        "proposed_target": "Keep internal or expose a documented Document API helper home."
+      },
+      {
+        "symbols": ["trackChangesHelpers", "fieldAnnotationHelpers", "SectionHelpers"],
+        "current_use": "Existing advanced integrations.",
+        "proposed_target": "Keep typed as legacy-supported. Do not expand."
+      }
+    ]
+  },
+  "implementation_shape": {
+    "source_layout": [
+      "packages/superdoc/src/public/",
+      "  index.ts                 # canonical top-level value + type facade",
+      "  types.ts                 # type-only facade for superdoc/types",
+      "  super-editor-compat.ts   # legacy compatibility facade",
+      "  ui.ts                    # superdoc/ui facade",
+      "  ui-react.ts              # superdoc/ui/react facade",
+      "  headless-toolbar.ts      # toolbar facade",
+      "  headless-toolbar-react.ts",
+      "  headless-toolbar-vue.ts"
+    ],
+    "notes": [
+      "Existing entry files can stay as thin wrappers during migration.",
+      "Public exports are explicit lists, not `export *` from implementation barrels.",
+      "Each exported name carries one tier classification recorded in `public-facade-policy.json`. Source-side annotations (TSDoc tags) are normalized in PR 2 to match the policy."
+    ]
+  },
+  "audit_consumption": {
+    "summary": "The audit (`deep-type-audit.mjs`) reads `public-facade-policy.json` as the authoritative classification source. Source JSDoc tags are normalized in PR 2 but are not the contract.",
+    "rationale": [
+      "TSDoc release tags (`@public`, `@beta`, `@internal`) do not survive `.d.ts` emission in our current pipeline. The audit walks emitted declarations and cannot recover tags from them.",
+      "Source files today carry malformed JSDoc (multi-typedef blocks, missing `replaceWith`/`removeIn` on `@deprecated`). Treating source as the authority would freeze that malformed shape into CI.",
+      "JSON is reviewable in a single PR, diffable, and exposes intent. Source annotations follow in PR 2 once the policy is the established contract."
+    ],
+    "future_state": [
+      "PR 2 normalizes source JSDoc to match the policy.",
+      "PR 3 wires `deep-type-audit.mjs` to read the policy: each tier gets a strict gate appropriate to its level (public must not collapse to `any`; legacy-root tolerated; internal must not be reachable from a public path).",
+      "If API Extractor or a similar tool starts preserving TSDoc tags in emitted declarations later, the audit can prefer source tags and use the JSON only for legacy-root and internal classifications."
+    ]
+  },
+  "ci_gates": [
+    {
+      "id": 1,
+      "name": "No wildcard public re-exports",
+      "description": "Files under `packages/superdoc/src/public/**` must not use `export *`. Compatibility files (`super-editor-compat.ts`) are explicitly allowlisted."
+    },
+    {
+      "id": 2,
+      "name": "No-growth snapshot for `superdoc/super-editor`",
+      "description": "Snapshot of names exported through the legacy subpath. New names appearing fail CI."
+    },
+    {
+      "id": 3,
+      "name": "Public type snapshot",
+      "description": "Top-level `superdoc` supported names tracked against a snapshot. Additions are intentional (PR adds the row to the policy)."
+    },
+    {
+      "id": 4,
+      "name": "Reachability ratio gate",
+      "description": "After rollup or curated-emit path is in place: emitted declarations reachable only through declared public paths."
+    },
+    {
+      "id": 5,
+      "name": "Consumer matrix authoritative",
+      "description": "Pack-and-install consumer typecheck across `bundler`, `node16`, `nodenext` with `skipLibCheck: false`. Unchanged from SD-2828."
+    }
+  ],
+  "sequencing": [
+    "Land this policy + renderer + reconciled RFC (PR 1).",
+    "Normalize source JSDoc to match the policy: split multi-typedef blocks, standard tags only, complete `@deprecated replaceWith=X removeIn=Y` per `comment-policy.md` (PR 2).",
+    "Implement explicit facade files under `packages/superdoc/src/public/` without changing runtime behavior.",
+    "Update docs and examples to point new code at `superdoc`, `superdoc/ui`, and `superdoc/headless-toolbar`.",
+    "Wire the audit to read the policy JSON; turn on per-tier strict gates (PR 3, sibling of SD-3046).",
+    "Retry declaration rollup against the facade input.",
+    "Migrate public-contract files to TypeScript only where the facade or rollup still needs cleaner input."
+  ],
+  "open_decisions": [
+    {
+      "id": 1,
+      "question": "Promote `Extension`, `Node`, `Mark`, `Attribute` classes to top-level `superdoc` extension-authoring surface?",
+      "default_if_unresolved": "Keep legacy-only. Extension authoring proceeds through the existing factory functions."
+    },
+    {
+      "id": 2,
+      "question": "Are layout types (`FlowBlock`, `Layout`, `PaintSnapshot`) customer-supported, or internal/debug-only?",
+      "default_if_unresolved": "Internal. Layout is owned by `layout-engine/` and is not part of the public contract today."
+    },
+    {
+      "id": 3,
+      "question": "Promote helper namespaces (`superEditorHelpers`, `trackChangesHelpers`, `fieldAnnotationHelpers`, `SectionHelpers`) to documented stable, or keep as legacy?",
+      "default_if_unresolved": "Legacy-root. Keep typed; do not expand. Document API is the strategic path."
+    },
+    {
+      "id": 4,
+      "question": "Should `registeredHandlers` remain exported at all?",
+      "default_if_unresolved": "Internal. Move behind the facade unless a consumer surfaces a real use case."
+    },
+    {
+      "id": 5,
+      "question": "Deprecation window length for `superdoc/super-editor` once migration docs are complete?",
+      "default_if_unresolved": "Compat-indefinitely. Per `package-boundaries.md` Decision 1: keep compiling, do not advertise. No removal date until usage data justifies one."
+    }
+  ],
+  "rfc_reconciliation": [
+    {
+      "file": "docs/architecture/package-boundaries.md",
+      "anchor_line": 228,
+      "issue": "Calls `superdoc/super-editor` a 'supported facade'; Decision 1 (line 144) classifies it as legacy public compatibility surface.",
+      "current_text": "Surgical TypeScript migration of the public contract files: configuration, command surfaces, toolbar/UI types, the supported `superdoc/super-editor` facade.",
+      "proposed_text": "Surgical TypeScript migration of the public contract files: configuration, command surfaces, toolbar/UI types, and the legacy `superdoc/super-editor` compatibility facade.",
+      "rationale": "Decision 1 is the single source of truth for the classification. The migration item should describe the facade by its actual tier so the policy in this document and the RFC say the same thing.",
+      "source_of_truth": "package-boundaries.md Decision 1 (line 144-148)."
+    }
+  ],
+  "narrative": {
+    "purpose": [
+      "SD-2828 made the published TypeScript surface compile for consumers. The remaining problem is that the surface is still implicit: public types are whatever the current entry barrels re-export, plus whatever those types reference transitively.",
+      "That implicit surface is why declaration rollup failed in SD-2965. Both tested bundlers could close the graph, but API Extractor surfaced forgotten exports, mixed local and exported declarations, and unresolved public names. The package is bundleable in principle; it is not yet curated enough to bundle safely.",
+      "This document, generated from `tests/consumer-typecheck/public-facade-policy.json`, defines the facade that should exist before retrying declaration rollup or doing broad TypeScript migration."
+    ],
+    "goals": [
+      "Make `superdoc` the canonical import path for new customer code.",
+      "Keep legacy public paths compiling without growing them.",
+      "Give every supported public type a stable name and owner.",
+      "Stop treating internal implementation types as public just because they are reachable.",
+      "Make future declaration rollup a packaging change, not an API discovery exercise."
+    ],
+    "non_goals": [
+      "Removing `superdoc/super-editor` now.",
+      "Publishing internal packages like `@superdoc/contracts`.",
+      "Migrating the whole repository to TypeScript.",
+      "Hiding existing legacy names in a patch or minor release."
+    ]
+  },
+  "source_annotation_mapping": [
+    {
+      "tier": "public",
+      "source_form": "@public",
+      "notes": "Supported stable contract. This is a real TSDoc release tag."
+    },
+    {
+      "tier": "beta",
+      "source_form": "@beta",
+      "notes": "Supported preview contract. This is a real TSDoc release tag."
+    },
+    {
+      "tier": "legacy-root",
+      "source_form": "@deprecated replaceWith=<target> removeIn=<version> or compat-indefinitely",
+      "notes": "`legacy-root` is a policy tier, not a TSDoc tag. Source annotations use the repository deprecation convention from comment-policy.md."
+    },
+    {
+      "tier": "internal",
+      "source_form": "@internal",
+      "notes": "Not part of the supported customer contract. This is a real TSDoc release tag."
+    }
+  ],
+  "symbols": [
+    {
+      "name": "SuperDoc",
+      "kind": "runtime_value",
+      "group": "Core document UI",
+      "tier": "public",
+      "import_path": "superdoc",
+      "notes": "Primary browser editor entry.",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "Editor",
+      "kind": "runtime_value",
+      "group": "Headless editor",
+      "tier": "public",
+      "import_path": "superdoc",
+      "notes": "Headless and server-side workflows. Prefer Document API for state mutation.",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "PresentationEditor",
+      "kind": "runtime_value",
+      "group": "Headless editor",
+      "tier": "public",
+      "import_path": "superdoc",
+      "notes": "Bridges editor events into layout/paint state.",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SuperConverter",
+      "kind": "runtime_value",
+      "group": "Import and export",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "DocxZipper",
+      "kind": "runtime_value",
+      "group": "Import and export",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "createZip",
+      "kind": "runtime_value",
+      "group": "Import and export",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "BlankDOCX",
+      "kind": "runtime_value",
+      "group": "Import and export",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "DOCX",
+      "kind": "runtime_value",
+      "group": "Import and export",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "PDF",
+      "kind": "runtime_value",
+      "group": "Import and export",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "HTML",
+      "kind": "runtime_value",
+      "group": "Import and export",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "getFileObject",
+      "kind": "runtime_value",
+      "group": "Import and export",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "Extensions",
+      "kind": "runtime_value",
+      "group": "Extension authoring",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "getStarterExtensions",
+      "kind": "runtime_value",
+      "group": "Extension authoring",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "getRichTextExtensions",
+      "kind": "runtime_value",
+      "group": "Extension authoring",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "defineNode",
+      "kind": "runtime_value",
+      "group": "Extension authoring",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "defineMark",
+      "kind": "runtime_value",
+      "group": "Extension authoring",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "isNodeType",
+      "kind": "runtime_value",
+      "group": "Extension authoring",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "assertNodeType",
+      "kind": "runtime_value",
+      "group": "Extension authoring",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "isMarkType",
+      "kind": "runtime_value",
+      "group": "Extension authoring",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "createTheme",
+      "kind": "runtime_value",
+      "group": "Theming",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "buildTheme",
+      "kind": "runtime_value",
+      "group": "Theming",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SuperEditor",
+      "kind": "runtime_value",
+      "group": "UI components",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "Toolbar",
+      "kind": "runtime_value",
+      "group": "UI components",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ContextMenu",
+      "kind": "runtime_value",
+      "group": "UI components",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SlashMenu",
+      "kind": "runtime_value",
+      "group": "UI components",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "notes": "Deprecated alias; do not advertise in new docs.",
+      "migration_target": "ContextMenu from `superdoc`.",
+      "removal_posture": "compat-indefinitely until a major release with migration notes.",
+      "evidence": "Deprecated alias in packages/super-editor/src/editors/v1/index.js:34; kept for existing root consumers."
+    },
+    {
+      "name": "AIWriter",
+      "kind": "runtime_value",
+      "group": "UI components",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SuperToolbar",
+      "kind": "runtime_value",
+      "group": "UI components",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Direct consumer fixture instantiates `new SuperToolbar(...)` in tests/consumer-typecheck/src/customer-scenario.ts:661 and asserts assignability at line 671.",
+      "notes": "Supported direct-instantiation surface; keep in the root facade with real constructor/config types."
+    },
+    {
+      "name": "fieldAnnotationHelpers",
+      "kind": "runtime_value",
+      "group": "Helpers",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "superdoc Document API or dedicated helper subpath (TBD)",
+      "removal_posture": "compat-indefinitely (pending Open Decision 3)"
+    },
+    {
+      "name": "trackChangesHelpers",
+      "kind": "runtime_value",
+      "group": "Helpers",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "superdoc Document API or dedicated helper subpath (TBD)",
+      "removal_posture": "compat-indefinitely (pending Open Decision 3)"
+    },
+    {
+      "name": "SectionHelpers",
+      "kind": "runtime_value",
+      "group": "Helpers",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "superdoc Document API or dedicated helper subpath (TBD)",
+      "removal_posture": "compat-indefinitely (pending Open Decision 3)"
+    },
+    {
+      "name": "superEditorHelpers",
+      "kind": "runtime_value",
+      "group": "Helpers",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "superdoc Document API or dedicated helper subpath (TBD)",
+      "removal_posture": "compat-indefinitely (pending Open Decision 3)"
+    },
+    {
+      "name": "TrackChangesBasePluginKey",
+      "kind": "runtime_value",
+      "group": "Plugin keys",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "notes": "ProseMirror integration escape hatch.",
+      "migration_target": "Document API or UI controller (Comments/TrackChanges slices)",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "CommentsPluginKey",
+      "kind": "runtime_value",
+      "group": "Plugin keys",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "notes": "ProseMirror integration escape hatch.",
+      "migration_target": "Document API or UI controller (Comments/TrackChanges slices)",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "getMarksFromSelection",
+      "kind": "runtime_value",
+      "group": "Low-level editor helpers",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "getActiveFormatting",
+      "kind": "runtime_value",
+      "group": "Low-level editor helpers",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "getAllowedImageDimensions",
+      "kind": "runtime_value",
+      "group": "Low-level editor helpers",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "registeredHandlers",
+      "kind": "runtime_value",
+      "group": "Converter internals",
+      "tier": "internal",
+      "import_path": "superdoc",
+      "notes": "Move behind facade unless an existing consumer is identified (Open Decision 4).",
+      "evidence": "Currently reachable; not documented; no known consumer use case."
+    },
+    {
+      "name": "AnnotatorHelpers",
+      "kind": "runtime_value",
+      "group": "Annotator helpers",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "notes": "Avoid new docs.",
+      "migration_target": "Document API or Annotator-specific subpath (TBD)",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "Config",
+      "kind": "type",
+      "group": "Configuration",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "Modules",
+      "kind": "type",
+      "group": "Configuration",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "User",
+      "kind": "type",
+      "group": "Configuration",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "Document",
+      "kind": "type",
+      "group": "Configuration",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "CollaborationConfig",
+      "kind": "type",
+      "group": "Configuration",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SuperDocTelemetryConfig",
+      "kind": "type",
+      "group": "Configuration",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "AwarenessState",
+      "kind": "type",
+      "group": "Configuration",
+      "tier": "public",
+      "import_path": "superdoc",
+      "notes": "Added in SD-2834.",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "DocumentApi",
+      "kind": "type",
+      "group": "Document API",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SelectionApi",
+      "kind": "type",
+      "group": "Document API",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SelectionInfo",
+      "kind": "type",
+      "group": "Document API",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "TextTarget",
+      "kind": "type",
+      "group": "Document API",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "TextAddress",
+      "kind": "type",
+      "group": "Document API",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "EntityAddress",
+      "kind": "type",
+      "group": "Document API",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "BlocksListResult",
+      "kind": "type",
+      "group": "Document API",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "BookmarkInfo",
+      "kind": "type",
+      "group": "Document API",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "EditorOptions",
+      "kind": "type",
+      "group": "Editor lifecycle",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "EditorLifecycleState",
+      "kind": "type",
+      "group": "Editor lifecycle",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "OpenOptions",
+      "kind": "type",
+      "group": "Editor lifecycle",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SaveOptions",
+      "kind": "type",
+      "group": "Editor lifecycle",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ExportOptions",
+      "kind": "type",
+      "group": "Editor lifecycle",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ExportDocxParams",
+      "kind": "type",
+      "group": "Editor lifecycle",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "EditorEventMap",
+      "kind": "type",
+      "group": "Editor lifecycle",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "EditorTransactionEvent",
+      "kind": "type",
+      "group": "Editor lifecycle",
+      "tier": "public",
+      "import_path": "superdoc",
+      "notes": "Transaction field narrowed to real `Transaction` in SD-2834.",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "Comment",
+      "kind": "type",
+      "group": "Comments and track changes",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "CommentElement",
+      "kind": "type",
+      "group": "Comments and track changes",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "CommentsPayload",
+      "kind": "type",
+      "group": "Comments and track changes",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "TrackChangesModuleConfig",
+      "kind": "type",
+      "group": "Comments and track changes",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SuperDocUI",
+      "kind": "type",
+      "group": "UI controller",
+      "tier": "public",
+      "import_path": "superdoc/ui",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SuperDocUIOptions",
+      "kind": "type",
+      "group": "UI controller",
+      "tier": "public",
+      "import_path": "superdoc/ui",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SuperDocUIState",
+      "kind": "type",
+      "group": "UI controller",
+      "tier": "public",
+      "import_path": "superdoc/ui",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SelectionSlice",
+      "kind": "type",
+      "group": "UI controller",
+      "tier": "public",
+      "import_path": "superdoc/ui",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "CommentsSlice",
+      "kind": "type",
+      "group": "UI controller",
+      "tier": "public",
+      "import_path": "superdoc/ui",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "TrackChangesSlice",
+      "kind": "type",
+      "group": "UI controller",
+      "tier": "public",
+      "import_path": "superdoc/ui",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ViewportHandle",
+      "kind": "type",
+      "group": "UI controller",
+      "tier": "public",
+      "import_path": "superdoc/ui",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "DocumentHandle",
+      "kind": "type",
+      "group": "UI controller",
+      "tier": "public",
+      "import_path": "superdoc/ui",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "CreateHeadlessToolbarOptions",
+      "kind": "type",
+      "group": "Toolbar",
+      "tier": "public",
+      "import_path": "superdoc/headless-toolbar",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "HeadlessToolbarController",
+      "kind": "type",
+      "group": "Toolbar",
+      "tier": "public",
+      "import_path": "superdoc/headless-toolbar",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "PublicToolbarItemId",
+      "kind": "type",
+      "group": "Toolbar",
+      "tier": "public",
+      "import_path": "superdoc/headless-toolbar",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ToolbarSnapshot",
+      "kind": "type",
+      "group": "Toolbar",
+      "tier": "public",
+      "import_path": "superdoc/headless-toolbar",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ProofingProvider",
+      "kind": "type",
+      "group": "Proofing",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ProofingCheckRequest",
+      "kind": "type",
+      "group": "Proofing",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ProofingCheckResult",
+      "kind": "type",
+      "group": "Proofing",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ProofingIssue",
+      "kind": "type",
+      "group": "Proofing",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ProofingConfig",
+      "kind": "type",
+      "group": "Proofing",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ProofingError",
+      "kind": "type",
+      "group": "Proofing",
+      "tier": "public",
+      "import_path": "superdoc",
+      "notes": "`cause` field narrowed from `any` to `unknown` in SD-2834.",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "ContextMenuConfig",
+      "kind": "type",
+      "group": "Theming and surfaces",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SurfaceResolver",
+      "kind": "type",
+      "group": "Theming and surfaces",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "SurfaceHandle",
+      "kind": "type",
+      "group": "Theming and surfaces",
+      "tier": "public",
+      "import_path": "superdoc",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "EditorExtension",
+      "kind": "type",
+      "group": "Extension authoring (types)",
+      "tier": "public",
+      "import_path": "superdoc/types",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "NodeName",
+      "kind": "type",
+      "group": "Extension authoring (types)",
+      "tier": "public",
+      "import_path": "superdoc/types",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "NodeAttrs",
+      "kind": "type",
+      "group": "Extension authoring (types)",
+      "tier": "public",
+      "import_path": "superdoc/types",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "MarkName",
+      "kind": "type",
+      "group": "Extension authoring (types)",
+      "tier": "public",
+      "import_path": "superdoc/types",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "MarkAttrs",
+      "kind": "type",
+      "group": "Extension authoring (types)",
+      "tier": "public",
+      "import_path": "superdoc/types",
+      "evidence": "Classified by SD-2966 as part of the supported customer facade; covered by consumer typecheck fixtures or existing package-boundary policy."
+    },
+    {
+      "name": "EditorState",
+      "kind": "type",
+      "group": "ProseMirror primitives",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them.",
+      "removal_posture": "compat-indefinitely while advanced consumers depend on them"
+    },
+    {
+      "name": "Transaction",
+      "kind": "type",
+      "group": "ProseMirror primitives",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them.",
+      "removal_posture": "compat-indefinitely while advanced consumers depend on them"
+    },
+    {
+      "name": "Schema",
+      "kind": "type",
+      "group": "ProseMirror primitives",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them.",
+      "removal_posture": "compat-indefinitely while advanced consumers depend on them"
+    },
+    {
+      "name": "EditorView",
+      "kind": "type",
+      "group": "ProseMirror primitives",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them.",
+      "removal_posture": "compat-indefinitely while advanced consumers depend on them"
+    },
+    {
+      "name": "ProseMirrorJSON",
+      "kind": "type",
+      "group": "ProseMirror primitives",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API for state mutation. ProseMirror types remain accessible for advanced consumers that explicitly need them.",
+      "removal_posture": "compat-indefinitely while advanced consumers depend on them"
+    },
+    {
+      "name": "EditorCommands",
+      "kind": "type",
+      "group": "Command internals",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API or UI command controller",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "CommandProps",
+      "kind": "type",
+      "group": "Command internals",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API or UI command controller",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "Command",
+      "kind": "type",
+      "group": "Command internals",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API or UI command controller",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "ChainedCommand",
+      "kind": "type",
+      "group": "Command internals",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API or UI command controller",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "CoreCommandMap",
+      "kind": "type",
+      "group": "Command internals",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API or UI command controller",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "ExtensionCommandMap",
+      "kind": "type",
+      "group": "Command internals",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API or UI command controller",
+      "removal_posture": "compat-indefinitely"
+    },
+    {
+      "name": "FlowBlock",
+      "kind": "type",
+      "group": "Layout internals",
+      "tier": "internal",
+      "import_path": "superdoc",
+      "notes": "Open Decision 2: keep as inspection/debug type or promote to public.",
+      "evidence": "Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`."
+    },
+    {
+      "name": "Layout",
+      "kind": "type",
+      "group": "Layout internals",
+      "tier": "internal",
+      "import_path": "superdoc",
+      "evidence": "Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`."
+    },
+    {
+      "name": "LayoutPage",
+      "kind": "type",
+      "group": "Layout internals",
+      "tier": "internal",
+      "import_path": "superdoc",
+      "evidence": "Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`."
+    },
+    {
+      "name": "LayoutFragment",
+      "kind": "type",
+      "group": "Layout internals",
+      "tier": "internal",
+      "import_path": "superdoc",
+      "evidence": "Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`."
+    },
+    {
+      "name": "Measure",
+      "kind": "type",
+      "group": "Layout internals",
+      "tier": "internal",
+      "import_path": "superdoc",
+      "evidence": "Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`."
+    },
+    {
+      "name": "SectionMetadata",
+      "kind": "type",
+      "group": "Layout internals",
+      "tier": "internal",
+      "import_path": "superdoc",
+      "evidence": "Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`."
+    },
+    {
+      "name": "PaintSnapshot",
+      "kind": "type",
+      "group": "Layout internals",
+      "tier": "internal",
+      "import_path": "superdoc",
+      "evidence": "Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`."
+    },
+    {
+      "name": "PositionHit",
+      "kind": "type",
+      "group": "Layout internals",
+      "tier": "internal",
+      "import_path": "superdoc",
+      "evidence": "Reachable but not documented for consumer use; layout is a paint-time concern owned by `layout-engine/`."
+    },
+    {
+      "name": "TrackChangesBasePluginKey",
+      "kind": "type",
+      "group": "Plugin key types",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API or UI controller",
+      "removal_posture": "compat-indefinitely (paired with the value re-exports)"
+    },
+    {
+      "name": "CommentsPluginKey",
+      "kind": "type",
+      "group": "Plugin key types",
+      "tier": "legacy-root",
+      "import_path": "superdoc",
+      "migration_target": "Document API or UI controller",
+      "removal_posture": "compat-indefinitely (paired with the value re-exports)"
+    }
+  ]
+}

--- a/tests/consumer-typecheck/render-facade-doc.mjs
+++ b/tests/consumer-typecheck/render-facade-doc.mjs
@@ -21,9 +21,12 @@ const POLICY = JSON.parse(readFileSync(POLICY_PATH, 'utf8'));
 
 const tierById = Object.fromEntries(POLICY.tiers.map((t) => [t.id, t]));
 
+const ALLOWED_KINDS = new Set(['runtime_value', 'type']);
+
 function validatePolicy() {
   const tierIds = new Set(POLICY.tiers.map((t) => t.id));
-  const seen = new Set();
+  const importPathIds = new Set(POLICY.import_paths.map((p) => p.path));
+  const statusIds = new Set((POLICY.classification_statuses || []).map((s) => s.id));
 
   for (const tier of POLICY.tiers) {
     if (tier.id === 'legacy-root' && tier.label.startsWith('@')) {
@@ -31,6 +34,22 @@ function validatePolicy() {
     }
   }
 
+  for (const ip of POLICY.import_paths) {
+    if (!tierIds.has(ip.tier_for_new_exports)) {
+      throw new Error(`Unknown tier_for_new_exports "${ip.tier_for_new_exports}" on import_path ${ip.path}`);
+    }
+    if (!ip.classification_status || !statusIds.has(ip.classification_status)) {
+      throw new Error(`Unknown classification_status "${ip.classification_status}" on import_path ${ip.path}`);
+    }
+  }
+
+  for (const m of POLICY.source_annotation_mapping || []) {
+    if (!tierIds.has(m.tier)) {
+      throw new Error(`Unknown tier "${m.tier}" in source_annotation_mapping`);
+    }
+  }
+
+  const seen = new Set();
   for (const symbol of POLICY.symbols) {
     const key = `${symbol.kind}|${symbol.import_path}|${symbol.name}`;
     if (seen.has(key)) {
@@ -38,6 +57,12 @@ function validatePolicy() {
     }
     seen.add(key);
 
+    if (!ALLOWED_KINDS.has(symbol.kind)) {
+      throw new Error(`Unknown kind "${symbol.kind}" for ${key}; expected one of ${[...ALLOWED_KINDS].join(', ')}`);
+    }
+    if (!importPathIds.has(symbol.import_path)) {
+      throw new Error(`Unknown import_path "${symbol.import_path}" for ${key}`);
+    }
     if (!tierIds.has(symbol.tier)) {
       throw new Error(`Unknown tier "${symbol.tier}" for ${key}`);
     }
@@ -66,20 +91,13 @@ function symbolsBy(kind, tiers) {
 function groupedSymbols(symbols) {
   const groups = new Map();
   for (const symbol of symbols) {
-    const key = [
-      symbol.group,
-      symbol.tier,
-      symbol.import_path,
-      symbol.migration_target || '',
-      symbol.evidence || '',
-    ].join('\0');
+    const key = [symbol.group, symbol.tier, symbol.import_path].join('\0');
     if (!groups.has(key)) {
       groups.set(key, {
         group: symbol.group,
         tier: symbol.tier,
         import_path: symbol.import_path,
         migration_target: symbol.migration_target,
-        evidence: symbol.evidence,
         members: [],
       });
     }
@@ -179,51 +197,77 @@ function renderSourceAnnotationMapping() {
   );
 }
 
+function renderClassificationStatuses() {
+  const statuses = POLICY.classification_statuses || [];
+  if (statuses.length === 0) return '';
+  const rows = statuses.map((s) => [s.id, s.summary]);
+  return section(
+    'Classification status',
+    [
+      'Each `import_paths[]` entry carries a `classification_status` that bounds how the audit may use `symbols[]`.',
+      '',
+      table(['Status', 'Meaning'], rows),
+    ].join('\n'),
+  );
+}
+
 function renderImportPaths() {
   const rows = POLICY.import_paths.map((p) => [
     `\`${p.path}\``,
     p.kind,
     tierLabel(p.tier_for_new_exports),
+    p.classification_status || '',
     p.decision,
   ]);
   return section(
     'Import Path Policy',
     [
-      table(['Import path', 'Kind', 'Tier for new exports', 'Decision'], rows),
+      table(['Import path', 'Kind', 'Tier for new exports', 'Classification status', 'Decision'], rows),
       '',
       'No other `superdoc/*` subpath should be added without updating `public-facade-policy.json`, `package.json` exports, the export-coverage audit, and the consumer matrix in the same PR.',
     ].join('\n'),
   );
 }
 
+function uniqueRemovalPostures(members) {
+  const set = new Set();
+  for (const m of members) if (m.removal_posture) set.add(m.removal_posture);
+  return [...set].join('; ');
+}
+
+function buildSupportedRow(g) {
+  const names = joinNames(g.members);
+  const notes = memberNotes(g.members) || '';
+  return [g.group, names, `Imported from \`${g.import_path}\`. ${notes}`.trim()];
+}
+
+function buildOtherRow(g) {
+  const names = joinNames(g.members);
+  const migrationOrEvidence = g.migration_target
+    ? `Migration target: ${g.migration_target}`
+    : (g.members[0]?.evidence || '');
+  const notes = memberNotes(g.members) || '';
+  const removal = uniqueRemovalPostures(g.members);
+  const trailing = [notes, removal && `Removal: ${removal}`].filter(Boolean).join(' ');
+  const cell = trailing ? `${migrationOrEvidence} ${trailing}`.trim() : migrationOrEvidence;
+  return [g.group, tierLabel(g.tier), names, cell];
+}
+
 function renderRuntimeValues() {
   const supported = groupedSymbols(symbolsBy('runtime_value', ['public', 'beta']));
   const other = groupedSymbols(symbolsBy('runtime_value', ['legacy-root', 'internal']));
 
-  const supportedRows = supported.map((g) => {
-    const names = joinNames(g.members);
-    const notes = memberNotes(g.members) || '';
-    return [g.group, names, `Imported from \`${g.import_path}\`. ${notes}`.trim()];
-  });
-
-  const otherRows = other.map((g) => [
-    g.group,
-    tierLabel(g.tier),
-    joinNames(g.members),
-    g.migration_target ? `Migration target: ${g.migration_target}` : (g.evidence || ''),
-  ]);
-
   return [
     section(
       'Supported runtime values',
-      table(['Group', 'Names', 'Notes'], supportedRows),
+      table(['Group', 'Names', 'Notes'], supported.map(buildSupportedRow)),
     ),
     section(
       'Legacy and internal runtime values',
       [
         'These currently appear or are reachable but are not part of the supported contract.',
         '',
-        table(['Group', 'Tier', 'Names', 'Migration / evidence'], otherRows),
+        table(['Group', 'Tier', 'Names', 'Migration / evidence / removal'], other.map(buildOtherRow)),
       ].join('\n'),
     ),
   ].join('\n');
@@ -233,26 +277,13 @@ function renderTypes() {
   const supported = groupedSymbols(symbolsBy('type', ['public', 'beta']));
   const other = groupedSymbols(symbolsBy('type', ['legacy-root', 'internal']));
 
-  const supportedRows = supported.map((g) => {
-    const names = joinNames(g.members);
-    const notes = memberNotes(g.members) || '';
-    return [g.group, names, `Imported from \`${g.import_path}\`. ${notes}`.trim()];
-  });
-
-  const otherRows = other.map((g) => [
-    g.group,
-    tierLabel(g.tier),
-    joinNames(g.members),
-    g.migration_target ? `Migration target: ${g.migration_target}` : (g.evidence || ''),
-  ]);
-
   return [
     section(
       'Public type groups',
       [
         'Public types are named from the customer workflow they support, not from the internal package that happens to define them.',
         '',
-        table(['Group', 'Names', 'Notes'], supportedRows),
+        table(['Group', 'Names', 'Notes'], supported.map(buildSupportedRow)),
       ].join('\n'),
     ),
     section(
@@ -260,7 +291,7 @@ function renderTypes() {
       [
         'Exported for compatibility or reachable as implementation detail. Not part of the supported contract.',
         '',
-        table(['Group', 'Tier', 'Names', 'Migration / evidence'], otherRows),
+        table(['Group', 'Tier', 'Names', 'Migration / evidence / removal'], other.map(buildOtherRow)),
       ].join('\n'),
     ),
   ].join('\n');
@@ -271,22 +302,23 @@ function renderSymbolPolicy() {
     const migrationOrEvidence = s.migration_target
       ? `Migration target: ${s.migration_target}`
       : (s.evidence || '');
+    const removal = s.removal_posture ? ` Removal: ${s.removal_posture.replace(/\.$/, '')}.` : '';
     return [
       `\`${s.name}\``,
       s.kind,
       s.group,
       tierLabel(s.tier),
       `\`${s.import_path}\``,
-      migrationOrEvidence,
+      `${migrationOrEvidence}${removal}`.trim(),
     ];
   });
 
   return section(
     'Symbol policy',
     [
-      'This flat list is the machine-readable contract the audit will consume. Grouped sections above are for review ergonomics.',
+      'This flat list is the machine-readable record reviewed in this PR. **Strict audit may consume `symbols[]` only for `import_paths` whose `classification_status` is `fully-classified`.** For partial paths, the table records reviewed symbols and known direction; it cannot drive strict gating until the path is promoted. Grouped sections above are for review ergonomics.',
       '',
-      table(['Symbol', 'Kind', 'Group', 'Tier', 'Import path', 'Migration / evidence'], rows),
+      table(['Symbol', 'Kind', 'Group', 'Tier', 'Import path', 'Migration / evidence / removal'], rows),
     ].join('\n'),
   );
 }
@@ -409,6 +441,7 @@ function render() {
     renderNonGoals(),
     renderTiers(),
     renderSourceAnnotationMapping(),
+    renderClassificationStatuses(),
     renderImportPaths(),
     renderRuntimeValues(),
     renderTypes(),

--- a/tests/consumer-typecheck/render-facade-doc.mjs
+++ b/tests/consumer-typecheck/render-facade-doc.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+/**
+ * Render the public type facade design doc from public-facade-policy.json.
+ *
+ * The JSON is the source of truth. Markdown is regenerated and committed.
+ * CI runs `--check` to fail on drift.
+ *
+ * Usage:
+ *   node render-facade-doc.mjs --check   # exit non-zero if committed doc differs
+ *   node render-facade-doc.mjs --write   # regenerate the committed doc
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const POLICY_PATH = resolve(HERE, 'public-facade-policy.json');
+const DOC_PATH = resolve(HERE, '..', '..', 'docs', 'architecture', 'public-type-facade.md');
+
+const POLICY = JSON.parse(readFileSync(POLICY_PATH, 'utf8'));
+
+const tierById = Object.fromEntries(POLICY.tiers.map((t) => [t.id, t]));
+
+function validatePolicy() {
+  const tierIds = new Set(POLICY.tiers.map((t) => t.id));
+  const seen = new Set();
+
+  for (const tier of POLICY.tiers) {
+    if (tier.id === 'legacy-root' && tier.label.startsWith('@')) {
+      throw new Error('legacy-root is a policy tier, not a source annotation tag');
+    }
+  }
+
+  for (const symbol of POLICY.symbols) {
+    const key = `${symbol.kind}|${symbol.import_path}|${symbol.name}`;
+    if (seen.has(key)) {
+      throw new Error(`Duplicate symbol policy entry: ${key}`);
+    }
+    seen.add(key);
+
+    if (!tierIds.has(symbol.tier)) {
+      throw new Error(`Unknown tier "${symbol.tier}" for ${key}`);
+    }
+    if (!symbol.name || !symbol.kind || !symbol.group || !symbol.import_path) {
+      throw new Error(`Incomplete symbol policy entry: ${key}`);
+    }
+    if (symbol.tier === 'legacy-root' && !symbol.migration_target) {
+      throw new Error(`Legacy-root symbol needs a migration_target: ${key}`);
+    }
+    if (symbol.tier === 'public' && !symbol.evidence) {
+      throw new Error(`Public symbol needs evidence: ${key}`);
+    }
+  }
+}
+
+function tierLabel(id) {
+  const t = tierById[id];
+  return t ? t.label : id;
+}
+
+function symbolsBy(kind, tiers) {
+  const allowed = new Set(tiers);
+  return POLICY.symbols.filter((s) => s.kind === kind && allowed.has(s.tier));
+}
+
+function groupedSymbols(symbols) {
+  const groups = new Map();
+  for (const symbol of symbols) {
+    const key = [
+      symbol.group,
+      symbol.tier,
+      symbol.import_path,
+      symbol.migration_target || '',
+      symbol.evidence || '',
+    ].join('\0');
+    if (!groups.has(key)) {
+      groups.set(key, {
+        group: symbol.group,
+        tier: symbol.tier,
+        import_path: symbol.import_path,
+        migration_target: symbol.migration_target,
+        evidence: symbol.evidence,
+        members: [],
+      });
+    }
+    groups.get(key).members.push(symbol);
+  }
+  return [...groups.values()];
+}
+
+function escapeCell(value) {
+  if (value === undefined || value === null) return '';
+  return String(value).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function table(headers, rows) {
+  const head = `| ${headers.join(' | ')} |`;
+  const sep = `| ${headers.map(() => '---').join(' | ')} |`;
+  const body = rows.map((r) => `| ${r.map(escapeCell).join(' | ')} |`).join('\n');
+  return [head, sep, body].join('\n');
+}
+
+function bullets(items) {
+  return items.map((s) => `- ${s}`).join('\n');
+}
+
+function numbered(items) {
+  return items.map((s, i) => `${i + 1}. ${s}`).join('\n');
+}
+
+function joinNames(members) {
+  return members.map((m) => `\`${m.name}\``).join(', ');
+}
+
+function memberNotes(members) {
+  const notes = members.filter((m) => m.notes);
+  if (notes.length === 0) return '';
+  return notes.map((m) => `\`${m.name}\` - ${m.notes}`).join('; ');
+}
+
+function section(title, body) {
+  return `## ${title}\n\n${body.trim()}\n`;
+}
+
+function renderHeader() {
+  const m = POLICY.metadata;
+  return [
+    '# SuperDoc Public Type Facade',
+    '',
+    `**Status:** ${m.status} (${m.ticket})  `,
+    `**Owner:** ${m.owner}  `,
+    `**Last updated:** ${m.last_updated}`,
+    '',
+    '<!--',
+    'This file is generated from tests/consumer-typecheck/public-facade-policy.json.',
+    'Do not edit by hand. Run `node tests/consumer-typecheck/render-facade-doc.mjs --write` to regenerate.',
+    'CI runs `node tests/consumer-typecheck/render-facade-doc.mjs --check` to fail on drift.',
+    '-->',
+  ].join('\n');
+}
+
+function renderPurpose() {
+  return section('Purpose', POLICY.narrative.purpose.join('\n\n'));
+}
+
+function renderGoals() {
+  return section('Goals', bullets(POLICY.narrative.goals));
+}
+
+function renderNonGoals() {
+  return section('Non-goals', bullets(POLICY.narrative.non_goals));
+}
+
+function renderTiers() {
+  const rows = POLICY.tiers.map((t) => [t.label, t.summary]);
+  return section(
+    'Visibility tiers',
+    [
+      'These are policy tiers, not necessarily source-code annotation tags.',
+      '',
+      table(['Policy tier', 'Meaning'], rows),
+    ].join('\n'),
+  );
+}
+
+function renderSourceAnnotationMapping() {
+  const rows = POLICY.source_annotation_mapping.map((m) => [
+    m.tier,
+    m.source_form,
+    m.notes,
+  ]);
+  return section(
+    'Source annotation mapping',
+    [
+      'Source annotations are normalized in a follow-up PR. The policy tier remains the audit source of truth.',
+      '',
+      table(['Policy tier', 'Source annotation form', 'Notes'], rows),
+    ].join('\n'),
+  );
+}
+
+function renderImportPaths() {
+  const rows = POLICY.import_paths.map((p) => [
+    `\`${p.path}\``,
+    p.kind,
+    tierLabel(p.tier_for_new_exports),
+    p.decision,
+  ]);
+  return section(
+    'Import Path Policy',
+    [
+      table(['Import path', 'Kind', 'Tier for new exports', 'Decision'], rows),
+      '',
+      'No other `superdoc/*` subpath should be added without updating `public-facade-policy.json`, `package.json` exports, the export-coverage audit, and the consumer matrix in the same PR.',
+    ].join('\n'),
+  );
+}
+
+function renderRuntimeValues() {
+  const supported = groupedSymbols(symbolsBy('runtime_value', ['public', 'beta']));
+  const other = groupedSymbols(symbolsBy('runtime_value', ['legacy-root', 'internal']));
+
+  const supportedRows = supported.map((g) => {
+    const names = joinNames(g.members);
+    const notes = memberNotes(g.members) || '';
+    return [g.group, names, `Imported from \`${g.import_path}\`. ${notes}`.trim()];
+  });
+
+  const otherRows = other.map((g) => [
+    g.group,
+    tierLabel(g.tier),
+    joinNames(g.members),
+    g.migration_target ? `Migration target: ${g.migration_target}` : (g.evidence || ''),
+  ]);
+
+  return [
+    section(
+      'Supported runtime values',
+      table(['Group', 'Names', 'Notes'], supportedRows),
+    ),
+    section(
+      'Legacy and internal runtime values',
+      [
+        'These currently appear or are reachable but are not part of the supported contract.',
+        '',
+        table(['Group', 'Tier', 'Names', 'Migration / evidence'], otherRows),
+      ].join('\n'),
+    ),
+  ].join('\n');
+}
+
+function renderTypes() {
+  const supported = groupedSymbols(symbolsBy('type', ['public', 'beta']));
+  const other = groupedSymbols(symbolsBy('type', ['legacy-root', 'internal']));
+
+  const supportedRows = supported.map((g) => {
+    const names = joinNames(g.members);
+    const notes = memberNotes(g.members) || '';
+    return [g.group, names, `Imported from \`${g.import_path}\`. ${notes}`.trim()];
+  });
+
+  const otherRows = other.map((g) => [
+    g.group,
+    tierLabel(g.tier),
+    joinNames(g.members),
+    g.migration_target ? `Migration target: ${g.migration_target}` : (g.evidence || ''),
+  ]);
+
+  return [
+    section(
+      'Public type groups',
+      [
+        'Public types are named from the customer workflow they support, not from the internal package that happens to define them.',
+        '',
+        table(['Group', 'Names', 'Notes'], supportedRows),
+      ].join('\n'),
+    ),
+    section(
+      'Legacy and internal type groups',
+      [
+        'Exported for compatibility or reachable as implementation detail. Not part of the supported contract.',
+        '',
+        table(['Group', 'Tier', 'Names', 'Migration / evidence'], otherRows),
+      ].join('\n'),
+    ),
+  ].join('\n');
+}
+
+function renderSymbolPolicy() {
+  const rows = POLICY.symbols.map((s) => {
+    const migrationOrEvidence = s.migration_target
+      ? `Migration target: ${s.migration_target}`
+      : (s.evidence || '');
+    return [
+      `\`${s.name}\``,
+      s.kind,
+      s.group,
+      tierLabel(s.tier),
+      `\`${s.import_path}\``,
+      migrationOrEvidence,
+    ];
+  });
+
+  return section(
+    'Symbol policy',
+    [
+      'This flat list is the machine-readable contract the audit will consume. Grouped sections above are for review ergonomics.',
+      '',
+      table(['Symbol', 'Kind', 'Group', 'Tier', 'Import path', 'Migration / evidence'], rows),
+    ].join('\n'),
+  );
+}
+
+function renderLegacyFacade() {
+  const lf = POLICY.legacy_super_editor_facade;
+  const rows = lf.known_symbol_decisions.map((d) => [
+    d.symbols.map((s) => `\`${s}\``).join(', '),
+    d.current_use,
+    d.proposed_target,
+  ]);
+  return section(
+    'Legacy `superdoc/super-editor` facade',
+    [
+      '`superdoc/super-editor` is a compatibility facade. Rules:',
+      '',
+      bullets(lf.rules),
+      '',
+      'Known symbols and their migration decisions:',
+      '',
+      table(['Symbols', 'Current use', 'Proposed target'], rows),
+    ].join('\n'),
+  );
+}
+
+function renderImplementationShape() {
+  const i = POLICY.implementation_shape;
+  return section(
+    'Implementation shape',
+    [
+      'Recommended source layout:',
+      '',
+      '```text',
+      ...i.source_layout,
+      '```',
+      '',
+      bullets(i.notes),
+    ].join('\n'),
+  );
+}
+
+function renderAuditConsumption() {
+  const a = POLICY.audit_consumption;
+  return section(
+    'Audit consumption',
+    [
+      a.summary,
+      '',
+      '**Rationale.**',
+      '',
+      bullets(a.rationale),
+      '',
+      '**Future state.**',
+      '',
+      bullets(a.future_state),
+    ].join('\n'),
+  );
+}
+
+function renderCiGates() {
+  const rows = POLICY.ci_gates.map((g) => [g.id, g.name, g.description]);
+  return section(
+    'CI gates after the facade exists',
+    [
+      'Existing SD-2828 gates stay. Add these once the facade is implemented:',
+      '',
+      table(['#', 'Gate', 'Description'], rows),
+    ].join('\n'),
+  );
+}
+
+function renderSequencing() {
+  return section('Sequencing', numbered(POLICY.sequencing));
+}
+
+function renderOpenDecisions() {
+  const rows = POLICY.open_decisions.map((d) => [
+    d.id,
+    d.question,
+    d.default_if_unresolved,
+  ]);
+  return section(
+    'Open decisions',
+    table(['#', 'Question', 'Default if unresolved'], rows),
+  );
+}
+
+function renderRfcReconciliation() {
+  if (!POLICY.rfc_reconciliation || POLICY.rfc_reconciliation.length === 0) {
+    return section('RFC reconciliation', 'No open RFC reconciliation items.');
+  }
+  const blocks = POLICY.rfc_reconciliation.map((r, idx) => {
+    return [
+      `### ${idx + 1}. \`${r.file}\` near line ${r.anchor_line}`,
+      '',
+      `**Issue.** ${r.issue}`,
+      '',
+      '**Current text.**',
+      '',
+      '> ' + r.current_text,
+      '',
+      '**Proposed text.**',
+      '',
+      '> ' + r.proposed_text,
+      '',
+      `**Rationale.** ${r.rationale}`,
+      '',
+      `**Source of truth.** ${r.source_of_truth}`,
+    ].join('\n');
+  });
+  return section('RFC reconciliation', blocks.join('\n\n'));
+}
+
+function render() {
+  const parts = [
+    renderHeader(),
+    '',
+    renderPurpose(),
+    renderGoals(),
+    renderNonGoals(),
+    renderTiers(),
+    renderSourceAnnotationMapping(),
+    renderImportPaths(),
+    renderRuntimeValues(),
+    renderTypes(),
+    renderSymbolPolicy(),
+    renderLegacyFacade(),
+    renderImplementationShape(),
+    renderAuditConsumption(),
+    renderCiGates(),
+    renderSequencing(),
+    renderOpenDecisions(),
+    renderRfcReconciliation(),
+  ];
+  // Ensure single trailing newline.
+  return parts.join('\n').replace(/\n+$/, '') + '\n';
+}
+
+function main() {
+  validatePolicy();
+
+  const args = process.argv.slice(2);
+  const mode = args.includes('--write') ? 'write' : args.includes('--check') ? 'check' : null;
+  if (!mode) {
+    console.error('Usage: render-facade-doc.mjs --write | --check');
+    process.exit(2);
+  }
+
+  const rendered = render();
+
+  if (mode === 'write') {
+    writeFileSync(DOC_PATH, rendered, 'utf8');
+    console.log(`Wrote ${DOC_PATH}`);
+    return;
+  }
+
+  let committed;
+  try {
+    committed = readFileSync(DOC_PATH, 'utf8');
+  } catch (err) {
+    console.error(`Cannot read ${DOC_PATH}: ${err.message}`);
+    console.error('Run `node tests/consumer-typecheck/render-facade-doc.mjs --write` to generate it.');
+    process.exit(1);
+  }
+
+  if (committed === rendered) {
+    console.log(`OK: ${DOC_PATH} matches public-facade-policy.json`);
+    return;
+  }
+
+  console.error(`DRIFT: ${DOC_PATH} does not match public-facade-policy.json`);
+  console.error('Run `node tests/consumer-typecheck/render-facade-doc.mjs --write` and commit the result.');
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
Establishes the **policy framework + initial classification + RFC reconciliation** for SuperDoc's public TypeScript facade. This is not the completed facade; partial subpaths are tracked in [SD-3147](https://linear.app/superdocworkspace/issue/SD-3147), which blocks the strict gate (SD-3046).

No runtime or API behavior changes. Adds:

- `tests/consumer-typecheck/public-facade-policy.json` - machine-readable policy. 112 symbols (79 public, 24 legacy-root, 9 internal; 38 runtime values + 74 types) classified by tier with per-symbol import path, migration target, removal posture, and evidence. Each `import_paths[]` entry carries `classification_status` (one of `fully-classified` / `partially-classified` / `pending-classification` / `legacy-frozen` / `asset`) so the audit knows which paths are safe to gate strictly.
- `tests/consumer-typecheck/render-facade-doc.mjs` - real generator with `--write` and `--check`. `validatePolicy()` rejects unknown tier, kind, import_path, classification_status, source_annotation_mapping tier; missing migration_target on legacy-root; missing evidence on public; duplicate symbol entries.
- `docs/architecture/public-type-facade.md` - generated review surface. Regenerate via `node tests/consumer-typecheck/render-facade-doc.mjs --write`.
- `docs/architecture/package-boundaries.md` - one-line reconciliation of step 5 with Decision 1 so the RFC and the new policy describe `superdoc/super-editor` the same way (legacy public compatibility, not a supported new facade).
- CI: drift check wired into `ci-superdoc`, `release-superdoc`, and `release-stable` next to the existing public-contract gates.

The drift check is the only enforcement in this PR. No strict typing gates change here; the audit will consume this policy in a separate PR (SD-3046) once SD-3147 promotes the partial subpaths to `fully-classified`.

**Honest classification status today:**

- `superdoc` (root): `partially-classified` - most surface enumerated; some still implicit
- `superdoc/types`, `superdoc/ui`, `superdoc/headless-toolbar`: `partially-classified` - headline types only
- `superdoc/ui/react`, `superdoc/headless-toolbar/react`, `/vue`: `pending-classification` - 0 symbols enumerated
- `superdoc/super-editor`, `/converter`, `/docx-zipper`, `/file-zipper`: `legacy-frozen` - no enumeration intended; future enforcement is no-growth snapshot
- `superdoc/style.css`: `asset`

Strict audit is required to skip non-`fully-classified` paths.

Follow-ups (separate PRs):

- **SD-3147**: enumerate the partial subpaths so they can be promoted to `fully-classified`. Blocks SD-3046.
- Normalize source JSDoc annotations to match the policy (split multi-typedef blocks, add `replaceWith` / `removeIn` where missing).
- Implement explicit facade files under `packages/superdoc/src/public/`.
- Wire `deep-type-audit.mjs` to read the policy JSON and run per-tier strict gates (SD-3046).

**Review focus**: the rendered doc is the review surface; check `docs/architecture/public-type-facade.md`. Tier classifications, migration targets, and `classification_status` honesty are the load-bearing decisions.

**Verified**: \`node tests/consumer-typecheck/render-facade-doc.mjs --check\` passes; new validator rejects six different invalid-policy mutations; branch rebased on \`origin/main\`.