### PR TITLE
fix(document-api): anchor pure-insert word-diff groups to preceding EQUAL token (SD-3044)

### DIFF
--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/tracked-rewrite.integration.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/tracked-rewrite.integration.test.ts
@@ -310,4 +310,70 @@ describe('doc.replace multi-paragraph integration', () => {
     expect(insertedTexts).toEqual(expect.arrayContaining(['Alpha']));
     expect(deletedTexts.join('')).toContain('hello world');
   });
+
+  // SD-3044: when the word-diff produces multiple groups with EQUAL tokens
+  // between them, inserted text used to anchor on the previous result op's
+  // end instead of the EQUAL token's end, piling all granular insertions on
+  // the first deletion site.
+  it('SD-3044: tracked rewrite with shared suffix anchors inserts correctly', () => {
+    editor = makeEditor(['[insert] of [insert], [insert] ("Investor")']);
+    const receipt = editor.doc.replace(
+      {
+        ref: getFirstMatchRef(editor, '[insert] of [insert], [insert] ("Investor")'),
+        text: 'John James Smith of [insert address], [insert] ("Investor")',
+      },
+      { changeMode: 'tracked' },
+    );
+
+    expect(receipt.success).toBe(true);
+
+    // Accepted view: drop trackDelete marks, keep everything else.
+    const acceptedParts: string[] = [];
+    editor.state.doc.descendants((node: any) => {
+      if (!node.isText || !node.text) return;
+      const isDeleted = node.marks.some((mark: any) => mark.type.name === TrackDeleteMarkName);
+      if (!isDeleted) acceptedParts.push(node.text);
+    });
+
+    expect(acceptedParts.join('')).toBe('John James Smith of [insert address], [insert] ("Investor")');
+
+    // Specifically guard against the buggy strings reported in the ticket.
+    const accepted = acceptedParts.join('');
+    expect(accepted).not.toContain('JohnJames');
+    expect(accepted).not.toContain('Smith  address');
+  });
+
+  it('SD-3044: tracked rewrite of long block preserves spacing across multiple equal anchors', () => {
+    editor = makeEditor([
+      '[insert] Pty Limited a company incorporated in Australia having its registered office at [insert] (ACN [insert])("Company")',
+    ]);
+    const target =
+      'Working Title Group Limited a company incorporated in New Zealand having its registered office at 29 Park Hill Road, Birkenhead, Auckland, 0626, NZ (NZBN 9429050880331)("Company")';
+
+    const receipt = editor.doc.replace(
+      {
+        ref: getFirstMatchRef(
+          editor,
+          '[insert] Pty Limited a company incorporated in Australia having its registered office at [insert] (ACN [insert])("Company")',
+        ),
+        text: target,
+      },
+      { changeMode: 'tracked' },
+    );
+
+    expect(receipt.success).toBe(true);
+
+    const acceptedParts: string[] = [];
+    editor.state.doc.descendants((node: any) => {
+      if (!node.isText || !node.text) return;
+      const isDeleted = node.marks.some((mark: any) => mark.type.name === TrackDeleteMarkName);
+      if (!isDeleted) acceptedParts.push(node.text);
+    });
+
+    const accepted = acceptedParts.join('');
+    expect(accepted).toBe(target);
+    expect(accepted).not.toContain('PtyTitle');
+    expect(accepted).not.toContain('AustraliaNew');
+    expect(accepted).not.toContain('(ACNPark');
+  });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/word-diff.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/word-diff.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { getWordChanges, type WordDiffOp } from './word-diff.ts';
+
+function applyOps(oldText: string, ops: WordDiffOp[]): string {
+  // Apply word ops to oldText to produce the expected new text. Ops anchor on
+  // oldText offsets and are applied left-to-right with cumulative offset.
+  let result = '';
+  let cursor = 0;
+  for (const op of ops) {
+    if (op.type === 'insert') {
+      // Copy unchanged text up to the insertion point, then insert.
+      result += oldText.slice(cursor, op.insertAt);
+      cursor = op.insertAt;
+      result += op.newText;
+    } else if (op.type === 'delete') {
+      result += oldText.slice(cursor, op.oldFrom);
+      cursor = op.oldTo;
+    } else {
+      result += oldText.slice(cursor, op.oldFrom);
+      cursor = op.oldTo;
+      result += op.newText;
+    }
+  }
+  result += oldText.slice(cursor);
+  return result;
+}
+
+describe('getWordChanges', () => {
+  it('returns empty for identical text', () => {
+    expect(getWordChanges('hello world', 'hello world')).toEqual([]);
+  });
+
+  it('returns single insert when old is empty', () => {
+    expect(getWordChanges('', 'hello')).toEqual([{ type: 'insert', insertAt: 0, newText: 'hello' }]);
+  });
+
+  it('returns single delete when new is empty', () => {
+    expect(getWordChanges('hello', '')).toEqual([{ type: 'delete', oldFrom: 0, oldTo: 5 }]);
+  });
+
+  it('produces correct REPLACE for a single word change', () => {
+    const ops = getWordChanges('hello world', 'goodbye world');
+    expect(applyOps('hello world', ops)).toBe('goodbye world');
+  });
+
+  it('produces correct ops when one word is replaced and the trailing one is kept', () => {
+    const ops = getWordChanges('foo bar', 'baz bar');
+    expect(applyOps('foo bar', ops)).toBe('baz bar');
+  });
+
+  // SD-3044: regression — insert-only groups between EQUAL tokens must anchor
+  // to the preceding EQUAL token's end, not to the previous result op's end.
+  it('SD-3044: insert between EQUAL tokens uses correct anchor', () => {
+    // Pattern: old has an EQUAL token that lands between two insert groups.
+    const ops = getWordChanges('a b c', 'x a y b c');
+    expect(applyOps('a b c', ops)).toBe('x a y b c');
+  });
+
+  it('SD-3044: regression with the exact suffix-trim shape from the Lighthouse fixture', () => {
+    // After prefix/suffix trim, the parties-investor block reduces to these
+    // strings. The trailing `]` of the second `[insert]` is in the suffix, so
+    // `[insert` (without the `]`) becomes a token that matches between old and
+    // new. Myers then produces three groups separated by EQUAL tokens — the
+    // bug was that the two pure-INSERT groups both anchored to char 8.
+    const oldTrimmed = '[insert] of [insert';
+    const newTrimmed = 'John James Smith of [insert address';
+    const ops = getWordChanges(oldTrimmed, newTrimmed);
+    expect(applyOps(oldTrimmed, ops)).toBe(newTrimmed);
+
+    // Specifically the bug produced two inserts at insertAt=8; with the fix,
+    // the second insert anchors past the preserved ` of [insert` (offset 19).
+    const inserts = ops.filter((o): o is Extract<WordDiffOp, { type: 'insert' }> => o.type === 'insert');
+    expect(inserts).toHaveLength(2);
+    const insertAts = inserts.map((o) => o.insertAt).sort((a, b) => a - b);
+    expect(insertAts[0]).toBe(9); // after the equal space (old[1])
+    expect(insertAts[1]).toBe(19); // after the equal `[insert` (old[4])
+  });
+
+  it('SD-3044: prefix-only equal anchors first insert past the prefix', () => {
+    const ops = getWordChanges('foo', 'foo bar');
+    expect(applyOps('foo', ops)).toBe('foo bar');
+    // After EQUAL `foo` (length 3), insert anchor must be 3 not 0.
+    const inserts = ops.filter((o): o is Extract<WordDiffOp, { type: 'insert' }> => o.type === 'insert');
+    if (inserts.length > 0) {
+      expect(inserts[0].insertAt).toBe(3);
+    }
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/word-diff.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/word-diff.ts
@@ -87,6 +87,13 @@ export function getWordChanges(oldText: string, newText: string): WordDiffOp[] {
       continue;
     }
 
+    // SD-3044: capture the index where this delete/insert group starts so we
+    // can inspect the step immediately preceding the group (typically an
+    // 'equal' that anchors a pure-insert group's position). After the inner
+    // while loop runs, `i` points past the group, so `steps[i - 1]` is the
+    // last delete/insert in this group and never reflects the prior anchor.
+    const groupStart = i;
+
     let deleteStart = -1;
     let deleteEnd = -1;
     let insertText = '';
@@ -108,7 +115,7 @@ export function getWordChanges(oldText: string, newText: string): WordDiffOp[] {
     } else if (deleteStart !== -1) {
       result.push({ type: 'delete', oldFrom: deleteStart, oldTo: deleteEnd });
     } else if (insertText.length > 0) {
-      const prevStep = i > 0 ? steps[i - 1] : null;
+      const prevStep = groupStart > 0 ? steps[groupStart - 1] : null;
       let insertAt = 0;
       if (prevStep && prevStep.type === 'equal') {
         const prevToken = oldTokens[prevStep.oldIdx];


### PR DESCRIPTION
## Demo

<img width="5212" height="3044" alt="CleanShot 2026-05-18 at 16 04 19@2x" src="https://github.com/user-attachments/assets/57a6842a-77f0-4b4d-a381-7185dc0e9324" />


## Summary

Fixes [SD-3044](https://linear.app/superdocworkspace/issue/SD-3044): tracked `text.rewrite` was inserting replacement text at shifted positions, producing strings like `JohnJames Smith  address of [insert]...` instead of `John James Smith of [insert address]...`. The bug survived accept-all, so it was written into exported DOCX.

## Root cause

In `packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/word-diff.ts`, `getWordChanges` computes a word-level diff and groups consecutive delete/insert ops into single ops. For *pure-insert* groups (no delete, just inserts surrounded by EQUAL tokens), it tried to anchor the insertion to the preceding EQUAL token:

```ts
const prevStep = i > 0 ? steps[i - 1] : null;  // ← bug
if (prevStep && prevStep.type === 'equal') { /* … */ }
else if (result.length > 0) {                  // fallback that actually runs
  insertAt = lastOp.oldTo ?? lastOp.insertAt ?? 0;
}
```

But by the time this code runs, the inner `while` loop has already advanced `i` past the group, so `steps[i - 1]` is the **last delete/insert of the current group** — never an EQUAL. The `prevStep.type === 'equal'` branch was dead code, and every pure-insert group fell back to the previous result op's end.

The bug only triggers when Myers can find EQUAL tokens between insert-only groups. The customer payload happens to do this because the prefix/suffix trim splits `[insert]` into `[insert` (without the `]`, which is part of the shared suffix), making `[insert` token-equal between old and new. Two insert-only groups in `[insert] of [insert` → `John James Smith of [insert address` both got `insertAt = 8`, piling `John`, `James Smith ` and ` address` at the first deletion site.

## Fix

Capture `groupStart` before the inner while loop and use it to look at the step BEFORE the group:

```diff
+    const groupStart = i;
     let deleteStart = -1;
     let deleteEnd = -1;
     let insertText = '';
     while (i < steps.length && (steps[i].type === 'delete' || steps[i].type === 'insert')) {
       …
     }
     …
     } else if (insertText.length > 0) {
-      const prevStep = i > 0 ? steps[i - 1] : null;
+      const prevStep = groupStart > 0 ? steps[groupStart - 1] : null;
```

One-line change. The previously-dead `prevStep.type === 'equal'` branch now runs and the existing `prevToken.offset + prevToken.text.length` logic produces the correct anchor.

## How to reproduce

The customer fixture is `Simple Agreement for future equity (SAFE) (5).docx`. Steps:

1. `pnpm dev` and open the SuperDoc dev app.
2. Upload the SAFE fixture.
3. Run the Lighthouse payload via the dev console:

   ```js
   window.superdocdev.editor.doc.mutations.apply({
     action: 'apply', atomic: true, changeMode: 'tracked',
     steps: [
       { id: 'parties-investor', op: 'text.rewrite',
         where: { by: 'block', nodeType: 'listItem', nodeId: '6FDB207C' },
         args: { replacement: { text: 'John James Smith of [insert address], [insert] ("Investor")' } } },
       { id: 'parties-company', op: 'text.rewrite',
         where: { by: 'block', nodeType: 'listItem', nodeId: '447A152E' },
         args: { replacement: { text: 'Working Title Group Limited a company incorporated in New Zealand having its registered office at 29 Park Hill Road, Birkenhead, Auckland, 0626, NZ (NZBN 9429050880331)("Company")' } } },
     ],
   });
   ```
4. Click "Accept tracked changes".

**Before the fix:**
```
JohnJames Smith  address of [insert], [insert] ("Investor")
Working TitleGroup  Limited a company incorporated in NewZealand  having its registered office at 29 Park Hill Road, Birkenhead, Auckland, 0626, NZ (NZBN 9429050880331)("Company")
```

**After the fix:**
```
John James Smith of [insert address], [insert] ("Investor")
Working Title Group Limited a company incorporated in New Zealand having its registered office at 29 Park Hill Road, Birkenhead, Auckland, 0626, NZ (NZBN 9429050880331)("Company")
```

## Test plan

- [x] New unit suite: `packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/word-diff.test.ts` (8 tests) — covers identity, empty-side, single replace, insert-only with surrounding EQUAL, the exact Lighthouse suffix-trim shape, and prefix-only equal anchoring.
- [x] Integration coverage added to `tracked-rewrite.integration.test.ts`:
  - `SD-3044: tracked rewrite with shared suffix anchors inserts correctly` — parties-investor shape; explicit guards against `JohnJames` and `Smith  address`.
  - `SD-3044: tracked rewrite of long block preserves spacing across multiple equal anchors` — parties-company shape; guards against `PtyTitle`, `AustraliaNew`, `(ACNPark`.
- [x] Full `super-editor` suite passes (1033 files, 13083 tests).
- [x] Manually verified end-to-end with the SAFE fixture in `pnpm dev`: applying the Lighthouse payload then accepting all tracked changes now produces the expected text for all four blocks (`3BD84854`, `7D51E57C`, `6FDB207C`, `447A152E`).

## Acceptance criteria (from ticket)

- [x] Lighthouse payload no longer produces `JohnJames`, `PtyTitleGroup`, `TitleGroup` (concatenated), or `AustraliaNewZealand`.
- [x] Accepting all tracked changes produces the expected replacement text with correct spacing.
- [x] Regression coverage exists for this payload shape (`tracked-rewrite.integration.test.ts` + `word-diff.test.ts`).
- [x] Existing granular tracked-rewrite behaviour preserved — full suite green, no `tracked-rewrite.integration.test.ts` cases regressed.

## Related

- Linked from: [SD-2787](https://linear.app/superdocworkspace/issue/SD-2787) (granular diff tracked changes).
- Blocks: IT-999 (AI edits add strange text in docs).