### PR TITLE
feat(types): legacy headless-toolbar public facade entry (SD-3179)

### DIFF
--- a/docs/architecture/package-boundaries.md
+++ b/docs/architecture/package-boundaries.md
@@ -109,9 +109,9 @@ The `superdoc` package currently exposes the following entries via `package.json
 | `./super-editor` | Yes | Legacy public compatibility surface | `imports-sub-export.ts` | Was effectively public when no other headless path existed. `Editor`, `PresentationEditor`, `getStarterExtensions`, `Extensions`, `SuperToolbar`, `SuperConverter`, `DocxZipper` and most of the surface are now exported from `superdoc` itself. Kept exported, not advertised, migration target is `superdoc`. See Decision 1. |
 | `./ui` | Yes | Public subpath | `imports-ui.ts` | Stays |
 | `./ui/react` | Yes | Public subpath | `imports-ui-react.ts` | Stays |
-| `./headless-toolbar` | Yes | Public subpath | `imports-headless-toolbar.ts` | Stays |
-| `./headless-toolbar/react` | Yes | Public subpath | `imports-headless-toolbar-react.ts` | Stays |
-| `./headless-toolbar/vue` | Yes | Public subpath | `imports-headless-toolbar-vue.ts` | Stays |
+| `./headless-toolbar` | Yes | Legacy public compatibility surface | `imports-headless-toolbar.ts` | Kept exported, not advertised. New custom UI integrations should use `superdoc/ui`. See Decision 4. |
+| `./headless-toolbar/react` | Yes | Legacy public compatibility surface | `imports-headless-toolbar-react.ts` | Framework helper for the legacy headless toolbar. Migration target is `superdoc/ui/react`. See Decision 4. |
+| `./headless-toolbar/vue` | Yes | Legacy public compatibility surface | `imports-headless-toolbar-vue.ts` | Framework helper for the legacy headless toolbar. New work that needs a Vue UI controller should track that as a separate decision; the legacy entry is kept compiling. See Decision 4. |
 | `./converter` | Yes (SD-2953) | Legacy public compatibility surface | `imports-converter.ts` | DOCX conversion is also reachable through `Editor.open` / `Editor.loadXmlData` / `SuperConverter` exported from `superdoc`. Kept exported, not advertised, migration target is `superdoc`. Types added in SD-2953 to satisfy strict-mode consumers. |
 | `./docx-zipper` | Yes (SD-2953) | Legacy public compatibility surface | `imports-docx-zipper.ts` | `DocxZipper` is exported from `superdoc`. Kept exported, not advertised, migration target is `superdoc`. Types added in SD-2953. |
 | `./file-zipper` | Yes (SD-2953) | Legacy public compatibility surface | `imports-file-zipper.ts` | `createZip` is exported from `superdoc`. Kept exported, not advertised, migration target is `superdoc`. Types added in SD-2953. |
@@ -182,7 +182,20 @@ The relocation pattern is what `superdoc` currently uses for several internal-bu
 
 **Context.** `./converter`, `./docx-zipper`, `./file-zipper` are exported subpaths whose functionality (DOCX conversion, zipping) is also reachable through `superdoc`'s main entry: `Editor.open`, `Editor.loadXmlData`, `SuperConverter`, `DocxZipper`, `createZip` are all exported from `superdoc`.
 
-**Decision.** All three subpaths are classified as **legacy public compatibility surface**. Migration target is `superdoc` itself (the symbols already exist there). We keep them exported, stop advertising them, and point new use at `superdoc`. SD-2953 added `types` fields and matrix fixtures so strict-mode consumers no longer hit TS7016; the export-coverage audit (`check-export-coverage.cjs`) now enforces that every `package.json` exports entry carries types, an asset classification, or a documented runtime-only allowlist entry.
+`./headless-toolbar` is the same shape with a different migration target: the next-generation custom UI story is `superdoc/ui` and `superdoc/ui/react` (the typed UI controller). Existing consumers of the headless-toolbar surface keep compiling; new integrations should use the UI controller entries.
+
+**Decision.** `./converter`, `./docx-zipper`, `./file-zipper`, and the `./headless-toolbar` family (`./headless-toolbar`, `./headless-toolbar/react`, `./headless-toolbar/vue`) are classified as **legacy public compatibility surface**.
+
+| Subpath | Migration target |
+| --- | --- |
+| `./converter` | `SuperConverter` from `superdoc` |
+| `./docx-zipper` | `DocxZipper` from `superdoc` |
+| `./file-zipper` | `createZip` from `superdoc` |
+| `./headless-toolbar` | `superdoc/ui` |
+| `./headless-toolbar/react` | `superdoc/ui/react` |
+| `./headless-toolbar/vue` | Track a Vue UI controller as a separate decision; the legacy entry is kept compiling. |
+
+We keep them exported, stop advertising them, and point new use at the migration target. SD-2953 added `types` fields and matrix fixtures so strict-mode consumers no longer hit TS7016; the export-coverage audit (`check-export-coverage.cjs`) now enforces that every `package.json` exports entry carries types, an asset classification, or a documented runtime-only allowlist entry. SD-3179 lands the source-side facade for `./headless-toolbar` under `packages/superdoc/src/public/legacy/` and extends SD-3176's no-growth snapshot list to cover `./headless-toolbar`, `./headless-toolbar/react`, and `./headless-toolbar/vue` so these subpaths cannot expand silently.
 
 ## Deliverables
 

--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -140,6 +140,12 @@ const cjsDeclarationShims = [
     source: path.join(distRoot, 'superdoc/src/public/index.d.ts'),
     target: './index.js',
   },
+  // SD-3179: legacy headless-toolbar facade entry.
+  {
+    file: path.join(distRoot, 'superdoc/src/public/legacy/headless-toolbar.d.cts'),
+    source: path.join(distRoot, 'superdoc/src/public/legacy/headless-toolbar.d.ts'),
+    target: './headless-toolbar.js',
+  },
 ];
 
 function isValidIdentifier(name) {

--- a/packages/superdoc/scripts/verify-public-facade-emit.cjs
+++ b/packages/superdoc/scripts/verify-public-facade-emit.cjs
@@ -1,21 +1,22 @@
 #!/usr/bin/env node
 /**
- * SD-3178 (Phase 3 of SD-3175): verify the explicit public facade emits a
- * declaration tree that is safe to ship.
+ * SD-3178 (Phase 3 of SD-3175): verify the explicit public facade entries
+ * emit declaration trees that are safe to ship.
  *
- * Runs as a postbuild step under `packages/superdoc/`. Loads the emitted
- * `dist/superdoc/src/public/index.d.ts` and `index.d.cts` with the
- * TypeScript compiler API and asserts:
+ * Runs as a postbuild step under `packages/superdoc/`. For each entry in
+ * the `FACADE_ENTRIES` config below, loads the emitted `.d.ts` and `.d.cts`
+ * with the TypeScript compiler API and asserts:
  *
  *   1. The expected symbol set is exported from each declaration file.
  *   2. The ESM and CJS declarations agree on the exported names.
- *   3. The command signature surface survives the facade emit. This is
- *      the SD-2965 regression vector: specific command signatures getting
- *      dropped or failing to flow through the facade. `EditorCommands` is
- *      `CoreCommands & ExtensionCommands & AllCommandSignatures & Record<string, AnyCommand>`,
- *      so the trailing `Record<string, AnyCommand>` makes any indexer
- *      lookup resolve even when the specific signatures are missing.
- *      The probe asserts the RETURN TYPE of two commands (`setBold`,
+ *   3. (Root entry only) The command signature surface survives the
+ *      facade emit. This is the SD-2965 regression vector: specific
+ *      command signatures getting dropped or failing to flow through the
+ *      facade. `EditorCommands` is `CoreCommands & ExtensionCommands &
+ *      AllCommandSignatures & Record<string, AnyCommand>`, so the
+ *      trailing `Record<string, AnyCommand>` makes any indexer lookup
+ *      resolve even when the specific signatures are missing. The probe
+ *      asserts the RETURN TYPE of two commands (`setBold`,
  *      `insertComment`) is `boolean`, not the `AnyCommand` fallback's
  *      `unknown`. Two commands from two signature sources (formatting +
  *      comments) catch partial drops a single-command probe would miss.
@@ -30,6 +31,14 @@
  *      not see the workspace specifier. Later SD-3178 follow-ups reduce
  *      how much the facade depends on that broader declaration graph.
  *
+ * Adding a new facade file:
+ *   - Create `packages/superdoc/src/public/<name>.ts` with named exports.
+ *   - Wire it into `vite.config.js` (`rollupOptions.input`) and the CJS
+ *     shim list in `scripts/ensure-types.cjs`.
+ *   - Append a `FACADE_ENTRIES` entry below with the expected symbol set.
+ *   - If the new entry re-exports `EditorCommands`, set
+ *     `runsCommandSignatureProbe: true`.
+ *
  * Exits non-zero on any failure. Designed to fail loud and early.
  */
 'use strict';
@@ -39,10 +48,7 @@ const path = require('node:path');
 
 const repoRoot = path.resolve(__dirname, '..', '..', '..');
 const distRoot = path.resolve(__dirname, '..', 'dist');
-const FACADE_ESM = path.join(distRoot, 'superdoc', 'src', 'public', 'index.d.ts');
-const FACADE_CJS = path.join(distRoot, 'superdoc', 'src', 'public', 'index.d.cts');
-
-const EXPECTED_NAMES = ['Config', 'Editor', 'EditorCommands', 'SuperDoc'].sort();
+const PUBLIC_DIST = path.join(distRoot, 'superdoc', 'src', 'public');
 
 let ts;
 try {
@@ -51,6 +57,47 @@ try {
   console.error('[verify-public-facade-emit] typescript is not available in this package.');
   process.exit(1);
 }
+
+// AIDEV-NOTE: Adding or removing an export from a facade file in
+// `packages/superdoc/src/public/**` must update the matching
+// `expectedNames` list below in the same PR. Skipping that step fails
+// this gate. Link the PR to SD-3175 (path-as-contract umbrella) for
+// reviewer sign-off when growth is intentional.
+const FACADE_ENTRIES = [
+  {
+    name: 'root (./index)',
+    esm: path.join(PUBLIC_DIST, 'index.d.ts'),
+    cjs: path.join(PUBLIC_DIST, 'index.d.cts'),
+    expectedNames: ['Config', 'Editor', 'EditorCommands', 'SuperDoc'],
+    runsCommandSignatureProbe: true,
+    ticket: 'SD-3178',
+  },
+  {
+    name: 'legacy/headless-toolbar',
+    esm: path.join(PUBLIC_DIST, 'legacy', 'headless-toolbar.d.ts'),
+    cjs: path.join(PUBLIC_DIST, 'legacy', 'headless-toolbar.d.cts'),
+    expectedNames: [
+      'CreateHeadlessToolbarOptions',
+      'HeadlessToolbarController',
+      'HeadlessToolbarSuperdocHost',
+      'HeadlessToolbarSurface',
+      'PublicToolbarItemId',
+      'ToolbarCommandState',
+      'ToolbarCommandStates',
+      'ToolbarContext',
+      'ToolbarExecuteFn',
+      'ToolbarPayloadMap',
+      'ToolbarSnapshot',
+      'ToolbarTarget',
+      'ToolbarValueMap',
+      'createHeadlessToolbar',
+      'headlessToolbarConstants',
+      'headlessToolbarHelpers',
+    ],
+    runsCommandSignatureProbe: false,
+    ticket: 'SD-3179',
+  },
+];
 
 function loadFile(file) {
   if (!fs.existsSync(file)) {
@@ -75,48 +122,39 @@ function listExportedNames(file) {
   const checker = program.getTypeChecker();
   const src = program.getSourceFile(file);
   const symbol = checker.getSymbolAtLocation(src) ?? (src && src.symbol);
-  if (!symbol) {
-    return { names: [], program, checker };
+  if (!symbol) return [];
+  return [...new Set(checker.getExportsOfModule(symbol).map((s) => s.getName()))].sort();
+}
+
+function checkSymbolSet(entry) {
+  const expected = [...entry.expectedNames].sort();
+  const actual = listExportedNames(entry.esm);
+  if (JSON.stringify(actual) === JSON.stringify(expected)) {
+    return { ok: true, actual };
   }
-  return {
-    names: [...new Set(checker.getExportsOfModule(symbol).map((s) => s.getName()))].sort(),
-    program,
-    checker,
-  };
+  console.error(`[verify-public-facade-emit] ${entry.name}: facade exports drifted.`);
+  console.error('  expected: ' + expected.join(', '));
+  console.error('  actual:   ' + actual.join(', '));
+  console.error(`  If this addition is intentional, update FACADE_ENTRIES["${entry.name}"].expectedNames in this script and link`);
+  console.error(`  the PR to ${entry.ticket} / SD-3175 (path-as-contract umbrella) for reviewer sign-off.`);
+  return { ok: false, actual };
 }
 
-let failed = false;
-
-// (1) Symbol set.
-const esm = listExportedNames(FACADE_ESM);
-if (JSON.stringify(esm.names) !== JSON.stringify(EXPECTED_NAMES)) {
-  console.error(`[verify-public-facade-emit] ESM facade exports drifted.`);
-  console.error('  expected: ' + EXPECTED_NAMES.join(', '));
-  console.error('  actual:   ' + esm.names.join(', '));
-  console.error('  If this addition is intentional, update EXPECTED_NAMES in this script and link');
-  console.error('  the PR to SD-3175 (path-as-contract umbrella) for reviewer sign-off.');
-  failed = true;
-}
-
-// (2) ESM/CJS parity.
-const cjs = listExportedNames(FACADE_CJS);
-if (JSON.stringify(esm.names) !== JSON.stringify(cjs.names)) {
-  const importOnly = esm.names.filter((n) => !cjs.names.includes(n));
-  const requireOnly = cjs.names.filter((n) => !esm.names.includes(n));
-  console.error('[verify-public-facade-emit] ESM/CJS facade declarations disagree on exports.');
+function checkEsmCjsParity(entry, esmNames) {
+  const cjsNames = listExportedNames(entry.cjs);
+  if (JSON.stringify(esmNames) === JSON.stringify(cjsNames)) return true;
+  const importOnly = esmNames.filter((n) => !cjsNames.includes(n));
+  const requireOnly = cjsNames.filter((n) => !esmNames.includes(n));
+  console.error(`[verify-public-facade-emit] ${entry.name}: ESM/CJS facade declarations disagree on exports.`);
   if (importOnly.length) console.error('  ESM-only:  ' + importOnly.join(', '));
   if (requireOnly.length) console.error('  CJS-only:  ' + requireOnly.join(', '));
   console.error('  Fix the CJS shim generator (packages/superdoc/scripts/ensure-types.cjs).');
-  failed = true;
+  return false;
 }
 
-// (3) Command signature survival: assert two commands return `boolean`,
-//     not the `AnyCommand` fallback. See header for why a bare resolution
-//     check is not enough (the `Record<string, AnyCommand>` intersection
-//     always satisfies the indexer).
-{
+function checkCommandSignatureProbe(entry) {
   const probe = `
-    import type { EditorCommands } from ${JSON.stringify(FACADE_ESM)};
+    import type { EditorCommands } from ${JSON.stringify(entry.esm)};
     type ReturnsBoolean<F> = F extends (...args: any[]) => boolean ? true : false;
     // Direct assignment of literal \`true\` to the conditional result. If the
     // signature is missing and the indexer falls back to AnyCommand, the
@@ -150,25 +188,22 @@ if (JSON.stringify(esm.names) !== JSON.stringify(cjs.names)) {
       ...program.getSemanticDiagnostics(),
       ...program.getDeclarationDiagnostics(),
     ];
-    if (diagnostics.length > 0) {
-      console.error('[verify-public-facade-emit] command signature probe failed.');
-      console.error('  A command (setBold or insertComment) does not return `boolean` through the facade.');
-      console.error('  This is the SD-2965 regression vector: specific command signatures were dropped or failed to flow through the facade, and EditorCommands fell back to the `AnyCommand` indexer.');
-      for (const d of diagnostics) {
-        const msg = typeof d.messageText === 'string'
-          ? d.messageText
-          : ts.flattenDiagnosticMessageText(d.messageText, '\n');
-        console.error('  - ' + msg);
-      }
-      failed = true;
+    if (diagnostics.length === 0) return true;
+    console.error(`[verify-public-facade-emit] ${entry.name}: command signature probe failed.`);
+    console.error('  A command (setBold or insertComment) does not return `boolean` through the facade.');
+    console.error('  This is the SD-2965 regression vector: specific command signatures were dropped or failed to flow through the facade, and EditorCommands fell back to the `AnyCommand` indexer.');
+    for (const d of diagnostics) {
+      const msg = typeof d.messageText === 'string'
+        ? d.messageText
+        : ts.flattenDiagnosticMessageText(d.messageText, '\n');
+      console.error('  - ' + msg);
     }
+    return false;
   } finally {
     try { fs.unlinkSync(probePath); } catch (_) {}
   }
 }
 
-// (4) No internal leaks in emitted code (strip JSDoc/line comments first so
-// that comments referencing `@superdoc/super-editor` in prose are not flagged).
 function stripComments(source) {
   return source
     .replace(/\/\*[\s\S]*?\*\//g, '')
@@ -181,16 +216,38 @@ const LEAK_PATTERNS = [
   { name: 'absolute source path', re: /['"][\/\\][^'"\n]*\/(packages|node_modules)\//g },
 ];
 
-for (const file of [FACADE_ESM, FACADE_CJS]) {
-  const code = stripComments(loadFile(file));
-  for (const pattern of LEAK_PATTERNS) {
-    const matches = code.match(pattern.re);
-    if (matches && matches.length > 0) {
-      console.error(`[verify-public-facade-emit] leak in ${path.relative(repoRoot, file)}:`);
-      console.error(`  ${pattern.name}: ${matches.slice(0, 5).join(', ')}`);
-      failed = true;
+function checkLeaks(entry) {
+  let ok = true;
+  for (const file of [entry.esm, entry.cjs]) {
+    const code = stripComments(loadFile(file));
+    for (const pattern of LEAK_PATTERNS) {
+      const matches = code.match(pattern.re);
+      if (matches && matches.length > 0) {
+        console.error(`[verify-public-facade-emit] ${entry.name}: leak in ${path.relative(repoRoot, file)}:`);
+        console.error(`  ${pattern.name}: ${matches.slice(0, 5).join(', ')}`);
+        ok = false;
+      }
     }
   }
+  return ok;
+}
+
+let failed = false;
+const summaryLines = [];
+
+for (const entry of FACADE_ENTRIES) {
+  const symbolResult = checkSymbolSet(entry);
+  if (!symbolResult.ok) failed = true;
+
+  if (!checkEsmCjsParity(entry, symbolResult.actual)) failed = true;
+
+  if (entry.runsCommandSignatureProbe && !checkCommandSignatureProbe(entry)) {
+    failed = true;
+  }
+
+  if (!checkLeaks(entry)) failed = true;
+
+  summaryLines.push(`${entry.name}: ${symbolResult.actual.length} exports`);
 }
 
 if (failed) {
@@ -199,4 +256,4 @@ if (failed) {
   process.exit(1);
 }
 
-console.log(`[verify-public-facade-emit] OK. Facade emits cleanly: ${esm.names.length} exports, ESM/CJS in parity, command signatures survive.`);
+console.log(`[verify-public-facade-emit] OK. Facade emits cleanly across ${FACADE_ENTRIES.length} entries (${summaryLines.join('; ')}).`);

--- a/packages/superdoc/src/public/legacy/headless-toolbar.test.ts
+++ b/packages/superdoc/src/public/legacy/headless-toolbar.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createHeadlessToolbar,
+  headlessToolbarConstants,
+  headlessToolbarHelpers,
+} from './headless-toolbar.js';
+
+/**
+ * Smoke test for the legacy public facade headless-toolbar entry (SD-3179).
+ * The three runtime re-exports need coverage so the facade file does not
+ * show 0% on the unit-test coverage report. Declaration-side validation
+ * (symbol set, ESM/CJS parity, leak grep) lives in
+ * `packages/superdoc/scripts/verify-public-facade-emit.cjs`.
+ */
+describe('public facade (legacy/headless-toolbar)', () => {
+  it('re-exports createHeadlessToolbar as a function', () => {
+    expect(typeof createHeadlessToolbar).toBe('function');
+  });
+
+  it('re-exports headlessToolbarConstants as an object', () => {
+    expect(headlessToolbarConstants).toBeDefined();
+    expect(typeof headlessToolbarConstants).toBe('object');
+  });
+
+  it('re-exports headlessToolbarHelpers as an object', () => {
+    expect(headlessToolbarHelpers).toBeDefined();
+    expect(typeof headlessToolbarHelpers).toBe('object');
+  });
+});

