### PR TITLE
feat(types): ui-react public facade entry (SD-3182)

### DIFF
--- a/packages/superdoc/scripts/verify-public-facade-emit.cjs
+++ b/packages/superdoc/scripts/verify-public-facade-emit.cjs
@@ -142,6 +142,32 @@ const FACADE_ENTRIES = [
     runsCommandSignatureProbe: false,
     ticket: 'SD-3180',
   },
+  // SD-3182: first supported-surface facade entry. The `superdoc/ui/react`
+  // subpath is the strategic React binding surface. SD-3147 classification:
+  // 12 public + 1 legacy/public-compat. Matches the existing `./ui/react`
+  // single-`types` shape, so `cjs: null`.
+  {
+    name: 'ui-react',
+    esm: path.join(PUBLIC_DIST, 'ui-react.d.ts'),
+    cjs: null,
+    expectedNames: [
+      'SuperDocHost',
+      'SuperDocUIProvider',
+      'useSetSuperDoc',
+      'useSuperDocCommand',
+      'useSuperDocComments',
+      'useSuperDocContentControls',
+      'useSuperDocDocument',
+      'useSuperDocHost',
+      'useSuperDocSelection',
+      'useSuperDocSlice',
+      'useSuperDocToolbar',
+      'useSuperDocTrackChanges',
+      'useSuperDocUI',
+    ],
+    runsCommandSignatureProbe: false,
+    ticket: 'SD-3182',
+  },
 ];
 
 function loadFile(file) {

--- a/packages/superdoc/src/public/ui-react.test.ts
+++ b/packages/superdoc/src/public/ui-react.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SuperDocUIProvider,
+  useSuperDocUI,
+  useSuperDocSelection,
+  useSuperDocComments,
+  useSetSuperDoc,
+} from './ui-react.js';
+
+/**
+ * Smoke test for the public facade ui-react entry (SD-3182).
+ * Confirms the runtime re-exports resolve. Declaration-side validation
+ * (symbol set, leak grep) lives in
+ * `packages/superdoc/scripts/verify-public-facade-emit.cjs`.
+ */
+describe('public facade (ui-react)', () => {
+  it('re-exports SuperDocUIProvider as a component', () => {
+    expect(typeof SuperDocUIProvider).toBe('function');
+  });
+
+  it('re-exports useSuperDocUI as a hook', () => {
+    expect(typeof useSuperDocUI).toBe('function');
+  });
+
+  it('re-exports domain hooks as functions', () => {
+    expect(typeof useSuperDocSelection).toBe('function');
+    expect(typeof useSuperDocComments).toBe('function');
+    expect(typeof useSetSuperDoc).toBe('function');
+  });
+});

