### PR TITLE
feat(public-facade): phase 4a flip subpath types to public facade (SD-3211)

### DIFF
--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -29,19 +29,19 @@
     },
     "./types": {
       "types": {
-        "import": "./dist/super-editor/src/types.d.ts",
-        "require": "./dist/super-editor/src/types.d.cts"
+        "import": "./dist/superdoc/src/public/types.d.ts",
+        "require": "./dist/superdoc/src/public/types.d.cts"
       },
       "source": "./src/types.ts",
       "import": "./dist/types.es.js",
       "require": "./dist/types.cjs"
     },
     "./converter": {
-      "types": "./dist/super-editor/src/editors/v1/core/super-converter/SuperConverter.d.ts",
+      "types": "./dist/superdoc/src/public/legacy/converter.d.ts",
       "import": "./dist/super-editor/converter.es.js"
     },
     "./docx-zipper": {
-      "types": "./dist/super-editor/src/editors/v1/core/DocxZipper.d.ts",
+      "types": "./dist/superdoc/src/public/legacy/docx-zipper.d.ts",
       "import": "./dist/super-editor/docx-zipper.es.js"
     },
     "./super-editor": {
@@ -54,32 +54,32 @@
       "require": "./dist/super-editor.cjs"
     },
     "./headless-toolbar": {
-      "types": "./dist/superdoc/src/headless-toolbar.d.ts",
+      "types": "./dist/superdoc/src/public/legacy/headless-toolbar.d.ts",
       "source": "./src/headless-toolbar.js",
       "import": "./dist/headless-toolbar.es.js"
     },
     "./ui": {
-      "types": "./dist/superdoc/src/ui.d.ts",
+      "types": "./dist/superdoc/src/public/ui.d.ts",
       "source": "./src/ui.js",
       "import": "./dist/ui.es.js"
     },
     "./ui/react": {
-      "types": "./dist/superdoc/src/ui-react.d.ts",
+      "types": "./dist/superdoc/src/public/ui-react.d.ts",
       "source": "./src/ui-react.js",
       "import": "./dist/ui-react.es.js"
     },
     "./headless-toolbar/react": {
-      "types": "./dist/superdoc/src/headless-toolbar-react.d.ts",
+      "types": "./dist/superdoc/src/public/legacy/headless-toolbar-react.d.ts",
       "source": "./src/headless-toolbar-react.js",
       "import": "./dist/headless-toolbar-react.es.js"
     },
     "./headless-toolbar/vue": {
-      "types": "./dist/superdoc/src/headless-toolbar-vue.d.ts",
+      "types": "./dist/superdoc/src/public/legacy/headless-toolbar-vue.d.ts",
       "source": "./src/headless-toolbar-vue.js",
       "import": "./dist/headless-toolbar-vue.es.js"
     },
     "./file-zipper": {
-      "types": "./dist/super-editor/src/editors/v1/core/super-converter/zipper.d.ts",
+      "types": "./dist/superdoc/src/public/legacy/file-zipper.d.ts",
       "import": "./dist/super-editor/file-zipper.es.js"
     },
     "./style.css": "./dist/style.css"
@@ -88,34 +88,34 @@
   "typesVersions": {
     "*": {
       "headless-toolbar": [
-        "./dist/superdoc/src/headless-toolbar.d.ts"
+        "./dist/superdoc/src/public/legacy/headless-toolbar.d.ts"
       ],
       "ui": [
-        "./dist/superdoc/src/ui.d.ts"
+        "./dist/superdoc/src/public/ui.d.ts"
       ],
       "ui/react": [
-        "./dist/superdoc/src/ui-react.d.ts"
+        "./dist/superdoc/src/public/ui-react.d.ts"
       ],
       "headless-toolbar/react": [
-        "./dist/superdoc/src/headless-toolbar-react.d.ts"
+        "./dist/superdoc/src/public/legacy/headless-toolbar-react.d.ts"
       ],
       "headless-toolbar/vue": [
-        "./dist/superdoc/src/headless-toolbar-vue.d.ts"
+        "./dist/superdoc/src/public/legacy/headless-toolbar-vue.d.ts"
       ],
       "super-editor": [
         "./dist/superdoc/src/super-editor.d.ts"
       ],
       "types": [
-        "./dist/super-editor/src/types.d.ts"
+        "./dist/superdoc/src/public/types.d.ts"
       ],
       "converter": [
-        "./dist/super-editor/src/editors/v1/core/super-converter/SuperConverter.d.ts"
+        "./dist/superdoc/src/public/legacy/converter.d.ts"
       ],
       "docx-zipper": [
-        "./dist/super-editor/src/editors/v1/core/DocxZipper.d.ts"
+        "./dist/superdoc/src/public/legacy/docx-zipper.d.ts"
       ],
       "file-zipper": [
-        "./dist/super-editor/src/editors/v1/core/super-converter/zipper.d.ts"
+        "./dist/superdoc/src/public/legacy/file-zipper.d.ts"
       ]
     }
   },


### PR DESCRIPTION
TypeScript contract switch for 9 scaffolded subpaths only. Each subpath's `types` and `typesVersions` field now resolves through the curated `dist/superdoc/src/public/**` declarations built by SD-3178 and its leaves.

Subpaths flipped: `./types`, `./ui`, `./ui/react`, `./headless-toolbar`, `./headless-toolbar/react`, `./headless-toolbar/vue`, `./converter`, `./docx-zipper`, `./file-zipper`.

**Not in this PR**:

- Root `.` entry stays on historical types. A dry-run flip surfaced a 196-name consumer-fixture surface vs the 24-name SD-3185 curated facade (31 of 57 matrix scenarios failed). The mismatch requires classification before flipping; tracked as Phase 4b ([SD-3212](https://linear.app/superdocworkspace/issue/SD-3212/phase-4b-root-contract-classification-flip)).
- `./super-editor` entry stays on historical types (SD-3181 deferred).
- No `import` / `require` / `source` field changes. Runtime module identity unchanged for every consumer.

**Verified locally**:

- Facade verifier: clean across 10 entries.
- Consumer-typecheck matrix: 57/57 scenarios pass.
- check-export-coverage: 12 entries OK.
- SD-3176 subpath snapshots: clean.

This is the safe half of Phase 4. The root half (SD-3212) is the strategic work, scoped separately to keep regressions isolated and to give the root classification its own evidence-based decision pass.

Related: SD-3211 (this PR), SD-3175 (path-as-contract umbrella), SD-3178 (Phase 3 scaffold), SD-3185 (root facade curation), SD-3212 (Phase 4b root work), SD-3181 (deferred super-editor).