### PR TITLE
[codex] Fix stable SDK PyPI recovery loop

### DIFF
--- a/scripts/__tests__/release-local.test.mjs
+++ b/scripts/__tests__/release-local.test.mjs
@@ -13,6 +13,7 @@ import {
   inferDryRunWouldRelease,
   splitPreviewArgs,
 } from '../release-local.mjs';
+import { shouldRecoverPackageRelease } from '../release-recovery-state.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../../');
@@ -317,6 +318,63 @@ test('stable recovery filters prerelease tags so *-next.* never resumes as @late
   assert.ok(
     content.includes("expectedBranch === 'stable'") && content.includes('listStableMergedTags(pkg.tagPattern, branchRef)'),
     'scripts/release-local-stable.mjs: stable recovery must consult the prerelease-filtered list',
+  );
+});
+
+test('stable recovery ignores PyPI gaps when SDK PyPI publishing is disabled', async () => {
+  assert.equal(
+    shouldRecoverPackageRelease({
+      publishComplete: true,
+      githubComplete: true,
+      pythonPublished: false,
+      hasPythonPackages: false,
+      tagAtHead: false,
+    }),
+    false,
+    'missing PyPI packages must not trigger recovery when the descriptor is not tracking Python packages',
+  );
+  assert.equal(
+    shouldRecoverPackageRelease({
+      publishComplete: true,
+      githubComplete: true,
+      pythonPublished: false,
+      hasPythonPackages: true,
+      tagAtHead: false,
+    }),
+    true,
+    'missing PyPI packages must trigger recovery once SDK PyPI tracking is restored',
+  );
+  assert.equal(
+    shouldRecoverPackageRelease({
+      publishComplete: false,
+      githubComplete: true,
+      pythonPublished: false,
+      hasPythonPackages: false,
+      tagAtHead: false,
+    }),
+    true,
+    'npm publish gaps must still trigger recovery while SDK PyPI publishing is disabled',
+  );
+  assert.equal(
+    shouldRecoverPackageRelease({
+      publishComplete: true,
+      githubComplete: false,
+      pythonPublished: false,
+      hasPythonPackages: false,
+      tagAtHead: false,
+    }),
+    true,
+    'GitHub release gaps must still trigger recovery while SDK PyPI publishing is disabled',
+  );
+
+  const content = await readRepoFile('scripts/release-local-stable.mjs');
+  assert.ok(
+    content.includes('const SDK_PYPI_ENABLED = false'),
+    'scripts/release-local-stable.mjs: must keep the SDK PyPI disabled state next to the recovery decision',
+  );
+  assert.ok(
+    /name: 'sdk'[\s\S]*\.\.\.\(SDK_PYPI_ENABLED[\s\S]*pythonPackages: SDK_PYTHON_PACKAGES[\s\S]*preparePythonSnapshot: prepareSdkPythonSnapshot/.test(content),
+    'scripts/release-local-stable.mjs: SDK Python tracking and snapshot recovery must move together behind SDK_PYPI_ENABLED',
   );
 });
 

--- a/scripts/release-local-stable.mjs
+++ b/scripts/release-local-stable.mjs
@@ -42,6 +42,7 @@ import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { listTags, pruneLocalOnlyReleaseTags, run, runSemanticRelease } from './release-local.mjs';
+import { shouldRecoverPackageRelease } from './release-recovery-state.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -73,6 +74,14 @@ const SDK_PYTHON_PACKAGES = [
   'superdoc-sdk-cli-windows-x64',
   'superdoc-sdk',
 ];
+
+// SDK PyPI publishing is intentionally disabled in release-stable.yml while
+// trusted publisher config and storage limits are fixed. Keep recovery from
+// treating missing PyPI versions as incomplete until that publish path is
+// restored. To re-enable: set this true, uncomment both recovered and primary
+// PyPI publish blocks in release-stable.yml, and run generate:all inside
+// prepareSdkPythonSnapshot before build-python-sdk.mjs.
+const SDK_PYPI_ENABLED = false;
 
 // superdoc ships under two npm names: `superdoc` (unscoped) and a
 // `@harbour-enterprises/superdoc` mirror published from the same tarball.
@@ -812,14 +821,20 @@ async function maybeRecoverIncompleteRelease(pkg, branchRef) {
     version,
   });
 
-  const needsSnapshotPython = Boolean(pkg.pythonPackages) && !state.pythonPublished && !isTagAtHead(latestTag);
-  const needsRecovery = !state.publishComplete || !state.githubComplete || needsSnapshotPython;
+  const tagAtHead = isTagAtHead(latestTag);
+  const needsRecovery = shouldRecoverPackageRelease({
+    publishComplete: state.publishComplete,
+    githubComplete: state.githubComplete,
+    pythonPublished: state.pythonPublished,
+    hasPythonPackages: Boolean(pkg.pythonPackages),
+    tagAtHead,
+  });
   if (!needsRecovery) {
     return null;
   }
 
   console.log(
-    `\nRecovering incomplete ${pkg.name} release ${latestTag}${isTagAtHead(latestTag) ? ' from current HEAD' : ' from tagged snapshot'}.`,
+    `\nRecovering incomplete ${pkg.name} release ${latestTag}${tagAtHead ? ' from current HEAD' : ' from tagged snapshot'}.`,
   );
   const recovery = await recoverPackageRelease(pkg, {
     tag: latestTag,
@@ -894,9 +909,13 @@ const packages = [
     tagPrefix: 'sdk-v',
     tagPattern: 'sdk-v*',
     npmPackages: SDK_NODE_NPM_PACKAGES,
-    pythonPackages: SDK_PYTHON_PACKAGES,
     resumePublish: resumeSdkPublish,
-    preparePythonSnapshot: prepareSdkPythonSnapshot,
+    ...(SDK_PYPI_ENABLED
+      ? {
+          pythonPackages: SDK_PYTHON_PACKAGES,
+          preparePythonSnapshot: prepareSdkPythonSnapshot,
+        }
+      : {}),
   },
   {
     name: 'mcp',

--- a/scripts/release-recovery-state.mjs
+++ b/scripts/release-recovery-state.mjs
@@ -1,0 +1,10 @@
+export function shouldRecoverPackageRelease({
+  publishComplete,
+  githubComplete,
+  pythonPublished = true,
+  hasPythonPackages = false,
+  tagAtHead = false,
+}) {
+  const needsSnapshotPython = Boolean(hasPythonPackages) && !pythonPublished && !tagAtHead;
+  return !publishComplete || !githubComplete || needsSnapshotPython;
+}


### PR DESCRIPTION
## Summary

- Add a pure release-recovery predicate for the stable orchestrator.
- Gate SDK PyPI recovery tracking behind `SDK_PYPI_ENABLED = false` while PyPI publish steps are intentionally disabled.
- Add regression coverage so missing PyPI packages do not trigger SDK recovery when SDK PyPI publishing is out of scope.

## Root Cause

The stable workflow has SDK PyPI publish steps commented out, but the release orchestrator still treated missing SDK PyPI packages as an incomplete release. That caused reruns to rebuild recovered Python artifacts from old SDK tags and then discard them, keeping the recovery loop alive.

## Validation

- `node --test --test-name-pattern "stable recovery ignores PyPI gaps" scripts/__tests__/release-local.test.mjs`
- `node --check scripts/release-local-stable.mjs && node --check scripts/release-recovery-state.mjs`