--- a/packages/superdoc/src/public/ui-react.ts
+++ b/packages/superdoc/src/public/ui-react.ts
@@ -1,0 +1,40 @@
+/**
+ * SuperDoc public facade: ui-react entry.
+ *
+ * SD-3182 under SD-3178 (Phase 3 of SD-3175). First supported-surface
+ * facade entry (after the legacy mirrors in SD-3179 / SD-3180). Mirrors
+ * the 13-name surface today reachable via the `superdoc/ui/react` subpath.
+ *
+ * Classification per SD-3147: 12 public + 1 legacy/public-compat
+ * (`useSuperDocContentControls`, preserved for compatibility).
+ *
+ * Strategy: re-export through the narrow `@superdoc/super-editor/ui/react`
+ * subpath rather than the broad `@superdoc/super-editor` root, matching the
+ * SD-3179 / SD-3180 narrow-import pattern. Keeps emitted bundles narrow.
+ *
+ * Rules for this file:
+ *   - AIDEV-NOTE: Named exports only. No `export *`. The supported-surface
+ *     contract is the explicit list below plus the SD-3147 classification.
+ *   - AIDEV-NOTE: Adding or removing an export here updates the
+ *     `expectedNames` for the `ui-react` entry in `FACADE_ENTRIES` inside
+ *     `packages/superdoc/scripts/verify-public-facade-emit.cjs` in the
+ *     same PR. The verifier postbuild fails on drift.
+ *   - This entry does not re-export `Editor` or `EditorCommands`, so the
+ *     verifier skips the command-signature probe.
+ */
+export {
+  SuperDocUIProvider,
+  useSuperDocUI,
+  useSuperDocHost,
+  useSetSuperDoc,
+  useSuperDocSlice,
+  useSuperDocSelection,
+  useSuperDocComments,
+  useSuperDocContentControls,
+  useSuperDocTrackChanges,
+  useSuperDocToolbar,
+  useSuperDocCommand,
+  useSuperDocDocument,
+} from '@superdoc/super-editor/ui/react';
+
+export type { SuperDocHost } from '@superdoc/super-editor/ui/react';

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -258,6 +258,10 @@ export default defineConfig(({ mode, command }) => {
           'public/legacy/converter': 'src/public/legacy/converter.ts',
           'public/legacy/docx-zipper': 'src/public/legacy/docx-zipper.ts',
           'public/legacy/file-zipper': 'src/public/legacy/file-zipper.ts',
+          // SD-3182: first supported-surface facade entry. The
+          // `superdoc/ui/react` subpath is the strategic React binding
+          // surface. SD-3147 classification: 12 public + 1 legacy/public-compat.
+          'public/ui-react': 'src/public/ui-react.ts',
         },
         external: [
           'yjs',


### PR DESCRIPTION
First supported-surface facade entry under [SD-3178](https://linear.app/superdocworkspace/issue/SD-3178) / Phase 3 of [SD-3175](https://linear.app/superdocworkspace/issue/SD-3175) (path-as-contract architecture). The `superdoc/ui/react` subpath is the strategic React binding surface — the next-generation custom UI story per [SD-3179](https://linear.app/superdocworkspace/issue/SD-3179)'s reframing of `superdoc/headless-toolbar` as legacy compat.

Smallest supported-surface entry on purpose: 13 symbols, lowest review blast radius. Proves the supported-facade pattern before tackling `ui.ts` (~70 symbols) and `types.ts` (~116 symbols).

## Inputs

- [SD-3147](https://linear.app/superdocworkspace/issue/SD-3147) classification (Linear comment, 2026-05-17): all 13 symbols pre-classified. 12 public + 1 legacy/public-compat (`useSuperDocContentControls`). Per SD-3147's framing, the public/legacy distinction is documentation posture, not facade inclusion — both tiers ship through the facade.

## What changes

- `packages/superdoc/src/public/ui-react.ts`: 12 named runtime re-exports (provider + 11 hooks) + 1 type re-export (`SuperDocHost`) through the **narrow** `@superdoc/super-editor/ui/react` subpath. Matches the SD-3179/SD-3180 narrow-import pattern; keeps the emitted bundle narrow.
- `vite.config.js`: new rollup input entry `public/ui-react`.
- `verify-public-facade-emit.cjs`: new `FACADE_ENTRIES` entry with all 13 `expectedNames`. `cjs: null` (matches the existing `./ui/react` single-`types` shape; Phase 4 decides whether to add CJS shims when the contract flips). `runsCommandSignatureProbe: false` (no `Editor` or `EditorCommands` re-exported here).
- `src/public/ui-react.test.ts`: 3 smoke assertions covering the provider + representative hooks.

No `package.json#exports` change. Phase 4 owns the contract flip.

## Verified locally

| Check | Result |
| --- | --- |
| Facade verifier clean | OK across 6 entries (root: 4, legacy/headless-toolbar: 16, legacy leaves: 4, ui-react: 13) |
| Drift on facade `.d.ts` (rename a symbol) | exit 1 with TS2305 `has no exported member` diagnostic — `skipLibCheck:false` hardening from SD-3180 works as intended |
| Vitest smoke tests | 12/12 pass |

## Related

- [SD-3175](https://linear.app/superdocworkspace/issue/SD-3175) (path-as-contract umbrella)
- [SD-3178](https://linear.app/superdocworkspace/issue/SD-3178) (Phase 3 umbrella)
- [SD-3147](https://linear.app/superdocworkspace/issue/SD-3147) (classification input — done as implementation input, not finalized API policy)
- [SD-3179](https://linear.app/superdocworkspace/issue/SD-3179) / [SD-3180](https://linear.app/superdocworkspace/issue/SD-3180) (same-pattern legacy entries)
- [SD-3182](https://linear.app/superdocworkspace/issue/SD-3182) (this PR)