### PR TITLE
feat(public-facade): legacy headless-toolbar/react and /vue (SD-3207)

### DIFF
--- a/packages/superdoc/scripts/ensure-types.cjs
+++ b/packages/superdoc/scripts/ensure-types.cjs
@@ -146,6 +146,17 @@ const cjsDeclarationShims = [
     source: path.join(distRoot, 'superdoc/src/public/legacy/headless-toolbar.d.ts'),
     target: './headless-toolbar.js',
   },
+  // SD-3207: legacy headless-toolbar framework helpers.
+  {
+    file: path.join(distRoot, 'superdoc/src/public/legacy/headless-toolbar-react.d.cts'),
+    source: path.join(distRoot, 'superdoc/src/public/legacy/headless-toolbar-react.d.ts'),
+    target: './headless-toolbar-react.js',
+  },
+  {
+    file: path.join(distRoot, 'superdoc/src/public/legacy/headless-toolbar-vue.d.cts'),
+    source: path.join(distRoot, 'superdoc/src/public/legacy/headless-toolbar-vue.d.ts'),
+    target: './headless-toolbar-vue.js',
+  },
   // SD-3184: types facade — type-only entry. The existing `./types`
   // subpath has split types.import/types.require declarations, so the
   // facade needs a real .d.cts shim. `typeOnly: true` forces the shim

--- a/packages/superdoc/scripts/verify-public-facade-emit.cjs
+++ b/packages/superdoc/scripts/verify-public-facade-emit.cjs
@@ -149,6 +149,25 @@ const FACADE_ENTRIES = [
     runsCommandSignatureProbe: false,
     ticket: 'SD-3179',
   },
+  // SD-3207: legacy headless-toolbar framework helpers. Each entry
+  // re-exports `useHeadlessToolbar` only. Same classification as the
+  // root `legacy/headless-toolbar` entry above.
+  {
+    name: 'legacy/headless-toolbar-react',
+    esm: path.join(PUBLIC_DIST, 'legacy', 'headless-toolbar-react.d.ts'),
+    cjs: path.join(PUBLIC_DIST, 'legacy', 'headless-toolbar-react.d.cts'),
+    expectedNames: ['useHeadlessToolbar'],
+    runsCommandSignatureProbe: false,
+    ticket: 'SD-3207',
+  },
+  {
+    name: 'legacy/headless-toolbar-vue',
+    esm: path.join(PUBLIC_DIST, 'legacy', 'headless-toolbar-vue.d.ts'),
+    cjs: path.join(PUBLIC_DIST, 'legacy', 'headless-toolbar-vue.d.cts'),
+    expectedNames: ['useHeadlessToolbar'],
+    runsCommandSignatureProbe: false,
+    ticket: 'SD-3207',
+  },
   // SD-3180: legacy leaf entries. These match the existing single-types
   // pattern of the live `superdoc/converter` / `superdoc/docx-zipper` /
   // `superdoc/file-zipper` subpaths, which do not have `.d.cts` shims

--- a/packages/superdoc/src/public/legacy/headless-toolbar-react.test.ts
+++ b/packages/superdoc/src/public/legacy/headless-toolbar-react.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { useHeadlessToolbar } from './headless-toolbar-react.js';
+
+/**
+ * Smoke test for the legacy public facade headless-toolbar/react entry
+ * (SD-3207). Verifies the runtime re-export is present so the facade
+ * file does not show 0% on the unit-test coverage report. Declaration-
+ * side validation lives in
+ * `packages/superdoc/scripts/verify-public-facade-emit.cjs`.
+ */
+describe('public facade (legacy/headless-toolbar-react)', () => {
+  it('re-exports useHeadlessToolbar as a function', () => {
+    expect(typeof useHeadlessToolbar).toBe('function');
+  });
+});

--- a/packages/superdoc/src/public/legacy/headless-toolbar-react.ts
+++ b/packages/superdoc/src/public/legacy/headless-toolbar-react.ts
@@ -1,0 +1,29 @@
+/**
+ * SuperDoc public facade: legacy headless-toolbar React framework helper.
+ *
+ * SD-3207 under SD-3178 (Phase 3 of SD-3175). Mirrors the existing
+ * `packages/superdoc/src/headless-toolbar-react.js` re-export under the
+ * path-as-contract facade. Phase 4 (the contract switch) flips
+ * `package.json#exports` `./headless-toolbar/react` to point at the
+ * emitted declarations under this tree.
+ *
+ * Classification: **legacy public compatibility surface.** Paired with
+ * `legacy/headless-toolbar.ts`; same posture. New custom UI integrations
+ * should use `superdoc/ui/react` (the strategic typed React binding).
+ * See `docs/architecture/package-boundaries.md` Decision 4.
+ *
+ * Rules for this file:
+ *   - AIDEV-NOTE: Named exports only. Growing this list ships a new
+ *     public symbol through a legacy compat path, which violates the
+ *     no-growth posture on this entry. The corresponding snapshot is
+ *     `tests/consumer-typecheck/snapshots/superdoc-headless-toolbar-react.txt`.
+ *   - AIDEV-NOTE: Adding or removing an export here updates the
+ *     `expectedNames` for the `legacy/headless-toolbar-react` entry in
+ *     `FACADE_ENTRIES` inside
+ *     `packages/superdoc/scripts/verify-public-facade-emit.cjs` in the
+ *     same PR. Skipping that step fails the postbuild gate.
+ *   - This entry does not re-export `Editor` or `EditorCommands`, so
+ *     the verifier skips the command-signature probe here.
+ */
+
+export { useHeadlessToolbar } from '@superdoc/super-editor/headless-toolbar/react';

