### PR TITLE
feat(consumer-typecheck): root classification closure gate (SD-3212 a1b)

### DIFF
--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -171,6 +171,13 @@ jobs:
         # companion .md but are not blockers on their own.
         run: node tests/consumer-typecheck/snapshot-superdoc-root-exports.mjs --check
 
+      - name: Root classification closure gate (SD-3212 PR A1b)
+        # Asserts the dependency-closure rule from the A1 classification:
+        # no supported-root or legacy-root exported root symbol may reference
+        # an internal-candidate root symbol in its public declared type.
+        # Catches the failure class behind Phase 4a's 31-failure dry-run.
+        run: node tests/consumer-typecheck/check-root-classification-closure.mjs
+
   unit-tests:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -135,6 +135,9 @@ jobs:
       - name: Root no-growth + 4-source inventory (SD-3212 PR A0)
         run: node tests/consumer-typecheck/snapshot-superdoc-root-exports.mjs --check
 
+      - name: Root classification closure gate (SD-3212 PR A1b)
+        run: node tests/consumer-typecheck/check-root-classification-closure.mjs
+
       - name: Release stable packages (orchestrator)
         id: stable_release
         env:

--- a/.github/workflows/release-superdoc.yml
+++ b/.github/workflows/release-superdoc.yml
@@ -159,6 +159,10 @@ jobs:
         # Same gate as PR CI. Catches releases that bypass PR CI.
         run: node tests/consumer-typecheck/snapshot-superdoc-root-exports.mjs --check
 
+      - name: Root classification closure gate (SD-3212 PR A1b)
+        # Same gate as PR CI. Catches releases that bypass PR CI.
+        run: node tests/consumer-typecheck/check-root-classification-closure.mjs
+
       # PR preview: publish with pr-<number> dist-tag
       - name: Publish PR preview
         if: inputs.pr_number

