### PR TITLE
feat(examples): minimal metadata-anchors Document API example (SD-3216)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -99,6 +99,7 @@ Put operation-level examples here even when the browser editor hosts the example
 | Example | Pattern |
 |---------|---------|
 | [content-controls/tagged-inline-text](./document-api/content-controls/tagged-inline-text) | The smallest content-control workflow: wrap a word, find by tag, update value. |
+| [metadata-anchors](./document-api/metadata-anchors) | The smallest metadata-anchor workflow: attach a JSON payload to a span, then list, get, resolve, and remove it. |
 
 ## Document Engine
 

--- a/examples/document-api/metadata-anchors/README.md
+++ b/examples/document-api/metadata-anchors/README.md
@@ -1,0 +1,40 @@
+# Metadata anchors
+
+The smallest anchored-payload workflow: attach a JSON payload to a span of text, then list, get, resolve, and remove it.
+
+## What this teaches
+
+- **Setup** (not the lesson, but needed so the lesson has something to act on):
+  - `doc.clearContent({})` clears the seeded document.
+  - `doc.insert({ value })` seeds one paragraph that contains the anchor phrase.
+  - `doc.extract({})` is used to find the anchor block id so the example can build a stable `SelectionTarget` for the click handlers.
+
+- **Teaching surface** (the actual lesson, in click order):
+  - `doc.metadata.attach({ target, namespace, id, payload })` anchors the payload to the span.
+  - `doc.metadata.list({ namespace })` lists every entry in the namespace.
+  - `doc.metadata.get({ id })` returns one entry's payload.
+  - `doc.metadata.resolve({ id })` returns the `SelectionTarget` the anchor currently covers.
+  - `doc.metadata.remove({ id })` strips the anchor wrapper and the payload entry.
+
+Every operation goes through `editor.doc.*`. The same operation set runs headless via the Node SDK and CLI.
+
+## Why this primitive exists
+
+A metadata anchor is a hidden inline content control whose `w:tag` carries a stable id, paired with a JSON payload in a namespaced custom XML data part. The customer-facing use case people most often build on this is **source-grounded citations** (see [`demos/custom-ui`](../../../demos/custom-ui) for the composed workflow), but the primitive is generic: any span-bound payload (citations, suggestion provenance, review markers, structured annotations) uses the same five operations.
+
+For the conceptual guide and the storage model, see [Document API > Anchored metadata](https://docs.superdoc.dev/document-api/features/anchored-metadata).
+
+## Run
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Click **Attach**, then **List** / **Get** / **Resolve** to inspect the entry, then **Remove** to strip it. Each click prints the operation's return value in the **Last operation** panel.
+
+## See also
+
+- [`demos/custom-ui`](../../../demos/custom-ui): composed reference workspace that uses these primitives behind a source-grounded citation flow with highlights, hover popovers, and a sources panel.
+- [Document API > Anchored metadata](https://docs.superdoc.dev/document-api/features/anchored-metadata): feature guide.
+- [Document API reference: metadata.*](https://docs.superdoc.dev/document-api/reference/metadata): per-operation inputs, outputs, and failure codes.

--- a/examples/document-api/metadata-anchors/index.html
+++ b/examples/document-api/metadata-anchors/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SuperDoc: metadata anchors</title>
+  </head>
+  <body>
+    <div class="app">
+      <section class="editor-area">
+        <div id="editor"></div>
+      </section>
+      <aside class="sidebar">
+        <section class="panel">
+          <h2>Metadata anchors</h2>
+          <p class="hint">
+            A metadata anchor is a hidden inline content control with a stable id, paired with a JSON payload in a
+            custom XML part. The lesson is the four operations underneath: <code>attach</code>, <code>list</code>,
+            <code>get</code>, <code>resolve</code>, <code>remove</code>.
+          </p>
+          <div class="actions">
+            <button class="btn primary" id="attach" type="button">Attach</button>
+            <button class="btn" id="list" type="button">List</button>
+            <button class="btn" id="get" type="button">Get</button>
+            <button class="btn" id="resolve" type="button">Resolve</button>
+            <button class="btn danger" id="remove" type="button">Remove</button>
+          </div>
+        </section>
+        <section class="panel">
+          <h3>Last operation</h3>
+          <pre class="result" id="result">(none)</pre>
+        </section>
+        <p class="status" id="status">Loading</p>
+      </aside>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/document-api/metadata-anchors/package.json
+++ b/examples/document-api/metadata-anchors/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@superdoc-examples/metadata-anchors",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "predev": "pnpm --filter superdoc build",
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "superdoc": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/examples/document-api/metadata-anchors/src/main.ts
+++ b/examples/document-api/metadata-anchors/src/main.ts
@@ -1,0 +1,209 @@
+/**
+ * Metadata anchors: the smallest anchored-payload workflow.
+ *
+ * Setup (not the lesson):
+ *   1. Seed one paragraph with anchor text.
+ *
+ * Teaching surface (the lesson, in click order):
+ *   1. `editor.doc.metadata.attach({ target, namespace, id, payload })`
+ *   2. `editor.doc.metadata.list({ namespace })`
+ *   3. `editor.doc.metadata.get({ id })`
+ *   4. `editor.doc.metadata.resolve({ id })`
+ *   5. `editor.doc.metadata.remove({ id })`
+ *
+ * Every operation goes through `editor.doc.*`. The same operation set
+ * runs headless via the Node SDK and CLI.
+ *
+ * A metadata anchor is a hidden inline content control around the
+ * anchored text whose `w:tag` carries a stable id, paired with a JSON
+ * payload in a namespaced custom XML data part. The customer-facing
+ * use case people most often build on this is source-grounded
+ * citations (see `demos/custom-ui`); the primitive is general and
+ * works for any span-bound payload.
+ */
+
+import { SuperDoc } from 'superdoc';
+import 'superdoc/style.css';
+import './style.css';
+
+type SelectionTarget = {
+  kind: 'selection';
+  start: { kind: 'text'; blockId: string; offset: number };
+  end: { kind: 'text'; blockId: string; offset: number };
+};
+
+type AnchoredMetadataPayload = Record<string, unknown>;
+
+type AnchoredMetadataInfo = {
+  id: string;
+  namespace: string;
+  partName: string;
+  payload: AnchoredMetadataPayload;
+};
+
+type AnchoredMetadataResolveInfo = {
+  id: string;
+  target: SelectionTarget;
+};
+
+type AnchoredMetadataAttachResult =
+  | { success: true; id: string; namespace: string; partName: string }
+  | { success: false; failure: { code: string; message: string } };
+
+type AnchoredMetadataMutationResult =
+  | { success: true }
+  | { success: false; failure: { code: string; message: string } };
+
+type DocumentApi = {
+  clearContent(input: Record<string, never>): { success: boolean; failure?: { code: string; message: string } };
+  insert(input: { value: string }): { success: boolean; failure?: { code: string; message: string } };
+  extract(input: Record<string, never>): { blocks: Array<{ nodeId: string; type: string; text: string }> };
+  metadata: {
+    attach(input: {
+      target: SelectionTarget;
+      namespace: string;
+      id?: string;
+      payload: AnchoredMetadataPayload;
+    }): AnchoredMetadataAttachResult;
+    list(input: { namespace?: string }): { total: number; items: Array<{ id: string; namespace: string; partName: string }> };
+    get(input: { id: string }): AnchoredMetadataInfo | null;
+    resolve(input: { id: string }): AnchoredMetadataResolveInfo | null;
+    remove(input: { id: string }): AnchoredMetadataMutationResult;
+  };
+};
+
+const NAMESPACE = 'urn:superdoc:example:metadata-anchors:1';
+const ID = 'anchor-1';
+const ANCHOR_PHRASE = 'metadata anchors';
+const SEED = `Hover over ${ANCHOR_PHRASE} below to see this primitive in action. Open the console to follow the operation receipts.`;
+const EMPTY_DOC = { type: 'doc', content: [{ type: 'paragraph' }] };
+
+const statusEl = qs<HTMLElement>('#status');
+const resultEl = qs<HTMLElement>('#result');
+const attachBtn = qs<HTMLButtonElement>('#attach');
+const listBtn = qs<HTMLButtonElement>('#list');
+const getBtn = qs<HTMLButtonElement>('#get');
+const resolveBtn = qs<HTMLButtonElement>('#resolve');
+const removeBtn = qs<HTMLButtonElement>('#remove');
+
+let api: DocumentApi | null = null;
+let anchorTarget: SelectionTarget | null = null;
+let attached = false;
+setBusy(true);
+
+const superdoc = new SuperDoc({
+  selector: '#editor',
+  documentMode: 'editing',
+  jsonOverride: EMPTY_DOC,
+  modules: { comments: false },
+  telemetry: { enabled: false },
+  onReady: ({ superdoc: sd }) => void initialize(sd as SuperDoc & { activeEditor: { doc: DocumentApi } | null }),
+});
+
+attachBtn.addEventListener('click', () => void run(doAttach));
+listBtn.addEventListener('click', () => void run(doList));
+getBtn.addEventListener('click', () => void run(doGet));
+resolveBtn.addEventListener('click', () => void run(doResolve));
+removeBtn.addEventListener('click', () => void run(doRemove));
+
+async function initialize(sd: SuperDoc & { activeEditor: { doc: DocumentApi } | null }): Promise<void> {
+  if (!sd.activeEditor?.doc) return setStatus('Document API unavailable');
+  api = sd.activeEditor.doc;
+
+  const cleared = api.clearContent({});
+  if (!cleared.success && cleared.failure?.code !== 'NO_OP') return setStatus(cleared.failure?.message ?? 'Setup failed');
+
+  const inserted = api.insert({ value: SEED });
+  if (!inserted.success) return setStatus(inserted.failure?.message ?? 'Setup failed');
+
+  // Cache the SelectionTarget for `ANCHOR_PHRASE` so each Attach click
+  // re-runs the same operation against the same span.
+  const block = api.extract({}).blocks.find((b) => b.text.includes(ANCHOR_PHRASE));
+  if (!block) return setStatus('Setup failed: anchor span not found');
+  const start = block.text.indexOf(ANCHOR_PHRASE);
+  anchorTarget = {
+    kind: 'selection',
+    start: { kind: 'text', blockId: block.nodeId, offset: start },
+    end: { kind: 'text', blockId: block.nodeId, offset: start + ANCHOR_PHRASE.length },
+  };
+
+  setStatus('Ready. Click Attach to anchor a payload to the highlighted span.');
+  refreshButtons();
+}
+
+// The lesson.
+
+function doAttach(): unknown {
+  if (!api || !anchorTarget) return null;
+  const result = api.metadata.attach({
+    target: anchorTarget,
+    namespace: NAMESPACE,
+    id: ID,
+    payload: { note: 'minimal example payload', createdAt: new Date().toISOString() },
+  });
+  if (result.success) attached = true;
+  return result;
+}
+
+function doList(): unknown {
+  if (!api) return null;
+  return api.metadata.list({ namespace: NAMESPACE });
+}
+
+function doGet(): unknown {
+  if (!api) return null;
+  return api.metadata.get({ id: ID });
+}
+
+function doResolve(): unknown {
+  if (!api) return null;
+  return api.metadata.resolve({ id: ID });
+}
+
+function doRemove(): unknown {
+  if (!api) return null;
+  const result = api.metadata.remove({ id: ID });
+  if (result.success) attached = false;
+  return result;
+}
+
+function run(op: () => unknown): void {
+  if (!api) return;
+  setBusy(true);
+  try {
+    const out = op();
+    resultEl.textContent = JSON.stringify(out, null, 2);
+    setStatus('Done.');
+  } catch (err) {
+    resultEl.textContent = String(err);
+    setStatus('Operation threw.');
+  } finally {
+    refreshButtons();
+  }
+}
+
+function refreshButtons(): void {
+  attachBtn.disabled = !api || attached;
+  listBtn.disabled = !api;
+  getBtn.disabled = !api || !attached;
+  resolveBtn.disabled = !api || !attached;
+  removeBtn.disabled = !api || !attached;
+}
+
+function setBusy(busy: boolean): void {
+  document.querySelectorAll<HTMLButtonElement>('button').forEach((b) => (b.disabled = busy));
+}
+
+function setStatus(text: string): void {
+  statusEl.textContent = text;
+}
+
+function qs<T extends Element>(selector: string): T {
+  const el = document.querySelector<T>(selector);
+  if (!el) throw new Error(`Missing element ${selector}`);
+  return el;
+}
+
+const teardown = () => superdoc.destroy();
+window.addEventListener('beforeunload', teardown);
+if (import.meta.hot) import.meta.hot.dispose(teardown);

--- a/examples/document-api/metadata-anchors/src/style.css
+++ b/examples/document-api/metadata-anchors/src/style.css
@@ -1,0 +1,100 @@
+:root {
+  --example-bg: var(--sd-ui-bg, #fff);
+  --example-canvas: var(--sd-surface-canvas, var(--sd-color-gray-50, #fafafa));
+  --example-border: var(--sd-ui-border, var(--sd-color-gray-400, #dbdbdb));
+  --example-text: var(--sd-color-gray-900, #212121);
+  --example-text-muted: var(--sd-ui-text-muted, var(--sd-color-gray-700, #666));
+  --example-accent: var(--sd-ui-action, var(--sd-color-blue-500, #1355ff));
+  --example-accent-hover: var(--sd-ui-action-hover, var(--sd-color-blue-600, #0f44cc));
+  --example-danger: var(--sd-ui-danger, #c0392b);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: var(--sd-ui-font-family, 'Inter', -apple-system, BlinkMacSystemFont, sans-serif);
+  font-size: var(--sd-font-size-400, 14px);
+  color: var(--example-text);
+  background: var(--example-canvas);
+}
+
+code, pre {
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.9em;
+}
+
+button { font: inherit; cursor: pointer; }
+
+.app { display: grid; grid-template-columns: 1fr 360px; height: 100vh; }
+.editor-area { overflow: auto; padding: 12px; }
+.sidebar {
+  background: var(--example-bg);
+  border-left: 1px solid var(--example-border);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.panel { padding: 14px 16px; border-bottom: 1px solid var(--example-border); }
+.panel h2, .panel h3 {
+  font-size: var(--sd-font-size-300, 13px);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--example-text-muted);
+  margin: 0 0 8px;
+}
+.panel .hint {
+  font-size: var(--sd-font-size-200, 12px);
+  color: var(--example-text-muted);
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+.actions { display: flex; flex-direction: column; gap: 6px; }
+
+.btn {
+  height: 30px;
+  padding: 0 14px;
+  background: transparent;
+  border: 1px solid var(--example-border);
+  border-radius: var(--sd-radius-50, 4px);
+  color: var(--example-text);
+  width: 100%;
+}
+.btn.primary {
+  background: var(--example-accent);
+  border-color: var(--example-accent);
+  color: var(--sd-ui-action-text, #fff);
+}
+.btn.primary:hover:not(:disabled) {
+  background: var(--example-accent-hover);
+  border-color: var(--example-accent-hover);
+  color: var(--sd-ui-action-text, #fff);
+}
+.btn.danger:not(:disabled) { color: var(--example-danger); border-color: var(--example-danger); }
+.btn:disabled { color: var(--example-text-muted); cursor: not-allowed; opacity: 0.5; }
+
+.result {
+  margin: 0;
+  padding: 10px 12px;
+  background: var(--example-canvas);
+  border: 1px solid var(--example-border);
+  border-radius: var(--sd-radius-50, 4px);
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: var(--sd-font-size-200, 12px);
+  line-height: 1.4;
+}
+
+.status {
+  margin: 0;
+  padding: 12px 16px;
+  font-size: var(--sd-font-size-200, 12px);
+  color: var(--example-text-muted);
+  border-top: 1px solid var(--example-border);
+  margin-top: auto;
+}

--- a/examples/document-api/metadata-anchors/tsconfig.json
+++ b/examples/document-api/metadata-anchors/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/examples/document-api/metadata-anchors/vite.config.ts
+++ b/examples/document-api/metadata-anchors/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    host: '127.0.0.1',
+  },
+});

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -140,6 +140,16 @@
     "ci": false
   },
   {
+    "id": "document-api-metadata-anchors",
+    "title": "Metadata anchors",
+    "category": "Document API",
+    "surface": "Metadata anchors",
+    "sourceRepo": "superdoc-dev/superdoc",
+    "sourcePath": "examples/document-api/metadata-anchors",
+    "docs": "https://docs.superdoc.dev/document-api/features/anchored-metadata",
+    "ci": false
+  },
+  {
     "id": "editor-theming",
     "title": "Theming",
     "category": "Editor",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,7 +562,7 @@ importers:
         version: 14.0.3
       mintlify:
         specifier: 4.2.531
-        version: 4.2.531(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/node@22.19.2)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 4.2.531(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/node@25.6.0)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       remark-mdx:
         specifier: ^3.1.1
         version: 3.1.1
@@ -1716,6 +1716,19 @@ importers:
       superdoc:
         specifier: workspace:*
         version: link:../../../../packages/superdoc
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: npm:rolldown-vite@7.3.1
+        version: rolldown-vite@7.3.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  examples/document-api/metadata-anchors:
+    dependencies:
+      superdoc:
+        specifier: workspace:*
+        version: link:../../../packages/superdoc
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -20169,6 +20182,7 @@ packages:
   rolldown-vite@7.3.1:
     resolution: {integrity: sha512-LYzdNAjRHhF2yA4JUQm/QyARyi216N2rpJ0lJZb8E9FU2y5v6Vk+xq/U4XBOxMefpWixT5H3TslmAHm1rqIq2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    deprecated: Use this package to migrate from Vite 7 to Vite 8. For the most recent updates, migrate to Vite 8 once you're ready.
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
@@ -26406,16 +26420,6 @@ snapshots:
       chalk: 4.1.2
       figures: 3.2.0
 
-  '@inquirer/checkbox@4.3.2(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.2
-
   '@inquirer/checkbox@4.3.2(@types/node@25.6.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -26441,13 +26445,6 @@ snapshots:
       '@inquirer/type': 1.5.5
       chalk: 4.1.2
 
-  '@inquirer/confirm@5.1.21(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-    optionalDependencies:
-      '@types/node': 22.19.2
-
   '@inquirer/confirm@5.1.21(@types/node@25.6.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.6.0)
@@ -26461,19 +26458,6 @@ snapshots:
       '@inquirer/type': 4.0.4(@types/node@18.19.130)
     optionalDependencies:
       '@types/node': 18.19.130
-
-  '@inquirer/core@10.3.2(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-      cli-width: 4.1.0
-      mute-stream: 2.0.0
-      signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.2
 
   '@inquirer/core@10.3.2(@types/node@25.6.0)':
     dependencies:
@@ -26541,14 +26525,6 @@ snapshots:
       chalk: 4.1.2
       external-editor: 3.1.0
 
-  '@inquirer/editor@4.2.23(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/external-editor': 1.0.3(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-    optionalDependencies:
-      '@types/node': 22.19.2
-
   '@inquirer/editor@4.2.23(@types/node@25.6.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.6.0)
@@ -26572,14 +26548,6 @@ snapshots:
       chalk: 4.1.2
       figures: 3.2.0
 
-  '@inquirer/expand@4.0.23(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.2
-
   '@inquirer/expand@4.0.23(@types/node@25.6.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.6.0)
@@ -26587,13 +26555,6 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.6.0
-
-  '@inquirer/external-editor@1.0.3(@types/node@22.19.2)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      '@types/node': 22.19.2
 
   '@inquirer/external-editor@1.0.3(@types/node@25.6.0)':
     dependencies:
@@ -26619,13 +26580,6 @@ snapshots:
       '@inquirer/type': 1.5.5
       chalk: 4.1.2
 
-  '@inquirer/input@4.3.1(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-    optionalDependencies:
-      '@types/node': 22.19.2
-
   '@inquirer/input@4.3.1(@types/node@25.6.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.6.0)
@@ -26640,13 +26594,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.130
 
-  '@inquirer/number@3.0.23(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-    optionalDependencies:
-      '@types/node': 22.19.2
-
   '@inquirer/number@3.0.23(@types/node@25.6.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.6.0)
@@ -26660,14 +26607,6 @@ snapshots:
       '@inquirer/type': 1.5.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-
-  '@inquirer/password@4.0.23(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-    optionalDependencies:
-      '@types/node': 22.19.2
 
   '@inquirer/password@4.0.23(@types/node@25.6.0)':
     dependencies:
@@ -26689,21 +26628,6 @@ snapshots:
       '@inquirer/rawlist': 1.2.16
       '@inquirer/select': 1.3.3
 
-  '@inquirer/prompts@7.10.1(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@22.19.2)
-      '@inquirer/confirm': 5.1.21(@types/node@22.19.2)
-      '@inquirer/editor': 4.2.23(@types/node@22.19.2)
-      '@inquirer/expand': 4.0.23(@types/node@22.19.2)
-      '@inquirer/input': 4.3.1(@types/node@22.19.2)
-      '@inquirer/number': 3.0.23(@types/node@22.19.2)
-      '@inquirer/password': 4.0.23(@types/node@22.19.2)
-      '@inquirer/rawlist': 4.1.11(@types/node@22.19.2)
-      '@inquirer/search': 3.2.2(@types/node@22.19.2)
-      '@inquirer/select': 4.4.2(@types/node@22.19.2)
-    optionalDependencies:
-      '@types/node': 22.19.2
-
   '@inquirer/prompts@7.10.1(@types/node@25.6.0)':
     dependencies:
       '@inquirer/checkbox': 4.3.2(@types/node@25.6.0)
@@ -26719,34 +26643,26 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/prompts@7.9.0(@types/node@22.19.2)':
+  '@inquirer/prompts@7.9.0(@types/node@25.6.0)':
     dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@22.19.2)
-      '@inquirer/confirm': 5.1.21(@types/node@22.19.2)
-      '@inquirer/editor': 4.2.23(@types/node@22.19.2)
-      '@inquirer/expand': 4.0.23(@types/node@22.19.2)
-      '@inquirer/input': 4.3.1(@types/node@22.19.2)
-      '@inquirer/number': 3.0.23(@types/node@22.19.2)
-      '@inquirer/password': 4.0.23(@types/node@22.19.2)
-      '@inquirer/rawlist': 4.1.11(@types/node@22.19.2)
-      '@inquirer/search': 3.2.2(@types/node@22.19.2)
-      '@inquirer/select': 4.4.2(@types/node@22.19.2)
+      '@inquirer/checkbox': 4.3.2(@types/node@25.6.0)
+      '@inquirer/confirm': 5.1.21(@types/node@25.6.0)
+      '@inquirer/editor': 4.2.23(@types/node@25.6.0)
+      '@inquirer/expand': 4.0.23(@types/node@25.6.0)
+      '@inquirer/input': 4.3.1(@types/node@25.6.0)
+      '@inquirer/number': 3.0.23(@types/node@25.6.0)
+      '@inquirer/password': 4.0.23(@types/node@25.6.0)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.6.0)
+      '@inquirer/search': 3.2.2(@types/node@25.6.0)
+      '@inquirer/select': 4.4.2(@types/node@25.6.0)
     optionalDependencies:
-      '@types/node': 22.19.2
+      '@types/node': 25.6.0
 
   '@inquirer/rawlist@1.2.16':
     dependencies:
       '@inquirer/core': 6.0.0
       '@inquirer/type': 1.5.5
       chalk: 4.1.2
-
-  '@inquirer/rawlist@4.1.11(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.2
 
   '@inquirer/rawlist@4.1.11(@types/node@25.6.0)':
     dependencies:
@@ -26755,15 +26671,6 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.6.0
-
-  '@inquirer/search@3.2.2(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.2
 
   '@inquirer/search@3.2.2(@types/node@25.6.0)':
     dependencies:
@@ -26781,16 +26688,6 @@ snapshots:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       figures: 3.2.0
-
-  '@inquirer/select@4.4.2(@types/node@22.19.2)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.2
 
   '@inquirer/select@4.4.2(@types/node@25.6.0)':
     dependencies:
@@ -26814,10 +26711,6 @@ snapshots:
   '@inquirer/type@1.5.5':
     dependencies:
       mute-stream: 1.0.0
-
-  '@inquirer/type@3.0.10(@types/node@22.19.2)':
-    optionalDependencies:
-      '@types/node': 22.19.2
 
   '@inquirer/type@3.0.10(@types/node@25.6.0)':
     optionalDependencies:
@@ -27383,11 +27276,11 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@mintlify/cli@4.0.1134(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/node@22.19.2)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+  '@mintlify/cli@4.0.1134(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/node@25.6.0)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
-      '@inquirer/prompts': 7.9.0(@types/node@22.19.2)
+      '@inquirer/prompts': 7.9.0(@types/node@25.6.0)
       '@mintlify/common': 1.0.865(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      '@mintlify/link-rot': 3.0.1043(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@mintlify/link-rot': 3.0.1043(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/prebuild': 1.0.1008(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/previewing': 4.0.1069(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/validation': 0.1.676(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -27398,7 +27291,7 @@ snapshots:
       front-matter: 4.0.2
       fs-extra: 11.2.0
       ink: 6.3.0(@types/react@19.2.14)(react@19.2.3)
-      inquirer: 12.3.0(@types/node@22.19.2)
+      inquirer: 12.3.0(@types/node@25.6.0)
       js-yaml: 4.1.0
       mdast-util-mdx-jsx: 3.2.0
       open: 8.4.2
@@ -27430,7 +27323,7 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@mintlify/common@1.0.661(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))(typescript@5.9.3)':
+  '@mintlify/common@1.0.661(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@asyncapi/parser': 3.4.0
       '@mintlify/mdx': 3.0.4(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -27470,7 +27363,7 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.1
       remark-stringify: 11.0.0
-      tailwindcss: 3.4.4(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))
+      tailwindcss: 3.4.4(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))
       unified: 11.0.5
       unist-builder: 4.0.0
       unist-util-map: 4.0.0
@@ -27554,13 +27447,13 @@ snapshots:
       - typescript
       - yaml
 
-  '@mintlify/link-rot@3.0.1043(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+  '@mintlify/link-rot@3.0.1043(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
       '@mintlify/common': 1.0.865(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/models': 0.0.296
       '@mintlify/prebuild': 1.0.1008(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@mintlify/previewing': 4.0.1069(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      '@mintlify/scraping': 4.0.522(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/scraping': 4.0.522(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))(typescript@5.9.3)
       '@mintlify/validation': 0.1.676(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       fs-extra: 11.1.0
       unist-util-visit: 4.1.2
@@ -27705,9 +27598,9 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@mintlify/scraping@4.0.522(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))(typescript@5.9.3)':
+  '@mintlify/scraping@4.0.522(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@mintlify/common': 1.0.661(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))(typescript@5.9.3)
+      '@mintlify/common': 1.0.661(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))(typescript@5.9.3)
       '@mintlify/openapi-parser': 0.0.8
       fs-extra: 11.1.1
       hast-util-to-mdast: 10.1.0
@@ -39069,12 +38962,12 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  inquirer@12.3.0(@types/node@22.19.2):
+  inquirer@12.3.0(@types/node@25.6.0):
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.2)
-      '@inquirer/prompts': 7.10.1(@types/node@22.19.2)
-      '@inquirer/type': 3.0.10(@types/node@22.19.2)
-      '@types/node': 22.19.2
+      '@inquirer/core': 10.3.2(@types/node@25.6.0)
+      '@inquirer/prompts': 7.10.1(@types/node@25.6.0)
+      '@inquirer/type': 3.0.10(@types/node@25.6.0)
+      '@types/node': 25.6.0
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
@@ -41444,9 +41337,9 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mintlify@4.2.531(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/node@22.19.2)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  mintlify@4.2.531(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/node@25.6.0)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
-      '@mintlify/cli': 4.0.1134(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/node@22.19.2)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@mintlify/cli': 4.0.1134(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(react@19.2.3))(@types/node@25.6.0)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.3))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/node'
@@ -43407,13 +43300,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.8
 
-  postcss-load-config@4.0.2(postcss@8.5.10)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.10)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
       postcss: 8.5.10
-      ts-node: 10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3)
 
   postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -46565,7 +46458,7 @@ snapshots:
       - tsx
       - yaml
 
-  tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3)):
+  tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -46584,7 +46477,7 @@ snapshots:
       postcss: 8.5.10
       postcss-import: 15.1.0(postcss@8.5.10)
       postcss-js: 4.1.0(postcss@8.5.10)
-      postcss-load-config: 4.0.2(postcss@8.5.10)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.5.10)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3))
       postcss-nested: 6.2.0(postcss@8.5.10)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -46950,14 +46843,14 @@ snapshots:
       '@swc/core': 1.15.21
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.2)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.2
+      '@types/node': 25.6.0
       acorn: 8.16.0
       acorn-walk: 8.3.5
       arg: 4.1.3


### PR DESCRIPTION
Adds the smallest readable example for the `editor.doc.metadata.*` primitive at `examples/document-api/metadata-anchors/`. Backs SD-3209 — the feature page needs a copy-paste artifact to link to, not just the composed `demos/custom-ui` workflow.

## What it teaches

Five operations, one button each. Each click prints the actual API return value to a side pane so the lesson is observable:

| Click order | Operation |
|---|---|
| 1 | `doc.metadata.attach({ target, namespace, id, payload })` |
| 2 | `doc.metadata.list({ namespace })` |
| 3 | `doc.metadata.get({ id })` |
| 4 | `doc.metadata.resolve({ id })` |
| 5 | `doc.metadata.remove({ id })` |

Setup (not the lesson): `clearContent` + `insert` seed text + `extract` to find the anchor block id, then build a stable `SelectionTarget` once at startup so each Attach click runs against the same span.

## Shape

Mirrors the sibling minimal example (`examples/document-api/content-controls/tagged-inline-text`):

- `package.json` template, `tsconfig.json`, `vite.config.ts` identical
- `style.css` uses the `--sd-*` token contract per `examples/AGENTS.md`
- README split: *Setup (not the lesson)* + *Teaching surface (the lesson)*, plus a `Why this primitive exists` paragraph and links to the composed demo and the feature/reference docs

Registered in `examples/manifest.json` and `examples/README.md` index table.

## Naming convention

Carrying SD-3209's framing:
- Customer-facing framing (source-grounded citations) is mentioned only as **the** use case people most often build on this primitive, with a link to the composed reference. The example itself stays primitive-focused: no legal scenario, no source panel, no RAG mock.
- In-prose primitive label: **metadata anchors**.
- API surface: `editor.doc.metadata.*`.

## Verified

Browser smoke (all five operations through the UI):

- **Attach** → `{ success: true, id: 'anchor-1', namespace: '...', partName: 'customXml/item1.xml' }`
- **List** → `{ total: 1, items: [{ id, handle: { ref: 'metadata:anchor-1', ... }, namespace, partName }], page, evaluatedRevision }`
- **Get** → `{ id, namespace, partName, payload: { note: 'minimal example payload', createdAt: '...' } }`
- **Resolve** → `{ id, target: { kind: 'selection', start: { kind: 'text', blockId, offset: 11 }, end: { kind: 'text', blockId, offset: 27 } } }` (offsets 11-27 match the anchored phrase in the seed)
- **Remove** → `{ success: true, id }` + button states cycle back to pre-attach

`tsc --noEmit` passes. Manifest validator passes. Zero em dashes in any touched file.

## Unblocks

SD-3209 (the feature page) — now has a minimal copy-paste artifact to link to alongside the composed `demos/custom-ui` reference.