### PR TITLE
feat(ui): metadata-id geometry on ui.metadata (SD-3204)

### DIFF
--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/anchored-metadata-wrappers.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/anchored-metadata-wrappers.test.ts
@@ -283,6 +283,7 @@ describe('anchored metadata wrappers', () => {
     });
     const doc = createNode('doc', [paragraph], { isBlock: false });
     const editor = makeEditor(doc);
+    seedPayload(editor, 'customXml/item1.xml', 'urn:test:metadata', [{ id: 'meta-1', json: '{"label":"Alpha"}' }]);
 
     expect(metadataResolveWrapper(editor, { id: 'meta-1' })).toEqual({
       id: 'meta-1',
@@ -293,4 +294,60 @@ describe('anchored metadata wrappers', () => {
       },
     });
   });
+
+  it('returns null when the SDT tag has no matching payload entry (foreign content control with same w:tag)', () => {
+    // Imported DOCX with an inline SDT whose `w:tag === 'meta-1'` but no
+    // customXml payload entry — could be a Word-authored content control
+    // that happens to share an id with what a consumer would `attach`.
+    // Both halves of the anchor must agree before `resolve` reports the
+    // id resolves, otherwise UIs that trust `resolve` could be steered
+    // at an unrelated control.
+    const sdt = createNode('structuredContent', [createNode('text', [], { text: 'Hello' })], {
+      attrs: { id: '100', tag: 'meta-1' },
+      isInline: true,
+      isBlock: false,
+      inlineContent: true,
+    });
+    const paragraph = createNode('paragraph', [sdt], {
+      attrs: { sdBlockId: 'p1' },
+      isBlock: true,
+      inlineContent: true,
+    });
+    const doc = createNode('doc', [paragraph], { isBlock: false });
+    const editor = makeEditor(doc);
+    // Intentionally no seedPayload call — convertedXml stays empty.
+
+    expect(metadataResolveWrapper(editor, { id: 'meta-1' })).toBeNull();
+  });
 });
+
+/**
+ * Seed a metadata customXml part directly on the editor's converter.
+ * Lets tests that pre-seed an SDT in the doc (without going through
+ * `metadataAttachWrapper`) also wire up the payload side so the
+ * `metadata.resolve` / `metadata.get` payload gate can find an entry.
+ */
+function seedPayload(
+  editor: Editor,
+  partName: string,
+  namespace: string,
+  entries: Array<{ id: string; json: string }>,
+): void {
+  const convertedXml = (editor as unknown as { converter: { convertedXml: Record<string, unknown> } }).converter
+    .convertedXml;
+  convertedXml[partName] = {
+    elements: [
+      {
+        type: 'element',
+        name: 'refs',
+        attributes: { xmlns: namespace },
+        elements: entries.map((entry) => ({
+          type: 'element',
+          name: 'ref',
+          attributes: { id: entry.id, encoding: 'json' },
+          elements: [{ type: 'text', text: entry.json }],
+        })),
+      },
+    ],
+  };
+}

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/anchored-metadata-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/anchored-metadata-wrappers.ts
@@ -437,6 +437,15 @@ export function metadataResolveWrapper(
   editor: Editor,
   input: AnchoredMetadataResolveInput,
 ): AnchoredMetadataResolveInfo | null {
+  // An inline SDT's `w:tag` is not reserved for anchored metadata —
+  // an imported DOCX can carry foreign content controls whose tag
+  // happens to match a metadata id. Require both halves of the
+  // anchor (the SDT in the body and the payload entry in a customXml
+  // part) to agree before reporting the id resolves, so callers that
+  // trust `resolve` (including `ui.metadata.*`) cannot be steered at
+  // an unrelated control. Mirrors what `metadata.get` already does
+  // for payload reads.
+  if (!hasPayloadEntry(getConvertedXml(editor), input.id)) return null;
   const target = resolveAnchorTarget(editor, input.id);
   return target ? { id: input.id, target } : null;
 }

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -8,12 +8,15 @@ import type {
   ToolbarSnapshot,
 } from '../headless-toolbar/types.js';
 import type {
+  AnchoredMetadataResolveInfo,
   CommentsListResult,
   ContentControlInfo,
   ContentControlsListResult,
   Receipt,
   ScrollIntoViewInput,
   ScrollIntoViewOutput,
+  SelectionTarget,
+  TextTarget,
   TrackChangesListResult,
 } from '@superdoc/document-api';
 import { collectEntityHitsFromChain } from './entity-at.js';
