### PR TITLE
fix(ci): sync stable after release completion

### DIFF
--- a/.github/workflows/sync-patches.yml
+++ b/.github/workflows/sync-patches.yml
@@ -1,22 +1,76 @@
 name: 🔄 Sync stable → main
 
+# Stable pushes first run semantic-release, which can append version/tag
+# commits back to stable. Sync only after that release lane finishes so main
+# never gets a PR from an intermediate stable head.
 on:
-  push:
-    branches:
-      - stable
+  workflow_run:
+    workflows:
+      - "📦 Release stable tooling (CLI/SDK/MCP)"
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
+
+concurrency:
+  group: sync-stable-to-main
+  cancel-in-progress: false
 
 jobs:
   sync-to-main:
     runs-on: ubuntu-latest
-    # Skip release commits (chore(release): ... [skip ci]) to avoid noisy no-op PRs
-    if: "!contains(github.event.head_commit.message, '[skip ci]') || github.event_name == 'workflow_dispatch'"
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.head_branch == 'stable' &&
+        (
+          github.event.workflow_run.conclusion == 'success' ||
+          github.event.workflow_run.conclusion == 'failure'
+        )
+      )
 
     steps:
+      - name: Wait for stable release lane to drain
+        if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          deadline=$((SECONDS + 1800))
+          while true; do
+            active_runs=$(gh run list \
+              --repo "$REPO" \
+              --branch stable \
+              --limit 100 \
+              --json databaseId,name,status,url \
+              --jq '[.[] | select((.name == "📦 Release stable tooling (CLI/SDK/MCP)" or .name == "📦 Release esign" or .name == "📦 Release template-builder") and .status != "completed")] | length')
+
+            if [ "$active_runs" -eq 0 ]; then
+              echo "Stable release lane is idle."
+              break
+            fi
+
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "Timed out waiting for stable release lane to drain."
+              gh run list \
+                --repo "$REPO" \
+                --branch stable \
+                --limit 100 \
+                --json databaseId,name,status,url \
+                --jq '.[] | select((.name == "📦 Release stable tooling (CLI/SDK/MCP)" or .name == "📦 Release esign" or .name == "📦 Release template-builder") and .status != "completed") | "\(.databaseId)\t\(.name)\t\(.status)\t\(.url)"'
+              exit 1
+            fi
+
+            echo "Waiting for ${active_runs} stable release run(s) to finish..."
+            sleep 30
+          done
+
       - name: Generate token
         id: generate_token
         uses: actions/create-github-app-token@v2

--- a/scripts/__tests__/release-local.test.mjs
+++ b/scripts/__tests__/release-local.test.mjs
@@ -301,6 +301,43 @@ test('stable release workflows serialize on the shared release-stable concurrenc
   }
 });
 
+test('stable-to-main sync waits for stable release completion', async () => {
+  const workflow = await readRepoFile('.github/workflows/sync-patches.yml');
+
+  assert.ok(
+    workflow.includes('workflow_run:'),
+    '.github/workflows/sync-patches.yml: must trigger from release workflow completion, not directly from stable pushes',
+  );
+  assert.ok(
+    /workflows:\s*\n\s*-\s*"📦 Release stable tooling \(CLI\/SDK\/MCP\)"/.test(workflow),
+    '.github/workflows/sync-patches.yml: must trigger after the stable release orchestrator completes',
+  );
+  assert.equal(
+    /push:\s*\n\s*branches:\s*\n\s*-\s*stable/.test(workflow),
+    false,
+    '.github/workflows/sync-patches.yml: must not fire immediately on stable branch pushes',
+  );
+  assert.ok(
+    workflow.includes("github.event.workflow_run.head_branch == 'stable'"),
+    '.github/workflows/sync-patches.yml: must scope automatic syncs to stable release runs',
+  );
+  assert.ok(
+    workflow.includes("github.event.workflow_run.conclusion == 'success'") &&
+      workflow.includes("github.event.workflow_run.conclusion == 'failure'"),
+    '.github/workflows/sync-patches.yml: must wait for release completion while still surfacing failed-release sync PRs for review',
+  );
+  assert.ok(
+    workflow.includes('actions: read'),
+    '.github/workflows/sync-patches.yml: must be able to inspect release workflow runs before syncing',
+  );
+  assert.ok(
+    workflow.includes('Wait for stable release lane to drain') &&
+      workflow.includes('"📦 Release esign"') &&
+      workflow.includes('"📦 Release template-builder"'),
+    '.github/workflows/sync-patches.yml: must wait for the remaining stable release workflows before syncing origin/stable',
+  );
+});
+
 test('MCP releaserc builds the package before publish so the tarball ships dist/', async () => {
   const content = await readRepoFile('apps/mcp/.releaserc.cjs');
   assert.ok(


### PR DESCRIPTION
## Summary

Move the stable-to-main sync workflow off direct `stable` push events and trigger it after the stable release orchestrator completes.

The sync job now waits for the remaining stable release lane workflows (`esign` and `template-builder`) to be idle before it reads `origin/stable`, so the generated sync PR is based on the final stable head instead of the pre-release merge commit.

## Rollout note

Merge this to `main` first so the `workflow_run` listener exists on the default branch. Then cherry-pick the same change to `stable` immediately to remove the old push-based trigger there.

During that short window, avoid merging new non-`[skip ci]` commits to `stable`; otherwise both the old stable workflow and the new default-branch `workflow_run` workflow can create sync PRs.

## Validation

- `node --test --test-name-pattern 'stable-to-main sync waits for stable release completion' scripts/__tests__/release-local.test.mjs`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/sync-patches.yml'); puts 'yaml ok'"`
- `git diff --check`

Full `node --test scripts/__tests__/release-local.test.mjs` still has the existing SSH URL rewrite and release-esign shared-workspace failures unrelated to this change.