--- a/packages/superdoc/src/public/legacy/headless-toolbar.ts
+++ b/packages/superdoc/src/public/legacy/headless-toolbar.ts
@@ -1,0 +1,57 @@
+/**
+ * SuperDoc public facade: legacy headless-toolbar entry.
+ *
+ * SD-3179 under SD-3178 (Phase 3 of SD-3175). This file mirrors the
+ * 16-name surface today reachable as the pair of
+ * `packages/superdoc/src/headless-toolbar.js` (3 runtime values) and
+ * `packages/superdoc/src/headless-toolbar.d.ts` (13 hand-maintained type
+ * re-exports). Combining them into a single `.ts` source lets the dts
+ * pipeline emit both `.d.ts` and `.d.cts` from one place.
+ *
+ * Classification: **legacy public compatibility surface.** The
+ * `superdoc/headless-toolbar` subpath is kept exported and typed so
+ * existing consumers continue to compile. It is not the recommended
+ * path for new custom UI integrations. New work should use
+ * `superdoc/ui` and `superdoc/ui/react` instead.
+ *
+ * Rules for this file:
+ *   - AIDEV-NOTE: Named exports only. No `export *` from
+ *     `@superdoc/super-editor`. Growing this list ships a new public
+ *     symbol through a legacy compat path, which violates the
+ *     no-growth posture this entry is classified under in
+ *     `docs/architecture/package-boundaries.md` Decision 4.
+ *   - AIDEV-NOTE: Adding or removing an export here updates the
+ *     `expectedNames` for the `legacy/headless-toolbar` entry in
+ *     `FACADE_ENTRIES` inside
+ *     `packages/superdoc/scripts/verify-public-facade-emit.cjs` in the
+ *     same PR. Skipping that step fails the postbuild gate.
+ *   - This entry does not re-export `Editor` or `EditorCommands`, so
+ *     the verifier skips the command-signature probe here. The root
+ *     entry (`../index.ts`) keeps that probe.
+ *   - Source still imports from the broad `@superdoc/super-editor`
+ *     entry. Tightening the type edge to the deeper
+ *     `super-editor/src/headless-toolbar/index.js` is not a priority
+ *     for a legacy frozen surface; the goal here is correct types,
+ *     not minimal graph.
+ */
+export {
+  createHeadlessToolbar,
+  headlessToolbarConstants,
+  headlessToolbarHelpers,
+} from '@superdoc/super-editor';
+
+export type {
+  CreateHeadlessToolbarOptions,
+  HeadlessToolbarController,
+  HeadlessToolbarSurface,
+  HeadlessToolbarSuperdocHost,
+  PublicToolbarItemId,
+  ToolbarCommandState,
+  ToolbarCommandStates,
+  ToolbarContext,
+  ToolbarExecuteFn,
+  ToolbarPayloadMap,
+  ToolbarSnapshot,
+  ToolbarTarget,
+  ToolbarValueMap,
+} from '@superdoc/super-editor';

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -237,16 +237,21 @@ export default defineConfig(({ mode, command }) => {
           'super-editor/docx-zipper': '@core/DocxZipper',
           'super-editor/converter': '@core/super-converter/SuperConverter',
           'super-editor/file-zipper': '@core/super-converter/zipper.js',
-          // SD-3178 (Phase 3 of SD-3175): root entry of the explicit public
-          // facade. Build emits the artifact alongside the existing entries
-          // so the facade declarations are available for postbuild
-          // verification.
+          // SD-3178 (Phase 3 of SD-3175): explicit public facade entries.
+          // Build emits the artifacts alongside the existing entries so the
+          // facade declarations are available for postbuild verification.
           // AIDEV-NOTE: `package.json#exports` is intentionally not yet
-          // updated to point at this entry. Phase 4 (a separate child of
-          // SD-3175) owns the contract switch. Adding a `./public` entry
-          // here without that ticket ships a new public subpath under the
-          // radar.
+          // updated to point at these entries. Phase 4 (a separate child
+          // of SD-3175) owns the contract switch. Adding `./public` or
+          // `./public/...` entries here without that ticket ships new
+          // public subpaths under the radar.
           'public': 'src/public/index.ts',
+          // SD-3179: legacy headless-toolbar facade entry. Classified as
+          // legacy public compatibility surface in
+          // `docs/architecture/package-boundaries.md` Decision 4. New
+          // custom UI integrations should use the `superdoc/ui` /
+          // `superdoc/ui/react` entries instead.
+          'public/legacy/headless-toolbar': 'src/public/legacy/headless-toolbar.ts',
         },
         external: [
           'yjs',

--- a/tests/consumer-typecheck/snapshot-superdoc-legacy-exports.mjs
+++ b/tests/consumer-typecheck/snapshot-superdoc-legacy-exports.mjs
@@ -4,10 +4,15 @@
  *
  * Snapshots the resolved named exports visible through these subpaths against
  * the packed-and-installed tarball:
- *   - superdoc/super-editor   (the dangerous one; `export *` from @superdoc/super-editor)
+ *   - superdoc/super-editor          (the dangerous one; `export *` from @superdoc/super-editor)
  *   - superdoc/converter
  *   - superdoc/docx-zipper
  *   - superdoc/file-zipper
+ *   - superdoc/headless-toolbar      (SD-3179 reclassified from public to legacy)
+ *   - superdoc/headless-toolbar/react
+ *   - superdoc/headless-toolbar/vue
+ *
+ * The authoritative list is the `SUBPATHS` constant below.
  *
  * Source parsing is insufficient because `superdoc/src/super-editor.js` is
  * `export * from '@superdoc/super-editor'`. The contract that ships is what
@@ -65,6 +70,11 @@ const SUBPATHS = [
   './converter',
   './docx-zipper',
   './file-zipper',
+  // SD-3179 reclassified the headless-toolbar subpaths from public to
+  // legacy compatibility surface. See package-boundaries.md Decision 4.
+  './headless-toolbar',
+  './headless-toolbar/react',
+  './headless-toolbar/vue',
 ];
 
 function resolveTypesEntries(exportsValue) {

--- a/tests/consumer-typecheck/snapshots/README.md
+++ b/tests/consumer-typecheck/snapshots/README.md
@@ -11,6 +11,9 @@ These files lock the public TypeScript surface that ships through SuperDoc's leg
 | `superdoc-converter.txt` | Resolved exports through `superdoc/converter` | Single-purpose legacy entry; freeze check. |
 | `superdoc-docx-zipper.txt` | Resolved exports through `superdoc/docx-zipper` | Single-purpose legacy entry; freeze check. |
 | `superdoc-file-zipper.txt` | Resolved exports through `superdoc/file-zipper` | Single-purpose legacy entry; freeze check. |
+| `superdoc-headless-toolbar.txt` | Resolved exports through `superdoc/headless-toolbar` | Reclassified as legacy in SD-3179 ahead of the `superdoc/ui` migration. 16-name surface; freeze check. |
+| `superdoc-headless-toolbar-react.txt` | Resolved exports through `superdoc/headless-toolbar/react` | Framework helper paired with `superdoc/headless-toolbar`. Migration target: `superdoc/ui/react`. |
+| `superdoc-headless-toolbar-vue.txt` | Resolved exports through `superdoc/headless-toolbar/vue` | Framework helper paired with `superdoc/headless-toolbar`. Migration target: tracked separately. |
 
 Snapshot scripts:
 
@@ -65,5 +68,5 @@ node snapshot-superdoc-legacy-exports.mjs --check
 - Does not classify supported public surfaces (root `superdoc`, `superdoc/ui`, etc.). That work lives in `tests/consumer-typecheck/public-facade-policy.json` and SD-2966 / SD-3147.
 - Does not catch leaks through non-legacy paths. The full path-as-contract facade lands under SD-3175.
 - Does not lock the *types* of exported symbols, only their names. A breaking change to an existing export's shape passes this gate.
-- Does not run against arbitrary subpaths. Only the four files listed above are tracked.
+- Does not run against arbitrary subpaths. Only the files listed in the table above are tracked. The authoritative list lives in `SUBPATHS` inside `tests/consumer-typecheck/snapshot-superdoc-legacy-exports.mjs`.
 - Does not enumerate every file reachable through existing wildcard export-map keys in `@superdoc/super-editor` (e.g. `"./*"`, `"./converter/internal/*"`). Snapshot A freezes the export-map key set; Snapshot B freezes the resolved `superdoc/super-editor` named export surface. A new file added under an existing wildcard that a consumer reaches via deep import (`@superdoc/super-editor/something-new`) passes both gates. Wildcard removal or shrinkage belongs to the later compat/major phases of SD-3175.

--- a/tests/consumer-typecheck/snapshots/superdoc-headless-toolbar-react.txt
+++ b/tests/consumer-typecheck/snapshots/superdoc-headless-toolbar-react.txt
@@ -1,0 +1,1 @@
+useHeadlessToolbar

--- a/tests/consumer-typecheck/snapshots/superdoc-headless-toolbar-vue.txt
+++ b/tests/consumer-typecheck/snapshots/superdoc-headless-toolbar-vue.txt
@@ -1,0 +1,1 @@
+useHeadlessToolbar

--- a/tests/consumer-typecheck/snapshots/superdoc-headless-toolbar.txt
+++ b/tests/consumer-typecheck/snapshots/superdoc-headless-toolbar.txt
@@ -1,0 +1,16 @@
+CreateHeadlessToolbarOptions
+HeadlessToolbarController
+HeadlessToolbarSuperdocHost
+HeadlessToolbarSurface
+PublicToolbarItemId
+ToolbarCommandState
+ToolbarCommandStates
+ToolbarContext
+ToolbarExecuteFn
+ToolbarPayloadMap
+ToolbarSnapshot
+ToolbarTarget
+ToolbarValueMap
+createHeadlessToolbar
+headlessToolbarConstants
+headlessToolbarHelpers


### PR DESCRIPTION
Second facade file under [SD-3178](https://linear.app/superdocworkspace/issue/SD-3178) / Phase 3 of [SD-3175](https://linear.app/superdocworkspace/issue/SD-3175) (path-as-contract architecture). Reframes the `./headless-toolbar` family as legacy public compatibility surface rather than supported new API.

## What changes

- `superdoc/headless-toolbar`, `superdoc/headless-toolbar/react`, and `superdoc/headless-toolbar/vue` are reclassified as **legacy public compatibility surface** in `docs/architecture/package-boundaries.md` (inventory table + Decision 4 migration table). Existing consumers keep compiling with full types; new custom UI integrations should use `superdoc/ui` and `superdoc/ui/react`.
- New facade file `packages/superdoc/src/public/legacy/headless-toolbar.ts` mirrors the 16-name surface (3 runtime + 13 types) under the path-as-contract structure. Named exports only.
- Pipeline wiring: new vite rollup input entry, CJS shim entry in `ensure-types.cjs`.
- `verify-public-facade-emit.cjs` refactored to be config-driven via a `FACADE_ENTRIES` list. Adding a new facade file is now a single append. Root entry keeps the command-signature probe; the headless-toolbar entry doesn't need it (no `EditorCommands` exposure).
- `tests/consumer-typecheck/snapshot-superdoc-legacy-exports.mjs`: [SD-3176](https://linear.app/superdocworkspace/issue/SD-3176)'s no-growth gate extended to cover the three headless-toolbar subpaths. Three new baseline files (16/1/1 resolved exports). Snapshots README updated.
- 3 smoke assertions for the runtime re-exports.

No `package.json#exports` change. Phase 4 owns the contract flip.

## Verified locally

| Check | Result |
| --- | --- |
| Facade verifier clean | OK across 2 entries (root: 4 exports, legacy/headless-toolbar: 16) |
| Drift on legacy/headless-toolbar facade `.d.ts` | exit 1 |
| Injected `@superdoc/*` leak in facade `.d.ts` | exit 1 |
| Command-signature probe still fires on root | confirmed |
| No-growth gate clean across all 7 legacy subpaths | OK |
| Drift on `superdoc/headless-toolbar` published `.d.ts` | exit 1 |
| Vitest smoke tests | 5/5 pass (2 root + 3 headless-toolbar) |

## Related

- [SD-3175](https://linear.app/superdocworkspace/issue/SD-3175) (path-as-contract umbrella)
- [SD-3178](https://linear.app/superdocworkspace/issue/SD-3178) / #3358 (Phase 3 root scaffold; merged)
- [SD-3176](https://linear.app/superdocworkspace/issue/SD-3176) (no-growth gates; extended here to cover the headless-toolbar family)
- [SD-3179](https://linear.app/superdocworkspace/issue/SD-3179) (this PR)