### PR TITLE
ci(release): use queue: max so multi-package stable pushes don't drop runs

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -27,8 +27,14 @@ permissions:
   packages: write
 
 concurrency:
+  # Release runs never cancel an in-progress release (each merge is a release-worthy
+  # state). queue: max keeps GitHub from dropping older pending stable releases when
+  # a stable push touches multiple wrapper packages in the shared release-stable group;
+  # default queue: single only allows one pending. queue: max requires
+  # cancel-in-progress: false (cannot be combined with true).
   group: ${{ github.ref_name == 'stable' && 'release-stable' || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref_name != 'stable' }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   release:
@@ -46,8 +52,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Refresh stable branch head
-        if: github.ref_name == 'stable'
+      - name: Refresh branch head
+        # Queued release runs may start against a stale checkout (queue: max
+        # plus cancel-in-progress: false). Refresh to the current branch head
+        # so @semantic-release/git pushes fast-forward; semantic-release no-ops
+        # if no new commits were added since the previous queued run released.
         run: |
           git fetch origin "${{ github.ref_name }}" --tags
           git checkout -B "${{ github.ref_name }}" "origin/${{ github.ref_name }}"

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -17,8 +17,14 @@ permissions:
   packages: write
 
 concurrency:
+  # Release runs never cancel an in-progress release (each merge is a release-worthy
+  # state). queue: max keeps GitHub from dropping older pending stable releases when
+  # a stable push touches multiple wrapper packages in the shared release-stable group;
+  # default queue: single only allows one pending. queue: max requires
+  # cancel-in-progress: false (cannot be combined with true).
   group: ${{ github.ref_name == 'stable' && 'release-stable' || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref_name != 'stable' }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   release:
@@ -36,8 +42,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Refresh stable branch head
-        if: github.ref_name == 'stable'
+      - name: Refresh branch head
+        # Queued release runs may start against a stale checkout (queue: max
+        # plus cancel-in-progress: false). Refresh to the current branch head
+        # so @semantic-release/git pushes fast-forward; semantic-release no-ops
+        # if no new commits were added since the previous queued run released.
         run: |
           git fetch origin "${{ github.ref_name }}" --tags
           git checkout -B "${{ github.ref_name }}" "origin/${{ github.ref_name }}"

--- a/.github/workflows/release-esign.yml
+++ b/.github/workflows/release-esign.yml
@@ -19,9 +19,13 @@ permissions:
 concurrency:
   # Stable releases share the `release-stable` group so @semantic-release/git
   # pushes to `stable` serialize across workflows; per-workflow groups would
-  # let releases race on `git push origin stable`.
+  # let releases race on `git push origin stable`. queue: max keeps GitHub
+  # from dropping older pending stable releases when a stable push touches
+  # multiple wrapper packages; default queue: single only allows one pending.
+  # queue: max requires cancel-in-progress: false (cannot be combined with true).
   group: ${{ github.ref_name == 'stable' && 'release-stable' || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref_name != 'stable' }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   release:
@@ -39,8 +43,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Refresh stable branch head
-        if: github.ref_name == 'stable'
+      - name: Refresh branch head
+        # Queued release runs may start against a stale checkout (queue: max
+        # plus cancel-in-progress: false). Refresh to the current branch head
+        # so @semantic-release/git pushes fast-forward; semantic-release no-ops
+        # if no new commits were added since the previous queued run released.
         run: |
           git fetch origin "${{ github.ref_name }}" --tags
           git checkout -B "${{ github.ref_name }}" "origin/${{ github.ref_name }}"

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -29,8 +29,14 @@ permissions:
   packages: write
 
 concurrency:
+  # Release runs never cancel an in-progress release (each merge is a release-worthy
+  # state). queue: max keeps GitHub from dropping older pending stable releases when
+  # a stable push touches multiple wrapper packages in the shared release-stable group;
+  # default queue: single only allows one pending. queue: max requires
+  # cancel-in-progress: false (cannot be combined with true).
   group: ${{ github.ref_name == 'stable' && 'release-stable' || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref_name != 'stable' }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   release:
@@ -48,8 +54,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Refresh stable branch head
-        if: github.ref_name == 'stable'
+      - name: Refresh branch head
+        # Queued release runs may start against a stale checkout (queue: max
+        # plus cancel-in-progress: false). Refresh to the current branch head
+        # so @semantic-release/git pushes fast-forward; semantic-release no-ops
+        # if no new commits were added since the previous queued run released.
         run: |
           git fetch origin "${{ github.ref_name }}" --tags
           git checkout -B "${{ github.ref_name }}" "origin/${{ github.ref_name }}"

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -30,9 +30,13 @@ permissions:
 concurrency:
   # Stable releases share the `release-stable` group so @semantic-release/git
   # pushes to `stable` serialize across workflows; per-workflow groups would
-  # let releases race on `git push origin stable`.
+  # let releases race on `git push origin stable`. queue: max keeps GitHub
+  # from dropping older pending stable releases when a stable push touches
+  # multiple wrapper packages; default queue: single only allows one pending.
+  # queue: max requires cancel-in-progress: false (cannot be combined with true).
   group: ${{ github.ref_name == 'stable' && 'release-stable' || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref_name != 'stable' }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   release:
@@ -50,8 +54,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Refresh stable branch head
-        if: github.ref_name == 'stable'
+      - name: Refresh branch head
+        # Queued release runs may start against a stale checkout (queue: max
+        # plus cancel-in-progress: false). Refresh to the current branch head
+        # so @semantic-release/git pushes fast-forward; semantic-release no-ops
+        # if no new commits were added since the previous queued run released.
         run: |
           git fetch origin "${{ github.ref_name }}" --tags
           git checkout -B "${{ github.ref_name }}" "origin/${{ github.ref_name }}"

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -44,8 +44,14 @@ permissions:
   id-token: write # PyPI trusted publishing (OIDC)
 
 concurrency:
+  # Release runs never cancel an in-progress release (each merge is a release-worthy
+  # state). queue: max keeps GitHub from dropping older pending stable releases when
+  # a stable push touches multiple wrapper packages in the shared release-stable group;
+  # default queue: single only allows one pending. queue: max requires
+  # cancel-in-progress: false (cannot be combined with true).
   group: ${{ github.ref_name == 'stable' && 'release-stable' || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref_name != 'stable' }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   # -------------------------------------------------------------------
@@ -71,8 +77,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Refresh stable branch head
-        if: github.ref_name == 'stable'
+      - name: Refresh branch head
+        # Queued release runs may start against a stale checkout (queue: max
+        # plus cancel-in-progress: false). Refresh to the current branch head
+        # so @semantic-release/git pushes fast-forward; semantic-release no-ops
+        # if no new commits were added since the previous queued run released.
         run: |
           git fetch origin "${{ github.ref_name }}" --tags
           git checkout -B "${{ github.ref_name }}" "origin/${{ github.ref_name }}"

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -29,9 +29,12 @@ concurrency:
   # `git push origin stable`, leaving npm/PyPI tarballs published without
   # a corresponding tag/commit pushed.
   # [skip ci] writeback runs use a per-run group so they cannot evict a real
-  # pending stable push while the bundle is active.
+  # pending stable push while the bundle is active. queue: max keeps GitHub
+  # from dropping older pending stable releases when a stable push touches
+  # multiple wrapper packages; default queue: single only allows one pending.
   group: ${{ github.event_name == 'push' && contains(github.event.head_commit.message, '[skip ci]') && format('release-stable-skip-{0}', github.run_id) || 'release-stable' }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   release:

--- a/.github/workflows/release-superdoc.yml
+++ b/.github/workflows/release-superdoc.yml
@@ -34,9 +34,13 @@ permissions:
 concurrency:
   # Stable releases share the `release-stable` group so @semantic-release/git
   # pushes to `stable` serialize across workflows; per-workflow groups would
-  # let releases race on `git push origin stable`.
+  # let releases race on `git push origin stable`. queue: max keeps GitHub
+  # from dropping older pending stable releases when a stable push touches
+  # multiple wrapper packages; default queue: single only allows one pending.
+  # queue: max requires cancel-in-progress: false (cannot be combined with true).
   group: ${{ github.ref_name == 'stable' && 'release-stable' || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref_name != 'stable' }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   release:
@@ -66,8 +70,12 @@ jobs:
           ref: ${{ steps.pr.outputs.sha || '' }}
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Refresh stable branch head
-        if: github.ref_name == 'stable' && !inputs.pr_number
+      - name: Refresh branch head
+        # Queued release runs may start against a stale checkout (queue: max
+        # plus cancel-in-progress: false). Refresh to the current branch head
+        # so @semantic-release/git pushes fast-forward; semantic-release no-ops
+        # if no new commits were added since the previous queued run released.
+        if: ${{ !inputs.pr_number }}
         run: |
           git fetch origin "${{ github.ref_name }}" --tags
           git checkout -B "${{ github.ref_name }}" "origin/${{ github.ref_name }}"

--- a/.github/workflows/release-template-builder.yml
+++ b/.github/workflows/release-template-builder.yml
@@ -19,9 +19,13 @@ permissions:
 concurrency:
   # Stable releases share the `release-stable` group so @semantic-release/git
   # pushes to `stable` serialize across workflows; per-workflow groups would
-  # let releases race on `git push origin stable`.
+  # let releases race on `git push origin stable`. queue: max keeps GitHub
+  # from dropping older pending stable releases when a stable push touches
+  # multiple wrapper packages; default queue: single only allows one pending.
+  # queue: max requires cancel-in-progress: false (cannot be combined with true).
   group: ${{ github.ref_name == 'stable' && 'release-stable' || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref_name != 'stable' }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   release:
@@ -39,8 +43,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Refresh stable branch head
-        if: github.ref_name == 'stable'
+      - name: Refresh branch head
+        # Queued release runs may start against a stale checkout (queue: max
+        # plus cancel-in-progress: false). Refresh to the current branch head
+        # so @semantic-release/git pushes fast-forward; semantic-release no-ops
+        # if no new commits were added since the previous queued run released.
         run: |
           git fetch origin "${{ github.ref_name }}" --tags
           git checkout -B "${{ github.ref_name }}" "origin/${{ github.ref_name }}"

--- a/.github/workflows/release-vscode-ext.yml
+++ b/.github/workflows/release-vscode-ext.yml
@@ -28,9 +28,13 @@ permissions:
 concurrency:
   # Stable releases share the `release-stable` group so @semantic-release/git
   # pushes to `stable` serialize across workflows; per-workflow groups would
-  # let releases race on `git push origin stable`.
+  # let releases race on `git push origin stable`. queue: max keeps GitHub
+  # from dropping older pending stable releases when a stable push touches
+  # multiple wrapper packages; default queue: single only allows one pending.
+  # queue: max requires cancel-in-progress: false (cannot be combined with true).
   group: ${{ github.ref_name == 'stable' && 'release-stable' || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref_name != 'stable' }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   release:
@@ -48,8 +52,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Refresh stable branch head
-        if: github.ref_name == 'stable'
+      - name: Refresh branch head
+        # Queued release runs may start against a stale checkout (queue: max
+        # plus cancel-in-progress: false). Refresh to the current branch head
+        # so @semantic-release/git pushes fast-forward; semantic-release no-ops
+        # if no new commits were added since the previous queued run released.
         run: |
           git fetch origin "${{ github.ref_name }}" --tags
           git checkout -B "${{ github.ref_name }}" "origin/${{ github.ref_name }}"

--- a/scripts/__tests__/release-local.test.mjs
+++ b/scripts/__tests__/release-local.test.mjs
@@ -301,6 +301,63 @@ test('stable release workflows serialize on the shared release-stable concurrenc
   }
 });
 
+test('release workflows queue (do not cancel) and use queue: max so multi-package stable pushes do not drop runs', async () => {
+  // GitHub Actions default concurrency queue allows one running + one
+  // pending per group. With three release workflows joining the shared
+  // `release-stable` group on a stable push that touches multiple
+  // wrapper packages, the third arrival is silently cancelled. queue: max
+  // raises the pending limit; cancel-in-progress: false ensures release
+  // runs are never cancelled by a newer release run (each merge is a
+  // release-worthy state). queue: max cannot be combined with
+  // cancel-in-progress: true (validation error).
+  const releaseWorkflows = [
+    '.github/workflows/release-cli.yml',
+    '.github/workflows/release-create.yml',
+    '.github/workflows/release-esign.yml',
+    '.github/workflows/release-mcp.yml',
+    '.github/workflows/release-react.yml',
+    '.github/workflows/release-sdk.yml',
+    '.github/workflows/release-stable.yml',
+    '.github/workflows/release-superdoc.yml',
+    '.github/workflows/release-template-builder.yml',
+    '.github/workflows/release-vscode-ext.yml',
+  ];
+
+  for (const file of releaseWorkflows) {
+    const content = await readRepoFile(file);
+    assert.ok(
+      /\n {2}cancel-in-progress: false\b/.test(content),
+      `${file}: cancel-in-progress must be the literal \`false\` (not a branch-conditional expression) so release runs never get cancelled by newer release runs`,
+    );
+    assert.equal(
+      /cancel-in-progress: \$\{\{/.test(content),
+      false,
+      `${file}: cancel-in-progress must not be a conditional expression; queue: max forbids cancel-in-progress: true on any branch`,
+    );
+    assert.ok(
+      /\n {2}queue: max\b/.test(content),
+      `${file}: must set queue: max so GitHub does not silently drop older pending stable releases when multiple release workflows fire on the same push`,
+    );
+
+    // Queued release runs may start against a stale checkout. Each workflow must
+    // refresh to the current branch head before semantic-release runs, otherwise
+    // @semantic-release/git push fails non-fast-forward against a branch that
+    // moved while the run was queued. The stable-only refresh that predates
+    // queue: max would leave main-firing queued runs against stale SHAs.
+    assert.equal(
+      /if: github\.ref_name == 'stable'\s*\n\s*run: \|\s*\n\s*git fetch origin/.test(content),
+      false,
+      `${file}: refresh step must not be gated on stable-only; queued main runs also need to refresh to avoid stale-checkout pushes`,
+    );
+    assert.ok(
+      /git fetch origin "\$\{\{ github\.ref_name \}\}" --tags\s*\n\s*git checkout -B "\$\{\{ github\.ref_name \}\}" "origin\/\$\{\{ github\.ref_name \}\}"/.test(content) ||
+        // release-stable.yml is stable-only and refreshes against the literal `stable` ref.
+        /git fetch origin stable --tags\s*\n\s*git checkout -B stable origin\/stable/.test(content),
+      `${file}: must refresh to the current branch head before semantic-release runs`,
+    );
+  }
+});
+
 test('stable-to-main sync waits for stable release completion', async () => {
   const workflow = await readRepoFile('.github/workflows/sync-patches.yml');
 


### PR DESCRIPTION
A stable push that touches more than one wrapper package fires three or more release workflows simultaneously, all joining the shared \`release-stable\` concurrency group. GitHub's default queue policy allows one running + one pending per group; the third arrival is silently cancelled. PR #3335 hit this exact case and dropped the template-builder release.

This sets \`queue: max\` + \`cancel-in-progress: false\` uniformly on all ten release workflows. \`queue: max\` raises the pending limit to 100 so stable pushes touching multiple wrapper packages no longer lose releases. \`cancel-in-progress: false\` is required by GitHub (queue: max forbids cancel-in-progress: true) and is the right semantics anyway: a newer merge landing shouldn't cancel an in-progress release.

The companion change is to drop the stable-only gate from each refresh step. With \`cancel-in-progress: false\` on main, a queued release run could otherwise execute against a stale checkout and fail when \`@semantic-release/git\` tries to push to an advanced branch head. Each queued run now refreshes to the current branch head before semantic-release runs; the second and later queued runs no-op when no new commits have landed since the previous run released.

- Adds \`queue: max\` to all ten release-*.yml workflows.
- Sets \`cancel-in-progress: false\` uniformly (was branch-conditional).
- Drops the \`if: github.ref_name == 'stable'\` gate from the refresh step in the nine wrapper workflows. \`release-superdoc.yml\` keeps its \`!inputs.pr_number\` guard so PR-preview dispatches still operate against the dispatched SHA. \`release-stable.yml\` is stable-only and already refreshed unconditionally.
- Regression test pins both halves of the contract across all ten files.

**Verified**: ruby YAML parse on all ten workflows; \`node --test scripts/__tests__/release-local.test.mjs\` adds one new passing test, the two pre-existing failures (SSH URL rewrite, release-esign shared workspace) are unrelated.