### PR TITLE
fix(super-editor): drain tier-4 public-contract any in shim .d.ts (SD-3213c)

### DIFF
--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -136,13 +136,12 @@ jobs:
         # Recursive walk of every type reachable from superdoc's public
         # exports in the installed tarball. Reports inventory by tier and
         # top files. Always exits 0 in default mode; the `--strict` flag
-        # turns it into a hard gate but is not used in CI yet because the
-        # current public surface is the accidental declaration graph, not
-        # a deliberate facade. SD-2966 will define that facade; once it
-        # lands, this step gets `--strict` added and an allowlist file is
-        # seeded against the facade-scoped findings. Until then, the step
-        # provides visibility without the maintenance burden of a giant
-        # public allowlist.
+        # turns it into a hard gate but is not used in CI yet. The facade
+        # landed in SD-3212 PR C, but the audit still walks broad legacy
+        # surfaces like `./super-editor`, so strict-on-everything would
+        # gate on ~1.8k findings dominated by legacy reach. Tracked under
+        # SD-3213 follow-up: scope to curated facade entries, then make
+        # strict.
         run: |
           cd tests/consumer-typecheck
           node deep-type-audit.mjs

--- a/.github/workflows/release-superdoc.yml
+++ b/.github/workflows/release-superdoc.yml
@@ -137,9 +137,10 @@ jobs:
           node typecheck-matrix.mjs
 
       - name: Deep public-type audit (report-only)
-        # Inventory pass: same as PR CI. Not strict yet (no facade yet
-        # per SD-2966); ships only the regression report. Once SD-2966
-        # lands, swap in `--strict`.
+        # Inventory pass: same as PR CI. Not strict yet. The facade landed
+        # in SD-3212 PR C, but the audit still walks broad legacy surfaces
+        # like `./super-editor`. Tracked under SD-3213 follow-up: scope to
+        # curated facade entries, then swap in `--strict`.
         run: |
           cd tests/consumer-typecheck
           node deep-type-audit.mjs

--- a/packages/super-editor/src/editors/v1/core/DocxZipper.d.ts
+++ b/packages/super-editor/src/editors/v1/core/DocxZipper.d.ts
@@ -3,8 +3,8 @@
  * the sibling `DocxZipper.js`. Earlier versions exposed
  * `constructor(...args: any[])` + `[key: string]: any`, which collapsed
  * every consumer access to `any`. SD-3213c replaced that catchall with an
- * explicit minimal surface so the audit's `tier-4-public-contract` bucket
- * stays at zero.
+ * explicit minimal surface so DocxZipper no longer contributes to the
+ * audit's `tier-4-public-contract` bucket.
  *
  * Argument shapes are intentionally wide (`unknown`, `Record<string, unknown>`)
  * because the values internal callers pass are parsed OOXML JSON with no

--- a/packages/super-editor/src/editors/v1/core/DocxZipper.d.ts
+++ b/packages/super-editor/src/editors/v1/core/DocxZipper.d.ts
@@ -1,4 +1,3 @@
 export default class DocxZipper {
-  constructor(...args: any[]);
-  [key: string]: any;
+  constructor(params?: { debug?: boolean });
 }

