### PR TITLE
fix(cli): surface connect failures in COLLABORATION_SYNC_TIMEOUT (SD-3233)

### DIFF
--- a/apps/cli/scripts/repro-sd-3233.ts
+++ b/apps/cli/scripts/repro-sd-3233.ts
@@ -1,0 +1,75 @@
+/**
+ * SD-3233 reproduction harness.
+ *
+ * Mirrors what `openCollaborativeDocument` does for the collab path:
+ * builds a CollaborationProfile, calls createCollaborationRuntime, waits
+ * for sync. If the WSS broker is unreachable, this should hang for 10s
+ * then emit COLLABORATION_SYNC_TIMEOUT — matching the customer's report.
+ *
+ * Wires up extra observers (status, connection-error, connection-close)
+ * to show what y-websocket is actually doing during the hang, which the
+ * CLI silently swallows today.
+ *
+ * Usage:
+ *   bun apps/cli/scripts/repro-sd-3233.ts <url> [documentId]
+ *
+ * Examples:
+ *   bun apps/cli/scripts/repro-sd-3233.ts ws://localhost:1234 superdoc-room    # local — should sync fast
+ *   bun apps/cli/scripts/repro-sd-3233.ts wss://nonexistent.invalid/ed test-room  # unreachable wss — should timeout
+ *   bun apps/cli/scripts/repro-sd-3233.ts wss://echo.websocket.events test-room   # reachable wss but not a yjs server
+ */
+import { createCollaborationRuntime } from '../src/lib/collaboration/runtime';
+import type { CollaborationProfile } from '../src/lib/collaboration/types';
+
+const url = process.argv[2];
+const documentId = process.argv[3] ?? 'sd-3233-repro';
+
+if (!url) {
+  console.error('usage: bun apps/cli/scripts/repro-sd-3233.ts <url> [documentId]');
+  process.exit(2);
+}
+
+const profile: CollaborationProfile = {
+  providerType: url.startsWith('wss://') || url.startsWith('ws://') ? 'y-websocket' : 'hocuspocus',
+  url,
+  documentId,
+  syncTimeoutMs: 10_000,
+};
+
+console.log(`Connecting: providerType=${profile.providerType} url=${url} documentId=${documentId}`);
+const startedAt = Date.now();
+const runtime = createCollaborationRuntime(profile);
+
+// Tap raw provider events that the CLI ignores today. These are the missing
+// diagnostic surface — uncovering them is the "holistic" half of SD-3233.
+const provider = runtime.provider as unknown as {
+  on?: (event: string, handler: (...args: unknown[]) => void) => void;
+};
+if (typeof provider.on === 'function') {
+  provider.on('status', (payload: unknown) => {
+    const status = (payload as { status?: string })?.status ?? payload;
+    console.log(`  [+${Date.now() - startedAt}ms] status: ${JSON.stringify(status)}`);
+  });
+  provider.on('connection-error', (...args: unknown[]) => {
+    console.log(`  [+${Date.now() - startedAt}ms] connection-error:`, args[0]?.constructor?.name ?? args[0]);
+  });
+  provider.on('connection-close', (...args: unknown[]) => {
+    const event = args[0] as { code?: number; reason?: string } | undefined;
+    console.log(`  [+${Date.now() - startedAt}ms] connection-close: code=${event?.code} reason="${event?.reason}"`);
+  });
+  provider.on('synced', () => {
+    console.log(`  [+${Date.now() - startedAt}ms] synced`);
+  });
+}
+
+try {
+  await runtime.waitForSync();
+  console.log(`\n✓ Sync succeeded after ${Date.now() - startedAt}ms`);
+} catch (err) {
+  console.log(`\n✗ Sync failed after ${Date.now() - startedAt}ms: ${(err as Error).message}`);
+  console.log(`  code: ${(err as { code?: string }).code}`);
+} finally {
+  runtime.dispose();
+}
+
+process.exit(0);