--- a/packages/superdoc/src/public/legacy/headless-toolbar-vue.test.ts
+++ b/packages/superdoc/src/public/legacy/headless-toolbar-vue.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { useHeadlessToolbar } from './headless-toolbar-vue.js';
+
+/**
+ * Smoke test for the legacy public facade headless-toolbar/vue entry
+ * (SD-3207). Verifies the runtime re-export is present so the facade
+ * file does not show 0% on the unit-test coverage report. Declaration-
+ * side validation lives in
+ * `packages/superdoc/scripts/verify-public-facade-emit.cjs`.
+ */
+describe('public facade (legacy/headless-toolbar-vue)', () => {
+  it('re-exports useHeadlessToolbar as a function', () => {
+    expect(typeof useHeadlessToolbar).toBe('function');
+  });
+});

--- a/packages/superdoc/src/public/legacy/headless-toolbar-vue.ts
+++ b/packages/superdoc/src/public/legacy/headless-toolbar-vue.ts
@@ -1,0 +1,30 @@
+/**
+ * SuperDoc public facade: legacy headless-toolbar Vue framework helper.
+ *
+ * SD-3207 under SD-3178 (Phase 3 of SD-3175). Mirrors the existing
+ * `packages/superdoc/src/headless-toolbar-vue.js` re-export under the
+ * path-as-contract facade. Phase 4 (the contract switch) flips
+ * `package.json#exports` `./headless-toolbar/vue` to point at the
+ * emitted declarations under this tree.
+ *
+ * Classification: **legacy public compatibility surface.** Paired with
+ * `legacy/headless-toolbar.ts`; same posture. Per
+ * `docs/architecture/package-boundaries.md` Decision 4, a Vue UI
+ * controller migration target is tracked as a separate decision; the
+ * legacy entry is kept compiling.
+ *
+ * Rules for this file:
+ *   - AIDEV-NOTE: Named exports only. Growing this list ships a new
+ *     public symbol through a legacy compat path, which violates the
+ *     no-growth posture on this entry. The corresponding snapshot is
+ *     `tests/consumer-typecheck/snapshots/superdoc-headless-toolbar-vue.txt`.
+ *   - AIDEV-NOTE: Adding or removing an export here updates the
+ *     `expectedNames` for the `legacy/headless-toolbar-vue` entry in
+ *     `FACADE_ENTRIES` inside
+ *     `packages/superdoc/scripts/verify-public-facade-emit.cjs` in the
+ *     same PR. Skipping that step fails the postbuild gate.
+ *   - This entry does not re-export `Editor` or `EditorCommands`, so
+ *     the verifier skips the command-signature probe here.
+ */
+
+export { useHeadlessToolbar } from '@superdoc/super-editor/headless-toolbar/vue';

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -252,6 +252,11 @@ export default defineConfig(({ mode, command }) => {
           // custom UI integrations should use the `superdoc/ui` /
           // `superdoc/ui/react` entries instead.
           'public/legacy/headless-toolbar': 'src/public/legacy/headless-toolbar.ts',
+          // SD-3207: legacy headless-toolbar framework helpers. Paired
+          // with the root above; same legacy classification. Each entry
+          // re-exports `useHeadlessToolbar` only.
+          'public/legacy/headless-toolbar-react': 'src/public/legacy/headless-toolbar-react.ts',
+          'public/legacy/headless-toolbar-vue': 'src/public/legacy/headless-toolbar-vue.ts',
           // SD-3180: legacy leaf facade entries mirroring the existing
           // single-export legacy subpaths. Same classification as
           // headless-toolbar above.


### PR DESCRIPTION
Two Phase-3 facade leaves under SD-3175's path-as-contract umbrella. Each entry re-exports `useHeadlessToolbar` only, classified as legacy public compatibility (same posture as `./headless-toolbar` root from SD-3179). New custom UI integrations should still use `superdoc/ui` / `superdoc/ui/react`.

- `src/public/legacy/headless-toolbar-{react,vue}.ts`: single named export each.
- Verifier extended (now 10 entries clean: 24/16/**1**/**1**/2/1/1/13/70/116 exports).
- `ensure-types.cjs` extended for Phase 4 readiness (now 8 CJS shims total).
- 2 smoke tests; consumer-typecheck snapshots already cover both subpaths from SD-3179.

No `package.json#exports` change. Phase 4 (the contract switch) remains a separate ticket. With this merged, the remaining Phase-3 facade work is `./super-editor` (deferred as SD-3181 due to surface size); all other Phase-3 leaves are now scaffolded.

**Verified locally**: facade verifier OK across 10 entries; consumer-typecheck 57/57 matrix scenarios pass; snapshot diff clean; smoke 2/2.

Related: SD-3207 (this PR), SD-3178 (Phase 3 umbrella), SD-3175 (path-as-contract umbrella), SD-3179 (root \`./headless-toolbar\` precedent), SD-3181 (deferred \`./super-editor\`).