### PR TITLE
fix(build): isolate shared/common declaration emit from @types auto-inclusion

### DIFF
--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 // SD-2864: canonical taxonomy for the published type surface. Mirrors
@@ -71,21 +72,36 @@ const SHARED_COMMON_DTS_TARGETS = typeSurface.sharedCommonDtsTargets;
   const sharedCommonDistDir = path.join(distRoot, 'shared/common');
   fs.mkdirSync(sharedCommonDistDir, { recursive: true });
   const sources = SHARED_COMMON_DTS_TARGETS.map((f) => path.join(repoRoot, 'shared/common', f));
-  const tscResult = _spawnSync(
-    tscBin,
-    [
-      '--declaration',
-      '--emitDeclarationOnly',
-      '--skipLibCheck',
-      '--target', 'ES2022',
-      '--module', 'ESNext',
-      '--moduleResolution', 'bundler',
-      '--outDir', sharedCommonDistDir,
-      '--rootDir', path.join(repoRoot, 'shared/common'),
-      ...sources,
-    ],
-    { stdio: 'inherit' },
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'superdoc-ensure-types-'));
+  const tempTsconfig = path.join(tempDir, 'tsconfig.shared-common.json');
+  // Keep this packaging-only emit independent of whichever @types packages pnpm hoists.
+  fs.writeFileSync(
+    tempTsconfig,
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          declaration: true,
+          emitDeclarationOnly: true,
+          skipLibCheck: true,
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          types: [],
+          outDir: sharedCommonDistDir,
+          rootDir: path.join(repoRoot, 'shared/common'),
+        },
+        files: sources,
+      },
+      null,
+      2,
+    )}\n`,
   );
+  let tscResult;
+  try {
+    tscResult = _spawnSync(tscBin, ['-p', tempTsconfig], { stdio: 'inherit' });
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
   if (tscResult.status !== 0) {
     console.error('[ensure-types] tsc failed emitting shared/common declarations');
     process.exit(1);


### PR DESCRIPTION
The standalone tsc call in `packages/superdoc/scripts/ensure-types.cjs` ran without a tsconfig, so TypeScript fell back to auto-loading every `@types/*` package visible in `node_modules`. When pnpm hoisted the deprecated `@types/minimatch@6` stub (a transitive dep of `@types/glob`, containing no `.d.ts`), tsc failed mid-build with `TS2688 Cannot find type definition file for 'minimatch'`. `skipLibCheck` does not help because the error fires before lib check. The failure surfaces on some fresh `pnpm install` outcomes and not others, depending on pnpm version and prior `node_modules` state.

Write a tiny temp tsconfig with `types: []` and invoke `tsc -p` against it, so this packaging emit is independent of whichever `@types/*` happen to be visible. The three `shared/common` sources don't use any Node ambient types, so an empty `types` array is the honest constraint - it also catches any future Node-ambient leak into the public declaration surface.

- Reproduced TS2688 by placing the `@types/minimatch` stub next to `@types/node` in a controlled `node_modules/@types/`
- Confirmed the new temp tsconfig succeeds under the same controlled `@types` layout
- `pnpm --filter superdoc run build:es` runs the full declaration audit chain green
- `dist/shared/common/*.d.ts` emitted as before