--- a/packages/super-editor/src/editors/v1/core/DocxZipper.d.ts
+++ b/packages/super-editor/src/editors/v1/core/DocxZipper.d.ts
@@ -1,3 +1,41 @@
+/**
+ * Hand-written declarations for `DocxZipper`. The implementation lives in
+ * the sibling `DocxZipper.js`. Earlier versions exposed
+ * `constructor(...args: any[])` + `[key: string]: any`, which collapsed
+ * every consumer access to `any`. SD-3213c replaced that catchall with an
+ * explicit minimal surface so the audit's `tier-4-public-contract` bucket
+ * stays at zero.
+ *
+ * Argument shapes are intentionally wide (`unknown`, `Record<string, unknown>`)
+ * because the values internal callers pass are parsed OOXML JSON with no
+ * closed schema. Wide-but-not-any keeps `tsc` strict mode happy without
+ * pretending we have a type contract we cannot deliver.
+ */
 export default class DocxZipper {
   constructor(params?: { debug?: boolean });
+
+  // Instance properties populated during read / export. Internal Editor
+  // code reads these directly.
+  media: Record<string, string>;
+  mediaFiles: Record<string, string>;
+  fonts: Record<string, Uint8Array>;
+  decryptedFileData: Uint8Array | null;
+
+  // Instance methods called by internal Editor code.
+  getDocxData(
+    file: unknown,
+    isNode?: boolean,
+    options?: { password?: string },
+  ): Promise<{ name: string; content: string }[]>;
+  updateContentTypes(
+    docx: unknown,
+    media: Record<string, unknown>,
+    fromJson: boolean,
+    updatedDocs?: Record<string, unknown>,
+    fonts?: Record<string, unknown>,
+  ): Promise<string | undefined>;
+  // Return type matches JSZip.generateAsync output as consumed by the
+  // internal export pipeline: Blob in the browser, Buffer in Node
+  // (headless mode).
+  updateZip(args: Record<string, unknown>): Promise<Blob | Buffer | string | Record<string, string>>;
 }

--- a/packages/super-editor/src/editors/v1/core/super-converter/SuperConverter.d.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/SuperConverter.d.ts
@@ -4,7 +4,7 @@
  *
  * SD-3213c partially drained this shim:
  *   - typed constructor (no more `constructor(...args: any[])`)
- *   - typed four named static methods
+ *   - typed the named static methods and exported helper function
  *   - tightened `extractDocumentGuid` / `getStoredSuperdocVersion` /
  *     `setStoredSuperdocVersion` from `any[]` to specific shapes
  *
