### PR TITLE
fix(custom-ui): guard citation metadata UI handle

### DIFF
--- a/demos/editor/custom-ui/src/components/CitationHighlights.tsx
+++ b/demos/editor/custom-ui/src/components/CitationHighlights.tsx
@@ -34,7 +34,8 @@ export function CitationHighlights() {
   const [entries, setEntries] = useState<HighlightEntry[]>([]);
 
   useEffect(() => {
-    if (!ui) {
+    const metadata = ui?.metadata;
+    if (!metadata?.getRect) {
       setEntries([]);
       return;
     }
@@ -42,7 +43,7 @@ export function CitationHighlights() {
     const remeasure = () => {
       const next: HighlightEntry[] = [];
       for (const c of citations) {
-        const result = ui.metadata.getRect({ id: c.id });
+        const result = metadata.getRect({ id: c.id });
         if (!result.success) continue;
         next.push({
           metadataId: c.id,

--- a/demos/editor/custom-ui/src/components/CitationsPanel.tsx
+++ b/demos/editor/custom-ui/src/components/CitationsPanel.tsx
@@ -25,8 +25,9 @@ export function CitationsPanel() {
   // had to call `metadata.resolve` and convert SelectionTarget to
   // TextTarget by hand before calling `ui.viewport.scrollIntoView`.
   const scrollTo = async (id: string) => {
-    if (!ui) return;
-    await ui.metadata.scrollIntoView({ id, block: 'center' });
+    const metadata = ui?.metadata;
+    if (!metadata?.scrollIntoView) return;
+    await metadata.scrollIntoView({ id, block: 'center' });
   };
 
   return (


### PR DESCRIPTION
## Summary

Fixes the custom-ui citation crash when the React wrapper renders before `ui.metadata` is available, or when a local dev server is still serving a stale `superdoc` build that predates SD-3204.

- guard `ui.metadata.getRect` in `CitationHighlights` before measuring citation overlays
- guard `ui.metadata.scrollIntoView` in `CitationsPanel` before running source-card navigation
- leave the panel usable instead of taking down the React tree with `Cannot read properties of undefined`

## Root cause

The demo assumed `useSuperDocUI()` always returned a handle with `metadata`. In the reported dev session, the checked-in source had `ui.metadata`, but the local built `superdoc` runtime being served by Vite did not, so `CitationHighlights` crashed on `ui.metadata.getRect`.

## Verification

- `pnpm --filter superdoc run build:es`
- `pnpm --filter custom-ui exec tsc --noEmit`
- browser smoke on `http://localhost:5189/`: inserted sample cited draft, verified 3 source cards and 3 citation highlights, with no `CitationHighlights` console error

Unrelated console noise remains: the Vue feature-flag warning and one 404 resource.