--- a/apps/cli/src/lib/collaboration/__tests__/runtime.test.ts
+++ b/apps/cli/src/lib/collaboration/__tests__/runtime.test.ts
@@ -163,3 +163,149 @@ describe('createCollaborationRuntime — hocuspocus', () => {
     expect(config.parameters).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// SD-3233: waitForProviderSync — connection-failure surfacing
+//
+// Standalone harness so each test gets a fresh provider with a real
+// event-emitter shape. Validates that connection-close events fired
+// during the sync wait surface on the COLLABORATION_SYNC_TIMEOUT
+// error's `details`, and that the success path stays clean.
+// ---------------------------------------------------------------------------
+
+const { waitForProviderSync } = await import('../runtime');
+
+type Handler = (...args: unknown[]) => void;
+
+function makeFakeProvider() {
+  const handlers = new Map<string, Set<Handler>>();
+  const provider = {
+    synced: false as boolean,
+    on(event: string, handler: Handler) {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event)!.add(handler);
+    },
+    off(event: string, handler: Handler) {
+      handlers.get(event)?.delete(handler);
+    },
+    emit(event: string, ...args: unknown[]) {
+      handlers.get(event)?.forEach((h) => h(...args));
+    },
+  };
+  return provider;
+}
+
+describe('waitForProviderSync — SD-3233 connection-failure capture', () => {
+  test('success path produces no failure details', async () => {
+    const provider = makeFakeProvider();
+    const promise = waitForProviderSync(provider as never, 500);
+
+    // Sync arrives normally.
+    setTimeout(() => provider.emit('synced'), 10);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  test('timeout error includes captured connection-close events', async () => {
+    const provider = makeFakeProvider();
+    const promise = waitForProviderSync(provider as never, 200);
+
+    // Fire two distinct connection-close events before the timeout fires.
+    setTimeout(() => provider.emit('connection-close', { code: 1006, reason: 'Failed to connect' }), 20);
+    setTimeout(() => provider.emit('connection-close', { code: 1015, reason: 'TLS handshake failed' }), 60);
+
+    try {
+      await promise;
+      throw new Error('expected timeout');
+    } catch (err) {
+      const e = err as { code: string; details?: { timeoutMs?: number; attempts?: number; lastErrors?: unknown[] } };
+      expect(e.code).toBe('COLLABORATION_SYNC_TIMEOUT');
+      expect(e.details?.timeoutMs).toBe(200);
+      expect(e.details?.attempts).toBe(2);
+      const errors = e.details?.lastErrors as Array<{ code?: number; reason?: string }>;
+      expect(errors).toHaveLength(2);
+      expect(errors[0]?.code).toBe(1006);
+      expect(errors[0]?.reason).toBe('Failed to connect');
+      expect(errors[1]?.code).toBe(1015);
+      expect(errors[1]?.reason).toBe('TLS handshake failed');
+    }
+  });
+
+  test('captured failures are bounded to the last 5', async () => {
+    const provider = makeFakeProvider();
+    const promise = waitForProviderSync(provider as never, 200);
+
+    // Fire eight connection-close events; only the last 5 should survive.
+    for (let i = 1; i <= 8; i += 1) {
+      const code = 4000 + i;
+      setTimeout(() => provider.emit('connection-close', { code, reason: `attempt-${i}` }), 5 * i);
+    }
+
+    try {
+      await promise;
+      throw new Error('expected timeout');
+    } catch (err) {
+      const e = err as { details?: { attempts?: number; lastErrors?: Array<{ reason?: string }> } };
+      expect(e.details?.attempts).toBe(5);
+      const reasons = e.details?.lastErrors?.map((entry) => entry.reason);
+      // Earliest three (attempt-1..attempt-3) dropped; last five retained in order.
+      expect(reasons).toEqual(['attempt-4', 'attempt-5', 'attempt-6', 'attempt-7', 'attempt-8']);
+    }
+  });
+
+  test('success after transient failures still resolves with no error details', async () => {
+    const provider = makeFakeProvider();
+    const promise = waitForProviderSync(provider as never, 500);
+
+    // Two failures then a successful sync.
+    setTimeout(() => provider.emit('connection-close', { code: 1006, reason: 'transient' }), 20);
+    setTimeout(() => provider.emit('connection-close', { code: 1006, reason: 'transient' }), 40);
+    setTimeout(() => provider.emit('synced'), 80);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  test('timeout without any connection-close events keeps the legacy details shape', async () => {
+    const provider = makeFakeProvider();
+    const promise = waitForProviderSync(provider as never, 100);
+
+    try {
+      await promise;
+      throw new Error('expected timeout');
+    } catch (err) {
+      const e = err as {
+        code: string;
+        details?: { timeoutMs?: number; attempts?: unknown; lastErrors?: unknown };
+      };
+      expect(e.code).toBe('COLLABORATION_SYNC_TIMEOUT');
+      expect(e.details?.timeoutMs).toBe(100);
+      // Backwards-compat: when no failures captured, attempts/lastErrors are omitted entirely.
+      expect(e.details?.attempts).toBeUndefined();
+      expect(e.details?.lastErrors).toBeUndefined();
+    }
+  });
+
+  test('handles connection-close events with missing fields gracefully', async () => {
+    const provider = makeFakeProvider();
+    const promise = waitForProviderSync(provider as never, 150);
+
+    // Event with no code/reason — could happen if the underlying socket dies oddly.
+    setTimeout(() => provider.emit('connection-close', {}), 10);
+    setTimeout(() => provider.emit('connection-close', undefined), 30);
+    setTimeout(() => provider.emit('connection-close', { code: 1006 }), 50);
+
+    try {
+      await promise;
+      throw new Error('expected timeout');
+    } catch (err) {
+      const e = err as { details?: { lastErrors?: Array<Record<string, unknown>> } };
+      const errors = e.details?.lastErrors ?? [];
+      expect(errors).toHaveLength(3);
+      // Each record has `at`, and optional code/reason without crashing on undefined.
+      for (const entry of errors) {
+        expect(typeof entry.at).toBe('number');
+      }
+      expect(errors[2]?.code).toBe(1006);
+    }
+  });
+});

--- a/apps/cli/src/lib/collaboration/runtime.ts
+++ b/apps/cli/src/lib/collaboration/runtime.ts
@@ -17,6 +17,31 @@ import type {
 
 export const DEFAULT_SYNC_TIMEOUT_MS = 10_000;
 const SYNC_POLL_INTERVAL_MS = 25;
+/**
+ * SD-3233: cap the number of recent connection-close events surfaced on
+ * COLLABORATION_SYNC_TIMEOUT. Five is enough to convey the failure
+ * pattern (typical y-websocket exponential backoff lands ~7 failures
+ * inside the 10s default window) without unbounded memory growth.
+ */
+const MAX_CAPTURED_FAILURES = 5;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of a single failed WebSocket connect attempt, captured during
+ * `waitForProviderSync` and surfaced on the timeout error's `details`
+ * to give callers actionable diagnostics. See SD-3233.
+ */
+export type ProviderConnectionFailure = {
+  /** Milliseconds elapsed since the sync wait started. */
+  at: number;
+  /** WebSocket close code (1006 for abnormal closure, 1015 TLS handshake, 4xxx custom). */
+  code?: number;
+  /** Human-readable close reason from the provider (e.g. "Failed to connect"). */
+  reason?: string;
+};
 
 // ---------------------------------------------------------------------------
 // Websocket sync helper
@@ -26,12 +51,30 @@ function isSynced(provider: SyncableProvider): boolean {
   return provider.synced === true || provider.isSynced === true;
 }
 
+/**
+ * Best-effort extraction of `code` and `reason` from a y-websocket /
+ * Hocuspocus `connection-close` event payload. The runtime types are
+ * loose (browser CloseEvent or close-event-shaped object), so we accept
+ * `unknown` and narrow defensively.
+ */
+function toFailureRecord(event: unknown, startedAt: number): ProviderConnectionFailure {
+  const record: ProviderConnectionFailure = { at: Date.now() - startedAt };
+  if (event && typeof event === 'object') {
+    const e = event as { code?: unknown; reason?: unknown };
+    if (typeof e.code === 'number') record.code = e.code;
+    if (typeof e.reason === 'string' && e.reason.length > 0) record.reason = e.reason;
+  }
+  return record;
+}
+
 export function waitForProviderSync(provider: SyncableProvider, timeoutMs: number): Promise<void> {
   if (isSynced(provider)) return Promise.resolve();
 
   return new Promise<void>((resolve, reject) => {
     let settled = false;
     const cleanup: Array<() => void> = [];
+    const failures: ProviderConnectionFailure[] = [];
+    const startedAt = Date.now();
 
     const finish = (error?: CliError) => {
       if (settled) return;
@@ -51,20 +94,37 @@ export function waitForProviderSync(provider: SyncableProvider, timeoutMs: numbe
       finish();
     };
 
+    // SD-3233: capture failed connect attempts so a 10s timeout surfaces
+    // the actual close reason (DNS, TLS, refused, auth, etc.) instead of
+    // a generic timeout. y-websocket pairs every connect failure with a
+    // `connection-close` event carrying the structured code/reason; the
+    // sibling `connection-error` is intentionally NOT subscribed because
+    // it adds no information beyond the close event.
+    const onConnectionClose = (event: unknown) => {
+      failures.push(toFailureRecord(event, startedAt));
+      if (failures.length > MAX_CAPTURED_FAILURES) {
+        failures.splice(0, failures.length - MAX_CAPTURED_FAILURES);
+      }
+    };
+
     if (provider.on) {
       provider.on('synced', onSync);
       cleanup.push(() => provider.off?.('synced', onSync));
 
       provider.on('sync', onSync);
       cleanup.push(() => provider.off?.('sync', onSync));
+
+      provider.on('connection-close', onConnectionClose);
+      cleanup.push(() => provider.off?.('connection-close', onConnectionClose));
     }
 
     const timer = setTimeout(() => {
-      finish(
-        new CliError('COLLABORATION_SYNC_TIMEOUT', `Collaboration sync timed out after ${timeoutMs}ms.`, {
-          timeoutMs,
-        }),
-      );
+      const details: Record<string, unknown> = { timeoutMs };
+      if (failures.length > 0) {
+        details.attempts = failures.length;
+        details.lastErrors = failures;
+      }
+      finish(new CliError('COLLABORATION_SYNC_TIMEOUT', `Collaboration sync timed out after ${timeoutMs}ms.`, details));
     }, timeoutMs);
     cleanup.push(() => clearTimeout(timer));
 


### PR DESCRIPTION
## Summary

Fixes [SD-3233](https://linear.app/superdocworkspace/issue/SD-3233). The customer's agent flow hit a 10s silent hang when the CLI couldn't reach their WSS broker; the error envelope came back with only `{ timeoutMs: 10000 }` and no clue what was wrong. They tried multiple Bun/Node debug env vars; none gave actionable info because the connection failures never made it out of the CLI.

This PR surfaces those failures on the timeout's `details` so customers (and our own future debugging) can see the actual close codes and reasons.

## Root cause (verified)

`waitForProviderSync` in `apps/cli/src/lib/collaboration/runtime.ts` only subscribed to success events (`synced`, `sync`). Every `connection-close` event y-websocket fired during its retry loop was swallowed. After 10s the timer fired with a generic timeout error.

The customer's interpretation — *"the CLI never attempts the WSS connect, because `lsof` shows zero TCP sockets"* — turned out to be a tooling artifact. y-websocket DOES retry on backoff (16ms → 216ms → 619ms → 1.4s → 3s → 5.5s → 8s). For an unreachable host the failures happen at the DNS layer BEFORE `socket()` is called, so no TCP socket ever shows up in `lsof` (correct), but the WebSocket layer emits a `connection-close` event for each attempt. The CLI was deaf to them.

## Verification chain

| Layer | Closed |
|---|---|
| Source-level repro via direct `bun run` script | ✓ |
| Compiled SEA binary (`bun build --compile`) with the customer-shape `--collaboration-json` invocation | ✓ |
| Customer's exact symptoms reproduced: 10s wait, zero sockets in `lsof`, generic timeout envelope | ✓ |
| Side-by-side before/after envelope comparison (below) | ✓ |
| Full CLI test suite green (1244 pass, 0 fail, 6 new tests) | ✓ |

## Before / after envelope (SEA binary, customer-shape invocation)

Command (identical in both runs):

```bash
./apps/cli/dist/superdoc open --session x --collaboration-json \
  '{"providerType":"y-websocket","url":"wss://unreachable.invalid/","documentId":"x","syncTimeoutMs":10000}'
```

**Before this PR:**

```json
{
  "ok": false,
  "error": {
    "code": "COLLABORATION_SYNC_TIMEOUT",
    "message": "Collaboration sync timed out after 10000ms.",
    "details": { "timeoutMs": 10000 }
  }
}
```

**After this PR:**

```json
{
  "ok": false,
  "error": {
    "code": "COLLABORATION_SYNC_TIMEOUT",
    "message": "Collaboration sync timed out after 10000ms.",
    "details": {
      "timeoutMs": 10000,
      "attempts": 5,
      "lastErrors": [
        { "at": 606,  "code": 1006, "reason": "Failed to connect" },
        { "at": 1406, "code": 1006, "reason": "WebSocket connection to '...' failed: Failed to connect" },
        { "at": 3008, "code": 1006, "reason": "Failed to connect" },
        { "at": 5510, "code": 1006, "reason": "WebSocket connection to '...' failed: Failed to connect" },
        { "at": 8011, "code": 1006, "reason": "Failed to connect" }
      ]
    }
  }
}
```

The `reason` field is the actionable piece. For a real broker:

- TLS handshake failure → `code: 1015` / `reason: "TLS handshake failed"`.
- Auth rejected → custom 4xxx close code with broker-specific reason.
- Bad path → 1006 + broker's HTTP upgrade reject text.
- DNS failure → `code: 1006` + the WebSocket layer's URL-included reason.

## Design notes

- **Same error code** (`COLLABORATION_SYNC_TIMEOUT`). Any SDK consumer matching on the code keeps working. The `details` additions are non-breaking — extra fields, never removed.
- **Bounded buffer** of 5 entries. Sufficient to convey the retry pattern (y-websocket's exponential backoff lands ~7 failures in 10s), prevents unbounded growth.
- **Only `connection-close` subscribed**, not `connection-error`. They always pair-fire; the close event carries structured `code` + `reason`; subscribing to both would duplicate without adding info.
- **Defensive narrowing** on the event payload. y-websocket / Hocuspocus close events are loosely typed (browser CloseEvent or close-event-shaped object). `toFailureRecord` accepts `unknown` and only sets `code`/`reason` if they're the right primitive types.
- **No behaviour change for the success path**. If `synced` fires before the timeout, `details` shape stays identical to before (just `{ timeoutMs }`).

## What's intentionally out of scope (follow-ups)

| Item | Why deferred |
|---|---|
| Fail-fast on N consecutive errors (`failFastOnConnectError` profile flag) | Tighter scope. Customer's primary pain is the silence, not the duration. Once errors surface, 10s is acceptable. Filing a follow-up. |
| Same surfacing on the Liveblocks runtime | Separate file (`liveblocks.ts`), separate provider event surface. Worth a parallel PR. |
| Real-time stderr streaming of `connection-error`/`connection-close` | UX feature, separable. JSON envelope is enough for the customer's stated need. |

## Answer to the customer's `BUN_OPTIONS=--inspect-wait` question

Yes, Bun-compiled SEA binaries support it. The inspector is statically linked into the Bun runtime, so `BUN_OPTIONS="--inspect-wait=ws://localhost:6499"` on the SEA executable will block on startup until a debugger attaches via debug.bun.sh. With this PR shipped, the customer probably won't need it — they'll get the close code/reason directly in their error output — but it's there as a fallback if a deeper investigation is ever needed.

## Test plan

### Unit (6 new in `runtime.test.ts`)
- Success path produces no failure details.
- Timeout error includes captured `connection-close` events with code + reason.
- Captured failures are bounded to the last 5 (fire 8, expect last 5 retained in order).
- Success after transient failures still resolves cleanly (no error details cruft).
- Timeout without any failures keeps the legacy `details` shape (`attempts`/`lastErrors` omitted).
- Graceful handling of malformed close events (missing/undefined `code` or `reason`).

### Manual (against compiled SEA binary)
- Customer-shape `--collaboration-json` invocation against an unreachable host → enriched envelope (above).
- Customer-shape invocation against a working local broker → no error envelope, document opens normally.

### Suites
- [x] `pnpm --filter @superdoc-dev/cli test` — **1244 pass, 0 fail, 8252 expect()**, 51 files.

## Acceptance criteria

- [x] Failed WSS connects surface their close code/reason on the timeout error.
- [x] Same error code (`COLLABORATION_SYNC_TIMEOUT`) preserved for backward compatibility.
- [x] No regressions in existing test suite.
- [x] Verified end-to-end against the compiled SEA binary with the documented invocation shape.

## Files changed

| File | Role |
|---|---|
| `apps/cli/src/lib/collaboration/runtime.ts` | Subscribe to `connection-close`, capture into bounded ring, include in timeout details. |
| `apps/cli/src/lib/collaboration/__tests__/runtime.test.ts` | 6 new test cases. |
| `apps/cli/scripts/repro-sd-3233.ts` | Dev tool: standalone harness that wires extra observers to show what the bridge sees during a hang. Useful for any future collab debugging. |

## Related

- Linked issue: IT-1082 (CLI Collab sync timeout).
- Customer report: Slack thread (chynes), Lighthouse-style agent flow.
