### PR TITLE
feat(audit): attribute findings by entry + root bucket (SD-3213d)

### DIFF
--- a/tests/consumer-typecheck/deep-type-audit.README.md
+++ b/tests/consumer-typecheck/deep-type-audit.README.md
@@ -102,6 +102,61 @@ entries (SD-3213 follow-up). Each entry has a stable key
 (`kind|file|symbolPath|snippet`) so reformatting and line shifts won't
 churn it.
 
+## Attribution (SD-3213d)
+
+Each report now prints three breakdowns alongside the historical tier
+and top-files tables, and writes a machine-readable JSON to
+`tmp/deep-type-audit-attribution.json` (gitignored). The point is to
+distinguish supported-root leaks from legacy compat reach from raw
+`./super-editor` noise, so PR 3 can scope a strict gate to the curated
+facade subset without guessing.
+
+The tables in a typical run look like:
+
+```
+[audit] By export entry (reachedFrom; one finding can count under several):
+   1237  .
+    728  ./super-editor
+     79  ./ui/react
+     70  ./headless-toolbar
+     56  ./types
+     ...
+
+[audit] By root bucket (only for findings reached from root '.'):
+    950  supported-root
+    190  legacy-root
+     97  internal-candidate
+
+[audit] Curated facade entries vs raw ./super-editor reach:
+   1089  reached only from curated facade entries
+    324  reached only from ./super-editor
+    404  reached from both
+```
+
+How to read these:
+
+- **By entry** sums to more than the distinct-finding total because one
+  finding can be reachable from several public entries. The same row in
+  the deduped findings table contributes a count to each entry in its
+  `reachedFrom` set.
+- **By root bucket** counts only findings whose `reachedFrom` includes
+  the root entry `.`, attributed via the top-level symbol in
+  `symbolPath` (e.g. `SuperDoc.provider.on(event)` → `SuperDoc` →
+  bucket from `snapshots/superdoc-root-classification.json`). If the
+  top-level parser fails or the symbol isn't in the classification, the
+  finding is counted as `unknown-root-export` so the parse failure rate
+  is visible.
+- **Curated facade vs raw** partitions every distinct finding into one
+  of three buckets (sums to the distinct total). "Curated facade
+  entries" means every public entry except `./super-editor` — i.e. the
+  set of entries routing through `src/public/**`. PR 3's strict scope
+  will live somewhere in this partition.
+
+The JSON artifact mirrors the text breakdown and also lists every
+finding with its `reachedFrom` and `rootBuckets` sets, so downstream
+tooling (e.g. PR 3's strict-scope selector) does not need to re-run the
+walker.
+
 ## Commands
 
 ```bash

--- a/tests/consumer-typecheck/deep-type-audit.mjs
+++ b/tests/consumer-typecheck/deep-type-audit.mjs
@@ -442,10 +442,51 @@ for (const root of roots) {
 function keyOf(f) {
   return [f.kind, f.file, f.symbolPath, f.snippet].join('|');
 }
+// Dedup preserves the existing stable key (kind|file|symbolPath|snippet)
+// so allowlist identity does not churn. SD-3213d enriches each deduped
+// row with attribution: `reachedFrom` is the set of package export entries
+// (subpaths) through which the same finding was recorded. The first
+// observation's other fields (line, symbolPath, etc.) win the row.
 const distinctFindings = new Map();
 for (const f of findings) {
   const k = keyOf(f);
-  if (!distinctFindings.has(k)) distinctFindings.set(k, f);
+  if (!distinctFindings.has(k)) {
+    distinctFindings.set(k, { ...f, reachedFrom: new Set([f.subpath]) });
+  } else {
+    distinctFindings.get(k).reachedFrom.add(f.subpath);
+  }
+}
+
+// SD-3213d: attribute root-entry findings to their root-classification
+// bucket (supported-root / legacy-root / internal-candidate). The
+// classification artifact lives in-repo, not in the installed fixture.
+// For findings not reached from the root entry, `rootBuckets` stays empty.
+// For root-reached findings whose top-level symbol isn't in the
+// classification, `rootBuckets` is ['unknown-root-export'] (counted
+// explicitly so reviewers can see the parse failure rate).
+const classificationPath = resolve(here, 'snapshots', 'superdoc-root-classification.json');
+const classification = existsSync(classificationPath)
+  ? JSON.parse(readFileSync(classificationPath, 'utf8'))
+  : { rows: [] };
+const rootBucketByName = new Map(classification.rows.map((r) => [r.name, r.bucket]));
+
+// symbolPath starts with the root export name followed by `.member`,
+// `(param)`, `[]`, `<N>`, `=>return`, `.<value>`, etc. The top-level
+// segment is everything before the first member/param/index/generic
+// boundary.
+function topLevelSymbolFrom(symbolPath) {
+  const m = symbolPath.match(/^([^.([<=]+)/);
+  return m ? m[1] : null;
+}
+
+for (const f of distinctFindings.values()) {
+  const buckets = new Set();
+  if (f.reachedFrom.has('.')) {
+    const top = topLevelSymbolFrom(f.symbolPath);
+    const bucket = top ? rootBucketByName.get(top) : null;
+    buckets.add(bucket ?? 'unknown-root-export');
+  }
+  f.rootBuckets = buckets;
 }
 
 const allowlistPath = resolve(here, 'deep-type-audit.allowlist.json');
@@ -533,6 +574,73 @@ console.log(``);
 console.log(`[audit] Top files:`);
 for (const [k, v] of Object.entries(fileCounts).sort((a, b) => b[1] - a[1]).slice(0, 10)) {
   console.log(`  ${v.toString().padStart(5)}  ${k}`);
+}
+
+// SD-3213d attribution tables. The point of these breakdowns is to
+// distinguish supported-root leaks from legacy compat reach from raw
+// ./super-editor noise, so PR 3 can scope the strict gate to the
+// curated facade subset without guessing.
+const entryCounts = {};
+const rootBucketCounts = {};
+let curatedOnly = 0;
+let rawOnly = 0;
+let both = 0;
+for (const f of tieredFindings) {
+  for (const e of f.reachedFrom) entryCounts[e] = (entryCounts[e] ?? 0) + 1;
+  for (const b of f.rootBuckets) rootBucketCounts[b] = (rootBucketCounts[b] ?? 0) + 1;
+  const reachesCurated = [...f.reachedFrom].some((e) => e !== './super-editor');
+  const reachesRaw = f.reachedFrom.has('./super-editor');
+  if (reachesCurated && reachesRaw) both++;
+  else if (reachesCurated) curatedOnly++;
+  else if (reachesRaw) rawOnly++;
+}
+console.log(``);
+console.log(`[audit] By export entry (reachedFrom; one finding can count under several):`);
+for (const [k, v] of Object.entries(entryCounts).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${v.toString().padStart(5)}  ${k}`);
+}
+console.log(``);
+console.log(`[audit] By root bucket (only for findings reached from root '.'):`);
+for (const [k, v] of Object.entries(rootBucketCounts).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${v.toString().padStart(5)}  ${k}`);
+}
+console.log(``);
+console.log(`[audit] Curated facade entries vs raw ./super-editor reach:`);
+console.log(`  ${curatedOnly.toString().padStart(5)}  reached only from curated facade entries`);
+console.log(`  ${rawOnly.toString().padStart(5)}  reached only from ./super-editor`);
+console.log(`  ${both.toString().padStart(5)}  reached from both`);
+
+// JSON attribution report. Lives under tmp/ (gitignored). PR 3 reads
+// this to drive strict-scope selection without re-running the walker.
+const tmpDir = resolve(repoRoot, 'tmp');
+try {
+  require('node:fs').mkdirSync(tmpDir, { recursive: true });
+  const reportPath = join(tmpDir, 'deep-type-audit-attribution.json');
+  const report = {
+    generatedAt: new Date().toISOString(),
+    totals: {
+      distinct: distinctFindings.size,
+      byTier: tierCounts,
+      byEntry: entryCounts,
+      byRootBucket: rootBucketCounts,
+      curatedFacadeVsRaw: { curatedOnly, rawOnly, both },
+    },
+    findings: tieredFindings.map((f) => ({
+      kind: f.kind,
+      file: f.file,
+      line: f.line,
+      symbolPath: f.symbolPath,
+      snippet: f.snippet,
+      tier: f.tier,
+      reachedFrom: [...f.reachedFrom].sort(),
+      rootBuckets: [...f.rootBuckets].sort(),
+    })),
+  };
+  writeFileSync(reportPath, JSON.stringify(report, null, 2) + '\n');
+  console.log(``);
+  console.log(`[audit] Wrote attribution report: ${relative(repoRoot, reportPath)}`);
+} catch (err) {
+  console.warn(`[audit] WARN: could not write attribution report: ${err.message}`);
 }
 
 const haveAllowlist = existsSync(allowlistPath);


### PR DESCRIPTION
Adds per-finding attribution to \`deep-type-audit.mjs\` so the strict-gate work (next PR) can scope to the curated facade subset without guessing which findings are supported-root leaks vs legacy compat reach vs raw \`./super-editor\` noise. Report-only — no new CI failure mode.

- Each deduped finding gains \`reachedFrom\` and \`rootBuckets\`. In memory these are Sets; the JSON serializes them as sorted arrays. Stable dedup key (\`kind|file|symbolPath|snippet\`) is preserved.
- Three new text tables printed: by export entry, by root bucket (root-reached only), curated-facade vs raw \`./super-editor\`.
- Machine-readable JSON at \`tmp/deep-type-audit-attribution.json\` (gitignored).
- Root-bucket attribution parses the top-level symbol from \`symbolPath\` and joins against \`superdoc-root-classification.json\`. Parser succeeded on every root finding in the current corpus (zero \`unknown-root-export\`).

**Review**: this PR reorganizes signal, it does not fix more \`any\`s. Finding counts and tier totals are unchanged from before.

**Verified**: build exit 0; matrix 57/57; audit reports 1817 distinct (same as before), attribution partition arithmetic checks (1089 curated-only + 324 raw-only + 404 both = 1817 distinct).