### PR TITLE
feat(custom-ui): migrate citation demo to ui.metadata.* (SD-3215)

### DIFF
--- a/demos/custom-ui/README.md
+++ b/demos/custom-ui/README.md
@@ -1,10 +1,10 @@
 # SuperDoc Custom UI demo
 
-A reference workspace built on the `superdoc/ui/react` surface. Toolbar, comment threads, tracked-change review, custom commands, DOCX round-trip, in one app.
+A reference workspace built on the `superdoc/ui/react` surface. The headline use case is **source-grounded citations**: insert a mock RAG-generated draft, see anchored citation highlights with hover previews, navigate from a sources panel, edit or remove citations. Wrapped in a full editor workspace: custom toolbar, comment threads, tracked-change review, custom commands, and DOCX round-trip.
 
-See the [Custom UI docs](https://docs.superdoc.dev/editor/custom-ui/overview) for the conceptual guide.
+See the [Custom UI docs](https://docs.superdoc.dev/editor/custom-ui/overview) for the conceptual guide, and the upcoming [source-grounded citations feature page](https://docs.superdoc.dev/document-api/features/anchored-metadata) for the citation story.
 
-This demo shows how the pieces compose in a real product, not a single-concept recipe. Read it alongside the docs above when you're wiring your own toolbar or panel.
+This demo shows how the pieces compose in a real product, not a single-concept recipe. Read it alongside the docs above when you're wiring your own toolbar, sources panel, or citation overlay.
 
 ## Run
 
@@ -21,6 +21,11 @@ Open http://localhost:5189.
 
 ## What you can do here
 
+- Open the **Sources** tab and click **Insert sample cited draft**. A mocked RAG-generated paragraph is inserted at the end of the document; each cited span is anchored with `editor.doc.metadata.attach` and rendered with a highlight overlay.
+- Hover a citation highlight to see the source's display text, locator, provider, and confidence. The popover reads the payload via `ui.viewport.entityAt` + `metadata.get`.
+- Click **Scroll to** in the sources panel to navigate to a cited span. Uses `ui.metadata.scrollIntoView({ id })`.
+- Click **Edit** on a citation to change `displayText`, `locator`, or `excerpt`. Calls `editor.doc.metadata.update`.
+- Click **Remove** to strip the anchor and payload. Calls `editor.doc.metadata.remove`.
 - Click toolbar buttons (bold, italic, lists, undo, redo) wired through `useSuperDocCommand`.
 - Insert a custom clause registered with `ui.commands.register`. The button works, and so does its keyboard shortcut `Mod-Shift-C`, declared on the registration rather than wired in a separate keydown listener.
 - Switch between Edit and Suggest. In Suggest, every edit lands as a tracked change.
@@ -29,6 +34,21 @@ Open http://localhost:5189.
 - Add a comment. The composer captures the selection on open, posts on submit, and restores the visible range on close so the user keeps their place.
 - Accept or reject tracked changes. Decided ones move to a Resolved section.
 - Export the doc, edit it in Word, click Import, watch the activity feed update.
+
+## Source-grounded citations
+
+The demo composes anchored citation pointers on top of `editor.doc.metadata.*` and `ui.metadata.*`:
+
+| Layer | What it does | Code |
+| --- | --- | --- |
+| **Mock RAG output** | Pre-canned text + per-citation payloads (sourceId, displayText, locator, excerpt, confidence). Stand-in for a real generation pipeline. | `mockDraft.ts` |
+| **Insert + attach** | Inserts the text via `editor.doc.insert`, then computes a `SelectionTarget` for each cited span and calls `editor.doc.metadata.attach` per citation. | `GenerateDraftButton.tsx`, `useCitations.ts` |
+| **Sources panel** | Lists citations grouped by `sourceId`. Scroll-to navigation uses `ui.metadata.scrollIntoView({ id })`. Edit form calls `editor.doc.metadata.update`. | `CitationsPanel.tsx` |
+| **Highlight overlay** | Renders one absolute-positioned rectangle per painted line of each cited span. Rects come from `ui.metadata.getRect({ id })`. Remeasures on scroll, resize, ResizeObserver, and MutationObserver. | `CitationHighlights.tsx` |
+| **Hover popover** | `ui.viewport.entityAt({ x, y })` returns the content control under the cursor; `metadata.get({ id })` fetches the payload to render. | `CitationPopover.tsx` |
+| **Persistence** | Hidden inline content controls in the body carry the stable id in `w:tag`; payloads live in a namespaced custom XML data part. Survives DOCX export, reopen, and Word save (validated by the `word-roundtrip` fixtures in the monorepo). | `editor.doc.metadata.*` |
+
+`ui.metadata.*` is the supported public surface for consumer-side geometry and navigation; consumers carry the metadata id and never see the SDT node id underneath.
 
 ## Architecture
 
@@ -39,7 +59,10 @@ SuperDocUIProvider                one controller per app
     ├── SelectionPopover          ui.selection.getAnchorRect, bubble menu over the selection
     ├── ContextMenu               ui.viewport.contextAt + ui.commands.getContextMenuItems(context) + item.invoke()
     ├── ContextMenuRegistrations  ui.commands.register({ contextMenu: { when } })
-    └── ActivitySidebar           ui.comments + ui.trackChanges + ui.selection
+    ├── CitationHighlights        ui.metadata.getRect, painted overlay across cited spans
+    ├── CitationPopover           ui.viewport.entityAt + metadata.get, hover preview
+    └── ActivitySidebar           ui.comments + ui.trackChanges + ui.selection (Activity tab)
+        ├── CitationsPanel        editor.doc.metadata.list/get/update/remove + ui.metadata.scrollIntoView (Sources tab)
         └── CommentComposer       ui.selection.capture / restore + ui.comments.createFromCapture
 ```
 
@@ -83,5 +106,5 @@ Right-click on plain text where no item matches falls through to the browser's n
 
 - No design system. Patterns over CSS, copy them into yours.
 - No backend. The clause library in `<InsertClauseButton>` is hardcoded. Real consumers fetch from their own API and call `reg.invalidate()` when permissions or availability change.
-- No AI provider. Custom commands can call any LLM from `execute`. The demo picked "Insert clause" because it's concrete and self-contained.
+- No live AI provider. The citation flow uses pre-canned draft text + payloads in `mockDraft.ts` instead of calling an LLM. Real consumers replace this with their RAG output, but the shape that flows into `editor.doc.metadata.attach` (text + cited ranges + payloads) stays the same.
 - Telemetry is off (`telemetry: { enabled: false }` in `EditorMount.tsx`) because there's no analytics endpoint to receive events. SuperDoc defaults to enabled.

--- a/demos/custom-ui/src/components/CitationHighlights.tsx
+++ b/demos/custom-ui/src/components/CitationHighlights.tsx
@@ -1,20 +1,20 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ViewportRect } from 'superdoc/ui';
-import { useSuperDocContentControls, useSuperDocUI } from 'superdoc/ui/react';
+import { useSuperDocUI } from 'superdoc/ui/react';
 import { useCitations } from './useCitations';
 
 /**
  * Renders absolute-positioned overlay rectangles on every cited span.
  *
- * Two-step lookup. `editor.doc.metadata.*` keys by the metadata id
- * (which is the SDT's `w:tag`); `ui.contentControls.getRect({ id })`
- * keys by the SDT's PM node id (which the painter stamps as
- * `data-sdt-id`). These are different identifiers. The contentControls
- * slice surfaces both per item (`target.nodeId` + `properties.tag`),
- * so we build a tag → nodeId map and translate at measure time.
+ * Geometry comes from `ui.metadata.getRect({ id })`. The handle hides
+ * the underlying lookup (metadata id = SDT `w:tag` → SDT node id →
+ * painter rect) so consumers only carry the metadata id they originally
+ * passed to `editor.doc.metadata.attach`. Before SD-3204 this demo had
+ * to compose `useSuperDocContentControls` + a tag → nodeId map +
+ * `ui.contentControls.getRect`; that bridge is now obviated.
  *
- * `getRect` returns `rects[]` — one ViewportRect per painted line of a
- * wrapped span — so line-wrapped citations get clean per-line
+ * `getRect` returns `rects[]` on success (one ViewportRect per painted
+ * line of a wrapped span), so line-wrapped citations get clean per-line
  * underlines without spilling across the page margin.
  *
  * Remeasure triggers: window scroll/resize, ResizeObserver on the
@@ -28,27 +28,10 @@ import { useCitations } from './useCitations';
  */
 type HighlightEntry = { metadataId: string; tooltip: string; rects: ViewportRect[] };
 
-type CCItem = { target?: { nodeId?: string }; properties?: { tag?: string } };
-
 export function CitationHighlights() {
   const ui = useSuperDocUI();
   const { citations } = useCitations();
-  const cc = useSuperDocContentControls();
   const [entries, setEntries] = useState<HighlightEntry[]>([]);
-
-  // tag (= metadata id) → PM node id. Refreshes whenever the slice
-  // items array reference changes.
-  const tagToNodeId = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const item of (cc.items ?? []) as unknown as CCItem[]) {
-      const tag = item.properties?.tag;
-      const nodeId = item.target?.nodeId;
-      if (typeof tag === 'string' && typeof nodeId === 'string') {
-        map.set(tag, nodeId);
-      }
-    }
-    return map;
-  }, [cc.items]);
 
   useEffect(() => {
     if (!ui) {
@@ -59,9 +42,7 @@ export function CitationHighlights() {
     const remeasure = () => {
       const next: HighlightEntry[] = [];
       for (const c of citations) {
-        const nodeId = tagToNodeId.get(c.id);
-        if (!nodeId) continue;
-        const result = ui.contentControls.getRect({ id: nodeId });
+        const result = ui.metadata.getRect({ id: c.id });
         if (!result.success) continue;
         next.push({
           metadataId: c.id,
@@ -91,8 +72,8 @@ export function CitationHighlights() {
     const resizeObserver = canvas ? new ResizeObserver(scheduleRemeasure) : null;
     if (canvas && resizeObserver) resizeObserver.observe(canvas);
 
-    // Skip the DOM-mutation observer when there are no citations to track —
-    // keeps the demo from observing the editor body when there's nothing to update.
+    // Skip the DOM-mutation observer when there are no citations to track,
+    // so the demo doesn't observe the editor body when there's nothing to update.
     const mutationObserver =
       canvas && citations.length > 0
         ? new MutationObserver(scheduleRemeasure)
@@ -108,7 +89,7 @@ export function CitationHighlights() {
       mutationObserver?.disconnect();
       if (rafHandle !== null) cancelAnimationFrame(rafHandle);
     };
-  }, [ui, citations, tagToNodeId]);
+  }, [ui, citations]);
 
   return (
     <div className="citation-highlights" aria-hidden>

--- a/demos/custom-ui/src/components/CitationsPanel.tsx
+++ b/demos/custom-ui/src/components/CitationsPanel.tsx
@@ -1,31 +1,32 @@
 import { useMemo, useState } from 'react';
 import { useSuperDocUI } from 'superdoc/ui/react';
-import { selectionTargetToTextTarget, type CitationInfo, type CitationPayload } from './citations-types';
+import type { CitationInfo, CitationPayload } from './citations-types';
 import { useCitations } from './useCitations';
 import { GenerateDraftButton } from './GenerateDraftButton';
 
 type UpdateCitation = (id: string, payload: CitationPayload) => { error?: string };
 
 /**
- * References panel. Renders citations grouped by `sourceId` — the
- * pattern Harvey / CoCounsel / Lexis+ use for the side panel beside
- * AI-generated output. Each source group shows the metadata and links
- * back to every cited span in the body. No manual composer; citations
- * arrive via `metadata.attach` from the mocked generation pipeline.
+ * References panel. Renders citations grouped by `sourceId`, the
+ * pattern legal-AI products use for the side panel beside generated
+ * output. Each source group shows the metadata and links back to
+ * every cited span in the body. No manual composer; citations arrive
+ * via `metadata.attach` from the mocked generation pipeline.
  */
 export function CitationsPanel() {
   const ui = useSuperDocUI();
-  const { citations, resolve, remove, update, loading } = useCitations();
+  const { citations, remove, update, loading } = useCitations();
   const [editingId, setEditingId] = useState<string | null>(null);
 
   const groups = useMemo(() => groupBySource(citations), [citations]);
 
+  // Single-call navigation: `ui.metadata.scrollIntoView` resolves the
+  // metadata id to its anchor range internally. Before SD-3204 the demo
+  // had to call `metadata.resolve` and convert SelectionTarget to
+  // TextTarget by hand before calling `ui.viewport.scrollIntoView`.
   const scrollTo = async (id: string) => {
     if (!ui) return;
-    const selectionTarget = resolve(id);
-    const textTarget = selectionTargetToTextTarget(selectionTarget);
-    if (!textTarget) return;
-    await ui.viewport.scrollIntoView({ target: textTarget });
+    await ui.metadata.scrollIntoView({ id, block: 'center' });
   };
 
   return (
@@ -120,7 +121,7 @@ function groupBySource(citations: CitationInfo[]): ReferenceGroup[] {
 }
 
 /**
- * Inline edit form. Exercises `metadata.update` — the lawyer can fix
+ * Inline edit form. Exercises `metadata.update` so the lawyer can fix
  * displayText, locator, or excerpt without re-running the generation
  * pipeline. `citationId`, `sourceId`, `sourceType`, and `provider` are
  * locked here because changing those would mean a different citation,
@@ -130,7 +131,7 @@ function groupBySource(citations: CitationInfo[]): ReferenceGroup[] {
  * `update` is passed from the parent `CitationsPanel` rather than read
  * via a child-local `useCitations()`. A payload-only `metadata.update`
  * does not change the SDT structure, so the parent's content-controls
- * slice does not tick — a child-local hook would only refresh the
+ * slice does not tick; a child-local hook would only refresh the
  * child's own copy of `citations`, leaving the parent panel stale on
  * Save.
  */

--- a/demos/manifest.json
+++ b/demos/manifest.json
@@ -14,8 +14,8 @@
   },
   {
     "id": "custom-ui",
-    "title": "Custom UI",
-    "description": "A full editor workspace with a custom toolbar, activity panel, comments, tracked changes, custom commands, import, and export.",
+    "title": "Custom UI with source-grounded citations",
+    "description": "Source-grounded citations grounded in the document: insert a mock RAG-generated draft, see anchored citation highlights with hover popovers, and navigate from a sources panel. Wrapped in a full editor workspace with a custom toolbar, activity panel, comments, tracked changes, custom commands, import, and export.",
     "category": "Editor",
     "sourceRepo": "superdoc-dev/superdoc",
     "sourcePath": "demos/custom-ui",


### PR DESCRIPTION
Migrates the SD-3208 citation showcase demo to the post-SD-3204 surface and reframes the gallery + README copy around source-grounded citations.

## API migration

The demo was merged before SD-3204 added `ui.metadata.*`. Consumer code still composed the bridge SD-3204 was filed to obviate:

- `CitationHighlights.tsx`: `useSuperDocContentControls` + a tag→nodeId map + `ui.contentControls.getRect`
- `CitationsPanel.tsx`: `metadata.resolve` + `selectionTargetToTextTarget` + `ui.viewport.scrollIntoView`

After this PR the consumer carries only the metadata id and `ui.metadata.*` hides the SDT-node-id resolution:

```ts
const result = ui.metadata.getRect({ id });
await ui.metadata.scrollIntoView({ id, block: 'center' });
```

`useSuperDocContentControls`, the `tagToNodeId` `useMemo`, and the `selectionTargetToTextTarget` import are all dropped from the components. The helper itself stays in `citations-types.ts` for now; cleanup of the now-unused export is out of scope.

## Gallery + README reframing

The demo gained the citation surface in SD-3208 but kept the generic "Custom UI" framing in `demos/manifest.json` ("a full editor workspace with a custom toolbar..."). For a Harvey-shaped reader scanning the gallery, that doesn't surface the use case the demo actually showcases.

- `manifest.json` description now leads with source-grounded citations and the citation surface, then mentions the surrounding editor workspace.
- `README.md` adds a `Source-grounded citations` section with a layer-by-layer architecture table (mock RAG output → insert + attach → sources panel → highlight overlay → hover popover → persistence) and updates the lead paragraph, the "What you can do here" bullets, the architecture diagram, and the "deliberately doesn't do" note about the mock RAG flow.

## Verified

Browser smoke: 3 citations inserted via the mock RAG draft render highlight rects at the cited spans; clicking **Scroll to** on `cite-001` centers it in the viewport via `block: 'center'`.

## Naming convention used

- Customer-facing copy says **source-grounded citations**.
- In-prose primitive label is **metadata anchors**.
- API surface stays `editor.doc.metadata.*`.

This convention is the one set in SD-3209's reframed description; this PR is the first place it lands.

## Sibling work

- SD-3216 — minimal `examples/document-api/metadata-anchors` example (Backlog).
- SD-3209 — `Document source-grounded citations with metadata anchors` feature page (blocked by this PR + SD-3216).