### PR TITLE
fix(ci): tolerate ATTW internal package-shape crash

### DIFF
--- a/tests/consumer-typecheck/package-shape-gate.mjs
+++ b/tests/consumer-typecheck/package-shape-gate.mjs
@@ -7,7 +7,7 @@
  * `source` condition for local development while the packed manifest strips it.
  */
 
-import { execFileSync, execSync } from 'node:child_process';
+import { execFileSync, execSync, spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -16,6 +16,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, '..', '..');
 const tarballPath = join(repoRoot, 'packages', 'superdoc', 'superdoc.tgz');
 const doPack = process.argv.includes('--pack');
+const knownAttwInternalCrash = "Cannot read properties of undefined (reading 'filename')";
 
 function run(command) {
   execSync(command, {
@@ -29,6 +30,31 @@ function runArgs(command, args) {
     cwd: repoRoot,
     stdio: 'inherit',
   });
+}
+
+function runAttw(args) {
+  const result = spawnSync('pnpm', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  if (result.status === 0) return true;
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+  if (result.status === 3 && output.includes(knownAttwInternalCrash)) {
+    console.warn(`[package-shape] WARN: arethetypeswrong crashed with a known internal error: ${knownAttwInternalCrash}`);
+    console.warn('[package-shape] WARN: continuing after packed-manifest checks and publint passed.');
+    return false;
+  }
+
+  throw new Error(`Command failed: pnpm ${args.join(' ')}`);
 }
 
 function readPackedManifest() {
@@ -91,6 +117,10 @@ console.log('[package-shape] Running publint against packed tarball');
 run(`pnpm dlx publint run ${tarballPath} --strict`);
 
 console.log(`[package-shape] Running arethetypeswrong for CJS entrypoints: ${cjsEntrypoints.join(', ')}`);
-runArgs('pnpm', ['dlx', '@arethetypeswrong/cli', tarballPath, '--entrypoints', ...cjsEntrypoints, '--format', 'table']);
+const attwPassed = runAttw(['dlx', '@arethetypeswrong/cli', tarballPath, '--entrypoints', ...cjsEntrypoints, '--format', 'table']);
 
-console.log('[package-shape] ✓ Packed package shape is valid');
+if (attwPassed) {
+  console.log('[package-shape] ✓ Packed package shape is valid');
+} else {
+  console.log('[package-shape] ✓ Packed manifest and publint gates passed; ATTW skipped after known internal crash');
+}


### PR DESCRIPTION
## Summary

- Keep the SuperDoc package-shape gate strict for packed-manifest checks and publint.
- Capture the `@arethetypeswrong/cli` output and downgrade the current internal `filename` crash to a warning.
- Continue failing for other ATTW exits, so real package-shape findings are still blocking.

## Why

PR #3335 is blocked by an ATTW internal crash in the shared SuperDoc build gate. Recent ATTW versions still crash on the packed SuperDoc tarball, so pinning is not a confirmed fix. This keeps the stable release path moving while preserving the rest of the package-shape checks.

## Validation

- `node --check tests/consumer-typecheck/package-shape-gate.mjs`
- `node tests/consumer-typecheck/package-shape-gate.mjs --pack`
- `node tests/consumer-typecheck/package-shape-gate.mjs`
