### PR TITLE
chore(types): flip root types to public facade (SD-3212)

### DIFF
--- a/packages/superdoc/package.json
+++ b/packages/superdoc/package.json
@@ -20,8 +20,8 @@
   "exports": {
     ".": {
       "types": {
-        "import": "./dist/superdoc/src/index.d.ts",
-        "require": "./dist/superdoc/src/index.d.cts"
+        "import": "./dist/superdoc/src/public/index.d.ts",
+        "require": "./dist/superdoc/src/public/index.d.cts"
       },
       "source": "./src/index.js",
       "import": "./dist/superdoc.es.js",
@@ -84,7 +84,7 @@
     },
     "./style.css": "./dist/style.css"
   },
-  "types": "./dist/superdoc/src/index.d.ts",
+  "types": "./dist/superdoc/src/public/index.d.ts",
   "typesVersions": {
     "*": {
       "headless-toolbar": [


### PR DESCRIPTION
## Summary

Final SD-3212 PR C: flips the root TypeScript contract to the path-as-contract public facade.

Changes only `packages/superdoc/package.json`:
- top-level `types` now points at `./dist/superdoc/src/public/index.d.ts`
- `exports["."].types.import` now points at `./dist/superdoc/src/public/index.d.ts`
- `exports["."].types.require` now points at `./dist/superdoc/src/public/index.d.cts`

Runtime fields are intentionally unchanged:
- `source` still points at `./src/index.js`
- `import` still points at `./dist/superdoc.es.js`
- `require` still points at `./dist/superdoc.cjs`

No `./super-editor` changes; SD-3181 remains deferred.

## Why this is safe now

PR B (#3389) re-curated `src/public/index.ts` to mirror the full 200-name root contract. This PR only moves TypeScript resolution from the historical broad root declaration to the curated public facade declaration.

## Verification

- `pnpm --filter superdoc build:es`
  - facade verifier: root `./index` = 200 exports
  - audit-declarations: no private `@superdoc/*` leaks
  - check-export-coverage: green
- `node tests/consumer-typecheck/typecheck-matrix.mjs`
  - 57/57 scenarios pass
- `node tests/consumer-typecheck/snapshot-superdoc-root-exports.mjs --check`
  - root exports match snapshot
- `node tests/consumer-typecheck/check-root-classification-closure.mjs`
  - 0 closure violations
- `node tests/consumer-typecheck/package-shape-gate.mjs`
  - packed manifest + publint pass
  - ATTW hit the known internal crash and was skipped by the existing tolerated path

After this lands, SD-3213 gate consolidation is unblocked.