--- a/tests/consumer-typecheck/check-root-classification-closure.mjs
+++ b/tests/consumer-typecheck/check-root-classification-closure.mjs
@@ -62,12 +62,26 @@ const bucketByName = Object.fromEntries(classification.rows.map((r) => [r.name, 
 const allRootNames = new Set(Object.keys(bucketByName));
 const internalCandidates = new Set(classification.rows.filter((r) => r.bucket === 'internal-candidate').map((r) => r.name));
 
-// Manual overrides for known-acceptable references. Use sparingly and with
-// a comment explaining why. The override skips the closure assertion for
-// the named reference even if it appears in internal-candidate.
-const OVERRIDES = new Set([
-  // (none today; add with PR + rationale)
+// Manual overrides for known-acceptable references. Each entry MUST include
+// a reason string explaining why the closure assertion is intentionally
+// skipped for this symbol. Empty reason is a structural error and will
+// abort. Use sparingly: the gate exists precisely to surface these.
+//
+// Adding an entry should land in its own PR with the rationale visible in
+// the commit message and the reason string referenceable from grep.
+//
+// Shape: Map<symbolName, reason>.
+const OVERRIDES = new Map([
+  // ['ExampleType', 'DOM global re-exposed via X; not a real classification leak (see SD-XXXX).'],
 ]);
+
+// Validate override shape at startup so we never accept an empty reason.
+for (const [name, reason] of OVERRIDES) {
+  if (typeof reason !== 'string' || reason.trim().length < 20) {
+    console.error(`[SD-3212 a1b] OVERRIDES entry '${name}' must include a reason string of >= 20 chars.`);
+    process.exit(2);
+  }
+}
 
 // Resolve the emitted root .d.ts path from the installed package.json#exports
 const pkg = JSON.parse(readFileSync(join(FIXTURE_SUPERDOC, 'package.json'), 'utf8'));
@@ -184,6 +198,10 @@ for (const exportSym of rootExports) {
   for (const refName of refs) {
     if (internalCandidates.has(refName) && !OVERRIDES.has(refName)) {
       violations.push({ exporter: name, exporterBucket: bucket, references: refName, referencesBucket: 'internal-candidate' });
+    }
+    // Note overridden references for telemetry/visibility.
+    if (internalCandidates.has(refName) && OVERRIDES.has(refName)) {
+      console.log(`[SD-3212 a1b] override applied: ${name} (${bucket}) references ${refName} (internal-candidate). Reason: ${OVERRIDES.get(refName)}`);
     }
   }
 }

--- a/tests/consumer-typecheck/check-root-classification-closure.mjs
+++ b/tests/consumer-typecheck/check-root-classification-closure.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * SD-3212 A1b — root classification closure gate.
+ *
+ * Reads tests/consumer-typecheck/snapshots/superdoc-root-classification.json
+ * and asserts: no `supported-root` or `legacy-root` exported root symbol
+ * references an `internal-candidate` root symbol in its public declared
+ * type. This catches the failure class where a public/legacy export
+ * depends on a supposedly-internal type — exactly the inconsistency that
+ * produced the 31-failure dry-run in Phase 4a and that the dependency-
+ * closure rule in A1 is meant to prevent.
+ *
+ * Scope (intentionally narrow for v1, per SD-3212 plan):
+ *   - Loads the emitted root .d.ts (via the packed-and-installed fixture).
+ *   - For each supported-root and legacy-root exported root symbol, walks
+ *     its declared type and collects the names of referenced root-exported
+ *     types (bounded recursion with a visited set).
+ *   - Fails on any reference whose name is classified internal-candidate.
+ *   - Allows manual overrides for DOM globals, ProseMirror upstream
+ *     types, generic utility shapes (anything not classified at root).
+ *
+ * Out of scope for v1:
+ *   - Runtime implementation analysis.
+ *   - Private field walks.
+ *   - Cross-package type origins (we only assert closure within names
+ *     that exist at root; non-root types are not subject to the gate).
+ *
+ * Usage:
+ *   node check-root-classification-closure.mjs
+ *
+ * CI runs this after the consumer-typecheck matrix has packed and
+ * installed the fixture.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '../..');
+const CLASSIFICATION = resolve(HERE, 'snapshots/superdoc-root-classification.json');
+const FIXTURE_SUPERDOC = resolve(HERE, 'node_modules', 'superdoc');
+
+if (!existsSync(FIXTURE_SUPERDOC)) {
+  console.error('[SD-3212 a1b] superdoc fixture is not installed.');
+  console.error('Run `node tests/consumer-typecheck/typecheck-matrix.mjs` first (packs and installs).');
+  process.exit(1);
+}
+if (!existsSync(CLASSIFICATION)) {
+  console.error('[SD-3212 a1b] Classification file not found:', CLASSIFICATION);
+  process.exit(1);
+}
+
+const req = createRequire(join(FIXTURE_SUPERDOC, 'package.json'));
+let ts;
+try { ts = req('typescript'); } catch {
+  ts = createRequire(join(HERE, 'package.json'))('typescript');
+}
+
+const classification = JSON.parse(readFileSync(CLASSIFICATION, 'utf8'));
+const bucketByName = Object.fromEntries(classification.rows.map((r) => [r.name, r.bucket]));
+const allRootNames = new Set(Object.keys(bucketByName));
+const internalCandidates = new Set(classification.rows.filter((r) => r.bucket === 'internal-candidate').map((r) => r.name));
+
+// Manual overrides for known-acceptable references. Use sparingly and with
+// a comment explaining why. The override skips the closure assertion for
+// the named reference even if it appears in internal-candidate.
+const OVERRIDES = new Set([
+  // (none today; add with PR + rationale)
+]);
+
+// Resolve the emitted root .d.ts path from the installed package.json#exports
+const pkg = JSON.parse(readFileSync(join(FIXTURE_SUPERDOC, 'package.json'), 'utf8'));
+const rootTypes = pkg.exports?.['.']?.types;
+const rootDtsRel = typeof rootTypes === 'string' ? rootTypes : rootTypes?.import ?? rootTypes?.default;
+if (!rootDtsRel) {
+  console.error('[SD-3212 a1b] Could not resolve root types path from installed package.json.');
+  process.exit(1);
+}
+const rootDts = resolve(FIXTURE_SUPERDOC, rootDtsRel);
+if (!existsSync(rootDts)) {
+  console.error('[SD-3212 a1b] Root .d.ts not found at:', rootDts);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// TS program
+// ---------------------------------------------------------------------------
+const program = ts.createProgram({
+  rootNames: [rootDts],
+  options: {
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ESNext,
+    noEmit: true,
+    skipLibCheck: true,
+    allowJs: false,
+    declaration: false,
+  },
+});
+const checker = program.getTypeChecker();
+const sf = program.getSourceFile(rootDts);
+if (!sf) { console.error('[SD-3212 a1b] Could not load root .d.ts as source file'); process.exit(1); }
+const rootSymbol = checker.getSymbolAtLocation(sf) ?? sf.symbol;
+if (!rootSymbol) { console.error('[SD-3212 a1b] Root module has no symbol'); process.exit(1); }
+const rootExports = checker.getExportsOfModule(rootSymbol);
+
+// ---------------------------------------------------------------------------
+// Walk a type and collect referenced root-symbol names (bounded recursion)
+// ---------------------------------------------------------------------------
+function collectRootReferences(type, visited = new Set(), depth = 0) {
+  const refs = new Set();
+  if (!type) return refs;
+  // Bound the walk; 6 levels is enough to see properties of nested types.
+  if (depth > 6) return refs;
+  const typeId = type.id ?? null;
+  if (typeId != null) {
+    if (visited.has(typeId)) return refs;
+    visited.add(typeId);
+  }
+  // Symbol identity: if this type's symbol's name is a root export, record it
+  const sym = type.aliasSymbol ?? type.symbol;
+  if (sym) {
+    const symName = sym.getName();
+    if (allRootNames.has(symName)) refs.add(symName);
+  }
+  // Walk union/intersection members
+  if (type.isUnionOrIntersection?.()) {
+    for (const sub of type.types || []) {
+      for (const r of collectRootReferences(sub, visited, depth + 1)) refs.add(r);
+    }
+  }
+  // Walk type arguments (e.g. Foo<Bar>, Array<X>)
+  const typeArgs = checker.getTypeArguments?.(type) ?? [];
+  for (const arg of typeArgs) {
+    for (const r of collectRootReferences(arg, visited, depth + 1)) refs.add(r);
+  }
+  // Walk apparent properties (object types, interfaces, classes)
+  const props = type.getProperties?.() ?? [];
+  for (const p of props) {
+    const pType = checker.getTypeOfSymbolAtLocation(p, sf);
+    for (const r of collectRootReferences(pType, visited, depth + 1)) refs.add(r);
+  }
+  // Walk call signatures (functions/methods)
+  const callSigs = checker.getSignaturesOfType?.(type, ts.SignatureKind.Call) ?? [];
+  for (const cs of callSigs) {
+    for (const param of cs.parameters || []) {
+      const pType = checker.getTypeOfSymbolAtLocation(param, sf);
+      for (const r of collectRootReferences(pType, visited, depth + 1)) refs.add(r);
+    }
+    const retType = cs.getReturnType?.();
+    if (retType) for (const r of collectRootReferences(retType, visited, depth + 1)) refs.add(r);
+  }
+  // Walk construct signatures (class constructors)
+  const ctorSigs = checker.getSignaturesOfType?.(type, ts.SignatureKind.Construct) ?? [];
+  for (const cs of ctorSigs) {
+    for (const param of cs.parameters || []) {
+      const pType = checker.getTypeOfSymbolAtLocation(param, sf);
+      for (const r of collectRootReferences(pType, visited, depth + 1)) refs.add(r);
+    }
+    const retType = cs.getReturnType?.();
+    if (retType) for (const r of collectRootReferences(retType, visited, depth + 1)) refs.add(r);
+  }
+  return refs;
+}
+
+// ---------------------------------------------------------------------------
+// Run the check
+// ---------------------------------------------------------------------------
+const violations = [];
+let inspected = 0;
+let skippedNotInClassification = 0;
+
+for (const exportSym of rootExports) {
+  const name = exportSym.getName();
+  const bucket = bucketByName[name];
+  if (!bucket) { skippedNotInClassification++; continue; }
+  if (bucket !== 'supported-root' && bucket !== 'legacy-root') continue;
+  inspected++;
+  const exportType = checker.getTypeOfSymbolAtLocation(exportSym, sf);
+  const refs = collectRootReferences(exportType);
+  // The export itself shows up in refs; exclude self.
+  refs.delete(name);
+  for (const refName of refs) {
+    if (internalCandidates.has(refName) && !OVERRIDES.has(refName)) {
+      violations.push({ exporter: name, exporterBucket: bucket, references: refName, referencesBucket: 'internal-candidate' });
+    }
+  }
+}
+
+console.log('[SD-3212 a1b] Root exports inspected:', inspected);
+console.log('[SD-3212 a1b] Skipped (not in classification snapshot):', skippedNotInClassification);
+console.log('[SD-3212 a1b] Violations:', violations.length);
+if (violations.length) {
+  for (const v of violations) {
+    console.error(`  - ${v.exporter} (${v.exporterBucket}) references ${v.references} (internal-candidate)`);
+  }
+  console.error('');
+  console.error('Closure-rule fix options:');
+  console.error('  1. Promote the referenced type from internal-candidate to legacy-root in superdoc-root-classification.json.');
+  console.error('  2. Tighten the exporter to not reference it.');
+  console.error('  3. If the reference is unavoidable and the type is genuinely DOM/upstream/utility-shaped, add a documented override in this script.');
+  process.exit(1);
+}
+console.log('[SD-3212 a1b] OK — no closure violations.');

--- a/tests/consumer-typecheck/snapshots/superdoc-root-classification.json
+++ b/tests/consumer-typecheck/snapshots/superdoc-root-classification.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-05-19T10:47:17.242Z",
+  "generatedAt": "2026-05-19T11:33:50.546Z",
   "summary": {
     "total": 200,
     "byBucket": {
-      "legacy-root": 59,
-      "internal-candidate": 9,
+      "legacy-root": 60,
+      "internal-candidate": 8,
       "supported-root": 132
     },
     "byConfidence": {
@@ -1534,10 +1534,10 @@
     },
     {
       "name": "SectionMetadata",
-      "bucket": "internal-candidate",
-      "rationale": "Layout/section engine metadata; not surfaced through public callbacks today.",
+      "bucket": "legacy-root",
+      "rationale": "Return-type member of PresentationEditor.getLayoutSnapshot() (line 2744): { layout, blocks, measures, sectionMetadata: SectionMetadata[] }. Legacy via PE closure; caught by the SD-3212 a1b closure gate after manual analysis missed it.",
       "confidence": "high",
-      "source": "locked",
+      "source": "closure-gate-promoted",
       "inDts": true,
       "inDcts": true,
       "inEsm": false,

--- a/tests/consumer-typecheck/snapshots/superdoc-root-classification.md
+++ b/tests/consumer-typecheck/snapshots/superdoc-root-classification.md
@@ -1,6 +1,6 @@
 # SD-3212 A1 — root classification
 
-Generated: 2026-05-19T10:47:17.245Z
+Generated: 2026-05-19T11:33:50.546Z
 Input: tests/consumer-typecheck/snapshots/superdoc-root-exports.json (200 names, locked baseline)
 
 ## Summary
@@ -8,9 +8,9 @@ Input: tests/consumer-typecheck/snapshots/superdoc-root-exports.json (200 names,
 | Bucket | Count |
 |---|---|
 | supported-root | 132 |
-| legacy-root | 59 |
+| legacy-root | 60 |
 | move-to-subpath | 0 |
-| internal-candidate | 9 |
+| internal-candidate | 8 |
 | NEEDS-REVIEW | 0 |
 | **total** | **200** |
 
@@ -153,7 +153,7 @@ Confidence: high=98, medium=100, needs-review=0.
 | `isMarkType` | high | locked | Runtime type guard for mark-type predicates. Customer-facing schema introspection helper. |
 | `isNodeType` | high | locked | Runtime type guard for node-type predicates. Customer-facing schema introspection helper. |
 
-## legacy-root (59)
+## legacy-root (60)
 
 | Name | Confidence | Source | Rationale |
 |---|---|---|---|
@@ -205,6 +205,7 @@ Confidence: high=98, medium=100, needs-review=0.
 | `RemoteCursorState` | high | locked | PE awareness/remote-cursor API surface type. Legacy via PE closure. |
 | `RemoteUserInfo` | high | locked | PE awareness/remote-cursor API surface type. Legacy via PE closure. |
 | `Schema` | high | pm-internal | ProseMirror primitive type. Editor state/view/schema/transaction are deprecated direct-access surfaces (CLAUDE.md). Customers should use Document API. |
+| `SectionMetadata` | high | closure-gate-promoted | Return-type member of PresentationEditor.getLayoutSnapshot() (line 2744): { layout, blocks, measures, sectionMetadata: SectionMetadata[] }. Legacy via PE closure; caught by the SD-3212 a1b closure gate after manual analysis missed it. |
 | `SlashMenu` | high | locked | Legacy component. Sparse public evidence (0 docs, 0 examples, 1 demo, 1 fixture) but currently typed. |
 | `SuperConverter` | high | locked | Legacy converter family entry. Same posture as ./converter subpath. |
 | `SuperEditor` | high | locked | Older naming, predates SuperDoc as the canonical entry. Keep compiling; new code should use SuperDoc. |
@@ -217,7 +218,7 @@ Confidence: high=98, medium=100, needs-review=0.
 | `VirtualizationOptions` | high | locked | Types fields in PresentationEditorOptions. Legacy via PE closure. |
 | `fieldAnnotationHelpers` | high | locked | Documented at apps/docs/extensions/field-annotation.mdx and demos/fields/src/App.vue. Real public surface today; should migrate after SD-3192 decides fieldAnnotations.* Document API. |
 
-## internal-candidate (9)
+## internal-candidate (8)
 
 | Name | Confidence | Source | Rationale |
 |---|---|---|---|
@@ -225,7 +226,6 @@ Confidence: high=98, medium=100, needs-review=0.
 | `LayoutUpdatePayload` | high | locked | Layout engine update payload. PE-internal; NOT used in any public Editor/PE method signature (the closure goes through `LayoutState & { layout; metrics? }`, not this named alias). |
 | `RemoteCursorsRenderPayload` | high | locked | PresentationEditor render-payload event. PE-internal; not in any public PE method signature. |
 | `SectionHelpers` | high | locked | Implementation helper in packages/super-editor/.../document-section/helpers.js, used by structured-content internals. |
-| `SectionMetadata` | high | locked | Layout/section engine metadata; not surfaced through public callbacks today. |
 | `TelemetryEvent` | high | locked | PresentationEditor layout/error/remoteCursorsRender event union. Source file marks adjacent types as "Internal Types". No public docs. |
 | `registeredHandlers` | high | locked | Registry side-effect; 0 docs, 0 examples. Not customer-facing API. |
 | `superEditorHelpers` | high | locked | Helper namespace bag. 0 docs, 0 examples. Likely accidental export. |


### PR DESCRIPTION
**Draft, stacked on #3380 (SD-3212 A1).** Implements the dependency-closure rule from A1 mechanically.

The closure rule: no `supported-root` or `legacy-root` exported root symbol may reference an `internal-candidate` root symbol in its public declared type. This is the gate that prevents the 31-failure problem from Phase 4a's dry-run from re-emerging during PR B.

**v1 scope (intentionally narrow):**

- Loads emitted root `.d.ts` via TS compiler API.
- For each `supported-root` and `legacy-root` exported symbol: walks declared type (properties, union/intersection members, call/construct signatures including parameters and return types, type arguments) with a bounded-depth visited-set walk.
- Asserts no referenced root symbol is `internal-candidate`.
- Supports a manual `OVERRIDES` set for DOM globals / upstream types / generic utility shapes (empty today; add with PR + rationale).

**Out of scope for v1:**

- Runtime implementation analysis.
- Private (`#`) field walks (TS hides them from `getProperties`).
- Cross-package type origins (only asserts within root-exported names).

**v1 caught a real violation on first run.** `SectionMetadata` was classified `internal-candidate` but is the return-type member of `PresentationEditor.getLayoutSnapshot()` at line 2744 (`{ ..., sectionMetadata: SectionMetadata[] }`). Manual classification missed it because the name also appears in `#private` fields at line 504. The closure walk traced `Editor → PresentationEditor → getLayoutSnapshot return → SectionMetadata`.

Fix applied in this PR: SectionMetadata promoted to legacy-root.

**Updated v6 distribution** (vs A1's v5):

| Bucket | v5 (A1) | v6 (this PR) |
|---|---|---|
| supported-root | 132 | 132 |
| legacy-root | 59 | 60 (+1 SectionMetadata) |
| internal-candidate | 9 | 8 (-1 SectionMetadata) |

**CI wiring**: gate added to `ci-superdoc.yml` (PR CI), `release-superdoc.yml`, `release-stable.yml` alongside the existing SD-3176 legacy and SD-3212 A0 root-export gates.

**Operational note for PR B**: with this gate in place, PR B can write `src/public/index.ts` with confidence that the classification is consistent. Any drift between the classification artifact and the emitted root surface will fail CI before merge.

**Verified locally**:

- Gate runs against packed fixture and reports 0 violations after SectionMetadata fix.
- 192 root exports inspected (some root-emitted names not in classification snapshot are skipped with a count; investigate if any drift).

**Related**:

- Parent (this PR's base): SD-3212 A1 classification — #3380
- SD-3212 (Phase 4b umbrella; A0 ✓, A1 in review, A1b this PR, B/C pending)
- SD-3175 (path-as-contract umbrella)