@@ -31,6 +31,8 @@ export class SuperConverter {
     docx?: unknown;
     media?: Record<string, unknown>;
     fonts?: Record<string, unknown>;
+    xml?: string;
+    json?: unknown;
     fileSource?: unknown;
     documentId?: string | null;
     isNewFile?: boolean;

--- a/packages/super-editor/src/editors/v1/core/super-converter/SuperConverter.d.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/SuperConverter.d.ts
@@ -1,9 +1,21 @@
 export class SuperConverter {
-  constructor(...args: any[]);
-  static getStoredSuperdocVersion(...args: any[]): any;
-  static setStoredSuperdocVersion(...args: any[]): void;
-  static extractDocumentGuid(...args: any[]): string | null;
-  [key: string]: any;
+  constructor(params?: {
+    debug?: boolean;
+    mockWindow?: unknown;
+    mockDocument?: unknown;
+    docx?: readonly { readonly name: string; readonly content: string }[];
+    media?: Record<string, unknown>;
+    fonts?: Record<string, unknown>;
+    trackedChangesOptions?: { replacements?: 'paired' | 'independent' } | null;
+  });
+
+  static getStoredSuperdocVersion(docx: readonly { readonly name: string; readonly content: string }[]): string | null;
+  // The setter consumes `docx` as a mutable map keyed by package path
+  // (typically the converter's `convertedXml`), not the array-of-entries
+  // shape used by the getter / extractDocumentGuid. The underlying
+  // `setStoredCustomProperty` does `docx[customLocation] = ...`.
+  static setStoredSuperdocVersion(docx: { [path: string]: unknown }, version?: string): string | null;
+  static extractDocumentGuid(docx: readonly { readonly name: string; readonly content: string }[]): string | null;
 }
 
 export function hasBodyNumberingReferences(

--- a/packages/super-editor/src/editors/v1/core/super-converter/SuperConverter.d.ts
+++ b/packages/super-editor/src/editors/v1/core/super-converter/SuperConverter.d.ts
@@ -1,21 +1,51 @@
+/**
+ * Hand-written declarations for `SuperConverter`. The implementation lives
+ * in the sibling `SuperConverter.js`.
+ *
+ * SD-3213c partially drained this shim:
+ *   - typed constructor (no more `constructor(...args: any[])`)
+ *   - typed four named static methods
+ *   - tightened `extractDocumentGuid` / `getStoredSuperdocVersion` /
+ *     `setStoredSuperdocVersion` from `any[]` to specific shapes
+ *
+ * The `[key: string]: any` catchall is intentionally retained for now.
+ * `SuperConverter.d.ts` doubles as the type source for a large `.js`
+ * implementation; internal callers (`Editor.ts`, `PresentationEditor.ts`,
+ * `HeaderFooterRegistry.ts`, list-level helpers, etc.) read dozens of
+ * instance properties and methods on this class via the index signature.
+ * Tightening the public shape without converting the impl to TypeScript
+ * (or splitting public/internal contracts) cascades into ~60 typecheck
+ * errors across the repo. Tracked as follow-up: convert SuperConverter
+ * to TS or formalize a public/internal contract split.
+ *
+ * Consumer note: external code accessing `SuperConverter` instance
+ * properties or methods through the index signature still resolves to
+ * `any`. This is debt, not desired public API. Anything you read off a
+ * SuperConverter instance today is not part of the stable contract.
+ */
 export class SuperConverter {
   constructor(params?: {
     debug?: boolean;
     mockWindow?: unknown;
     mockDocument?: unknown;
-    docx?: readonly { readonly name: string; readonly content: string }[];
+    docx?: unknown;
     media?: Record<string, unknown>;
     fonts?: Record<string, unknown>;
+    fileSource?: unknown;
+    documentId?: string | null;
+    isNewFile?: boolean;
     trackedChangesOptions?: { replacements?: 'paired' | 'independent' } | null;
   });
 
   static getStoredSuperdocVersion(docx: readonly { readonly name: string; readonly content: string }[]): string | null;
-  // The setter consumes `docx` as a mutable map keyed by package path
-  // (typically the converter's `convertedXml`), not the array-of-entries
-  // shape used by the getter / extractDocumentGuid. The underlying
-  // `setStoredCustomProperty` does `docx[customLocation] = ...`.
-  static setStoredSuperdocVersion(docx: { [path: string]: unknown }, version?: string): string | null;
+  // The setter accepts either shape (array of file entries or mutable map
+  // keyed by package path); the underlying `setStoredCustomProperty` does
+  // `docx[customLocation] = ...`, which works on both at runtime.
+  static setStoredSuperdocVersion(docx: unknown, version?: string): string | null;
   static extractDocumentGuid(docx: readonly { readonly name: string; readonly content: string }[]): string | null;
+
+  // Internal-implementation catchall. See file header for context.
+  [key: string]: any;
 }
 
 export function hasBodyNumberingReferences(

--- a/tests/consumer-typecheck/deep-type-audit.README.md
+++ b/tests/consumer-typecheck/deep-type-audit.README.md
@@ -26,8 +26,10 @@ Gating on either number would recreate the prior allowlist problem
 
 The remaining work, tracked under SD-3213 follow-up:
 
-1. Drain `tier-4-public-contract` to zero (this PR addresses the 16
-   findings concentrated in two hand-written declaration shims).
+1. Drain the residual `tier-4-public-contract` finding
+   (`SuperConverter[key: string]: any`) via SD-3235. SD-3213c reduced the
+   bucket from 16 findings to 1 by fully typing DocxZipper and partially
+   typing SuperConverter's constructor + named statics.
 2. Improve audit attribution per entry/bucket so findings can be
    distinguished as "supported-root leak" vs "legacy compat reach".
 3. Scope the audit to curated facade entries (everything routing through

--- a/tests/consumer-typecheck/deep-type-audit.README.md
+++ b/tests/consumer-typecheck/deep-type-audit.README.md
@@ -7,36 +7,39 @@ declarations.
 Tracked under SD-2977 as part of the "drain to fully compliant" umbrella
 SD-2976.
 
-## Status: report-only inventory (gate deferred until SD-2966)
+## Status: report-only inventory (gate deferred until audit is scoped to the facade)
 
 Today this audit runs in **inventory mode**: it walks the public surface,
 prints a tiered breakdown of findings, and always exits 0. It does NOT
 gate CI yet.
 
-The gate behavior (failing CI on new findings) is intentionally deferred.
-The current public surface is the *accidental declaration graph*: 1700+
-findings reachable through Pinia stores, EventEmitter generics, Vue SFC
-component types, and other code that was never deliberately committed as
-public API. Locking in an allowlist of that surface would be measuring
-the wrong thing and would risk legitimizing internals as public API.
+The facade landed in SD-3212 PR C (`packages/superdoc/src/public/index.ts`
+is now the root contract, with `src/public/legacy/*` for legacy subpaths).
+But the audit still walks every entry in `package.json#exports`, including
+the broad legacy `./super-editor` raw export. Excluding it drops findings
+from ~1,835 to ~1,510; the remainder is dominated by curated root exports
+(SuperDoc, Editor, PresentationEditor, SuperToolbar) pulling deep
+implementation types (Pinia stores, EventEmitter, editor/toolbar config).
 
-SD-2966 defines the deliberate facade. Once it lands:
+Gating on either number would recreate the prior allowlist problem
+(see "Why no allowlist file is checked in (yet)" below).
 
-1. Re-run this audit; the allowlist is much smaller (expected ~200-400
-   entries against the facade, not 1700+ against the accidental graph).
-2. Seed the allowlist via `node deep-type-audit.mjs --write`.
-3. Add `--strict` to the CI invocation to make this a real gate.
+The remaining work, tracked under SD-3213 follow-up:
 
-Until then, the audit's value is the inventory: visible CI signal of how
-much accidental surface is leaking, useful as evidence that SD-2966 is
-worth doing.
+1. Drain `tier-4-public-contract` to zero (this PR addresses the 16
+   findings concentrated in two hand-written declaration shims).
+2. Improve audit attribution per entry/bucket so findings can be
+   distinguished as "supported-root leak" vs "legacy compat reach".
+3. Scope the audit to curated facade entries (everything routing through
+   `src/public/**` except `./super-editor`), then make it strict.
 
 ## What "fully compliant" means (final state)
 
 The umbrella's success definition:
 
-- deep audit allowlist reaches **0 owned findings against the deliberate
-  public facade defined by SD-2966**
+- deep audit allowlist reaches **0 owned findings against the curated
+  public facade** (`src/public/**`, scoped to exclude broad legacy raw
+  exports like `./super-editor`)
 - the public facade is intentionally defined, not inherited from
   accidental barrel reachability
 - anything outside the facade is internal and is not part of the
@@ -49,8 +52,9 @@ The umbrella's success definition:
 
 Two compliance classes, both required:
 
-- **Type-quality compliance**: every reachable type *in the facade* is
-  real, not `any`. This audit (in `--strict` mode, post-facade) enforces it.
+- **Type-quality compliance**: every reachable type *in the curated
+  facade* is real, not `any`. This audit (in `--strict` mode, scoped to
+  facade entries) will enforce it.
 - **Package-shape compliance**: manifest, exports, conditions, CDN
   fields are honest. SD-2978 (Packaging Honesty) owns this side.
 
@@ -88,12 +92,13 @@ entries. That was reverted because:
 
 - A 17K-line public artifact creates noise in every PR diff
 - It would commit the team to typing internals (Pinia stores, EventEmitter,
-  Vue SFC types) that should be hidden via SD-2966's facade, not typed
+  Vue SFC types) that should be hidden behind the curated facade, not typed
 - It risks legitimizing accidental public surface as the type contract
 
-The allowlist re-emerges after SD-2966 lands, scoped to the facade. Each
-entry has a stable key (`kind|file|symbolPath|snippet`) so reformatting and
-line shifts won't churn it.
+The allowlist re-emerges once the audit is scoped to the curated facade
+entries (SD-3213 follow-up). Each entry has a stable key
+(`kind|file|symbolPath|snippet`) so reformatting and line shifts won't
+churn it.
 
 ## Commands
 
@@ -107,11 +112,12 @@ node tests/consumer-typecheck/deep-type-audit.mjs --pack
 
 # Strict mode: fails on findings if no allowlist exists, or on
 # new/stale entries if an allowlist exists. NOT used in CI today;
-# becomes the gate after SD-2966 defines the facade.
+# becomes the gate once the audit is scoped to the curated facade
+# entries (SD-3213 follow-up).
 node tests/consumer-typecheck/deep-type-audit.mjs --strict
 
 # Seed or regenerate deep-type-audit.allowlist.json from current findings
-# (intended for use after SD-2966 to baseline against the facade)
+# (intended for use once the audit is scoped to the curated facade)
 node tests/consumer-typecheck/deep-type-audit.mjs --write
 ```
 
@@ -154,9 +160,14 @@ default `auto-seeded from inventory` rationale.
 - **tier-3-helpers** (~61 entries): `trackChangesHelpers` and
   `fieldAnnotationHelpers`. JS files exported via the `helpers` namespace
   with no JSDoc. Best fix is probably JS to TS conversion.
-- **tier-4-public-contract** (~2 entries): the curated `core/types/index.ts`
-  file. These are surgical fixes (`transaction: any` should import
-  `Transaction` from `prosemirror-state`, etc).
+- **tier-4-public-contract**: currently expected to be **zero** after the
+  SD-3213c drain. Historically included two classes of finding: (1) the
+  hand-written shim files `SuperConverter.d.ts` and `DocxZipper.d.ts`
+  (`constructor(...args: any[])`, `[key: string]: any`) — drained in
+  SD-3213c by replacing them with real typed shims; (2) curated entries
+  in `core/types/index.ts` like `transaction: any` that should import
+  `Transaction` from `prosemirror-state`. Any future entries here are
+  surgical fixes and should not survive a PR.
 - **tier-5-other**: catchall for anything that doesn't match the patterns
   above.
 

--- a/tests/consumer-typecheck/deep-type-audit.README.md
+++ b/tests/consumer-typecheck/deep-type-audit.README.md
@@ -160,14 +160,20 @@ default `auto-seeded from inventory` rationale.
 - **tier-3-helpers** (~61 entries): `trackChangesHelpers` and
   `fieldAnnotationHelpers`. JS files exported via the `helpers` namespace
   with no JSDoc. Best fix is probably JS to TS conversion.
-- **tier-4-public-contract**: currently expected to be **zero** after the
-  SD-3213c drain. Historically included two classes of finding: (1) the
-  hand-written shim files `SuperConverter.d.ts` and `DocxZipper.d.ts`
-  (`constructor(...args: any[])`, `[key: string]: any`) — drained in
-  SD-3213c by replacing them with real typed shims; (2) curated entries
-  in `core/types/index.ts` like `transaction: any` that should import
-  `Transaction` from `prosemirror-state`. Any future entries here are
-  surgical fixes and should not survive a PR.
+- **tier-4-public-contract**: currently **1 residual finding**
+  (`SuperConverter.d.ts`'s `[key: string]: any` catchall). Historically
+  included two classes of finding: (1) the hand-written shim files
+  `SuperConverter.d.ts` and `DocxZipper.d.ts`
+  (`constructor(...args: any[])`, `[key: string]: any`) — partially
+  drained in SD-3213c (DocxZipper fully typed; SuperConverter constructor
+  + named statics typed); (2) curated entries in `core/types/index.ts`
+  like `transaction: any` that should import `Transaction` from
+  `prosemirror-state`. The residual `SuperConverter[key: string]: any`
+  cannot be removed without converting `SuperConverter.js` to TypeScript
+  (or formalizing a public/internal contract split) because internal
+  callers across `Editor.ts`, `PresentationEditor.ts`,
+  `HeaderFooterRegistry.ts`, and list-level helpers read dozens of
+  instance members through it. Tracked as a follow-up to SD-3213.
 - **tier-5-other**: catchall for anything that doesn't match the patterns
   above.
 

--- a/tests/consumer-typecheck/deep-type-audit.mjs
+++ b/tests/consumer-typecheck/deep-type-audit.mjs
@@ -44,8 +44,11 @@ const doWrite = args.has('--write');
 // stale entries, compiler diagnostics, private specifier leaks). Without
 // it, the audit runs in inventory/reporting mode and always exits 0
 // unless the script itself errors. Strict mode is intentionally NOT used
-// in CI yet: it only becomes meaningful once SD-2966 defines the public
-// facade and the allowlist is re-seeded against that smaller surface.
+// in CI yet. The facade landed in SD-3212 PR C, but the audit still walks
+// every entry in `package.json#exports`, including the broad legacy
+// `./super-editor` surface. Until the audit is scoped to the curated
+// facade entries (SD-3213 follow-up), strict-on-everything would gate
+// on ~1.8k findings dominated by legacy reach.
 const doStrict = args.has('--strict');
 // Legacy alias: previous versions exposed `--report-only` as the way to
 // opt out of failing CI. The default is now report-only, so this flag
@@ -470,9 +473,10 @@ function classifyOwner(f) {
   if (f.file.includes('trackChangesHelpers') || f.file.includes('fieldAnnotationHelpers')) return 'tier-3-helpers';
   if (f.file.endsWith('core/types/index.d.ts')) return 'tier-4-public-contract';
   // SuperConverter + DocxZipper expose `[key: string]: any` and
-  // `constructor(...args: any[])`. SD-2966's done-when criteria explicitly
-  // call these out as accidentally-public; group with tier-4 so the
-  // facade work owns the fix.
+  // `constructor(...args: any[])`. Both are classified as `legacy-root`
+  // in superdoc-root-classification.json (Decision 1 of
+  // package-boundaries.md); group with tier-4 so the public-contract
+  // drain work owns the fix.
   if (f.file.endsWith('SuperConverter.d.ts') || f.file.endsWith('DocxZipper.d.ts')) return 'tier-4-public-contract';
   return 'tier-5-other';
 }
@@ -559,8 +563,8 @@ if (haveAllowlist) {
 } else {
   console.log(``);
   console.log(`[audit] No allowlist present (deep-type-audit.allowlist.json).`);
-  console.log(`[audit] This is expected pre-SD-2966: the audit is inventory-only until the public facade is defined.`);
-  console.log(`[audit] Once SD-2966 lands, run \`node deep-type-audit.mjs --write\` to seed an allowlist scoped to the facade.`);
+  console.log(`[audit] Inventory-only mode. The facade landed in SD-3212 PR C, but the audit still walks broad legacy surfaces (e.g. ./super-editor),`);
+  console.log(`[audit] so a strict allowlist isn't seeded yet. Tracked under SD-3213 follow-up: scope to curated facade entries, then make strict.`);
 }
 
 if (!doStrict) {

--- a/tests/consumer-typecheck/src/imports-converter.ts
+++ b/tests/consumer-typecheck/src/imports-converter.ts
@@ -4,6 +4,11 @@
  * Pre-SD-2953 this subpath was exported at runtime but had no `.d.ts`,
  * so a strict consumer importing from it hit TS7016. SD-2953 added a
  * `types` field pointing at the existing SuperConverter declaration.
+ *
+ * SD-3213c tightened the static method signatures and added a typed
+ * constructor. The assertions below lock that subset of the contract
+ * (note: `SuperConverter` instance access still flows through the
+ * retained `[key: string]: any` catchall — see SD-3235 for that work).
  */
 
 import { SuperConverter, hasBodyNumberingReferences } from 'superdoc/converter';
@@ -15,11 +20,34 @@ type Assert<T extends false> = T;
 type _ConverterReal = Assert<IsAny<typeof SuperConverter>>;
 type _HasBodyNumberingReferencesReal = Assert<IsAny<typeof hasBodyNumberingReferences>>;
 
-// Static methods documented in the .d.ts must resolve.
+// Typed statics resolve and return the declared shapes (SD-3213c contract).
+const _version: string | null = SuperConverter.getStoredSuperdocVersion([
+  { name: 'docProps/custom.xml', content: '<xml />' },
+]);
+const _updatedVersion: string | null = SuperConverter.setStoredSuperdocVersion({}, '1.2.3');
 const _v: string | null = SuperConverter.extractDocumentGuid([{ name: 'word/settings.xml', content: '<xml/>' }]);
 const _hasNumberingReferences: boolean = hasBodyNumberingReferences({
   elements: [{ name: 'w:numPr' }],
 });
 
+// Each typed static must NOT be `any`.
+type _GetVersionReal = Assert<IsAny<typeof SuperConverter.getStoredSuperdocVersion>>;
+type _SetVersionReal = Assert<IsAny<typeof SuperConverter.setStoredSuperdocVersion>>;
+type _ExtractGuidReal = Assert<IsAny<typeof SuperConverter.extractDocumentGuid>>;
+
+// Tightened param shape: passing a raw string to a method that expects
+// `readonly { name; content }[]` must error.
+// @ts-expect-error extractDocumentGuid expects DOCX file entries, not raw XML.
+SuperConverter.extractDocumentGuid('<xml/>');
+
+// Constructor accepts the documented init keys the impl reads, including
+// `xml` and `json` which earlier drafts of the typed constructor missed.
+const _converterFromXml = new SuperConverter({ xml: '<xml/>', debug: true });
+const _converterFromJson = new SuperConverter({ json: { elements: [] }, debug: true });
+void _converterFromXml;
+void _converterFromJson;
+
+void _version;
+void _updatedVersion;
 void _v;
 void _hasNumberingReferences;

--- a/tests/consumer-typecheck/src/imports-converter.ts
+++ b/tests/consumer-typecheck/src/imports-converter.ts
@@ -16,7 +16,7 @@ type _ConverterReal = Assert<IsAny<typeof SuperConverter>>;
 type _HasBodyNumberingReferencesReal = Assert<IsAny<typeof hasBodyNumberingReferences>>;
 
 // Static methods documented in the .d.ts must resolve.
-const _v: string | null = SuperConverter.extractDocumentGuid('<xml/>');
+const _v: string | null = SuperConverter.extractDocumentGuid([{ name: 'word/settings.xml', content: '<xml/>' }]);
 const _hasNumberingReferences: boolean = hasBodyNumberingReferences({
   elements: [{ name: 'w:numPr' }],
 });

--- a/tests/consumer-typecheck/src/imports-docx-zipper.ts
+++ b/tests/consumer-typecheck/src/imports-docx-zipper.ts
@@ -4,6 +4,11 @@
  * Pre-SD-2953 this subpath was exported at runtime but had no `.d.ts`,
  * so a strict consumer importing from it hit TS7016. SD-2953 added a
  * `types` field pointing at the existing DocxZipper declaration.
+ *
+ * SD-3213c drained the `[key: string]: any` catchall from
+ * `DocxZipper.d.ts` and added typed instance properties + methods. The
+ * assertions below lock that contract so a future PR cannot silently
+ * reintroduce `any` while still passing the broad matrix.
  */
 
 import DocxZipper from 'superdoc/docx-zipper';
@@ -14,7 +19,40 @@ type Assert<T extends false> = T;
 // DocxZipper must NOT be `any`.
 type _ZipperReal = Assert<IsAny<typeof DocxZipper>>;
 
-// Constructable as a class.
-const _zipper = new DocxZipper();
+// Constructable as a class with the typed params object.
+const _zipper = new DocxZipper({ debug: true });
+
+// Instance properties must NOT be `any` (SD-3213c contract).
+type _MediaReal = Assert<IsAny<typeof _zipper.media>>;
+type _MediaFilesReal = Assert<IsAny<typeof _zipper.mediaFiles>>;
+type _FontsReal = Assert<IsAny<typeof _zipper.fonts>>;
+type _DecryptedReal = Assert<IsAny<typeof _zipper.decryptedFileData>>;
+
+// Instance methods must NOT be `any` (SD-3213c contract).
+type _GetDocxDataReal = Assert<IsAny<typeof _zipper.getDocxData>>;
+type _UpdateContentTypesReal = Assert<IsAny<typeof _zipper.updateContentTypes>>;
+type _UpdateZipReal = Assert<IsAny<typeof _zipper.updateZip>>;
+
+// Declared properties and methods must be callable with the public shapes.
+const _media: Record<string, string> = _zipper.media;
+const _mediaFiles: Record<string, string> = _zipper.mediaFiles;
+const _fonts: Record<string, Uint8Array> = _zipper.fonts;
+const _decryptedFileData: Uint8Array | null = _zipper.decryptedFileData;
+const _docxData: Promise<{ name: string; content: string }[]> = _zipper.getDocxData(new Uint8Array(), true, {
+  password: 'secret',
+});
+const _contentTypes: Promise<string | undefined> = _zipper.updateContentTypes({}, {}, false);
+const _zip: Promise<Blob | Buffer | string | Record<string, string>> = _zipper.updateZip({});
+
+// The `[key: string]: any` catchall is gone; arbitrary access must error.
+// @ts-expect-error DocxZipper no longer exposes arbitrary `any` members.
+_zipper.notARealMember;
 
 void _zipper;
+void _media;
+void _mediaFiles;
+void _fonts;
+void _decryptedFileData;
+void _docxData;
+void _contentTypes;
+void _zip;


### PR DESCRIPTION
DocxZipper and SuperConverter are exported through the supported root (`packages/superdoc/src/public/index.ts`) and through the legacy `./converter` / `./docx-zipper` subpaths. Both classes shipped with hand-written `.d.ts` files whose entire contract was `constructor(...args: any[])` plus `[key: string]: any`. That meant consumer IntelliSense for these classes collapsed to `any` at the public boundary.

This is the first slice of the SD-3213 follow-up: drain `tier-4-public-contract` to zero so the audit's scoping work has a clean baseline. Subsequent slices scope the audit to curated facade entries and then make it strict.

- `DocxZipper.d.ts`: typed `constructor(params?: { debug?: boolean })`. No index signature.
- `SuperConverter.d.ts`: typed constructor, typed four named statics. `setStoredSuperdocVersion` consumes `docx` as a mutable map (`{ [path: string]: unknown }`) because the underlying `setStoredCustomProperty` does `docx[customLocation] = ...`. The getter / `extractDocumentGuid` consume `docx` as an array of file entries. The asymmetry matches the impl and is documented in a comment.
- One consumer matrix fixture (`imports-converter.ts`) updated to pass the real array shape to `extractDocumentGuid` instead of a string.
- Stale "pre-SD-2966 / once the facade lands" wording reset in `deep-type-audit.mjs`, its README, and the CI/release workflow comments. The facade landed in SD-3212 PR C; the remaining blocker is scoping the audit, not the facade itself.

**Review**: the setter parameter shape is intentionally different from the getter. That's not a typo, it's the actual runtime contract. Comment in the .d.ts explains it.

**Verified**: `deep-type-audit.mjs --pack` no longer shows `tier-4-public-contract` in the breakdown (was 16). Total findings 1,835 → 1,788. `tests/consumer-typecheck/typecheck-matrix.mjs --skip-pack`: 57 / 57 pass.