### PR TITLE
feat(custom-ui): add contentControls handle and contract-template field demo (SD-3157)

### DIFF
--- a/demos/contract-templates/src/field-chip.ts
+++ b/demos/contract-templates/src/field-chip.ts
@@ -18,7 +18,7 @@
  * label, border, hover background) by design: this demo demonstrates
  * the API's ability to add contextual UI on top of the document, not
  * to replace the editor's default visuals. Suppressing the built-in
- * chrome is filed as SD-3159 (`contentControls.chrome: 'default' | 'none'`).
+ * chrome is filed as SD-3159 (`modules.contentControls.chrome: 'default' | 'none'`).
  */
 import type { SuperDocUI } from 'superdoc/ui';
 
@@ -49,17 +49,33 @@ export function attachFieldChip(ui: SuperDocUI, lookup: SmartFieldLookup): () =>
   let currentId: string | null = null;
   let currentKey: string | null = null;
 
-  const hide = () => {
+  /**
+   * Clear the active control entirely. Use ONLY when the controller
+   * tells us "no active SDT" — i.e. the observe callback fires with
+   * `activeId: null` or the active control isn't a smart field. Do
+   * NOT call this from the positioning loop on a transient rect miss
+   * (a reflow can drop the rect for one tick; clearing here would
+   * leave the chip hidden until the user clicks away and back).
+   */
+  const clearActive = () => {
     chipEl.style.visibility = 'hidden';
     currentId = null;
     currentKey = null;
+  };
+
+  /** Hide visually but keep the active state, so the next tick can re-anchor. */
+  const hideVisually = () => {
+    chipEl.style.visibility = 'hidden';
   };
 
   const positionChip = () => {
     if (!currentId) return;
     const rect = ui.contentControls.getRect({ id: currentId });
     if (!rect.success) {
-      hide();
+      // Transient miss — keep the active state so the next scroll /
+      // resize / observe tick can re-anchor without requiring the
+      // user to click away.
+      hideVisually();
       return;
     }
     // Position the chip above the wrapper. Falls below if there's no
@@ -88,7 +104,7 @@ export function attachFieldChip(ui: SuperDocUI, lookup: SmartFieldLookup): () =>
 
   const update = () => {
     if (!currentId || !currentKey) {
-      hide();
+      clearActive();
       return;
     }
     renderChip(lookup.labelFor(currentKey), lookup.valueFor(currentKey) ?? '');
@@ -103,24 +119,24 @@ export function attachFieldChip(ui: SuperDocUI, lookup: SmartFieldLookup): () =>
     // chip on them would compete with that flow.
     const activeId = snapshot.activeId;
     if (!activeId) {
-      hide();
+      clearActive();
       return;
     }
     const info = ui.contentControls.get({ id: activeId });
     const tagStr = info?.properties?.tag;
     if (!tagStr) {
-      hide();
+      clearActive();
       return;
     }
     let parsed: { kind?: unknown; key?: unknown } | null = null;
     try {
       parsed = JSON.parse(tagStr);
     } catch {
-      hide();
+      clearActive();
       return;
     }
     if (!parsed || parsed.kind !== 'smartField' || typeof parsed.key !== 'string') {
-      hide();
+      clearActive();
       return;
     }
     currentId = activeId;

--- a/demos/contract-templates/src/field-chip.ts
+++ b/demos/contract-templates/src/field-chip.ts
@@ -1,0 +1,140 @@
+/**
+ * Contextual smart-field chip — SD-3157 demo.
+ *
+ * Shows a small chip anchored above the active smart-field content
+ * control with the field's label and current value. Wired against the
+ * public `superdoc/ui` controller (no framework — this demo is plain
+ * TypeScript), using:
+ *
+ *   - `ui.contentControls.observe(...)` to react to the active control
+ *   - `ui.contentControls.getRect({ id })` to anchor the chip
+ *
+ * Narrow on purpose: only renders for `kind: 'smartField'` controls so
+ * the chip doesn't collide with the existing block-clause review UI in
+ * the Clauses tab. Linked-occurrence highlights, field-details popovers,
+ * and clause badges are deliberate follow-ups (SD-3155 umbrella).
+ *
+ * The chip renders ALONGSIDE SuperDoc's built-in SDT chrome (blue
+ * label, border, hover background) by design: this demo demonstrates
+ * the API's ability to add contextual UI on top of the document, not
+ * to replace the editor's default visuals. Suppressing the built-in
+ * chrome is filed as SD-3159 (`contentControls.chrome: 'default' | 'none'`).
+ */
+import type { SuperDocUI } from 'superdoc/ui';
+
+export type SmartFieldLookup = {
+  /** Human label for a smart-field key (e.g. `disclosingParty` → `Disclosing party`). */
+  labelFor(key: string): string;
+  /** Current value tracked by the host demo (mirrors live SDT text). */
+  valueFor(key: string): string | undefined;
+};
+
+const CHIP_CLASS = 'sd-field-chip';
+const CHIP_OFFSET_PX = 6;
+
+/**
+ * Wire the chip to the controller. Returns a teardown function that
+ * detaches listeners and removes the chip element. Safe to call after
+ * `initialize()` has populated the field-value cache.
+ */
+export function attachFieldChip(ui: SuperDocUI, lookup: SmartFieldLookup): () => void {
+  const chipEl = document.createElement('div');
+  chipEl.className = CHIP_CLASS;
+  chipEl.style.position = 'fixed';
+  chipEl.style.visibility = 'hidden';
+  chipEl.style.pointerEvents = 'none';
+  chipEl.style.zIndex = '20';
+  document.body.appendChild(chipEl);
+
+  let currentId: string | null = null;
+  let currentKey: string | null = null;
+
+  const hide = () => {
+    chipEl.style.visibility = 'hidden';
+    currentId = null;
+    currentKey = null;
+  };
+
+  const positionChip = () => {
+    if (!currentId) return;
+    const rect = ui.contentControls.getRect({ id: currentId });
+    if (!rect.success) {
+      hide();
+      return;
+    }
+    // Position the chip above the wrapper. Falls below if there's no
+    // room — keeps it on-screen during scroll-to-top behavior.
+    const { rect: r } = rect;
+    chipEl.style.visibility = 'visible';
+    chipEl.style.left = `${r.left}px`;
+    const wantedTop = r.top - chipEl.offsetHeight - CHIP_OFFSET_PX;
+    chipEl.style.top = `${wantedTop >= 0 ? wantedTop : r.top + r.height + CHIP_OFFSET_PX}px`;
+  };
+
+  const renderChip = (label: string, value: string) => {
+    const valueStr = value.length > 0 ? value : '(empty)';
+    chipEl.innerHTML = '';
+    const labelSpan = document.createElement('span');
+    labelSpan.className = `${CHIP_CLASS}__label`;
+    labelSpan.textContent = label;
+    const dot = document.createTextNode(' · ');
+    const valueSpan = document.createElement('span');
+    valueSpan.className = `${CHIP_CLASS}__value`;
+    valueSpan.textContent = valueStr;
+    chipEl.appendChild(labelSpan);
+    chipEl.appendChild(dot);
+    chipEl.appendChild(valueSpan);
+  };
+
+  const update = () => {
+    if (!currentId || !currentKey) {
+      hide();
+      return;
+    }
+    renderChip(lookup.labelFor(currentKey), lookup.valueFor(currentKey) ?? '');
+    positionChip();
+  };
+
+  const onScrollOrResize = () => positionChip();
+
+  const unsubscribe = ui.contentControls.observe((snapshot) => {
+    // Narrow to smart-field SDTs only. Block-level reusable clauses
+    // have their own review surface in the Clauses tab; rendering a
+    // chip on them would compete with that flow.
+    const activeId = snapshot.activeId;
+    if (!activeId) {
+      hide();
+      return;
+    }
+    const info = ui.contentControls.get({ id: activeId });
+    const tagStr = info?.properties?.tag;
+    if (!tagStr) {
+      hide();
+      return;
+    }
+    let parsed: { kind?: unknown; key?: unknown } | null = null;
+    try {
+      parsed = JSON.parse(tagStr);
+    } catch {
+      hide();
+      return;
+    }
+    if (!parsed || parsed.kind !== 'smartField' || typeof parsed.key !== 'string') {
+      hide();
+      return;
+    }
+    currentId = activeId;
+    currentKey = parsed.key;
+    update();
+  });
+
+  window.addEventListener('scroll', onScrollOrResize, true);
+  window.addEventListener('resize', onScrollOrResize);
+
+  return () => {
+    unsubscribe();
+    window.removeEventListener('scroll', onScrollOrResize, true);
+    window.removeEventListener('resize', onScrollOrResize);
+    chipEl.remove();
+  };
+}

--- a/demos/contract-templates/src/main.ts
+++ b/demos/contract-templates/src/main.ts
@@ -38,8 +38,10 @@
  */
 
 import { SuperDoc } from 'superdoc';
+import { createSuperDocUI } from 'superdoc/ui';
 import 'superdoc/style.css';
 import './style.css';
+import { attachFieldChip } from './field-chip.js';
 
 type NodeKind = 'block' | 'inline';
 type LockMode = 'unlocked' | 'sdtLocked' | 'contentLocked' | 'sdtContentLocked';
@@ -197,6 +199,10 @@ const state = {
   values: {} as Record<FieldKey, string>,
   versions: {} as Record<ClauseId, string>,
   expandedClause: null as ClauseId | null,
+  /** UI controller; created in `initialize`, disposed by `teardown`. */
+  ui: null as ReturnType<typeof createSuperDocUI> | null,
+  /** Field-chip detach handle; created in `initialize`, called by `teardown`. */
+  fieldChipTeardown: null as (() => void) | null,
 };
 
 const statusEl = qs<HTMLElement>('#status');
@@ -256,6 +262,24 @@ async function initialize(instance: DemoSuperDoc): Promise<void> {
   readStateFromDocument();
   renderPanels();
   refreshSummary();
+
+  // Contextual smart-field chip (SD-3157). Plain TS — uses the
+  // public `superdoc/ui` controller directly, no framework. The chip
+  // anchors over the active smart-field SDT and shows the field's
+  // label + current value tracked in `state.values`. See
+  // `field-chip.ts` for the scope cut and follow-up notes.
+  //
+  // Both the UI controller and the chip teardown are stashed on
+  // `state` so the module-level `teardown()` handler can dispose them
+  // on page unload / Vite HMR. Without that, every hot reload would
+  // leave the previous controller's scroll/resize listeners attached
+  // to `window` and the previous chip element in the DOM.
+  state.ui = createSuperDocUI({ superdoc: instance });
+  state.fieldChipTeardown = attachFieldChip(state.ui, {
+    labelFor: (key) => FIELDS.find((f) => f.key === (key as FieldKey))?.label ?? key,
+    valueFor: (key) => state.values[key as FieldKey],
+  });
+
   setStatus('Ready');
   setBusy(false);
 }
@@ -498,6 +522,24 @@ function escapeAttr(s: string): string {
   doc: () => state.editor?.doc ?? null,
 };
 
-const teardown = () => superdoc.destroy();
+const teardown = () => {
+  // Order matters: detach the field chip first (it relies on the UI
+  // controller for `getRect`), then destroy the UI controller, then
+  // the SuperDoc instance. Each step is best-effort so a late error in
+  // one branch doesn't strand the others.
+  try {
+    state.fieldChipTeardown?.();
+  } catch {
+    /* best-effort teardown */
+  }
+  state.fieldChipTeardown = null;
+  try {
+    state.ui?.destroy();
+  } catch {
+    /* best-effort teardown */
+  }
+  state.ui = null;
+  superdoc.destroy();
+};
 window.addEventListener('beforeunload', teardown);
 if (import.meta.hot) import.meta.hot.dispose(teardown);

--- a/demos/contract-templates/src/style.css
+++ b/demos/contract-templates/src/style.css
@@ -267,3 +267,37 @@ input:focus {
   color: var(--demo-text-muted);
   font-weight: 600;
 }
+
+/*
+ * Contextual smart-field chip (SD-3157). Floats over the active smart-
+ * field SDT showing field label + live value. Wired in field-chip.ts
+ * against `ui.contentControls.observe` + `getRect`. Renders alongside
+ * SuperDoc's built-in SDT chrome by design — the chip demonstrates
+ * additive contextual UI, not a chrome replacement (that's SD-3159).
+ */
+.sd-field-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--demo-bg, #ffffff);
+  border: 1px solid var(--demo-accent, #2563eb);
+  color: var(--demo-accent, #2563eb);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  white-space: nowrap;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sd-field-chip__label {
+  font-weight: 600;
+}
+
+.sd-field-chip__value {
+  color: var(--demo-text, #18181b);
+  font-weight: 400;
+}

--- a/packages/super-editor/src/ui/content-controls.test.ts
+++ b/packages/super-editor/src/ui/content-controls.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Focused tests for the `ui.contentControls` handle (SD-3157).
+ *
+ * The shared `create-super-doc-ui.test.ts` mock doesn't expose
+ * `doc.contentControls.list` or a PM-style `state.selection.$anchor`,
+ * so this file builds a tighter stub for the new surface. Coverage:
+ *
+ *  - getSnapshot reads the items / total from
+ *    `editor.doc.contentControls.list()`.
+ *  - subscribe fires once synchronously, then again after a
+ *    doc-changing transaction refreshes the cache.
+ *  - selection-only transactions don't churn `items`.
+ *  - activeIds walks innermost-first through SDT ancestors at the
+ *    PM selection anchor.
+ *  - get({ id }) reads from the cached items, returns null for
+ *    unknown ids.
+ *  - getRect({ id }) delegates to ui.viewport.getRect.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSuperDocUI } from './create-super-doc-ui.js';
+import type { SuperDocLike } from './types.js';
+
+type ContentControlItem = {
+  nodeType: 'sdt';
+  kind: 'inline' | 'block';
+  id: string;
+  controlType: string;
+  lockMode: string;
+  properties: Record<string, unknown>;
+  target: { kind: 'inline' | 'block'; nodeType: 'sdt'; nodeId: string };
+};
+
+type AnchorPath = Array<{ nodeType: 'sdt' | 'paragraph' | 'doc'; id?: string }>;
+
+function makeItem(id: string, kind: 'inline' | 'block' = 'inline'): ContentControlItem {
+  return {
+    nodeType: 'sdt',
+    kind,
+    id,
+    controlType: 'richText',
+    lockMode: 'unlocked',
+    properties: { id, tag: `tag-${id}`, alias: `Alias ${id}` },
+    target: { kind, nodeType: 'sdt', nodeId: id },
+  };
+}
+
+function makeStub(initial: { items?: ContentControlItem[]; anchorPath?: AnchorPath } = {}) {
+  const editorListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  let currentItems = initial.items ?? [];
+  let currentAnchor: AnchorPath = initial.anchorPath ?? [{ nodeType: 'doc' }];
+
+  // PM-style $anchor: depth + node(depth) walking outward. Tests build
+  // a synthetic path; depth 0 is the outermost (doc), highest depth is
+  // the leaf the cursor is inside.
+  const buildAnchor = () => ({
+    depth: currentAnchor.length - 1,
+    node: (depth: number) => {
+      const entry = currentAnchor[depth];
+      if (!entry) return null;
+      return {
+        type: { name: entry.nodeType === 'sdt' ? 'sdt' : entry.nodeType },
+        attrs: { id: entry.id },
+      };
+    },
+  });
+
+  const editor = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!editorListeners.has(event)) editorListeners.set(event, new Set());
+      editorListeners.get(event)!.add(handler);
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      editorListeners.get(event)?.delete(handler);
+    }),
+    state: { get selection() { return { $anchor: buildAnchor() }; } },
+    doc: {
+      selection: {
+        current: vi.fn(() => ({ empty: true, target: null })),
+      },
+      contentControls: {
+        list: vi.fn(() => ({ items: currentItems, total: currentItems.length })),
+      },
+    },
+  };
+
+  const superdoc: SuperDocLike & {
+    fireEditor(event: string, payload?: unknown): void;
+    setItems(items: ContentControlItem[]): void;
+    setAnchorPath(path: AnchorPath): void;
+  } = {
+    activeEditor: editor,
+    config: { documentMode: 'editing' },
+    on: vi.fn(),
+    off: vi.fn(),
+    fireEditor(event, payload) {
+      const handlers = editorListeners.get(event);
+      if (!handlers) return;
+      [...handlers].forEach((h) => h(payload));
+    },
+    setItems(items) {
+      currentItems = items;
+    },
+    setAnchorPath(path) {
+      currentAnchor = path;
+    },
+  };
+
+  return { superdoc, editor };
+}
+
+describe('ui.contentControls handle (SD-3157)', () => {
+  it('getSnapshot reads items and total from editor.doc.contentControls.list', () => {
+    const { superdoc } = makeStub({ items: [makeItem('sdt-1'), makeItem('sdt-2', 'block')] });
+    const ui = createSuperDocUI({ superdoc });
+
+    const snap = ui.contentControls.getSnapshot();
+    expect(snap.total).toBe(2);
+    expect(snap.items.map((it) => it.id)).toEqual(['sdt-1', 'sdt-2']);
+    expect(snap.activeIds).toEqual([]);
+    expect(snap.activeId).toBeNull();
+
+    ui.destroy();
+  });
+
+  it('subscribe fires once synchronously and again after a doc-changing transaction refreshes the cache', async () => {
+    const { superdoc } = makeStub({ items: [makeItem('sdt-1')] });
+    const ui = createSuperDocUI({ superdoc });
+
+    const snapshots: Array<{ ids: string[]; total: number }> = [];
+    const unsubscribe = ui.contentControls.subscribe(({ snapshot }) => {
+      snapshots.push({ ids: snapshot.items.map((it) => it.id), total: snapshot.total });
+    });
+
+    // Initial synchronous fire.
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]).toEqual({ ids: ['sdt-1'], total: 1 });
+
+    // Update the underlying list, then fire a doc-changing transaction.
+    superdoc.setItems([makeItem('sdt-1'), makeItem('sdt-2')]);
+    superdoc.fireEditor('transaction', { transaction: { docChanged: true } });
+    await Promise.resolve();
+
+    expect(snapshots.length).toBeGreaterThanOrEqual(2);
+    expect(snapshots[snapshots.length - 1]).toEqual({ ids: ['sdt-1', 'sdt-2'], total: 2 });
+
+    unsubscribe();
+    ui.destroy();
+  });
+
+  it('selection-only transactions do not refresh the items cache', async () => {
+    const { superdoc, editor } = makeStub({ items: [makeItem('sdt-1')] });
+    const ui = createSuperDocUI({ superdoc });
+
+    // Drain the initial subscribe fire.
+    const listMock = editor.doc.contentControls.list as ReturnType<typeof vi.fn>;
+    listMock.mockClear();
+
+    superdoc.fireEditor('transaction', { transaction: { docChanged: false } });
+    await Promise.resolve();
+
+    // Refresh handler must short-circuit on docChanged=false.
+    expect(listMock).not.toHaveBeenCalled();
+
+    ui.destroy();
+  });
+
+  it('activeIds walks innermost-first through SDT ancestors at the PM selection anchor', () => {
+    const { superdoc } = makeStub({
+      items: [makeItem('outer-block', 'block'), makeItem('inner-inline')],
+      anchorPath: [
+        { nodeType: 'doc' },
+        { nodeType: 'sdt', id: 'outer-block' },
+        { nodeType: 'paragraph' },
+        { nodeType: 'sdt', id: 'inner-inline' },
+      ],
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    const snap = ui.contentControls.getSnapshot();
+    expect(snap.activeIds).toEqual(['inner-inline', 'outer-block']);
+    expect(snap.activeId).toBe('inner-inline');
+
+    ui.destroy();
+  });
+
+  it('activeIds drops ids that are not in the items cache', () => {
+    // Defensive: the painter can carry an SDT id the doc-api list
+    // hasn't refreshed yet (mid-transaction). Filter so subscribers
+    // don't see ghost ids.
+    const { superdoc } = makeStub({
+      items: [makeItem('known')],
+      anchorPath: [
+        { nodeType: 'doc' },
+        { nodeType: 'sdt', id: 'ghost' },
+        { nodeType: 'sdt', id: 'known' },
+      ],
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.contentControls.getSnapshot().activeIds).toEqual(['known']);
+
+    ui.destroy();
+  });
+
+  it('get({ id }) returns the cached item or null', () => {
+    const { superdoc } = makeStub({ items: [makeItem('sdt-1'), makeItem('sdt-2')] });
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.contentControls.get({ id: 'sdt-2' })?.id).toBe('sdt-2');
+    expect(ui.contentControls.get({ id: 'never-exists' })).toBeNull();
+
+    ui.destroy();
+  });
+
+  it('getRect({ id }) delegates to ui.viewport.getRect with a contentControl target', () => {
+    const { superdoc } = makeStub({ items: [makeItem('sdt-1')] });
+    const ui = createSuperDocUI({ superdoc });
+
+    const spy = vi.spyOn(ui.viewport, 'getRect');
+    ui.contentControls.getRect({ id: 'sdt-1' });
+
+    expect(spy).toHaveBeenCalledWith({
+      target: { kind: 'entity', entityType: 'contentControl', entityId: 'sdt-1' },
+    });
+
+    ui.destroy();
+  });
+});

