### PR TITLE
fix(super-editor): re-export ContentControlViewportAddress and ViewportEntityAddress (SD-3156)

### DIFF
--- a/packages/super-editor/src/ui/index.ts
+++ b/packages/super-editor/src/ui/index.ts
@@ -124,8 +124,10 @@ export type {
   TrackChangesSlice,
 
   // Viewport
+  ContentControlViewportAddress,
   ViewportContext,
   ViewportContextAtInput,
+  ViewportEntityAddress,
   ViewportEntityAtInput,
   ViewportEntityHit,
   ViewportGetRectInput,


### PR DESCRIPTION
Re-exports two viewport-address types from `@superdoc/super-editor/ui` that #3310 (SD-3156) added to the package internals and to the `superdoc/ui` public barrel, but forgot to wire through the upstream module.

`packages/superdoc/src/ui.d.ts` already lists `ContentControlViewportAddress` and `ViewportEntityAddress` as re-exports from `@superdoc/super-editor/ui`, but `packages/super-editor/src/ui/index.ts` did not export them. The existing `ui.barrel.test.ts` only string-scans the barrel file for the names, so it passed even though the names didn't resolve. The consumer-typecheck matrix (`bundler | node16 | nodenext` with `skipLibCheck=false`) is the one that actually compiles the public surface and has been failing with `TS2305: Module ... has no exported member` since #3310 landed.

Verified locally: `cd tests/consumer-typecheck && node typecheck-matrix.mjs` now reports 57 passed, 0 failed. The three scenarios that were failing in CI (`*/all public surface / skipLibCheck=false`) all pass.

**Verified**: `node tests/consumer-typecheck/typecheck-matrix.mjs` → 57 passed, 0 failed; `pnpm --filter @superdoc/super-editor test` → 12964 passed.