### PR TITLE
fix(direction): recognize Hebrew/Arabic presentation forms as strong-RTL (SD-3169)

### DIFF
--- a/packages/layout-engine/painters/dom/src/features/inline-direction/run-direction.test.ts
+++ b/packages/layout-engine/painters/dom/src/features/inline-direction/run-direction.test.ts
@@ -201,6 +201,31 @@ describe('regex coverage smoke tests', () => {
     expect(STRONG_RTL_CHAR_RE.test('2026')).toBe(false);
   });
 
+  // SD-3169: presentation forms used by legacy fonts must classify as strong-RTL
+  // for mixed-bidi boundary detection to fire on them. Run-direction rendering
+  // already fails safe for these (unknown text → 'rtl'), but the regex must
+  // recognize them directly so the painter's helper stays consistent with the
+  // mixed-bidi-backspace boundary detector.
+  it('STRONG_RTL_CHAR_RE matches Hebrew/Arabic presentation forms', () => {
+    // Hebrew Presentation Forms FB1D-FB4F
+    expect(STRONG_RTL_CHAR_RE.test('\uFB21')).toBe(true); // Hebrew Letter Wide Alef
+    expect(STRONG_RTL_CHAR_RE.test('\uFB4F')).toBe(true); // Hebrew Ligature Alef Lamed
+    // Arabic Presentation Forms-A FB50-FDFF
+    expect(STRONG_RTL_CHAR_RE.test('\uFB50')).toBe(true); // Arabic Letter Alef Wasla Isolated
+    expect(STRONG_RTL_CHAR_RE.test('\uFDF2')).toBe(true); // Arabic Ligature Allah Isolated
+    // Arabic Presentation Forms-B FE70-FEFF
+    expect(STRONG_RTL_CHAR_RE.test('\uFE70')).toBe(true); // Arabic Fathatan Isolated
+    expect(STRONG_RTL_CHAR_RE.test('\uFEFC')).toBe(true); // Arabic Ligature Lam With Alef Final
+  });
+
+  it('STRONG_RTL_CHAR_RE excludes noncharacters and the BOM', () => {
+    // FDD0-FDEF are Unicode noncharacters in the Arabic-A range.
+    expect(STRONG_RTL_CHAR_RE.test('\uFDD0')).toBe(false);
+    expect(STRONG_RTL_CHAR_RE.test('\uFDEF')).toBe(false);
+    // FEFF is ZERO WIDTH NO-BREAK SPACE / BOM, not RTL.
+    expect(STRONG_RTL_CHAR_RE.test('\uFEFF')).toBe(false);
+  });
+
   it('LATIN_DIGIT_NEUTRAL_ONLY_RE matches Latin + digit + neutral chars', () => {
     expect(LATIN_DIGIT_NEUTRAL_ONLY_RE.test('Hello world')).toBe(true);
     expect(LATIN_DIGIT_NEUTRAL_ONLY_RE.test('copy 2')).toBe(true);

--- a/packages/layout-engine/painters/dom/src/features/inline-direction/run-direction.ts
+++ b/packages/layout-engine/painters/dom/src/features/inline-direction/run-direction.ts
@@ -71,7 +71,7 @@ export const normalizeRtlDateTokenForWordParity = (text: string): string => {
  * - rtl-tagged + contains strong-RTL chars -> 'rtl' (standard case)
  * - rtl-tagged + only Latin/digit/neutral -> null (per §17.3.2.30, unspecified;
  *   Word does not visually reorder these, so omit dir to inherit paragraph)
- * - rtl-tagged + other (e.g. East Asian, presentation forms) -> 'rtl' (fail-safe)
+ * - rtl-tagged + other (e.g. East Asian, symbols outside the neutral set) -> 'rtl' (fail-safe)
  * - NOT rtl-tagged + date-like numeric text -> 'ltr' (Word-parity: keeps date
  *   LTR-classified within an RTL paragraph context so digits don't drift)
  * - NOT rtl-tagged + anything else -> null (let paragraph + UBA decide)

--- a/packages/layout-engine/painters/dom/src/features/inline-direction/run-direction.ts
+++ b/packages/layout-engine/painters/dom/src/features/inline-direction/run-direction.ts
@@ -22,12 +22,16 @@
 export const RTL_DATE_LIKE_TOKEN_RE = /^-?\d+(?:[./-]\d+)+$/;
 
 /**
- * Matches strong-RTL characters in the Hebrew / Arabic / Syriac core blocks.
+ * Matches strong-RTL characters across Hebrew, Arabic, and adjacent RTL scripts
+ * including presentation forms (FB1D-FB4F Hebrew, FB50-FDFF Arabic-A,
+ * FE70-FEFF Arabic-B). The block range covers Hebrew, Arabic, Syriac, NKo,
+ * etc.; the Script properties add presentation forms without including
+ * noncharacters (FDD0-FDEF) or the BOM (FEFF).
  *
- * Known gap: misses Hebrew presentation forms (FB1D-FB4F) and Arabic
- * presentation forms (FB50-FDFF, FE70-FEFF). Tracked under SD-2767 follow-ups.
+ * AIDEV-NOTE: also duplicated in super-editor's mixed-bidi-backspace extension.
+ * Consolidating crosses a layer boundary; tracked under SD-3169 follow-ups.
  */
-export const STRONG_RTL_CHAR_RE = /[\u0590-\u08FF]/;
+export const STRONG_RTL_CHAR_RE = /[\u0590-\u08FF\p{Script=Hebrew}\p{Script=Arabic}]/u;
 
 /**
  * Matches runs whose content is exclusively Latin / digit / neutral. Used as

--- a/packages/super-editor/src/editors/v1/extensions/mixed-bidi-backspace/mixed-bidi-backspace.js
+++ b/packages/super-editor/src/editors/v1/extensions/mixed-bidi-backspace/mixed-bidi-backspace.js
@@ -1,7 +1,13 @@
 // @ts-nocheck
 import { Extension } from '@core/Extension.js';
 
-const STRONG_RTL_CHAR_RE = /[\u0590-\u08FF]/;
+// SD-3169: widen beyond Hebrew/Arabic core blocks to include Hebrew/Arabic
+// presentation forms (FB1D-FB4F, FB50-FDFF, FE70-FEFF) used by legacy fonts
+// and some authoring tools. The Unicode Script properties catch presentation
+// forms while excluding noncharacters (FDD0-FDEF) and the BOM (FEFF).
+// AIDEV-NOTE: also duplicated in painter-dom features/inline-direction/run-direction.ts.
+// Consolidating crosses a layer boundary; tracked under SD-3169 follow-ups.
+const STRONG_RTL_CHAR_RE = /[\u0590-\u08FF\p{Script=Hebrew}\p{Script=Arabic}]/u;
 const STRONG_LTR_CHAR_RE = /[A-Za-z\u00C0-\u024F]/;
 
 const isStrongRtl = (char) => STRONG_RTL_CHAR_RE.test(char);

--- a/packages/super-editor/src/editors/v1/extensions/mixed-bidi-backspace/mixed-bidi-backspace.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/mixed-bidi-backspace/mixed-bidi-backspace.test.js
@@ -175,4 +175,55 @@ describe('mixedBidiBackspace (chain command)', () => {
     expect(__TEST_ONLY__.hasMixedDirectionBoundary('A', 'B')).toBe(false);
     expect(__TEST_ONLY__.hasMixedDirectionBoundary('א', 'ש')).toBe(false);
   });
+
+  // SD-3169: Hebrew/Arabic presentation forms (legacy ligature codepoints used
+  // by older fonts and some legacy systems) live outside the Hebrew/Arabic
+  // core blocks. The Phase 6 STRONG_RTL_CHAR_RE = /[\u0590-\u08FF]/ missed
+  // them, so a paragraph mixing presentation-form Hebrew/Arabic with Latin
+  // would not have its boundary detected and mixed-bidi Backspace would not
+  // fire. Pin via the helper and the end-to-end command path.
+  describe('SD-3169 Hebrew/Arabic presentation forms', () => {
+    it('hasMixedDirectionBoundary recognizes Hebrew presentation forms (FB1D-FB4F)', () => {
+      // \uFB21 = Hebrew Letter Wide Alef. Boundary against Latin must register.
+      expect(__TEST_ONLY__.hasMixedDirectionBoundary('\uFB21', 'A')).toBe(true);
+      expect(__TEST_ONLY__.hasMixedDirectionBoundary('A', '\uFB21')).toBe(true);
+      // \uFB4F = Hebrew Ligature Alef Lamed (last code point in the range).
+      expect(__TEST_ONLY__.hasMixedDirectionBoundary('\uFB4F', 'B')).toBe(true);
+    });
+
+    it('hasMixedDirectionBoundary recognizes Arabic Presentation Forms-A (FB50-FDFF)', () => {
+      // \uFB50 = Arabic Letter Alef Wasla Isolated Form (first code point).
+      expect(__TEST_ONLY__.hasMixedDirectionBoundary('\uFB50', 'A')).toBe(true);
+      // \uFDF2 = Arabic Ligature Allah Isolated Form.
+      expect(__TEST_ONLY__.hasMixedDirectionBoundary('\uFDF2', 'A')).toBe(true);
+    });
+
+    it('hasMixedDirectionBoundary recognizes Arabic Presentation Forms-B (FE70-FEFF)', () => {
+      // \uFE70 = Arabic Fathatan Isolated Form (first code point).
+      expect(__TEST_ONLY__.hasMixedDirectionBoundary('\uFE70', 'A')).toBe(true);
+      // \uFEFC = Arabic Ligature Lam With Alef Final Form (last letter form).
+      expect(__TEST_ONLY__.hasMixedDirectionBoundary('\uFEFC', 'A')).toBe(true);
+    });
+
+    it('hasMixedDirectionBoundary excludes noncharacters in the Arabic A range', () => {
+      // FDD0-FDEF are Unicode noncharacters, not strong-RTL.
+      // FEFF is ZERO WIDTH NO-BREAK SPACE (BOM), not strong-RTL.
+      expect(__TEST_ONLY__.hasMixedDirectionBoundary('\uFDD0', 'A')).toBe(false);
+      expect(__TEST_ONLY__.hasMixedDirectionBoundary('\uFEFF', 'A')).toBe(false);
+    });
+
+    it('returns true and mutates tr on presentation-form-Hebrew + Latin boundary', () => {
+      const { state, view, tr } = setupContext({
+        text: '\uFB21A',
+        charLefts: [10, 20],
+        caretRect: makeRect(20, 10, 1, 12),
+        selectionFrom: 11,
+        pmBase: 10,
+      });
+
+      const handled = mixedBidiBackspace()({ state, view, tr, dispatch: vi.fn() });
+      expect(handled).toBe(true);
+      expect(tr.delete).toHaveBeenCalledWith(10, 11);
+    });
+  });
 });


### PR DESCRIPTION
Partial close of SD-3169. Phase 6's \`STRONG_RTL_CHAR_RE = /[\u0590-\u08FF]/\` covered Hebrew, Arabic, and adjacent core blocks but missed legacy presentation-form codepoints used by older fonts and some authoring tools.

**Where it mattered**

Mixed-bidi-backspace boundary detection. A paragraph with presentation-form Hebrew/Arabic next to Latin would not have its boundary recognized, so Backspace at the boundary would not fire the mixed-bidi handler. Run-direction rendering already failed safe via the helper's fallback branch, so visual output was unaffected for the rendering path - this is specifically a boundary-detection bug, not a rendering bug.

**What lands**

Widen both copies of \`STRONG_RTL_CHAR_RE\` to combine the original block range with Unicode Script properties:

\`\`\`
/[\u0590-\u08FF\p{Script=Hebrew}\p{Script=Arabic}]/u
\`\`\`

Script properties catch Hebrew/Arabic characters in the presentation-form blocks (FB1D-FB4F Hebrew, FB50-FDFF Arabic-A, FE70-FEFF Arabic-B) while correctly excluding noncharacters (FDD0-FDEF) and the BOM (FEFF), since those aren't classified as Hebrew or Arabic by the Unicode Script property.

The two copies (in \`super-editor\` and \`painter-dom\`) stay separated for now since consolidating crosses a layer boundary that the routing table doesn't bless. Tracked as a small follow-up.

**Tests**

- \`mixed-bidi-backspace.test.js\`: 5 new cases pinning presentation-form boundary detection, noncharacter exclusion, BOM exclusion, plus an end-to-end command test that returned \`false\` before the fix and now returns \`true\`.
- \`run-direction.test.ts\`: 2 new cases pinning the painter classifier matches presentation forms and excludes noncharacters.

All package tests green: painter-dom 1095, super-editor 30 keymap/backspace tests. Build sweep clean.

Partial close of SD-3169. Remaining sub-items: w:dir embedding, w:bdo override, w:lang/@bidi Hebrew vs Arabic numerics, source RLM/LRM preservation.