### PR TITLE
fix(esign): align pdf config type with SuperDoc

### DIFF
--- a/packages/esign/src/types.ts
+++ b/packages/esign/src/types.ts
@@ -56,8 +56,8 @@ export interface SubmitConfig {
   component?: React.ComponentType<SubmitButtonProps>;
 }
 
-export interface PdfModuleConfig {
-  pdfLib: any;
+export interface PdfModuleConfig extends Record<string, unknown> {
+  pdfLib: object;
   workerSrc?: string;
   setWorker?: boolean;
   textLayer?: boolean;


### PR DESCRIPTION
## Summary

- Update eSign's `PdfModuleConfig` to satisfy SuperDoc's widened PDF module config type.
- Narrow `pdfLib` from `any` to `object`, matching the SuperDoc module contract.

## Why

PR #3337 touches `packages/esign/.releaserc.cjs`, which triggers eSign CI on `main`. The eSign type check was failing because SuperDoc's `Config.modules.pdf` now includes `Record<string, unknown>`, while eSign's local `PdfModuleConfig` did not.

## Validation

- `pnpm install`
- `pnpm run build:superdoc`
- `pnpm --filter @superdoc-dev/esign type-check`
- `pnpm --filter @superdoc-dev/esign lint` (passes with existing warnings)
- `pnpm --filter @superdoc-dev/esign build`
- `pnpm --filter @superdoc-dev/esign test`