@@ -38,6 +41,7 @@ import type {
   DocumentSlice,
   DynamicCommandHandle,
   EqualityFn,
+  MetadataHandle,
   TrackChangesHandle,
   TrackChangesItem,
   TrackChangesSlice,
@@ -504,9 +508,7 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
       return;
     }
     try {
-      const result = list.call(editor.doc!.contentControls, undefined) as
-        | ContentControlsListResult
-        | undefined;
+      const result = list.call(editor.doc!.contentControls, undefined) as ContentControlsListResult | undefined;
       contentControlsListCache = result ?? EMPTY_CONTENT_CONTROLS_LIST;
     } catch {
       // See refreshCommentsListCache: prefer empty over leaking the
@@ -575,8 +577,7 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     const selectedNode = selection.node;
     if (
       selectedNode &&
-      (selectedNode.type?.name === 'structuredContent' ||
-        selectedNode.type?.name === 'structuredContentBlock')
+      (selectedNode.type?.name === 'structuredContent' || selectedNode.type?.name === 'structuredContentBlock')
     ) {
       const id = selectedNode.attrs?.id;
       if (typeof id === 'string' && id.length > 0 && validIds.has(id)) {
@@ -589,10 +590,7 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     const anchor = selection.$anchor;
     if (anchor && typeof anchor.depth === 'number' && typeof anchor.node === 'function') {
       for (let d = anchor.depth; d >= 0; d -= 1) {
-        const node = anchor.node(d) as
-          | { type?: { name?: string }; attrs?: { id?: unknown } }
-          | null
-          | undefined;
+        const node = anchor.node(d) as { type?: { name?: string }; attrs?: { id?: unknown } } | null | undefined;
         const typeName = node?.type?.name;
         if (typeName !== 'structuredContent' && typeName !== 'structuredContentBlock') continue;
         const id = node?.attrs?.id;
@@ -2217,6 +2215,85 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     },
   };
 
+  // Resolve a metadata id (= the SDT's w:tag) to the SDT's content-
+  // control id, reading from the same cached slice contentControls.get
+  // uses. The match is on `properties.tag`, which is the value passed
+  // to `editor.doc.metadata.attach` (or the auto-generated id when the
+  // caller omits one). Globally unique within a document — attach
+  // rejects duplicate ids — so the first match is the only match.
+  const findContentControlIdByMetadataId = (metadataId: string): string | null => {
+    for (const item of contentControlsListCache.items) {
+      if (item.properties?.tag === metadataId) return item.id;
+    }
+    return null;
+  };
+
+  // Convert a same-block or cross-block SelectionTarget into the
+  // TextTarget shape `ui.viewport.scrollIntoView` accepts. Returns
+  // null when the selection contains a `nodeEdge` endpoint, which has
+  // no clean TextTarget representation — callers map that to a
+  // failure rather than guessing a fallback position.
+  const selectionTargetToTextTarget = (target: SelectionTarget): TextTarget | null => {
+    const { start, end } = target;
+    if (start.kind !== 'text' || end.kind !== 'text') return null;
+    if (start.blockId === end.blockId) {
+      return {
+        kind: 'text',
+        segments: [{ blockId: start.blockId, range: { start: start.offset, end: end.offset } }],
+        ...(target.story ? { story: target.story } : {}),
+      };
+    }
+    // Cross-block: anchored-metadata v1 attaches over same-block text
+    // ranges only, so this branch is defensive. Represent as two
+    // collapsed segments at the start and end points;
+    // `scrollRangeIntoView` walks the segments in document order and
+    // scrolls to the first one, so the effect is "scroll to the start
+    // endpoint" — accepted as the defensive fallback rather than
+    // approximating a bounding box across blocks. If a future metadata
+    // path produces a real cross-block anchor we should revisit this
+    // (likely by returning null and surfacing the failure to the caller).
+    return {
+      kind: 'text',
+      segments: [
+        { blockId: start.blockId, range: { start: start.offset, end: start.offset } },
+        { blockId: end.blockId, range: { start: end.offset, end: end.offset } },
+      ],
+      ...(target.story ? { story: target.story } : {}),
+    };
+  };
+
+  const metadata: MetadataHandle = {
+    getRect({ id }: { id: string }) {
+      if (!id) return { success: false, reason: 'invalid-target' };
+      const ccId = findContentControlIdByMetadataId(id);
+      if (ccId === null) return { success: false, reason: 'unresolved' };
+      return contentControls.getRect({ id: ccId });
+    },
+    async scrollIntoView({
+      id,
+      block,
+      behavior,
+    }: {
+      id: string;
+      block?: ScrollIntoViewInput['block'];
+      behavior?: ScrollIntoViewInput['behavior'];
+    }): Promise<ScrollIntoViewOutput> {
+      if (!id) return { success: false };
+      const editor = superdoc.activeEditor as SuperDocEditorLike | undefined;
+      const resolveFn = editor?.doc?.metadata?.resolve;
+      if (typeof resolveFn !== 'function') return { success: false };
+      const info = resolveFn.call(editor!.doc!.metadata!, { id }) as AnchoredMetadataResolveInfo | null;
+      if (!info) return { success: false };
+      const textTarget = selectionTargetToTextTarget(info.target);
+      if (!textTarget) return { success: false };
+      return viewport.scrollIntoView({
+        target: textTarget,
+        ...(block !== undefined ? { block } : {}),
+        ...(behavior !== undefined ? { behavior } : {}),
+      });
+    },
+  };
+
   const destroy = () => {
     if (destroyed) return;
     destroyed = true;
@@ -2253,6 +2330,7 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     comments,
     trackChanges,
     contentControls,
+    metadata,
     selection,
     viewport,
     document,

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -2262,9 +2262,26 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     };
   };
 
+  // Confirm `id` actually maps to a stored metadata payload before
+  // we trust the cc.items tag→nodeId map. An imported DOCX can carry
+  // foreign inline content controls whose `w:tag` happens to match a
+  // metadata id; without this gate, a tag-only lookup would return
+  // the foreign control's geometry. The source path
+  // (`editor.doc.metadata.resolve`) was tightened to require both
+  // halves of the anchor (SDT + payload) to agree; this defensive
+  // gate keeps `ui.metadata.*` symmetrical for direct callers that
+  // skip `resolve`.
+  const hasMetadataPayload = (id: string): boolean => {
+    const editor = superdoc.activeEditor as SuperDocEditorLike | undefined;
+    const getFn = editor?.doc?.metadata?.get;
+    if (typeof getFn !== 'function') return false;
+    return getFn.call(editor!.doc!.metadata!, { id }) !== null;
+  };
+
   const metadata: MetadataHandle = {
     getRect({ id }: { id: string }) {
       if (!id) return { success: false, reason: 'invalid-target' };
+      if (!hasMetadataPayload(id)) return { success: false, reason: 'unresolved' };
       const ccId = findContentControlIdByMetadataId(id);
       if (ccId === null) return { success: false, reason: 'unresolved' };
       return contentControls.getRect({ id: ccId });
@@ -2279,6 +2296,7 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
       behavior?: ScrollIntoViewInput['behavior'];
     }): Promise<ScrollIntoViewOutput> {
       if (!id) return { success: false };
+      if (!hasMetadataPayload(id)) return { success: false };
       const editor = superdoc.activeEditor as SuperDocEditorLike | undefined;
       const resolveFn = editor?.doc?.metadata?.resolve;
       if (typeof resolveFn !== 'function') return { success: false };

--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -2275,7 +2275,11 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
     const editor = superdoc.activeEditor as SuperDocEditorLike | undefined;
     const getFn = editor?.doc?.metadata?.get;
     if (typeof getFn !== 'function') return false;
-    return getFn.call(editor!.doc!.metadata!, { id }) !== null;
+    // `!= null` (not `!== null`) so a stub or adapter returning
+    // `undefined` for an unknown id is treated as absent — production
+    // `metadata.get` returns `null`, but the structural type permits
+    // either and we want both paths to gate the same way.
+    return getFn.call(editor!.doc!.metadata!, { id }) != null;
   };
 
   const metadata: MetadataHandle = {

--- a/packages/super-editor/src/ui/index.ts
+++ b/packages/super-editor/src/ui/index.ts
@@ -127,6 +127,9 @@ export type {
   ContentControlsHandle,
   ContentControlsSlice,
 
+  // Anchored metadata (SD-3204)
+  MetadataHandle,
+
   // Viewport
   ContentControlViewportAddress,
   ViewportContext,

--- a/packages/super-editor/src/ui/metadata.test.ts
+++ b/packages/super-editor/src/ui/metadata.test.ts
@@ -46,6 +46,14 @@ function makeItem(ccId: string, metadataTag: string): ContentControlItem {
 
 function makeStub(opts: {
   items?: ContentControlItem[];
+  /**
+   * Per-id metadata payloads. `null` means "no payload entry" (returned
+   * by `metadata.get` for ids that aren't anchored metadata, e.g. foreign
+   * inline SDTs imported from Word). Defaults to a present payload for
+   * every id mentioned in `resolveByMetadataId`, so existing scrollIntoView
+   * tests don't need to spell it out.
+   */
+  payloadByMetadataId?: Record<string, unknown | null>;
   resolveByMetadataId?: Record<
     string,
     {
@@ -60,6 +68,19 @@ function makeStub(opts: {
 }) {
   const items = opts.items ?? [];
   const resolveByMetadataId = opts.resolveByMetadataId ?? {};
+  // Default payload map: every `properties.tag` in cc.items is treated as
+  // a real metadata anchor (i.e. `metadata.get` returns a non-null payload).
+  // The foreign-SDT test opts out by passing `payloadByMetadataId` with the
+  // id mapped to `null`, simulating an imported DOCX whose SDT carries that
+  // tag but has no customXml payload entry.
+  const payloadByMetadataId =
+    opts.payloadByMetadataId ??
+    Object.fromEntries(
+      items
+        .map((item) => item.properties.tag)
+        .filter((tag): tag is string => typeof tag === 'string')
+        .map((tag) => [tag, { __seeded: true }]),
+    );
 
   const editor = {
     on: vi.fn(),
@@ -71,6 +92,7 @@ function makeStub(opts: {
       selection: { current: vi.fn(() => ({ empty: true, target: null })) },
       contentControls: { list: vi.fn(() => ({ items, total: items.length })) },
       metadata: {
+        get: vi.fn((input: { id: string }) => (input.id in payloadByMetadataId ? payloadByMetadataId[input.id] : null)),
         resolve: vi.fn((input: { id: string }) => resolveByMetadataId[input.id] ?? null),
       },
     },
@@ -130,6 +152,29 @@ describe('ui.metadata.getRect (SD-3204)', () => {
 
     ui.destroy();
   });
+
+  it('returns unresolved when an SDT has the matching tag but no metadata payload entry (foreign control)', () => {
+    // Imported DOCX with an inline SDT whose `w:tag === 'meta-A'` but no
+    // customXml payload — could be a Word-authored content control that
+    // happens to share an id with a metadata anchor. The UI handle must
+    // not delegate to viewport.getRect for that control; if it did,
+    // citation highlights / popovers would land on an unrelated form
+    // field. The source-side fix to `editor.doc.metadata.resolve` plus
+    // this UI-layer payload gate keep both surfaces consistent.
+    const { superdoc } = makeStub({
+      items: [makeItem('sdt-7', 'meta-A')],
+      payloadByMetadataId: { 'meta-A': null },
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    const spy = vi.spyOn(ui.viewport, 'getRect');
+    const result = ui.metadata.getRect({ id: 'meta-A' });
+
+    expect(result).toEqual({ success: false, reason: 'unresolved' });
+    expect(spy).not.toHaveBeenCalled();
+
+    ui.destroy();
+  });
 });
 
 describe('ui.metadata.scrollIntoView (SD-3204)', () => {
@@ -170,6 +215,32 @@ describe('ui.metadata.scrollIntoView (SD-3204)', () => {
     const { superdoc } = makeStub({
       items: [makeItem('sdt-7', 'meta-A')],
       resolveByMetadataId: { 'meta-A': null },
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    const spy = vi.spyOn(ui.viewport, 'scrollIntoView');
+    const out = await ui.metadata.scrollIntoView({ id: 'meta-A' });
+
+    expect(out).toEqual({ success: false });
+    expect(spy).not.toHaveBeenCalled();
+
+    ui.destroy();
+  });
+
+  it('returns { success: false } when the SDT tag has no metadata payload (foreign control, same bridge as getRect)', async () => {
+    const { superdoc } = makeStub({
+      items: [makeItem('sdt-7', 'meta-A')],
+      payloadByMetadataId: { 'meta-A': null },
+      resolveByMetadataId: {
+        'meta-A': {
+          id: 'meta-A',
+          target: {
+            kind: 'selection',
+            start: { kind: 'text', blockId: 'p1', offset: 0 },
+            end: { kind: 'text', blockId: 'p1', offset: 5 },
+          },
+        },
+      },
     });
     const ui = createSuperDocUI({ superdoc });
 

--- a/packages/super-editor/src/ui/metadata.test.ts
+++ b/packages/super-editor/src/ui/metadata.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Focused tests for the `ui.metadata` handle (SD-3204).
+ *
+ * The handle's job is to hide the metadata-id → SDT node-id bridge
+ * that custom UI would otherwise compose from `useSuperDocContentControls`
+ * + a tag→nodeId map + `ui.contentControls.getRect`. These tests
+ * exercise that bridge directly:
+ *
+ *  - getRect({ id }) maps metadata id (= w:tag) to the SDT's content-
+ *    control id and delegates to ui.viewport.getRect.
+ *  - getRect with empty id returns invalid-target.
+ *  - getRect with an id that has no matching cc.items entry returns
+ *    unresolved (the bridge boundary the bot review on SD-3208
+ *    explicitly called out).
+ *  - scrollIntoView({ id }) resolves metadata id → SelectionTarget,
+ *    converts to TextTarget, and delegates to ui.viewport.scrollIntoView.
+ *  - scrollIntoView with unknown id / nodeEdge endpoint returns
+ *    { success: false } rather than scrolling to an approximation.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSuperDocUI } from './create-super-doc-ui.js';
+import type { SuperDocLike } from './types.js';
+
+type ContentControlItem = {
+  nodeType: 'sdt';
+  kind: 'inline' | 'block';
+  id: string;
+  controlType: string;
+  lockMode: string;
+  properties: Record<string, unknown>;
+  target: { kind: 'inline' | 'block'; nodeType: 'sdt'; nodeId: string };
+};
+
+function makeItem(ccId: string, metadataTag: string): ContentControlItem {
+  return {
+    nodeType: 'sdt',
+    kind: 'inline',
+    id: ccId,
+    controlType: 'richText',
+    lockMode: 'unlocked',
+    properties: { tag: metadataTag },
+    target: { kind: 'inline', nodeType: 'sdt', nodeId: ccId },
+  };
+}
+
+function makeStub(opts: {
+  items?: ContentControlItem[];
+  resolveByMetadataId?: Record<
+    string,
+    {
+      id: string;
+      target: {
+        kind: 'selection';
+        start: { kind: 'text' | 'nodeEdge'; blockId?: string; offset?: number; [k: string]: unknown };
+        end: { kind: 'text' | 'nodeEdge'; blockId?: string; offset?: number; [k: string]: unknown };
+      };
+    } | null
+  >;
+}) {
+  const items = opts.items ?? [];
+  const resolveByMetadataId = opts.resolveByMetadataId ?? {};
+
+  const editor = {
+    on: vi.fn(),
+    off: vi.fn(),
+    state: {
+      selection: { $anchor: { depth: 0, node: () => ({ type: { name: 'doc' } }) } },
+    },
+    doc: {
+      selection: { current: vi.fn(() => ({ empty: true, target: null })) },
+      contentControls: { list: vi.fn(() => ({ items, total: items.length })) },
+      metadata: {
+        resolve: vi.fn((input: { id: string }) => resolveByMetadataId[input.id] ?? null),
+      },
+    },
+  };
+
+  const superdoc: SuperDocLike = {
+    activeEditor: editor,
+    config: { documentMode: 'editing' },
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+
+  return { superdoc, editor };
+}
+
+describe('ui.metadata.getRect (SD-3204)', () => {
+  it('maps metadata id (= w:tag) to cc node id and delegates to ui.viewport.getRect', () => {
+    const { superdoc } = makeStub({
+      items: [makeItem('sdt-7', 'meta-A')],
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    const spy = vi.spyOn(ui.viewport, 'getRect');
+    ui.metadata.getRect({ id: 'meta-A' });
+
+    expect(spy).toHaveBeenCalledWith({
+      target: { kind: 'entity', entityType: 'contentControl', entityId: 'sdt-7' },
+    });
+
+    ui.destroy();
+  });
+
+  it('returns invalid-target on empty id', () => {
+    const { superdoc } = makeStub({ items: [] });
+    const ui = createSuperDocUI({ superdoc });
+
+    const spy = vi.spyOn(ui.viewport, 'getRect');
+    const result = ui.metadata.getRect({ id: '' });
+
+    expect(result).toEqual({ success: false, reason: 'invalid-target' });
+    expect(spy).not.toHaveBeenCalled();
+
+    ui.destroy();
+  });
+
+  it('returns unresolved when no cc.items entry has a matching properties.tag (bridge boundary)', () => {
+    const { superdoc } = makeStub({
+      items: [makeItem('sdt-7', 'meta-A')],
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    const spy = vi.spyOn(ui.viewport, 'getRect');
+    const result = ui.metadata.getRect({ id: 'meta-Z' });
+
+    expect(result).toEqual({ success: false, reason: 'unresolved' });
+    expect(spy).not.toHaveBeenCalled();
+
+    ui.destroy();
+  });
+});
+
+describe('ui.metadata.scrollIntoView (SD-3204)', () => {
+  it('resolves metadata id and delegates to ui.viewport.scrollIntoView with a same-block TextTarget', async () => {
+    const { superdoc, editor } = makeStub({
+      items: [makeItem('sdt-7', 'meta-A')],
+      resolveByMetadataId: {
+        'meta-A': {
+          id: 'meta-A',
+          target: {
+            kind: 'selection',
+            start: { kind: 'text', blockId: 'p1', offset: 3 },
+            end: { kind: 'text', blockId: 'p1', offset: 12 },
+          },
+        },
+      },
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    const spy = vi.spyOn(ui.viewport, 'scrollIntoView').mockResolvedValue({ success: true });
+    const out = await ui.metadata.scrollIntoView({ id: 'meta-A', block: 'center', behavior: 'smooth' });
+
+    expect(editor.doc.metadata.resolve).toHaveBeenCalledWith({ id: 'meta-A' });
+    expect(spy).toHaveBeenCalledWith({
+      target: {
+        kind: 'text',
+        segments: [{ blockId: 'p1', range: { start: 3, end: 12 } }],
+      },
+      block: 'center',
+      behavior: 'smooth',
+    });
+    expect(out).toEqual({ success: true });
+
+    ui.destroy();
+  });
+
+  it('returns { success: false } on unknown id without calling viewport.scrollIntoView', async () => {
+    const { superdoc } = makeStub({
+      items: [makeItem('sdt-7', 'meta-A')],
+      resolveByMetadataId: { 'meta-A': null },
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    const spy = vi.spyOn(ui.viewport, 'scrollIntoView');
+    const out = await ui.metadata.scrollIntoView({ id: 'meta-A' });
+
+    expect(out).toEqual({ success: false });
+    expect(spy).not.toHaveBeenCalled();
+
+    ui.destroy();
+  });
+
+  it('returns { success: false } when the SelectionTarget endpoint is a nodeEdge (no clean TextTarget shape)', async () => {
+    const { superdoc } = makeStub({
+      items: [makeItem('sdt-7', 'meta-A')],
+      resolveByMetadataId: {
+        'meta-A': {
+          id: 'meta-A',
+          target: {
+            kind: 'selection',
+            start: { kind: 'text', blockId: 'p1', offset: 0 },
+            end: { kind: 'nodeEdge' },
+          },
+        },
+      },
+    });
+    const ui = createSuperDocUI({ superdoc });
+
+    const spy = vi.spyOn(ui.viewport, 'scrollIntoView');
+    const out = await ui.metadata.scrollIntoView({ id: 'meta-A' });
+
+    expect(out).toEqual({ success: false });
+    expect(spy).not.toHaveBeenCalled();
+
+    ui.destroy();
+  });
+});

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -124,12 +124,17 @@ export interface SuperDocEditorLike {
     /**
      * Anchored-metadata member on the Document API. Used by
      * `ui.metadata.*` to look up an entry's resolved range from its
-     * id. Structurally typed loose for the same stub-friendly reason
-     * as `comments` / `trackChanges` / `contentControls`; the
-     * controller asserts the concrete `AnchoredMetadataResolveInfo`
-     * shape after calling.
+     * id, and to verify (via `get`) that the id actually maps to a
+     * stored payload before delegating to the SDT-keyed geometry
+     * path — a w:tag on its own can come from a Word-authored
+     * content control with no metadata payload, so the payload side
+     * has to agree. Structurally typed loose for the same
+     * stub-friendly reason as `comments` / `trackChanges` /
+     * `contentControls`; the controller asserts the concrete shapes
+     * after calling.
      */
     metadata?: {
+      get?(input: { id: string }): unknown | null;
       resolve?(input: { id: string }): unknown | null;
     };
     /**

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -122,6 +122,17 @@ export interface SuperDocEditorLike {
       list?(query?: unknown): unknown;
     };
     /**
+     * Anchored-metadata member on the Document API. Used by
+     * `ui.metadata.*` to look up an entry's resolved range from its
+     * id. Structurally typed loose for the same stub-friendly reason
+     * as `comments` / `trackChanges` / `contentControls`; the
+     * controller asserts the concrete `AnchoredMetadataResolveInfo`
+     * shape after calling.
+     */
+    metadata?: {
+      resolve?(input: { id: string }): unknown | null;
+    };
+    /**
      * Insert content at a positional target. Surfaces the typed
      * doc-API signature so custom commands can call
      * `editor.doc.insert(...)` without a structural cast. The control
@@ -465,6 +476,60 @@ export interface ContentControlsHandle {
   getRect(input: { id: string }): ViewportRectResult;
 }
 
+/**
+ * Anchored-metadata domain handle exposed on `ui.metadata`. Sugar over
+ * the metadata-id → content-control-id → painter geometry bridge that
+ * custom UI would otherwise compose by hand: callers carry only the
+ * metadata id (the value they passed to `editor.doc.metadata.attach`)
+ * and never see the SDT node id underneath.
+ *
+ * Read / scroll only — there are no mutation methods in v1. All
+ * mutations (`attach` / `update` / `remove`) stay on
+ * `editor.doc.metadata.*`; this handle is a UI surface, not a parallel
+ * mutation contract.
+ *
+ * No `namespace` parameter: `editor.doc.metadata.attach` enforces
+ * globally unique ids within a document (collisions fail with
+ * `INVALID_INPUT`), so the id is sufficient to identify an entry.
+ * No `getRects` either — `getRect`'s success variant already exposes
+ * the per-line `rects[]` array; a second method with the same return
+ * shape would just add API noise.
+ */
+export interface MetadataHandle {
+  /**
+   * Painter rect for the anchor identified by metadata `id`. Internally
+   * resolves metadata-id → SDT node-id via the cached content-controls
+   * slice and delegates to {@link ContentControlsHandle.getRect}, so
+   * the success shape and failure reasons match the rest of the
+   * `ui.*.getRect` family exactly.
+   *
+   * Failure mapping:
+   *   - empty id → `'invalid-target'`
+   *   - unknown id in current document → `'unresolved'`
+   *   - SDT exists but not painted (virtualized / pre-paint) → the
+   *     reason from `contentControls.getRect` (typically
+   *     `'not-mounted'` or `'not-ready'`) is propagated as-is.
+   */
+  getRect(input: { id: string }): ViewportRectResult;
+  /**
+   * Scroll the viewport to the anchored span identified by metadata
+   * `id`. Internally calls `editor.doc.metadata.resolve` to get a
+   * `SelectionTarget`, converts it to a `TextTarget` (the shape
+   * `ui.viewport.scrollIntoView` accepts), and forwards
+   * `block`/`behavior` unchanged. Returns the same
+   * `ScrollIntoViewOutput` shape as `ui.viewport.scrollIntoView`;
+   * unknown ids, `nodeEdge` endpoints, and other shapes that can't be
+   * cleanly represented as a `TextTarget` resolve to
+   * `{ success: false }` rather than silently scrolling to an
+   * approximation.
+   */
+  scrollIntoView(input: {
+    id: string;
+    block?: import('@superdoc/document-api').ScrollIntoViewInput['block'];
+    behavior?: import('@superdoc/document-api').ScrollIntoViewInput['behavior'];
+  }): Promise<import('@superdoc/document-api').ScrollIntoViewOutput>;
+}
+
 export interface CommentsSlice {
   /** Total count from the list result (before pagination, if any). */
   total: number;
@@ -576,6 +641,16 @@ export interface SuperDocUI {
    * is the mutation contract.
    */
   contentControls: ContentControlsHandle;
+
+  /**
+   * Anchored-metadata domain — read + scroll surface keyed on the
+   * metadata id (= the value passed to `editor.doc.metadata.attach`).
+   * Hides the metadata-id → SDT-node-id bridge so custom UI doesn't
+   * have to compose `useSuperDocContentControls` + a tag → nodeId map
+   * + `ui.contentControls.getRect` itself. v1 has no mutation methods
+   * — `editor.doc.metadata.*` is the mutation contract.
+   */
+  metadata: MetadataHandle;
 
   /**
    * Selection domain — single subscription + read surface for
@@ -1644,9 +1719,7 @@ export type ContentControlViewportAddress = {
  * Document API's `EntityAddress` (comment / tracked change) with the
  * UI-local content-control address.
  */
-export type ViewportEntityAddress =
-  | import('@superdoc/document-api').EntityAddress
-  | ContentControlViewportAddress;
+export type ViewportEntityAddress = import('@superdoc/document-api').EntityAddress | ContentControlViewportAddress;
 
 export interface ViewportGetRectInput {
   /**

--- a/packages/superdoc/scripts/verify-public-facade-emit.cjs
+++ b/packages/superdoc/scripts/verify-public-facade-emit.cjs
@@ -268,6 +268,7 @@ const FACADE_ENTRIES = [
       'DynamicCommandHandle',
       'EntityAddress',
       'EqualityFn',
+      'MetadataHandle',
       'Receipt',
       'ScrollIntoViewInput',
       'ScrollIntoViewOutput',

--- a/packages/superdoc/src/public/ui.ts
+++ b/packages/superdoc/src/public/ui.ts
@@ -2,11 +2,11 @@
  * SuperDoc public facade: ui entry.
  *
  * SD-3183 under SD-3178 (Phase 3 of SD-3175). Largest supported-surface
- * facade entry. Mirrors the 70-name surface today reachable via the
- * `superdoc/ui` subpath: 3 runtime values + 67 types.
+ * facade entry. Mirrors the 71-name surface today reachable via the
+ * `superdoc/ui` subpath: 3 runtime values + 68 types.
  *
- * Classification per SD-3147: 49 public + 21 legacy/public-compat. All
- * 70 re-exported through the facade — tier distinction is documentation
+ * Classification per SD-3147: 50 public + 21 legacy/public-compat. All
+ * 71 re-exported through the facade — tier distinction is documentation
  * posture, not facade inclusion.
  *
  * Strategy: re-export through the narrow `@superdoc/super-editor/ui`
@@ -68,6 +68,7 @@ export type {
   DynamicCommandHandle,
   EntityAddress,
   EqualityFn,
+  MetadataHandle,
   Receipt,
   ScrollIntoViewInput,
   ScrollIntoViewOutput,

--- a/packages/superdoc/src/ui.barrel.test.ts
+++ b/packages/superdoc/src/ui.barrel.test.ts
@@ -59,3 +59,9 @@ describe('superdoc/ui public barrel (SD-3157)', () => {
     expect(BARREL_TEXT).toMatch(/type\s+ContentControlsHandle\b/);
   });
 });
+
+describe('superdoc/ui public barrel (SD-3204)', () => {
+  it('re-exports MetadataHandle', () => {
+    expect(BARREL_TEXT).toMatch(/type\s+MetadataHandle\b/);
+  });
+});

--- a/packages/superdoc/src/ui.d.ts
+++ b/packages/superdoc/src/ui.d.ts
@@ -26,6 +26,7 @@ export {
   type DynamicCommandHandle,
   type EntityAddress,
   type EqualityFn,
+  type MetadataHandle,
   type Receipt,
   type ScrollIntoViewInput,
   type ScrollIntoViewOutput,


### PR DESCRIPTION
Adds `ui.metadata.getRect({ id })` and `ui.metadata.scrollIntoView({ id })` keyed on the metadata id — the value the consumer passed to `editor.doc.metadata.attach`. Hides the metadata-id → SDT-node-id → painter-geometry bridge that the SD-3208 demo's `CitationHighlights` had to compose by hand from `useSuperDocContentControls` + a tag→nodeId map + `ui.contentControls.getRect`.

## What the handle does

- `getRect({ id })` reads the cached content-controls slice, finds the item whose `properties.tag === id`, and delegates to `ui.contentControls.getRect({ id: <SDT node id> })`. Return shape is `ViewportRectResult`, identical to the rest of the `ui.*.getRect` family.
- `scrollIntoView({ id, block?, behavior? })` calls `editor.doc.metadata.resolve` for the `SelectionTarget`, converts it to a `TextTarget` (the shape `ui.viewport.scrollIntoView` accepts), and forwards `block` / `behavior` unchanged.

## Failure mapping

Reuses the existing `ViewportRectResult` union — consumers learn one error model across `ui.viewport`, `ui.contentControls`, and `ui.metadata`.

| Input | Result |
|---|---|
| `id: ''` | `{ success: false, reason: 'invalid-target' }` |
| `id` not in `cc.items` (no matching `properties.tag`) | `{ success: false, reason: 'unresolved' }` |
| SDT exists but unpainted | propagates `contentControls.getRect` (`'not-mounted'` / `'not-ready'`) |

`scrollIntoView` returns `{ success: false }` for unknown ids and for `nodeEdge` endpoints (no clean `TextTarget` representation) rather than scrolling to an approximation.

## What's out

- No `getRects` — `ViewportRectResult.success.rects[]` already exposes the per-line array; a sibling method with the same return shape would just add API noise.
- No `namespace` param — `metadata.attach` enforces globally unique ids within a document.
- No `ui.metadata({ namespace })` handle, no React hook, no attach helpers. Those wait for second-customer signal that composing from primitives is too awkward.

## Cross-block scroll

Anchored metadata v1 attaches over same-block text ranges only, so the cross-block branch of the local `SelectionTarget → TextTarget` converter is defensive. It returns two collapsed segments at start and end points; `scrollRangeIntoView` walks segments in document order and scrolls to the first, so the effect is "scroll to the start endpoint." If a future metadata path produces a real cross-block anchor we revisit this — likely by returning `null` and surfacing the failure to the caller. Comment in `create-super-doc-ui.ts` flags the revisit condition.

## Public facade

`MetadataHandle` re-exported through `superdoc/ui` via the four facade files (`ui.d.ts`, `public/ui.ts`, `verify-public-facade-emit.cjs` `expectedNames`, `ui.barrel.test.ts` regression). Facade count goes 70 → 71 (3 runtime + 68 types).

**Verified**:
- `src/ui/metadata.test.ts` → 6/6 (3 getRect including the bridge-boundary test, 3 scrollIntoView)
- `src/ui/*` full suite → 312/312
- `src/ui.barrel.test.ts` → 7/7
- `verify-public-facade-emit.cjs` → ui: 71 exports
- `pnpm --filter superdoc run build:es` → clean