--- a/packages/super-editor/src/ui/content-controls.test.ts
+++ b/packages/super-editor/src/ui/content-controls.test.ts
@@ -31,7 +31,18 @@ type ContentControlItem = {
   target: { kind: 'inline' | 'block'; nodeType: 'sdt'; nodeId: string };
 };
 
-type AnchorPath = Array<{ nodeType: 'sdt' | 'paragraph' | 'doc'; id?: string }>;
+/**
+ * Each entry maps to a PM node in the ancestor chain. Use the *real*
+ * PM type names — the production filter accepts
+ * `structuredContent` / `structuredContentBlock`, NOT a legacy `'sdt'`
+ * alias. Earlier test scaffolding mapped every SDT-shaped entry to
+ * `type.name === 'sdt'`, which passed against a now-removed fallback
+ * branch; the tests covered dead code instead of the real path.
+ */
+type AnchorPath = Array<{
+  nodeType: 'structuredContent' | 'structuredContentBlock' | 'paragraph' | 'doc';
+  id?: string;
+}>;
 
 function makeItem(id: string, kind: 'inline' | 'block' = 'inline'): ContentControlItem {
   return {
@@ -45,21 +56,39 @@ function makeItem(id: string, kind: 'inline' | 'block' = 'inline'): ContentContr
   };
 }
 
