### PR TITLE
feat(types): types public facade entry — type-only (SD-3184)

### DIFF
--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -146,13 +146,27 @@ const cjsDeclarationShims = [
     source: path.join(distRoot, 'superdoc/src/public/legacy/headless-toolbar.d.ts'),
     target: './headless-toolbar.js',
   },
+  // SD-3184: types facade — type-only entry. The existing `./types`
+  // subpath has split types.import/types.require declarations, so the
+  // facade needs a real .d.cts shim. `typeOnly: true` forces the shim
+  // to re-export every name with `export type`, never `export declare
+  // const`, even for names that have value origins upstream (defineNode,
+  // defineMark, isNodeType, assertNodeType, isMarkType). This matches
+  // the ESM .d.ts which uses `export type { ... }` for the same names
+  // and the runtime contract (`dist/public/types.es.js` is empty).
+  {
+    file: path.join(distRoot, 'superdoc/src/public/types.d.cts'),
+    source: path.join(distRoot, 'superdoc/src/public/types.d.ts'),
+    target: './types.js',
+    typeOnly: true,
+  },
 ];
 
 function isValidIdentifier(name) {
   return /^[$A-Z_a-z][$\w]*$/.test(name);
 }
 
-function emitCjsDeclarationShim({ file, source, target }) {
+function emitCjsDeclarationShim({ file, source, target, typeOnly = false }) {
   const ts = require('typescript');
   const program = ts.createProgram([source], {
     target: ts.ScriptTarget.ES2022,
@@ -183,6 +197,19 @@ function emitCjsDeclarationShim({ file, source, target }) {
     const resolved = (symbol.flags & ts.SymbolFlags.Alias) ? checker.getAliasedSymbol(symbol) : symbol;
     const hasValue = Boolean(resolved.flags & ts.SymbolFlags.Value);
     const hasType = Boolean(resolved.flags & ts.SymbolFlags.Type);
+
+    // typeOnly: re-export every name as a type, regardless of upstream
+    // origin. SD-3184: `superdoc/types` is contracted as type-only, so
+    // value-origin names (defineNode, defineMark, isNodeType,
+    // assertNodeType, isMarkType) must NOT appear as `export declare
+    // const` in the CJS shim — that would advertise a runtime value
+    // the empty runtime bundle does not provide.
+    if (typeOnly) {
+      const typeAlias = `__Cjs_${name}`;
+      importLines.push(`import type { ${name} as ${typeAlias} } from '${target}' with { "resolution-mode": "import" };`);
+      exportLines.push(`export type { ${typeAlias} as ${name} };`);
+      continue;
+    }
 
     if (hasType) {
       const typeAlias = `__Cjs_${name}`;

--- a/packages/superdoc/scripts/verify-public-facade-emit.cjs
+++ b/packages/superdoc/scripts/verify-public-facade-emit.cjs
@@ -259,8 +259,15 @@ const FACADE_ENTRIES = [
   // (defineNode, defineMark, isNodeType, assertNodeType, isMarkType)
   // but kept type-only here to match today's contract.
   //
-  // SD-3147 classification: 37 public + 79 legacy/public-compat. The
-  // existing `./types` package.json#exports entry uses split
+  // SD-3147 classification (corrected, see SD-3185): 26 public + 90
+  // legacy/public-compat. Command-augmentation infrastructure
+  // (CoreCommandMap, ExtensionCommandMap, EditorCommands, etc.) is
+  // legacy/public-compat — typed for backward compat, kept compiling,
+  // not advertised — per the @deprecated tags on `editor.commands` in
+  // Editor.ts and AGENTS.md's "use editor.doc" guidance. All 116 names
+  // remain in the facade; only the tier label changes.
+  //
+  // The existing `./types` package.json#exports entry uses split
   // types.import/types.require, so this facade has a real .d.cts shim
   // and the verifier exercises ESM/CJS parity.
   {

--- a/packages/superdoc/scripts/verify-public-facade-emit.cjs
+++ b/packages/superdoc/scripts/verify-public-facade-emit.cjs
@@ -253,6 +253,147 @@ const FACADE_ENTRIES = [
     runsCommandSignatureProbe: false,
     ticket: 'SD-3183',
   },
+  // SD-3184: types facade — type-only entry. 116 names from the
+  // existing superdoc/types declaration surface, all exported as
+  // `export type { ... }`. Five names are value-origin upstream
+  // (defineNode, defineMark, isNodeType, assertNodeType, isMarkType)
+  // but kept type-only here to match today's contract.
+  //
+  // SD-3147 classification: 37 public + 79 legacy/public-compat. The
+  // existing `./types` package.json#exports entry uses split
+  // types.import/types.require, so this facade has a real .d.cts shim
+  // and the verifier exercises ESM/CJS parity.
+  {
+    name: 'types',
+    esm: path.join(PUBLIC_DIST, 'types.d.ts'),
+    cjs: path.join(PUBLIC_DIST, 'types.d.cts'),
+    // SD-3184: superdoc/types is contracted type-only. The CJS shim
+    // must not emit `export declare const` for any name (would
+    // advertise a runtime value the empty runtime bundle does not
+    // provide). The verifier scans the emitted .d.cts and fails on
+    // value declarations.
+    typeOnly: true,
+    expectedNames: [
+      "BlockNodeAttributes",
+      "BoldAttrs",
+      "BookmarkEndAttrs",
+      "BookmarkStartAttrs",
+      "BorderSpec",
+      "CanCommand",
+      "CanObject",
+      "CellMargins",
+      "ChainableCommandObject",
+      "ChainedCommand",
+      "Command",
+      "CommandProps",
+      "CommentMarkAttrs",
+      "CommentRangeEndAttrs",
+      "CommentRangeStartAttrs",
+      "CommentReferenceAttrs",
+      "ContentBlockAttrs",
+      "ContentBlockMarginOffset",
+      "ContentBlockSize",
+      "CoreCommandMap",
+      "CoreCommands",
+      "DocumentAttrs",
+      "DocumentPartObjectAttrs",
+      "DocumentSectionAttrs",
+      "EditorCommands",
+      "ExtensionCommandMap",
+      "ExtensionCommands",
+      "FieldAnnotationAttrs",
+      "FieldAnnotationSize",
+      "HardBreakAttrs",
+      "HighlightAttrs",
+      "HighlightColor",
+      "ImageAttrs",
+      "ImagePadding",
+      "ImageSize",
+      "ImageTransformData",
+      "ImageWrap",
+      "IndentationProperties",
+      "InlineNodeAttributes",
+      "ItalicAttrs",
+      "LineBreakAttrs",
+      "LinkAttrs",
+      "ListRendering",
+      "MarkAttributesMap",
+      "MarkAttrs",
+      "MarkConfig",
+      "MarkName",
+      "MentionAttrs",
+      "NodeAttributesMap",
+      "NodeAttrs",
+      "NodeConfig",
+      "NodeName",
+      "NumberingProperties",
+      "OxmlNodeAttributes",
+      "OxmlNodeConfig",
+      "PageNumberAttrs",
+      "PageReferenceAttrs",
+      "ParagraphAttrs",
+      "ParagraphProperties",
+      "PassthroughBlockAttrs",
+      "PassthroughInlineAttrs",
+      "PermEndAttrs",
+      "PermStartAttrs",
+      "ProseMirrorJSON",
+      "ProseMirrorJSONMark",
+      "ProseMirrorJSONNode",
+      "RunAttrs",
+      "RunProperties",
+      "SectionMargins",
+      "ShadingProperties",
+      "ShapeContainerAttrs",
+      "ShapeGroupAttrs",
+      "ShapeGroupMarginOffset",
+      "ShapeGroupPadding",
+      "ShapeGroupSize",
+      "ShapeNodeAttributes",
+      "ShapeTextboxAttrs",
+      "SpacingProperties",
+      "StrikeAttrs",
+      "StructuredContentAttrs",
+      "StructuredContentBlockAttrs",
+      "TabAttrs",
+      "TableAttrs",
+      "TableBorders",
+      "TableCellAttrs",
+      "TableCellProperties",
+      "TableGrid",
+      "TableHeaderAttrs",
+      "TableLook",
+      "TableMeasurement",
+      "TableNodeAttributes",
+      "TableOfContentsAttrs",
+      "TableProperties",
+      "TableRowAttrs",
+      "TableRowProperties",
+      "TargetFrameOption",
+      "TextAttrs",
+      "TextContainerAttributes",
+      "TextStyleAttrs",
+      "ThemeColor",
+      "TotalPageCountAttrs",
+      "TrackDeleteAttrs",
+      "TrackFormatAttrs",
+      "TrackFormatEntry",
+      "TrackInsertAttrs",
+      "TypedMark",
+      "TypedNode",
+      "UnderlineAttrs",
+      "UnderlineStyle",
+      "VectorShapeAttrs",
+      "VectorShapeTextInsets",
+      "assertNodeType",
+      "defineMark",
+      "defineNode",
+      "isMarkType",
+      "isNodeType",
+    ],
+    runsCommandSignatureProbe: false,
+    ticket: 'SD-3184',
+  },
 ];
 
 function loadFile(file) {
@@ -423,6 +564,23 @@ function checkLeaks(entry) {
 let failed = false;
 const summaryLines = [];
 
+function checkTypeOnlyShape(entry) {
+  if (!entry.typeOnly || !entry.cjs) return true;
+  if (!fs.existsSync(entry.cjs)) return true;
+  const content = fs.readFileSync(entry.cjs, 'utf8');
+  // `export declare const NAME` (or `let`/`var`) in a typeOnly entry's
+  // shim means the generator emitted a value declaration despite the
+  // type-only contract. The empty runtime bundle would not back it.
+  const valueDecls = content.match(/^\s*export\s+declare\s+(?:const|let|var)\s+\w+/gm);
+  if (!valueDecls || valueDecls.length === 0) return true;
+  console.error(`[verify-public-facade-emit] ${entry.name}: typeOnly entry shim contains value declarations.`);
+  for (const decl of valueDecls.slice(0, 10)) {
+    console.error('  - ' + decl.trim());
+  }
+  console.error('  Fix `emitCjsDeclarationShim` in `packages/superdoc/scripts/ensure-types.cjs` so the typeOnly branch emits `export type` for every name.');
+  return false;
+}
+
 for (const entry of FACADE_ENTRIES) {
   const symbolResult = checkSymbolSet(entry);
   if (!symbolResult.ok) failed = true;
@@ -437,6 +595,7 @@ for (const entry of FACADE_ENTRIES) {
   }
 
   if (!checkLeaks(entry)) failed = true;
+  if (!checkTypeOnlyShape(entry)) failed = true;
 
   summaryLines.push(`${entry.name}: ${symbolResult.actual.length} exports`);
 }

--- a/packages/superdoc/src/public/types.test.ts
+++ b/packages/superdoc/src/public/types.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import * as typesNS from './types.js';
+
+/**
+ * Smoke test for the public facade types entry (SD-3184).
+ *
+ * `superdoc/types` is a type-only subpath — no runtime exports. The runtime
+ * bundle should be effectively empty. Declaration-side validation (116-symbol
+ * type set, ESM/CJS parity) lives in
+ * `packages/superdoc/scripts/verify-public-facade-emit.cjs`.
+ */
+describe('public facade (types)', () => {
+  it('runtime module has no enumerable exports (type-only contract)', () => {
+    const keys = Object.keys(typesNS).filter((k) => k !== 'default');
+    expect(keys).toEqual([]);
+  });
+});

--- a/packages/superdoc/src/public/types.ts
+++ b/packages/superdoc/src/public/types.ts
@@ -6,9 +6,22 @@
  * `superdoc/types` subpath — schema attributes, command maps, ProseMirror
  * JSON shapes, augmentation infrastructure, and theme types.
  *
- * Classification per SD-3147: 37 public + 79 legacy/public-compat. All
- * 116 re-exported through the facade — tier distinction is documentation
+ * Classification per SD-3147 (corrected): **26 public + 90 legacy/public-compat**.
+ * All 116 re-exported through the facade — tier distinction is documentation
  * posture, not facade inclusion.
+ *
+ * The original SD-3147 classification labeled the command-augmentation
+ * infrastructure (`CoreCommandMap`, `ExtensionCommandMap`, `EditorCommands`,
+ * `CoreCommands`, `ExtensionCommands`, `CommandProps`, `Command`,
+ * `ChainedCommand`, `ChainableCommandObject`, `CanCommand`, `CanObject`)
+ * as `public, reason: augmentation-infrastructure`. That tier is wrong:
+ * those types exist to type the `editor.commands.*` surface, which is
+ * marked `@deprecated` in `Editor.ts` (lines 1411, 1597, 1605) and
+ * `packages/superdoc/AGENTS.md` ("editor commands is deprecated and will
+ * be removed; use the Document API"). Reclassifying as legacy/public-compat
+ * matches policy: typed for backward compat, kept compiling, not advertised
+ * as recommended API. Phase 4's package.json#exports flip preserves them
+ * unchanged. SD-3185 carries the SD-3147 corrigendum.
  *
  * `superdoc/types` is a **type-only** subpath. The runtime artifact
  * (`dist/types.es.js`) is effectively empty. Five names that have value

--- a/packages/superdoc/src/public/types.ts
+++ b/packages/superdoc/src/public/types.ts
@@ -1,0 +1,159 @@
+/**
+ * SuperDoc public facade: types entry.
+ *
+ * SD-3184 under SD-3178 (Phase 3 of SD-3175). Last large supported-surface
+ * facade entry. Mirrors the 116-name surface today reachable via the
+ * `superdoc/types` subpath — schema attributes, command maps, ProseMirror
+ * JSON shapes, augmentation infrastructure, and theme types.
+ *
+ * Classification per SD-3147: 37 public + 79 legacy/public-compat. All
+ * 116 re-exported through the facade — tier distinction is documentation
+ * posture, not facade inclusion.
+ *
+ * `superdoc/types` is a **type-only** subpath. The runtime artifact
+ * (`dist/types.es.js`) is effectively empty. Five names that have value
+ * origins upstream are deliberately exported as TYPE-ONLY here, matching
+ * today's contract:
+ *
+ *   - `defineNode`, `defineMark` (factory functions upstream)
+ *   - `isNodeType`, `assertNodeType`, `isMarkType` (type-guard functions upstream)
+ *
+ * Consumers who want the runtime helpers reach them from `superdoc` itself,
+ * which already exports them. Promoting them to runtime exports here would
+ * change the subpath contract.
+ *
+ * Strategy: re-export through the narrow `@superdoc/super-editor/types`
+ * subpath rather than the broad root.
+ *
+ * Rules for this file:
+ *   - AIDEV-NOTE: Type-only via `export type { ... }`. Do NOT add `export { ... }`
+ *     for any of the 5 value-origin names. That would change `superdoc/types`
+ *     from a type-only contract to one that ships runtime helpers.
+ *   - AIDEV-NOTE: Adding or removing an export here updates `expectedNames`
+ *     for the `types` entry in `FACADE_ENTRIES` inside
+ *     `packages/superdoc/scripts/verify-public-facade-emit.cjs` in the
+ *     same PR. The verifier postbuild fails on drift.
+ *   - This entry has a real `public/types.d.cts` shim (unlike SD-3180/SD-3182/SD-3183
+ *     entries) because the existing `./types` package.json#exports entry
+ *     uses split `types.import` / `types.require` declarations.
+ *   - This entry does not re-export `Editor` or `EditorCommands`, so the
+ *     verifier skips the command-signature probe.
+ */
+export type {
+  BlockNodeAttributes,
+  BoldAttrs,
+  BookmarkEndAttrs,
+  BookmarkStartAttrs,
+  BorderSpec,
+  CanCommand,
+  CanObject,
+  CellMargins,
+  ChainableCommandObject,
+  ChainedCommand,
+  Command,
+  CommandProps,
+  CommentMarkAttrs,
+  CommentRangeEndAttrs,
+  CommentRangeStartAttrs,
+  CommentReferenceAttrs,
+  ContentBlockAttrs,
+  ContentBlockMarginOffset,
+  ContentBlockSize,
+  CoreCommandMap,
+  CoreCommands,
+  DocumentAttrs,
+  DocumentPartObjectAttrs,
+  DocumentSectionAttrs,
+  EditorCommands,
+  ExtensionCommandMap,
+  ExtensionCommands,
+  FieldAnnotationAttrs,
+  FieldAnnotationSize,
+  HardBreakAttrs,
+  HighlightAttrs,
+  HighlightColor,
+  ImageAttrs,
+  ImagePadding,
+  ImageSize,
+  ImageTransformData,
+  ImageWrap,
+  IndentationProperties,
+  InlineNodeAttributes,
+  ItalicAttrs,
+  LineBreakAttrs,
+  LinkAttrs,
+  ListRendering,
+  MarkAttributesMap,
+  MarkAttrs,
+  MarkConfig,
+  MarkName,
+  MentionAttrs,
+  NodeAttributesMap,
+  NodeAttrs,
+  NodeConfig,
+  NodeName,
+  NumberingProperties,
+  OxmlNodeAttributes,
+  OxmlNodeConfig,
+  PageNumberAttrs,
+  PageReferenceAttrs,
+  ParagraphAttrs,
+  ParagraphProperties,
+  PassthroughBlockAttrs,
+  PassthroughInlineAttrs,
+  PermEndAttrs,
+  PermStartAttrs,
+  ProseMirrorJSON,
+  ProseMirrorJSONMark,
+  ProseMirrorJSONNode,
+  RunAttrs,
+  RunProperties,
+  SectionMargins,
+  ShadingProperties,
+  ShapeContainerAttrs,
+  ShapeGroupAttrs,
+  ShapeGroupMarginOffset,
+  ShapeGroupPadding,
+  ShapeGroupSize,
+  ShapeNodeAttributes,
+  ShapeTextboxAttrs,
+  SpacingProperties,
+  StrikeAttrs,
+  StructuredContentAttrs,
+  StructuredContentBlockAttrs,
+  TabAttrs,
+  TableAttrs,
+  TableBorders,
+  TableCellAttrs,
+  TableCellProperties,
+  TableGrid,
+  TableHeaderAttrs,
+  TableLook,
+  TableMeasurement,
+  TableNodeAttributes,
+  TableOfContentsAttrs,
+  TableProperties,
+  TableRowAttrs,
+  TableRowProperties,
+  TargetFrameOption,
+  TextAttrs,
+  TextContainerAttributes,
+  TextStyleAttrs,
+  ThemeColor,
+  TotalPageCountAttrs,
+  TrackDeleteAttrs,
+  TrackFormatAttrs,
+  TrackFormatEntry,
+  TrackInsertAttrs,
+  TypedMark,
+  TypedNode,
+  UnderlineAttrs,
+  UnderlineStyle,
+  VectorShapeAttrs,
+  VectorShapeTextInsets,
+  assertNodeType,
+  defineMark,
+  defineNode,
+  isMarkType,
+  isNodeType,
+} from '@superdoc/super-editor/types';

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -267,6 +267,11 @@ export default defineConfig(({ mode, command }) => {
           // `@superdoc/super-editor/ui` (narrow), not the root barrel —
           // `audit-bundle.cjs` enforces shape on `dist/public/ui.es.js`.
           'public/ui': 'src/public/ui.ts',
+          // SD-3184: types facade — type-only entry. 116 names, all
+          // `export type { ... }`. The existing `./types` subpath has
+          // split types.import/types.require declarations, so this
+          // facade adds a `public/types.d.cts` shim via ensure-types.cjs.
+          'public/types': 'src/public/types.ts',
         },
         external: [
           'yjs',


### PR DESCRIPTION
Last large supported-surface facade entry under [SD-3178](https://linear.app/superdocworkspace/issue/SD-3178) / Phase 3 of [SD-3175](https://linear.app/superdocworkspace/issue/SD-3175). `superdoc/types` is the extension-author contract.

## Inputs

- [SD-3147](https://linear.app/superdocworkspace/issue/SD-3147) classification: 116 symbols total, 37 public + 79 legacy/public-compat, 0 internal-candidate.

## Type-only preservation (load-bearing)

`superdoc/types` is documented as a **type-only** subpath. The current runtime bundle (`dist/types.es.js`) is effectively empty.

Five of the 116 names are value-origin upstream:
- `defineNode`, `defineMark` (factory functions)
- `isNodeType`, `assertNodeType`, `isMarkType` (type-guard functions)

The existing `src/types.ts` already strips them to type-only via `export type *`. The new facade preserves this. The first draft of this PR had a real bug here — the CJS shim generator was emitting `export declare const defineNode` for these 5 names, contradicting the type-only contract.

**Fixed via a new `typeOnly: true` flag on `cjsDeclarationShims`:**
- `ensure-types.cjs`: when `typeOnly: true`, the shim generator emits `import type` + `export type` for every name and skips `export declare const`.
- `verify-public-facade-emit.cjs`: new `checkTypeOnlyShape()` gate that scans the emitted `.d.cts` and rejects any `export declare (const|let|var)`. Durable protection against regression.

## CJS shim required (unlike SD-3180/SD-3182/SD-3183)

The existing `./types` package exports entry uses `types.import` / `types.require`:

```json
"types": {
  "import": "./dist/super-editor/src/types.d.ts",
  "require": "./dist/super-editor/src/types.d.cts"
}
```

So this facade has a real `.d.cts` shim and the verifier exercises ESM/CJS parity.

## What changes

- `packages/superdoc/src/public/types.ts`: type-only facade, 116 names via narrow `@superdoc/super-editor/types`.
- `packages/superdoc/src/public/types.test.ts`: smoke test asserting the runtime module has zero enumerable exports.
- `vite.config.js`: new rollup input `public/types`.
- `ensure-types.cjs`: new `typeOnly: true` flag on `cjsDeclarationShims`; entry for `public/types.d.cts`.
- `verify-public-facade-emit.cjs`: types `FACADE_ENTRIES` entry (116 expectedNames, `cjs` set, `typeOnly: true`) + new `checkTypeOnlyShape()` gate.

No `package.json#exports` change.

## Verified locally

| Check | Result |
| --- | --- |
| Facade verifier clean across 8 entries | OK (types: 116 exports) |
| Runtime bundle empty | `dist/public/types.es.js` is 0 bytes |
| CJS shim has zero `export declare const` | confirmed |
| Drift on facade `.d.ts` | exit 1 with TS2305 on both `.d.ts` and `.d.cts` (parity catches CJS-side miss) |
| Injected `export declare const defineNode` into `.d.cts` | exit 1 with "typeOnly entry shim contains value declarations" |
| Vitest smoke test | 1/1 pass |

## Remaining Phase 3 work

- `superdoc/super-editor` (203 names, SD-3181) — deferred legacy mirror
- `superdoc/headless-toolbar/react` and `/vue` — 1 symbol each, small
- `superdoc/style.css` — asset entry handling

Then Phase 4 (the `package.json#exports` flip).

## Related

- [SD-3175](https://linear.app/superdocworkspace/issue/SD-3175) (path-as-contract umbrella)
- [SD-3178](https://linear.app/superdocworkspace/issue/SD-3178) (Phase 3 umbrella)
- [SD-3147](https://linear.app/superdocworkspace/issue/SD-3147) (classification input)
- [SD-3182](https://linear.app/superdocworkspace/issue/SD-3182) / [SD-3183](https://linear.app/superdocworkspace/issue/SD-3183) (same supported-facade pattern, single-types shape)
- [SD-3184](https://linear.app/superdocworkspace/issue/SD-3184) (this PR)