### PR TITLE
test: trigger agent-docs audit (do not merge)

### DIFF
--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -99,3 +99,9 @@ Other props like `documentMode` and callbacks are handled without rebuild.
 pnpm --filter @superdoc-dev/react build
 pnpm --filter @superdoc-dev/react test
 ```
+
+## Testing the audit (do not merge)
+
+See `packages/nonexistent/foo.ts` for the bridge layer.
+
+@./does-not-exist.md


### PR DESCRIPTION
Test PR for the agent-docs audit workflow added in #3299. Intentionally introduces:

- 1 broken path ref: `packages/nonexistent/foo.ts`
- 1 broken `@import`: `./does-not-exist.md`

Expect a sticky comment from the `Agent docs audit` workflow with both findings. Will be closed without merging.