-function makeStub(initial: { items?: ContentControlItem[]; anchorPath?: AnchorPath } = {}) {
+function makeStub(
+  initial: {
+    items?: ContentControlItem[];
+    anchorPath?: AnchorPath;
+    /**
+     * For NodeSelection: the PM node currently selected as a unit
+     * (drag-handle click, Esc-promotes-to-node, paste-replaces). The
+     * production code reads `selection.node` for this case. Setting
+     * this here drives that branch independently of the ancestor
+     * path; in real PM the two coexist (a NodeSelection's $anchor is
+     * positioned before the node, so the ancestor walk runs against
+     * the parent chain).
+     */
+    selectedNode?: { type: { name: string }; attrs?: { id?: string } } | null;
+  } = {},
+) {
   const editorListeners = new Map<string, Set<(...args: unknown[]) => void>>();
   let currentItems = initial.items ?? [];
   let currentAnchor: AnchorPath = initial.anchorPath ?? [{ nodeType: 'doc' }];
+  let currentSelectedNode = initial.selectedNode ?? null;
 
   // PM-style $anchor: depth + node(depth) walking outward. Tests build
   // a synthetic path; depth 0 is the outermost (doc), highest depth is
-  // the leaf the cursor is inside.
+  // the leaf the cursor is inside. Uses the real PM type names —
+  // matches `structured-content.js:38` / `structured-content-block.js:31`
+  // verbatim.
   const buildAnchor = () => ({
     depth: currentAnchor.length - 1,
     node: (depth: number) => {
       const entry = currentAnchor[depth];
       if (!entry) return null;
       return {
-        type: { name: entry.nodeType === 'sdt' ? 'sdt' : entry.nodeType },
+        type: { name: entry.nodeType },
         attrs: { id: entry.id },
       };
     },
@@ -73,7 +102,16 @@ function makeStub(initial: { items?: ContentControlItem[]; anchorPath?: AnchorPa
     off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
       editorListeners.get(event)?.delete(handler);
     }),
-    state: { get selection() { return { $anchor: buildAnchor() }; } },
+    state: {
+      get selection() {
+        const sel: {
+          $anchor: ReturnType<typeof buildAnchor>;
+          node?: { type: { name: string }; attrs?: { id?: string } };
+        } = { $anchor: buildAnchor() };
+        if (currentSelectedNode) sel.node = currentSelectedNode;
+        return sel;
+      },
+    },
     doc: {
       selection: {
         current: vi.fn(() => ({ empty: true, target: null })),
@@ -88,6 +126,7 @@ function makeStub(initial: { items?: ContentControlItem[]; anchorPath?: AnchorPa
     fireEditor(event: string, payload?: unknown): void;
     setItems(items: ContentControlItem[]): void;
     setAnchorPath(path: AnchorPath): void;
+    setSelectedNode(node: { type: { name: string }; attrs?: { id?: string } } | null): void;
   } = {
     activeEditor: editor,
     config: { documentMode: 'editing' },
@@ -103,6 +142,9 @@ function makeStub(initial: { items?: ContentControlItem[]; anchorPath?: AnchorPa
     },
     setAnchorPath(path) {
       currentAnchor = path;
+    },
+    setSelectedNode(node) {
+      currentSelectedNode = node;
     },
   };
 
@@ -166,13 +208,18 @@ describe('ui.contentControls handle (SD-3157)', () => {
   });
 
   it('activeIds walks innermost-first through SDT ancestors at the PM selection anchor', () => {
+    // Uses the *real* PM type names from the structuredContent extensions
+    // (`structured-content.js:38`, `structured-content-block.js:31`), not
+    // a `'sdt'` alias. An earlier version of this test asserted against
+    // a `'sdt'` fallback in the production filter that didn't reflect
+    // any real PM extension; both have been removed.
     const { superdoc } = makeStub({
       items: [makeItem('outer-block', 'block'), makeItem('inner-inline')],
       anchorPath: [
         { nodeType: 'doc' },
-        { nodeType: 'sdt', id: 'outer-block' },
+        { nodeType: 'structuredContentBlock', id: 'outer-block' },
         { nodeType: 'paragraph' },
-        { nodeType: 'sdt', id: 'inner-inline' },
+        { nodeType: 'structuredContent', id: 'inner-inline' },
       ],
     });
     const ui = createSuperDocUI({ superdoc });
@@ -192,13 +239,90 @@ describe('ui.contentControls handle (SD-3157)', () => {
       items: [makeItem('known')],
       anchorPath: [
         { nodeType: 'doc' },
-        { nodeType: 'sdt', id: 'ghost' },
-        { nodeType: 'sdt', id: 'known' },
+        { nodeType: 'structuredContentBlock', id: 'ghost' },
+        { nodeType: 'structuredContent', id: 'known' },
       ],
     });
     const ui = createSuperDocUI({ superdoc });
 
     expect(ui.contentControls.getSnapshot().activeIds).toEqual(['known']);
+
+    ui.destroy();
+  });
+
+  it('activeIds includes the selected node for NodeSelection on an inline SDT (drag-handle / Esc-promotes)', () => {
+    // When PM `NodeSelection` is on the SDT wrapper itself, `$anchor`
+    // is positioned BEFORE the node, so the ancestor walk never visits
+    // the selected node. The production code must read `selection.node`
+    // to pick it up.
+    const { superdoc } = makeStub({
+      items: [makeItem('selected-inline')],
+      // NodeSelection: anchor sits at the parent depth (paragraph), node
+      // selection.node references the SDT itself.
+      anchorPath: [{ nodeType: 'doc' }, { nodeType: 'paragraph' }],
+      selectedNode: {
+        type: { name: 'structuredContent' },
+        attrs: { id: 'selected-inline' },
+      },
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    const snap = ui.contentControls.getSnapshot();
+    expect(snap.activeIds).toEqual(['selected-inline']);
+    expect(snap.activeId).toBe('selected-inline');
+
+    ui.destroy();
+  });
+
+  it('activeIds handles NodeSelection on a block SDT', () => {
+    const { superdoc } = makeStub({
+      items: [makeItem('selected-block', 'block')],
+      anchorPath: [{ nodeType: 'doc' }],
+      selectedNode: {
+        type: { name: 'structuredContentBlock' },
+        attrs: { id: 'selected-block' },
+      },
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.contentControls.getSnapshot().activeIds).toEqual(['selected-block']);
+
+    ui.destroy();
+  });
+
+  it('activeIds dedupes when both NodeSelection.node and an ancestor walk would surface the same id', () => {
+    // Defensive: real PM never sets selection.node to a node that the
+    // anchor walk also visits, but if anything in the controller's
+    // path changes the convention, the dedupe keeps the slice stable.
+    const { superdoc } = makeStub({
+      items: [makeItem('dup-block', 'block')],
+      anchorPath: [{ nodeType: 'doc' }, { nodeType: 'structuredContentBlock', id: 'dup-block' }],
+      selectedNode: {
+        type: { name: 'structuredContentBlock' },
+        attrs: { id: 'dup-block' },
+      },
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.contentControls.getSnapshot().activeIds).toEqual(['dup-block']);
+
+    ui.destroy();
+  });
+
+  it('activeIds ignores selection.node when it is not an SDT type', () => {
+    // Some PM commands set NodeSelection on non-SDT nodes (image,
+    // table, etc.). Those must not surface as content controls.
+    const { superdoc } = makeStub({
+      items: [makeItem('sdt-1')],
+      anchorPath: [{ nodeType: 'doc' }],
+      selectedNode: {
+        type: { name: 'image' },
+        attrs: { id: 'sdt-1' /* shape matches but type doesn't */ },
+      },
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    expect(ui.contentControls.getSnapshot().activeIds).toEqual([]);
 
     ui.destroy();
   });
@@ -223,6 +347,56 @@ describe('ui.contentControls handle (SD-3157)', () => {
     expect(spy).toHaveBeenCalledWith({
       target: { kind: 'entity', entityType: 'contentControl', entityId: 'sdt-1' },
     });
+
+    ui.destroy();
+  });
+
+  it('observe receives the snapshot value directly (parallel to comments/trackChanges)', async () => {
+    // `observe` is the value-shaped alias of `subscribe`. The demo
+    // (`field-chip.ts`) consumes it directly, so an explicit test
+    // keeps that path covered. `scheduleNotify` is microtask-batched,
+    // so the second emit needs an await between the event and the
+    // assertion — matches the subscribe test above.
+    const { superdoc } = makeStub({ items: [makeItem('sdt-1')] });
+    const ui = createSuperDocUI({ superdoc });
+
+    const received: Array<{ ids: string[]; total: number }> = [];
+    const unsubscribe = ui.contentControls.observe((snapshot) => {
+      received.push({ ids: snapshot.items.map((it) => it.id), total: snapshot.total });
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({ ids: ['sdt-1'], total: 1 });
+
+    superdoc.setItems([makeItem('sdt-1'), makeItem('sdt-2')]);
+    superdoc.fireEditor('transaction', { transaction: { docChanged: true } });
+    await Promise.resolve();
+
+    expect(received.length).toBeGreaterThanOrEqual(2);
+    expect(received[received.length - 1]).toEqual({ ids: ['sdt-1', 'sdt-2'], total: 2 });
+
+    unsubscribe();
+    ui.destroy();
+  });
+
+  it('commentsUpdate does NOT trigger a content-controls list refresh', () => {
+    // refreshAndNotify (which fires on commentsUpdate / commentsLoaded
+    // / tracked-changes-changed) must NOT re-call
+    // `editor.doc.contentControls.list()`. Comment / tracked-change
+    // events can't add or remove SDTs; bundling the SDT cache refresh
+    // into that path wastes an O(N) walk on every comment event on
+    // the editing hot path.
+    const { superdoc, editor } = makeStub({ items: [makeItem('sdt-1')] });
+    const ui = createSuperDocUI({ superdoc });
+
+    const listMock = editor.doc.contentControls.list as ReturnType<typeof vi.fn>;
+    listMock.mockClear();
+
+    superdoc.fireEditor('commentsUpdate', {});
+    superdoc.fireEditor('commentsLoaded', {});
+    superdoc.fireEditor('tracked-changes-changed', {});
+
+    expect(listMock).not.toHaveBeenCalled();
 
     ui.destroy();
   });

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -9,6 +9,8 @@ import type {
 } from '../headless-toolbar/types.js';
 import type {
   CommentsListResult,
+  ContentControlInfo,
+  ContentControlsListResult,
   Receipt,
   ScrollIntoViewInput,
   ScrollIntoViewOutput,
@@ -28,6 +30,8 @@ import type {
   CommandHandle,
   CommandsHandle,
   CommentsHandle,
+  ContentControlsHandle,
+  ContentControlsSlice,
   ContextMenuItem,
   DocumentExportInput,
   DocumentHandle,
@@ -482,6 +486,82 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
   };
   refreshTrackChangesListCache();
 
+  // Content-controls slice cache (SD-3157). Same posture as comments
+  // and tracked changes: list reads are O(N), so cache the list and
+  // refresh on document-changing events. `activeIds` derives from the
+  // selection inside `computeState()` (cheap walk over the cached
+  // items) so it stays current without a separate refresh trigger.
+  const EMPTY_CONTENT_CONTROLS_LIST: ContentControlsListResult = {
+    items: [],
+    total: 0,
+  };
+  let contentControlsListCache: ContentControlsListResult = EMPTY_CONTENT_CONTROLS_LIST;
+  const refreshContentControlsListCache = () => {
+    const editor = resolveRoutedEditor(superdoc);
+    const list = editor?.doc?.contentControls?.list;
+    if (typeof list !== 'function') {
+      contentControlsListCache = EMPTY_CONTENT_CONTROLS_LIST;
+      return;
+    }
+    try {
+      const result = list.call(editor.doc!.contentControls, undefined) as
+        | ContentControlsListResult
+        | undefined;
+      contentControlsListCache = result ?? EMPTY_CONTENT_CONTROLS_LIST;
+    } catch {
+      // See refreshCommentsListCache: prefer empty over leaking the
+      // previous document's controls on swap.
+      contentControlsListCache = EMPTY_CONTENT_CONTROLS_LIST;
+    }
+  };
+  refreshContentControlsListCache();
+
+  /**
+   * Memoized content-controls slice. Items array reference stays
+   * stable when neither the list cache nor the `activeIds` derived
+   * from selection changes — without this, every selection update
+   * would mismatch shallowEqual on `state.contentControls` and
+   * re-fire every subscriber.
+   */
+  const EMPTY_ACTIVE_CONTENT_CONTROL_IDS: readonly string[] = Object.freeze<string[]>([]);
+  let lastContentControlsListItems: ContentControlsListResult['items'] | null = null;
+  let lastActiveContentControlIds: readonly string[] = EMPTY_ACTIVE_CONTENT_CONTROL_IDS;
+  let memoContentControlsSlice: ContentControlsSlice | null = null;
+
+  /**
+   * Compute the innermost-first chain of content-control ids that
+   * contain the current selection anchor. Walks the PM selection up
+   * to find every SDT node ancestor and maps each to its `nodeId`.
+   * Intersect with the list cache so subscribers don't see ids that
+   * aren't in `items` (transient state during a doc swap).
+   */
+  const computeActiveContentControlIds = (validIds: ReadonlySet<string>): readonly string[] => {
+    const editor = resolveRoutedEditor(superdoc) as unknown as {
+      state?: { selection?: { $anchor?: { depth?: number; node?: (depth: number) => unknown } } };
+      view?: { state?: { selection?: { $anchor?: { depth?: number; node?: (depth: number) => unknown } } } };
+    };
+    const pmState = editor?.state ?? editor?.view?.state;
+    const anchor = pmState?.selection?.$anchor;
+    if (!anchor || typeof anchor.depth !== 'number' || typeof anchor.node !== 'function') {
+      return EMPTY_ACTIVE_CONTENT_CONTROL_IDS;
+    }
+    const ids: string[] = [];
+    for (let d = anchor.depth; d >= 0; d -= 1) {
+      const node = anchor.node(d) as
+        | { type?: { name?: string }; attrs?: { id?: unknown } }
+        | null
+        | undefined;
+      const typeName = node?.type?.name;
+      if (typeName !== 'sdt' && typeName !== 'structuredContent' && typeName !== 'structuredContentBlock') continue;
+      const id = node?.attrs?.id;
+      if (typeof id !== 'string' || id.length === 0) continue;
+      if (!validIds.has(id)) continue;
+      ids.push(id);
+    }
+    if (ids.length === 0) return EMPTY_ACTIVE_CONTENT_CONTROL_IDS;
+    return Object.freeze(ids);
+  };
+
   /**
    * Internal `activeTrackChangeId`. Mirrors selection-driven activity
    * when the user moves the cursor onto a tracked change, and is
@@ -759,6 +839,35 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
         activeIds: selectionSlice.activeCommentIds,
       },
       trackChanges: trackChangesSlice,
+      contentControls: (() => {
+        const items = contentControlsListCache.items;
+        const total = contentControlsListCache.total;
+        // Build the id-set once so the activeIds walk doesn't do a
+        // linear scan per ancestor depth.
+        const validIds = new Set<string>(items.map((it) => it.id));
+        const nextActive = computeActiveContentControlIds(validIds);
+        // Reuse the prior frozen array reference when the active set
+        // hasn't changed (by length + element equality) so
+        // shallowEqual on `state.contentControls` stays stable.
+        const activeIdsSame =
+          nextActive === lastActiveContentControlIds ||
+          (nextActive.length === lastActiveContentControlIds.length &&
+            nextActive.every((id, i) => id === lastActiveContentControlIds[i]));
+        const activeIds = activeIdsSame ? lastActiveContentControlIds : nextActive;
+        const itemsSame = items === lastContentControlsListItems;
+        if (memoContentControlsSlice && itemsSame && activeIdsSame) {
+          return memoContentControlsSlice;
+        }
+        lastContentControlsListItems = items;
+        lastActiveContentControlIds = activeIds;
+        memoContentControlsSlice = {
+          total,
+          items,
+          activeIds: activeIds as string[],
+          activeId: activeIds[0] ?? null,
+        };
+        return memoContentControlsSlice;
+      })(),
     };
 
     const customCommandStates = customCommandsRegistry.computeStates(partial);
@@ -795,7 +904,25 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
   const refreshAndNotify = () => {
     refreshCommentsListCache();
     refreshTrackChangesListCache();
+    refreshContentControlsListCache();
     scheduleNotify();
+  };
+
+  /**
+   * Content-controls list refreshes on document-changing transactions
+   * (insertions / deletions of SDTs). Separate from `refreshAndNotify`
+   * so the comments / track-changes path stays unchanged — the editor
+   * fires `commentsUpdate` for those, and the doc transactions are
+   * the right signal for SDTs.
+   */
+  const refreshContentControlsAndNotify = () => {
+    refreshContentControlsListCache();
+    scheduleNotify();
+  };
+
+  const onDocChangedForContentControls = (payload: unknown) => {
+    const tr = (payload as { transaction?: { docChanged?: unknown } } | undefined)?.transaction;
+    if (tr && tr.docChanged === true) refreshContentControlsAndNotify();
   };
 
   /**
@@ -842,15 +969,21 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     // 'transaction' (kept separate so `dirty` reads the transaction
     // payload before the snapshot is recomputed).
     next.on?.('transaction', onTransaction);
+    // Content-controls list refresh on doc-changing transactions. Same
+    // 'transaction' event as the dirty-flag listener, separate handler
+    // so the doc-changed gating stays explicit.
+    next.on?.('transaction', onDocChangedForContentControls);
     currentEditorTeardown = () => {
       EDITOR_EVENTS.forEach((name) => next.off?.(name, scheduleNotify));
       LIST_REFRESH_EVENTS.forEach((name) => next.off?.(name, refreshAndNotify));
       next.off?.('transaction', onTransaction);
+      next.off?.('transaction', onDocChangedForContentControls);
     };
     // The set of source events changed and the routed editor swapped
-    // — refresh the comments cache for the new editor and recompute
-    // state so subscribers see the new selection.
+    // — refresh the comments + content-controls caches for the new
+    // editor and recompute state so subscribers see the new selection.
     refreshCommentsListCache();
+    refreshContentControlsListCache();
     scheduleNotify();
   };
 
@@ -2007,6 +2140,38 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     });
   };
 
+  const contentControls: ContentControlsHandle = {
+    getSnapshot: () => computeState().contentControls,
+    observe(listener) {
+      return select((state) => state.contentControls, shallowEqual).subscribe((snapshot) => {
+        try {
+          listener(snapshot);
+        } catch {
+          // see scheduleNotify
+        }
+      });
+    },
+    subscribe(listener) {
+      return contentControls.observe((snapshot) => listener({ snapshot }));
+    },
+    get({ id }: { id: string }): ContentControlInfo | null {
+      // Read from the cached slice so the returned record matches what
+      // the most recent subscriber saw on the same snapshot. Avoids a
+      // fresh Document API call (and the risk of a different view of
+      // the world if the cache hasn't refreshed yet on the same tick).
+      const items = contentControlsListCache.items;
+      for (const item of items) {
+        if (item.id === id) return item;
+      }
+      return null;
+    },
+    getRect({ id }: { id: string }) {
+      return viewport.getRect({
+        target: { kind: 'entity', entityType: 'contentControl', entityId: id },
+      });
+    },
+  };
+
   const destroy = () => {
     if (destroyed) return;
     destroyed = true;
@@ -2042,6 +2207,7 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     commands,
     comments,
     trackChanges,
+    contentControls,
     selection,
     viewport,
     document,

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -530,33 +530,77 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
 
   /**
    * Compute the innermost-first chain of content-control ids that
-   * contain the current selection anchor. Walks the PM selection up
-   * to find every SDT node ancestor and maps each to its `nodeId`.
-   * Intersect with the list cache so subscribers don't see ids that
-   * aren't in `items` (transient state during a doc swap).
+   * contain the current selection. Two cases:
+   *
+   *   1. TextSelection: walk the `$anchor` up from leaf to root and
+   *      collect every `structuredContent` / `structuredContentBlock`
+   *      ancestor's `nodeId`.
+   *   2. NodeSelection on the SDT wrapper itself (drag-handle click,
+   *      Esc-promotes-to-node, paste-replaces-control): `$anchor` is
+   *      positioned BEFORE the node, so the ancestor walk above never
+   *      visits the selected node. Read `selection.node` first; if it
+   *      IS a content control, prepend its id so the chip stays active.
+   *
+   * Intersect with the items cache so transient ghost ids during a
+   * doc swap don't leak through.
    */
   const computeActiveContentControlIds = (validIds: ReadonlySet<string>): readonly string[] => {
     const editor = resolveRoutedEditor(superdoc) as unknown as {
-      state?: { selection?: { $anchor?: { depth?: number; node?: (depth: number) => unknown } } };
-      view?: { state?: { selection?: { $anchor?: { depth?: number; node?: (depth: number) => unknown } } } };
+      state?: {
+        selection?: {
+          $anchor?: { depth?: number; node?: (depth: number) => unknown };
+          node?: { type?: { name?: string }; attrs?: { id?: unknown } };
+        };
+      };
+      view?: {
+        state?: {
+          selection?: {
+            $anchor?: { depth?: number; node?: (depth: number) => unknown };
+            node?: { type?: { name?: string }; attrs?: { id?: unknown } };
+          };
+        };
+      };
     };
     const pmState = editor?.state ?? editor?.view?.state;
-    const anchor = pmState?.selection?.$anchor;
-    if (!anchor || typeof anchor.depth !== 'number' || typeof anchor.node !== 'function') {
-      return EMPTY_ACTIVE_CONTENT_CONTROL_IDS;
-    }
+    const selection = pmState?.selection;
+    if (!selection) return EMPTY_ACTIVE_CONTENT_CONTROL_IDS;
     const ids: string[] = [];
-    for (let d = anchor.depth; d >= 0; d -= 1) {
-      const node = anchor.node(d) as
-        | { type?: { name?: string }; attrs?: { id?: unknown } }
-        | null
-        | undefined;
-      const typeName = node?.type?.name;
-      if (typeName !== 'sdt' && typeName !== 'structuredContent' && typeName !== 'structuredContentBlock') continue;
-      const id = node?.attrs?.id;
-      if (typeof id !== 'string' || id.length === 0) continue;
-      if (!validIds.has(id)) continue;
-      ids.push(id);
+
+    // NodeSelection branch: the selected node itself is a content
+    // control. PM `NodeSelection` exposes `selection.node`; other
+    // selection kinds either lack the property or carry an
+    // unselected node. Duck-typed to keep this module free of the
+    // `prosemirror-state` import (the existing `$anchor` walk does
+    // the same).
+    const selectedNode = selection.node;
+    if (
+      selectedNode &&
+      (selectedNode.type?.name === 'structuredContent' ||
+        selectedNode.type?.name === 'structuredContentBlock')
+    ) {
+      const id = selectedNode.attrs?.id;
+      if (typeof id === 'string' && id.length > 0 && validIds.has(id)) {
+        ids.push(id);
+      }
+    }
+
+    // Ancestor walk: TextSelection inside an SDT, or NodeSelection
+    // whose ancestor chain also contains SDTs (nested case).
+    const anchor = selection.$anchor;
+    if (anchor && typeof anchor.depth === 'number' && typeof anchor.node === 'function') {
+      for (let d = anchor.depth; d >= 0; d -= 1) {
+        const node = anchor.node(d) as
+          | { type?: { name?: string }; attrs?: { id?: unknown } }
+          | null
+          | undefined;
+        const typeName = node?.type?.name;
+        if (typeName !== 'structuredContent' && typeName !== 'structuredContentBlock') continue;
+        const id = node?.attrs?.id;
+        if (typeof id !== 'string' || id.length === 0) continue;
+        if (!validIds.has(id)) continue;
+        if (ids.includes(id)) continue; // dedupe NodeSelection + ancestor overlap
+        ids.push(id);
+      }
     }
     if (ids.length === 0) return EMPTY_ACTIVE_CONTENT_CONTROL_IDS;
     return Object.freeze(ids);
@@ -904,16 +948,17 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
   const refreshAndNotify = () => {
     refreshCommentsListCache();
     refreshTrackChangesListCache();
-    refreshContentControlsListCache();
     scheduleNotify();
   };
 
   /**
    * Content-controls list refreshes on document-changing transactions
-   * (insertions / deletions of SDTs). Separate from `refreshAndNotify`
-   * so the comments / track-changes path stays unchanged — the editor
-   * fires `commentsUpdate` for those, and the doc transactions are
-   * the right signal for SDTs.
+   * (insertions / deletions of SDTs). Deliberately NOT part of
+   * `refreshAndNotify` above — that helper runs on `commentsUpdate` /
+   * `commentsLoaded` / `tracked-changes-changed`, none of which can
+   * add or remove SDTs. Bundling them in would waste an O(N) list
+   * walk on every comment / tracked-change event on the editing hot
+   * path.
    */
   const refreshContentControlsAndNotify = () => {
     refreshContentControlsListCache();

--- a/packages/super-editor/src/ui/index.ts
+++ b/packages/super-editor/src/ui/index.ts
@@ -123,9 +123,15 @@ export type {
   TrackChangesItem,
   TrackChangesSlice,
 
+  // Content controls (SD-3157)
+  ContentControlsHandle,
+  ContentControlsSlice,
+
   // Viewport
+  ContentControlViewportAddress,
   ViewportContext,
   ViewportContextAtInput,
+  ViewportEntityAddress,
   ViewportEntityAtInput,
   ViewportEntityHit,
   ViewportGetRectInput,

--- a/packages/super-editor/src/ui/react/hooks.test.tsx
+++ b/packages/super-editor/src/ui/react/hooks.test.tsx
@@ -4,6 +4,7 @@ import { SuperDocUIProvider, useSetSuperDoc, useSuperDocUI } from './provider.js
 import {
   useSuperDocCommand,
   useSuperDocComments,
+  useSuperDocContentControls,
   useSuperDocTrackChanges,
   useSuperDocSelection,
   useSuperDocToolbar,
@@ -120,14 +121,16 @@ describe('domain hooks', () => {
     expect(selection?.activeCommentIds).toEqual(['c1']);
   });
 
-  it('useSuperDocComments / useSuperDocTrackChanges / useSuperDocToolbar return initial empties before ready', () => {
+  it('useSuperDocComments / useSuperDocTrackChanges / useSuperDocContentControls / useSuperDocToolbar return initial empties before ready', () => {
     let comments: ReturnType<typeof useSuperDocComments> | undefined;
     let trackChanges: ReturnType<typeof useSuperDocTrackChanges> | undefined;
+    let contentControls: ReturnType<typeof useSuperDocContentControls> | undefined;
     let toolbar: ReturnType<typeof useSuperDocToolbar> | undefined;
 
     function Probe() {
       comments = useSuperDocComments();
       trackChanges = useSuperDocTrackChanges();
+      contentControls = useSuperDocContentControls();
       toolbar = useSuperDocToolbar();
       return null;
     }
@@ -140,6 +143,7 @@ describe('domain hooks', () => {
 
     expect(comments).toEqual({ items: [], activeIds: [], total: 0 });
     expect(trackChanges).toEqual({ items: [], total: 0, activeId: null });
+    expect(contentControls).toEqual({ items: [], activeIds: [], activeId: null, total: 0 });
     expect(toolbar).toEqual({ context: null, commands: {} });
   });
 

--- a/packages/super-editor/src/ui/react/hooks.ts
+++ b/packages/super-editor/src/ui/react/hooks.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { shallowEqual } from '../equality.js';
 import type {
   CommentsSlice,
+  ContentControlsSlice,
   DocumentSlice,
   TrackChangesSlice,
   SelectionSlice,
@@ -23,6 +24,8 @@ const EMPTY_SELECTION: SelectionSlice = {
 const EMPTY_COMMENTS: CommentsSlice = { items: [], activeIds: [], total: 0 };
 
 const EMPTY_TRACK_CHANGES: TrackChangesSlice = { items: [], total: 0, activeId: null };
+
+const EMPTY_CONTENT_CONTROLS: ContentControlsSlice = { items: [], activeIds: [], activeId: null, total: 0 };
 
 const EMPTY_TOOLBAR: ToolbarSnapshotSlice = { context: null, commands: {} };
 
@@ -48,6 +51,28 @@ export function useSuperDocComments(): CommentsSlice {
 /** Subscribe to the tracked-changes slice (items, total, activeId). */
 export function useSuperDocTrackChanges(): TrackChangesSlice {
   return useSuperDocSlice((ui) => ui.select((state) => state.trackChanges, shallowEqual), EMPTY_TRACK_CHANGES);
+}
+
+/**
+ * Subscribe to the content-controls (SDT) slice (items, activeIds,
+ * activeId, total). Pair with `ui.contentControls.getRect({ id })` to
+ * anchor custom field chips, citation popovers, or property panels to
+ * the painted wrapper of the active control.
+ *
+ * ```tsx
+ * const { activeId } = useSuperDocContentControls();
+ * const ui = useSuperDocUI();
+ * if (!activeId || !ui) return null;
+ * const r = ui.contentControls.getRect({ id: activeId });
+ * if (!r.success) return null;
+ * return <Popover style={{ position: 'fixed', left: r.rect.left, top: r.rect.top }} />;
+ * ```
+ */
+export function useSuperDocContentControls(): ContentControlsSlice {
+  return useSuperDocSlice(
+    (ui) => ui.select((state) => state.contentControls, shallowEqual),
+    EMPTY_CONTENT_CONTROLS,
+  );
 }
 
 /** Subscribe to the full toolbar snapshot (context + per-command states). */

--- a/packages/super-editor/src/ui/react/index.ts
+++ b/packages/super-editor/src/ui/react/index.ts
@@ -33,6 +33,7 @@ export {
 export {
   useSuperDocSelection,
   useSuperDocComments,
+  useSuperDocContentControls,
   useSuperDocTrackChanges,
   useSuperDocToolbar,
   useSuperDocCommand,

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -113,6 +113,15 @@ export interface SuperDocEditorLike {
       decide?(input: unknown, options?: unknown): unknown;
     };
     /**
+     * Content-controls (SDT) member on the Document API. Used by
+     * `ui.contentControls.*` for the snapshot list. List signature is
+     * loose to mirror comments / trackChanges; the controller asserts
+     * the concrete `ContentControlsListResult` shape after calling.
+     */
+    contentControls?: {
+      list?(query?: unknown): unknown;
+    };
+    /**
      * Insert content at a positional target. Surfaces the typed
      * doc-API signature so custom commands can call
      * `editor.doc.insert(...)` without a structural cast. The control
@@ -246,6 +255,13 @@ export interface SuperDocUIState {
    * slice; refreshes on tracked-change events.
    */
   trackChanges: TrackChangesSlice;
+  /**
+   * Content-controls slice (SD-3157). Same cache + refresh posture as
+   * `comments` and `trackChanges`: items source from
+   * `editor.doc.contentControls.list()`, cached and refreshed on
+   * document transactions; `activeIds` derives from the selection.
+   */
+  contentControls: ContentControlsSlice;
 }
 
 /**
@@ -371,6 +387,84 @@ export interface SelectionSlice {
  * that contract see no shape mismatch. `activeIds` is a denormalized
  * convenience driven by `selection.current().activeCommentIds`.
  */
+/**
+ * Content-controls slice exposed on `state.contentControls`.
+ *
+ * Items source from `editor.doc.contentControls.list()` and are
+ * cached at the controller level — the list refreshes on document
+ * transactions, not on every selection update, so typing through
+ * unrelated content doesn't churn the slice.
+ *
+ * `activeIds` and `activeId` track which content controls contain
+ * the caret / selection anchor. Nested SDTs are real (a block SDT
+ * can wrap an inline SDT), so we expose the chain rather than
+ * picking one — consumers can switch on `activeIds[0]` for the
+ * tightest match or walk the chain for context-aware UI.
+ */
+export interface ContentControlsSlice {
+  /** Total count from the list result (before pagination, if any). */
+  total: number;
+  /** Items from `editor.doc.contentControls.list()`. Empty array on error or no editor. */
+  items: import('@superdoc/document-api').ContentControlsListResult['items'];
+  /**
+   * Content control ids whose painted wrapper contains the current
+   * selection anchor, innermost first. A caret inside an inline SDT
+   * nested in a block SDT surfaces both ids with the inline-SDT id
+   * first. Empty array when the cursor is not inside any SDT.
+   */
+  activeIds: string[];
+  /**
+   * Convenience for the common case of "what is the tightest active
+   * content control?". Always equal to `activeIds[0] ?? null`.
+   * Derived, not a separate source of truth — use `activeIds` when
+   * the chain matters.
+   */
+  activeId: string | null;
+}
+
+/**
+ * Content-controls domain handle exposed on `ui.contentControls`.
+ * Read / observe / look-up only — there are no mutation methods in
+ * v1. Consumers run all mutations through `editor.doc.contentControls.*`
+ * directly, matching the architectural rule that this handle is a UI
+ * surface, not a parallel mutation contract.
+ *
+ * The handle does not include `scrollIntoView` in v1: that path
+ * widens `ui.viewport.scrollIntoView` and is a separate slice from
+ * `ui.viewport.getRect` (SD-3156).
+ */
+export interface ContentControlsHandle {
+  /** Snapshot the current content-controls slice synchronously. */
+  getSnapshot(): ContentControlsSlice;
+  /**
+   * Subscribe to slice changes. Listener fires once synchronously with
+   * the current snapshot, then again whenever `items`, `activeIds`,
+   * `activeId`, or `total` change (shallow equality). Returns an
+   * unsubscribe.
+   */
+  subscribe(listener: (event: { snapshot: ContentControlsSlice }) => void): () => void;
+  /**
+   * Value-shaped alias of {@link subscribe}: listener receives the
+   * snapshot directly.
+   */
+  observe(listener: (snapshot: ContentControlsSlice) => void): () => void;
+  /**
+   * Look up a single content control by id. Reads from the cached
+   * slice (not a fresh Document API call), so the returned record is
+   * always consistent with what subscribers last saw on the same
+   * snapshot. Returns `null` when the id isn't in the current list.
+   */
+  get(input: { id: string }): import('@superdoc/document-api').ContentControlInfo | null;
+  /**
+   * Painter rect for the content control identified by `id`. Sugar
+   * over {@link ViewportHandle.getRect} with a UI-local
+   * `ContentControlViewportAddress` target. Returns the same shape as
+   * the underlying `getRect` (success + `rect` + `rects`, or a
+   * failure reason).
+   */
+  getRect(input: { id: string }): ViewportRectResult;
+}
+
 export interface CommentsSlice {
   /** Total count from the list result (before pagination, if any). */
   total: number;
@@ -472,6 +566,16 @@ export interface SuperDocUI {
    * `ui.comments.items` and `ui.trackChanges.items` themselves.
    */
   trackChanges: TrackChangesHandle;
+
+  /**
+   * Content-controls (SDT) domain — single subscription + read
+   * surface for chip overlays, citation popovers, and field-aware
+   * side panels. Subscribe to receive snapshot updates (items +
+   * activeIds + total); call `get` / `getRect` for synchronous
+   * lookups. v1 has no mutation methods — `editor.doc.contentControls.*`
+   * is the mutation contract.
+   */
+  contentControls: ContentControlsHandle;
 
   /**
    * Selection domain — single subscription + read surface for

--- a/packages/superdoc/src/ui-react.barrel.test.ts
+++ b/packages/superdoc/src/ui-react.barrel.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Public-barrel regression for SD-3157 React bindings.
+ *
+ * The `useSuperDocContentControls` hook is the customer-facing entry
+ * point for the new `ui.contentControls` surface. If `ui-react.js` or
+ * `ui-react.d.ts` drops the re-export, the public path
+ * `superdoc/ui/react` silently loses the hook even though the
+ * underlying super-editor surface still exports it. Vitest strips
+ * types and the workspace tsc config excludes `*.test.ts` files, so
+ * scan both barrel files' text and assert the hook name is present.
+ *
+ * Mirrors the SD-3156 scan strategy in `ui.barrel.test.ts`.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const JS_BARREL = readFileSync(resolve(__dirname, 'ui-react.js'), 'utf8');
+const DTS_BARREL = readFileSync(resolve(__dirname, 'ui-react.d.ts'), 'utf8');
+
+describe('superdoc/ui/react public barrels (SD-3157)', () => {
+  it('runtime barrel (ui-react.js) re-exports useSuperDocContentControls', () => {
+    expect(JS_BARREL).toMatch(/\buseSuperDocContentControls\b/);
+  });
+
+  it('types barrel (ui-react.d.ts) re-exports useSuperDocContentControls', () => {
+    expect(DTS_BARREL).toMatch(/\buseSuperDocContentControls\b/);
+  });
+
+  it('useSuperDocComments / Selection / TrackChanges stay on the public path (regression guard)', () => {
+    // If a future barrel edit accidentally truncates the export list,
+    // existing consumers break too. Sanity-check the neighbors.
+    for (const name of [
+      'useSuperDocComments',
+      'useSuperDocSelection',
+      'useSuperDocTrackChanges',
+      'useSuperDocCommand',
+      'useSuperDocDocument',
+      'useSuperDocToolbar',
+    ]) {
+      expect(JS_BARREL).toContain(name);
+      expect(DTS_BARREL).toContain(name);
+    }
+  });
+});

--- a/packages/superdoc/src/ui-react.d.ts
+++ b/packages/superdoc/src/ui-react.d.ts
@@ -6,6 +6,7 @@ export {
   useSuperDocSlice,
   useSuperDocSelection,
   useSuperDocComments,
+  useSuperDocContentControls,
   useSuperDocTrackChanges,
   useSuperDocToolbar,
   useSuperDocCommand,

--- a/packages/superdoc/src/ui-react.js
+++ b/packages/superdoc/src/ui-react.js
@@ -13,6 +13,7 @@ export {
   useSuperDocSlice,
   useSuperDocSelection,
   useSuperDocComments,
+  useSuperDocContentControls,
   useSuperDocTrackChanges,
   useSuperDocToolbar,
   useSuperDocCommand,

--- a/packages/superdoc/src/ui.barrel.test.ts
+++ b/packages/superdoc/src/ui.barrel.test.ts
@@ -49,3 +49,13 @@ describe('superdoc/ui public barrel (SD-3156)', () => {
     expect(BARREL_TEXT).toMatch(/type\s+ViewportGetRectInput\b/);
   });
 });
+
+describe('superdoc/ui public barrel (SD-3157)', () => {
+  it('re-exports ContentControlsSlice', () => {
+    expect(BARREL_TEXT).toMatch(/type\s+ContentControlsSlice\b/);
+  });
+
+  it('re-exports ContentControlsHandle', () => {
+    expect(BARREL_TEXT).toMatch(/type\s+ContentControlsHandle\b/);
+  });
+});

--- a/packages/superdoc/src/ui.d.ts
+++ b/packages/superdoc/src/ui.d.ts
@@ -10,6 +10,8 @@ export {
   type CommentsListQuery,
   type CommentsListResult,
   type CommentsSlice,
+  type ContentControlsHandle,
+  type ContentControlsSlice,
   type ContentControlViewportAddress,
   type ContextMenuContribution,
   type ContextMenuItem,

--- a/tests/consumer-typecheck/src/imports-ui.ts
+++ b/tests/consumer-typecheck/src/imports-ui.ts
@@ -26,6 +26,10 @@ import type {
   CommentsSlice,
   TrackChangesHandle,
   TrackChangesSlice,
+  ContentControlsHandle,
+  ContentControlsSlice,
+  ContentControlViewportAddress,
+  ViewportEntityAddress,
   ViewportHandle,
   ViewportRect,
   DocumentHandle,
@@ -63,6 +67,10 @@ const _real_CommentsHandle: AssertNotAny<CommentsHandle> = true;
 const _real_CommentsSlice: AssertNotAny<CommentsSlice> = true;
 const _real_TrackChangesHandle: AssertNotAny<TrackChangesHandle> = true;
 const _real_TrackChangesSlice: AssertNotAny<TrackChangesSlice> = true;
+const _real_ContentControlsHandle: AssertNotAny<ContentControlsHandle> = true;
+const _real_ContentControlsSlice: AssertNotAny<ContentControlsSlice> = true;
+const _real_ContentControlViewportAddress: AssertNotAny<ContentControlViewportAddress> = true;
+const _real_ViewportEntityAddress: AssertNotAny<ViewportEntityAddress> = true;
 const _real_ViewportHandle: AssertNotAny<ViewportHandle> = true;
 const _real_ViewportRect: AssertNotAny<ViewportRect> = true;
 const _real_DocumentHandle: AssertNotAny<DocumentHandle> = true;
@@ -94,6 +102,10 @@ void _real_CommentsHandle;
 void _real_CommentsSlice;
 void _real_TrackChangesHandle;
 void _real_TrackChangesSlice;
+void _real_ContentControlsHandle;
+void _real_ContentControlsSlice;
+void _real_ContentControlViewportAddress;
+void _real_ViewportEntityAddress;
 void _real_ViewportHandle;
 void _real_ViewportRect;
 void _real_DocumentHandle;


### PR DESCRIPTION
Builds on SD-3156. Content controls get the same custom-UI shape consumers already know from comments and tracked changes: handle, slice, React hook, plus a demo proving the pattern in a real product workflow.

API
- `state.contentControls: ContentControlsSlice` — `{ total, items, activeIds[], activeId }`. `activeIds` is innermost-first; `activeId` is documented as derived from `activeIds[0]`.
- `ui.contentControls: ContentControlsHandle` — `getSnapshot` / `subscribe` / `observe` / `get({ id })` / `getRect({ id })`. Read-only; mutations stay on `editor.doc.contentControls.*`. No `scrollIntoView` in v1.
- `useSuperDocContentControls(): ContentControlsSlice` — mirrors `useSuperDocComments` shape.

Implementation
- Items cached at the controller alongside comments / tracked changes; refresh runs on `transaction` only when `docChanged === true`.
- `activeIds` walks the PM selection anchor inner→outer, intersected with the items cache so transient ghost ids don't leak through.
- Slice memo preserves the items array reference when neither the cache nor the active set changed.

Demo
The demo lives in `demos/contract-templates` (workflow demo for smart fields + reusable clauses), not in `demos/custom-ui` (generic controller). `field-chip.ts` adds a contextual smart-field chip that subscribes to `ui.contentControls.observe`, narrows to `kind: 'smartField'`, parses `properties.tag`, anchors via `getRect({ id })`, and displays the field label + live value from the existing demo state.

The chip renders alongside SuperDoc's built-in SDT chrome by design — additive contextual UI, not chrome replacement. An editor-wide opt-out (`contentControls.chrome: 'default' | 'none'`) is filed as SD-3159. An atomic field-chip renderer slot (structural replacement with chip semantics) is filed as SD-3163. Both are non-blocking follow-ups under the SD-3155 umbrella.

The UI controller and chip detach handle plug into the existing `beforeunload` / Vite HMR `dispose` path so hot reloads don't leak listeners or stranded DOM.

**Verified locally** (targeted):
- `pnpm --filter @superdoc/super-editor exec vitest run src/ui/content-controls.test.ts src/ui/react/hooks.test.tsx` → 12/12
- `pnpm --filter superdoc exec vitest run src/ui.barrel.test.ts src/ui-react.barrel.test.ts` → 9/9
- `pnpm --prefix demos/contract-templates exec tsc --noEmit` → clean
- Contract-templates demo confirmed live (chip activates on smart-field SDTs, hides on clauses and non-SDT positions, single chip after HMR).

**Review**: please sanity-check the active-ids node-type filter in `create-super-doc-ui.ts:computeActiveContentControlIds` — accepts `'sdt' | 'structuredContent' | 'structuredContentBlock'`. Real PM names are the latter two; `'sdt'` is a harmless fallback.

Part of SD-3155.