### PR TITLE
feat(audit): supported-root strict no-new-any gate (SD-3213e)

### DIFF
--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -132,19 +132,16 @@ jobs:
           cd tests/consumer-typecheck
           node typecheck-matrix.mjs
 
-      - name: Deep public-type audit (report-only)
-        # Recursive walk of every type reachable from superdoc's public
-        # exports in the installed tarball. Reports inventory by tier and
-        # top files. Always exits 0 in default mode; the `--strict` flag
-        # turns it into a hard gate but is not used in CI yet. The facade
-        # landed in SD-3212 PR C, but the audit still walks broad legacy
-        # surfaces like `./super-editor`, so strict-on-everything would
-        # gate on ~1.8k findings dominated by legacy reach. Tracked under
-        # SD-3213 follow-up: scope to curated facade entries, then make
-        # strict.
-        run: |
-          cd tests/consumer-typecheck
-          node deep-type-audit.mjs
+      - name: Deep public-type audit (supported-root strict, SD-3213e)
+        # Single invocation does both: (1) prints the broad inventory
+        # (tier counts, top files, entry/root-bucket attribution) for
+        # visibility, and (2) gates on the supported-root subset against
+        # `deep-type-audit.supported-root-allowlist.json`. Fails on any
+        # new `any` finding reachable from root `.` via an export
+        # classified as `supported-root`, AND on stale entries (a drain
+        # landed but the allowlist wasn't shrunk). The broad audit
+        # remains report-only because it includes legacy/raw reach.
+        run: node tests/consumer-typecheck/deep-type-audit.mjs --strict-supported-root
 
       - name: Package shape gates
         # External package-shape linters (publint + attw) running against

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -119,10 +119,10 @@ jobs:
           cd tests/consumer-typecheck
           node typecheck-matrix.mjs
 
-      - name: Deep public-type audit (report-only)
-        run: |
-          cd tests/consumer-typecheck
-          node deep-type-audit.mjs
+      - name: Deep public-type audit (supported-root strict, SD-3213e)
+        # Single invocation: broad inventory + supported-root strict gate.
+        # Same gate as PR CI. Catches releases that bypass PR CI.
+        run: node tests/consumer-typecheck/deep-type-audit.mjs --strict-supported-root
 
       - name: Package shape gates
         run: node tests/consumer-typecheck/package-shape-gate.mjs

--- a/.github/workflows/release-superdoc.yml
+++ b/.github/workflows/release-superdoc.yml
@@ -136,14 +136,11 @@ jobs:
           cd tests/consumer-typecheck
           node typecheck-matrix.mjs
 
-      - name: Deep public-type audit (report-only)
-        # Inventory pass: same as PR CI. Not strict yet. The facade landed
-        # in SD-3212 PR C, but the audit still walks broad legacy surfaces
-        # like `./super-editor`. Tracked under SD-3213 follow-up: scope to
-        # curated facade entries, then swap in `--strict`.
-        run: |
-          cd tests/consumer-typecheck
-          node deep-type-audit.mjs
+      - name: Deep public-type audit (supported-root strict, SD-3213e)
+        # Same gate as PR CI. One invocation prints the broad inventory
+        # AND runs the supported-root strict gate against the committed
+        # allowlist. Catches releases that bypass PR CI.
+        run: node tests/consumer-typecheck/deep-type-audit.mjs --strict-supported-root
 
       - name: Package shape gates
         # External package-shape linters (publint + attw) running against

--- a/tests/consumer-typecheck/deep-type-audit.README.md
+++ b/tests/consumer-typecheck/deep-type-audit.README.md
@@ -157,25 +157,81 @@ finding with its `reachedFrom` and `rootBuckets` sets, so downstream
 tooling (e.g. PR 3's strict-scope selector) does not need to re-run the
 walker.
 
+## Supported-root strict gate (SD-3213e)
+
+The first real public-contract no-new-any gate. Filters findings to the
+subset whose `rootBuckets` includes `supported-root` (i.e. reached from
+root entry `.` via an export that the SD-3212 classification labels as
+supported public API) and compares them against a committed allowlist.
+
+- Allowlist file: `tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json`.
+- **The allowlist is current known debt, not accepted API quality.**
+  Drain PRs reduce it; the gate fails on stale entries to force the
+  reduction to be recorded.
+- Excludes `legacy-root`, `internal-candidate`, and raw `./super-editor`
+  reach. Each has its own drain story (legacy = compat, internal-candidate
+  = should be hidden, raw = redesign) and would obscure the
+  supported-root signal if mixed in.
+- CI invokes one command (`--strict-supported-root`) that prints the
+  broad inventory AND runs the gate. No second workflow step.
+- Top offender files + symbols are printed on every run so drain PRs
+  know where to start.
+
+```bash
+# CI invocation: broad report + supported-root strict gate, one process.
+node tests/consumer-typecheck/deep-type-audit.mjs --strict-supported-root
+
+# Seed or regenerate the supported-root allowlist (after a drain or
+# when seeding for the first time).
+node tests/consumer-typecheck/deep-type-audit.mjs --pack --write --strict-supported-root
+```
+
+## Gate map (which gate owns what)
+
+Multiple gates run against the public surface; each owns a distinct
+failure class. Before adding a new gate, check whether one of these
+already covers the concern.
+
+| Gate | Owns |
+|---|---|
+| `typecheck-matrix.mjs` | Consumer `tsc --noEmit` across module modes (Bundler / Node16 / NodeNext). Catches **resolution errors and missing exports**. |
+| `deep-type-audit.mjs` | Recursive `any` detection on every type reachable from public exports. Owns the **supported-root strict gate** (`--strict-supported-root`). |
+| `package-shape-gate.mjs` | `publint` + `attw --pack`. Catches **manifest issues**: condition ordering, masquerading ESM, missing CDN files, unpublished `source` paths. |
+| `snapshot.mjs` | Drift detection on three export inventories (super-editor package keys, legacy subpath resolved exports, root 4-source inventory). Catches **silent surface growth**. |
+| `check-root-classification-closure.mjs` | Dependency-closure rule: no `supported-root` or `legacy-root` export references an `internal-candidate` type in its declared public type. |
+| `verify-public-facade-emit.cjs` | Curated `src/public/**` facade ↔ emitted `.d.ts` parity (symbol set, ESM/CJS parity, leak grep, command signatures). Runs at postbuild. |
+| `audit-declarations.cjs` | Private workspace specifier leaks (`@superdoc/*`) and declaration-emit hygiene. Runs at postbuild. |
+
+Each gate runs once. PRs should extend an existing gate before adding
+a new one — see SD-3213e (PR which added the supported-root mode to
+the existing `deep-type-audit.mjs` rather than introducing a new
+script).
+
 ## Commands
 
 ```bash
 # Default: report-only inventory. Prints findings, always exits 0
-# (unless the script itself errors). Used by CI today.
+# (unless the script itself errors).
 node tests/consumer-typecheck/deep-type-audit.mjs
 
 # Pack + install superdoc into the fixture, then run inventory
 node tests/consumer-typecheck/deep-type-audit.mjs --pack
 
-# Strict mode: fails on findings if no allowlist exists, or on
-# new/stale entries if an allowlist exists. NOT used in CI today;
-# becomes the gate once the audit is scoped to the curated facade
-# entries (SD-3213 follow-up).
+# Supported-root strict gate (CI). Prints broad inventory AND fails on
+# new/stale entries in the supported-root allowlist.
+node tests/consumer-typecheck/deep-type-audit.mjs --strict-supported-root
+
+# Broad strict mode: fails on findings against the broad allowlist.
+# Not used in CI yet — the broad allowlist would be ~1.8k entries
+# dominated by legacy reach. Reserved for future work.
 node tests/consumer-typecheck/deep-type-audit.mjs --strict
 
-# Seed or regenerate deep-type-audit.allowlist.json from current findings
-# (intended for use once the audit is scoped to the curated facade)
+# Seed or regenerate the broad allowlist.
 node tests/consumer-typecheck/deep-type-audit.mjs --write
+
+# Seed or regenerate the supported-root allowlist (run after a drain
+# PR to shrink the baseline).
+node tests/consumer-typecheck/deep-type-audit.mjs --pack --write --strict-supported-root
 ```
 
 ## Updating the allowlist

--- a/tests/consumer-typecheck/deep-type-audit.mjs
+++ b/tests/consumer-typecheck/deep-type-audit.mjs
@@ -17,10 +17,13 @@
  *     for visibility but does not block CI on its own.
  *
  * Run:
- *   node deep-type-audit.mjs                # check against allowlist (CI mode)
- *   node deep-type-audit.mjs --pack         # pack+install before checking
- *   node deep-type-audit.mjs --write        # regenerate allowlist from current findings
- *   node deep-type-audit.mjs --report-only  # print findings, never fail
+ *   node deep-type-audit.mjs                          # report-only inventory (default)
+ *   node deep-type-audit.mjs --pack                   # pack+install before running
+ *   node deep-type-audit.mjs --strict-supported-root  # CI gate (SD-3213e)
+ *   node deep-type-audit.mjs --strict                 # broad strict mode (not in CI)
+ *   node deep-type-audit.mjs --write                  # regenerate broad allowlist
+ *   node deep-type-audit.mjs --pack --write --strict-supported-root
+ *                                                     # regenerate supported-root allowlist
  *
  * The fixture is intentionally outside the pnpm workspace so this audits
  * the customer-visible surface, not workspace symlinks. Install pattern
@@ -50,10 +53,17 @@ const doWrite = args.has('--write');
 // facade entries (SD-3213 follow-up), strict-on-everything would gate
 // on ~1.8k findings dominated by legacy reach.
 const doStrict = args.has('--strict');
+// SD-3213e: scoped strict gate. Filters findings to the supported-root
+// subset (rootBuckets includes 'supported-root') and compares against
+// `deep-type-audit.supported-root-allowlist.json`. Fails on new findings
+// (regression) AND stale entries (a drain landed; allowlist must shrink).
+// Orthogonal to `--strict` and `--pack`. Wired into CI as the first real
+// no-new-any gate for the public contract.
+const doStrictSupportedRoot = args.has('--strict-supported-root');
 // Legacy alias: previous versions exposed `--report-only` as the way to
 // opt out of failing CI. The default is now report-only, so this flag
 // becomes a no-op (kept so existing invocations don't break).
-const reportOnly = args.has('--report-only') || !doStrict;
+const reportOnly = args.has('--report-only') || (!doStrict && !doStrictSupportedRoot);
 
 // -- Optional pack + install (must run BEFORE requiring typescript so a
 // fresh checkout where tests/consumer-typecheck/node_modules is empty can
@@ -506,6 +516,35 @@ for (const [key, f] of distinctFindings) {
 }
 const staleAllowlistKeys = [...remainingAllowlist];
 
+// SD-3213e: supported-root scoped gate. The broad allowlist above tracks
+// everything; this scoped one tracks ONLY findings reachable from root
+// '.' whose top-level symbol is classified as `supported-root`. That is
+// the subset that directly affects documented consumer IntelliSense.
+// Legacy-root, internal-candidate, and raw `./super-editor` reach are
+// intentionally excluded from this first strict gate; each has its own
+// drain story (legacy = compat, internal-candidate = should be hidden,
+// raw = redesign).
+const supportedRootAllowlistPath = resolve(here, 'deep-type-audit.supported-root-allowlist.json');
+const supportedRootAllowlist = existsSync(supportedRootAllowlistPath)
+  ? JSON.parse(readFileSync(supportedRootAllowlistPath, 'utf8'))
+  : { version: 1, generatedAt: null, entries: [] };
+const supportedRootAllowlistByKey = new Map(supportedRootAllowlist.entries.map((e) => [e.key, e]));
+
+const supportedRootFindings = new Map();
+for (const [key, f] of distinctFindings) {
+  if (f.rootBuckets.has('supported-root')) supportedRootFindings.set(key, f);
+}
+const newSupportedRoot = [];
+const remainingSupportedRoot = new Set(supportedRootAllowlistByKey.keys());
+for (const [key, f] of supportedRootFindings) {
+  if (supportedRootAllowlistByKey.has(key)) {
+    remainingSupportedRoot.delete(key);
+  } else {
+    newSupportedRoot.push({ key, ...f });
+  }
+}
+const staleSupportedRootKeys = [...remainingSupportedRoot];
+
 // -- Owner classification helper (used when seeding the allowlist) ---------
 function classifyOwner(f) {
   if (f.owner === 'upstream') return 'upstream';
@@ -523,7 +562,34 @@ function classifyOwner(f) {
 }
 
 // -- Write mode -----------------------------------------------------------
+// `--write` interacts with the scope flag: with `--strict-supported-root`,
+// it regenerates only the supported-root allowlist; otherwise it
+// regenerates the broad allowlist.
 if (doWrite) {
+  if (doStrictSupportedRoot) {
+    const sorted = [...supportedRootFindings.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const next = {
+      version: 1,
+      scope: 'supported-root',
+      generatedAt: new Date().toISOString(),
+      entries: sorted.map(([key, f]) => {
+        const existing = supportedRootAllowlistByKey.get(key);
+        return {
+          key,
+          kind: f.kind,
+          symbolPath: f.symbolPath,
+          file: f.file,
+          line: f.line,
+          snippet: f.snippet,
+          owner: existing?.owner ?? classifyOwner(f),
+          rationale: existing?.rationale ?? `auto-seeded from inventory (supported-root scope)`,
+        };
+      }),
+    };
+    writeFileSync(supportedRootAllowlistPath, JSON.stringify(next, null, 2) + '\n');
+    console.log(`[audit] Wrote supported-root allowlist with ${next.entries.length} entries to ${relative(repoRoot, supportedRootAllowlistPath)}`);
+    process.exit(0);
+  }
   const sorted = [...distinctFindings.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
   const next = {
     version: 1,
@@ -670,15 +736,89 @@ if (haveAllowlist) {
   }
 } else {
   console.log(``);
-  console.log(`[audit] No allowlist present (deep-type-audit.allowlist.json).`);
-  console.log(`[audit] Inventory-only mode. The facade landed in SD-3212 PR C, but the audit still walks broad legacy surfaces (e.g. ./super-editor),`);
-  console.log(`[audit] so a strict allowlist isn't seeded yet. Tracked under SD-3213 follow-up: scope to curated facade entries, then make strict.`);
+  console.log(`[audit] No broad allowlist present (deep-type-audit.allowlist.json).`);
+  console.log(`[audit] The supported-root strict gate runs separately (--strict-supported-root); see the [supported-root] section below.`);
 }
 
-if (!doStrict) {
+// SD-3213e: supported-root strict gate report. Always print when there
+// is a supported-root allowlist, regardless of mode, so reviewers see
+// drain progress and top offenders even in report-only runs.
+const haveSupportedRootAllowlist = existsSync(supportedRootAllowlistPath);
+if (haveSupportedRootAllowlist) {
   console.log(``);
-  console.log(`[audit] PASS (report-only mode; pass --strict to gate CI on findings)`);
+  console.log(`[audit] [supported-root] Allowlist (current debt): ${supportedRootAllowlist.entries.length} entries`);
+  console.log(`[audit] [supported-root] Current findings: ${supportedRootFindings.size}`);
+  console.log(`[audit] [supported-root] New (not in allowlist): ${newSupportedRoot.length}`);
+  console.log(`[audit] [supported-root] Stale (in allowlist, drained): ${staleSupportedRootKeys.length}`);
+
+  // Top offenders: which files contribute the most to remaining debt. Drain
+  // PRs should start from here. Counts come from the CURRENT findings set
+  // (not the allowlist) so newly-introduced files surface too.
+  const offenderByFile = {};
+  const offenderBySymbol = {};
+  for (const f of supportedRootFindings.values()) {
+    offenderByFile[f.file] = (offenderByFile[f.file] ?? 0) + 1;
+    const top = (f.symbolPath.match(/^([^.([<=]+)/) ?? [])[1] ?? '?';
+    offenderBySymbol[top] = (offenderBySymbol[top] ?? 0) + 1;
+  }
+  console.log(``);
+  console.log(`[audit] [supported-root] Top offender files (drain targets):`);
+  for (const [k, v] of Object.entries(offenderByFile).sort((a, b) => b[1] - a[1]).slice(0, 5)) {
+    console.log(`  ${v.toString().padStart(5)}  ${k}`);
+  }
+  console.log(``);
+  console.log(`[audit] [supported-root] Top offender root symbols:`);
+  for (const [k, v] of Object.entries(offenderBySymbol).sort((a, b) => b[1] - a[1]).slice(0, 5)) {
+    console.log(`  ${v.toString().padStart(5)}  ${k}`);
+  }
+
+  if (newSupportedRoot.length > 0) {
+    console.log(``);
+    console.log(`[audit] [supported-root] NEW FINDINGS (regression):`);
+    for (const f of newSupportedRoot.slice(0, 50)) {
+      console.log(`  + ${f.kind}  ${f.symbolPath}`);
+      console.log(`        ${f.file}:${f.line}`);
+      console.log(`        ${f.snippet}`);
+    }
+    if (newSupportedRoot.length > 50) console.log(`  ... and ${newSupportedRoot.length - 50} more`);
+  }
+  if (staleSupportedRootKeys.length > 0) {
+    console.log(``);
+    console.log(`[audit] [supported-root] STALE (drain landed; allowlist must shrink):`);
+    for (const k of staleSupportedRootKeys.slice(0, 50)) {
+      const e = supportedRootAllowlistByKey.get(k);
+      console.log(`  - ${e.kind}  ${e.symbolPath}  (${e.file}:${e.line})`);
+    }
+    if (staleSupportedRootKeys.length > 50) console.log(`  ... and ${staleSupportedRootKeys.length - 50} more`);
+  }
+}
+
+if (!doStrict && !doStrictSupportedRoot) {
+  console.log(``);
+  console.log(`[audit] PASS (report-only mode; pass --strict or --strict-supported-root to gate CI on findings)`);
   process.exit(0);
+}
+
+if (doStrictSupportedRoot) {
+  if (!haveSupportedRootAllowlist && supportedRootFindings.size > 0) {
+    console.log(``);
+    console.log(`[audit] FAIL (--strict-supported-root): no supported-root allowlist exists yet but findings are present.`);
+    console.log(`[audit] - To seed the allowlist, run: node deep-type-audit.mjs --pack --write --strict-supported-root`);
+    process.exit(1);
+  }
+  if (haveSupportedRootAllowlist && (newSupportedRoot.length > 0 || staleSupportedRootKeys.length > 0)) {
+    console.log(``);
+    console.log(`[audit] FAIL (--strict-supported-root)`);
+    console.log(`[audit] - The allowlist is current known debt, not accepted API. New entries are regressions.`);
+    console.log(`[audit] - Stale entries mean a drain landed; the allowlist must shrink (run --write to regenerate).`);
+    console.log(`[audit] - To accept an intentional new finding (rare), run: node deep-type-audit.mjs --pack --write --strict-supported-root`);
+    process.exit(1);
+  }
+  if (!doStrict) {
+    console.log(``);
+    console.log(`[audit] PASS (--strict-supported-root)`);
+    process.exit(0);
+  }
 }
 
 if (haveAllowlist && (newFindings.length > 0 || staleAllowlistKeys.length > 0)) {

--- a/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
+++ b/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
@@ -1,0 +1,9507 @@
+{
+  "version": 1,
+  "scope": "supported-root",
+  "generatedAt": "2026-05-20T18:55:13.670Z",
+  "entries": [
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.converter[string]|converter: SuperConverter;",
+      "kind": "index",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.converter[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 146,
+      "snippet": "converter: SuperConverter;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.extensionService[string]|extensionService: ExtensionService;",
+      "kind": "index",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.extensionService[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 104,
+      "snippet": "extensionService: ExtensionService;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Extensions.<value>.Node.new(config).editor.converter[string]|converter: SuperConverter;",
+      "kind": "index",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.converter[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 146,
+      "snippet": "converter: SuperConverter;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Extensions.<value>.Node.new(config).editor.extensionService[string]|extensionService: ExtensionService;",
+      "kind": "index",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.extensionService[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 104,
+      "snippet": "extensionService: ExtensionService;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.converter[string]|converter: SuperConverter;",
+      "kind": "index",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.converter[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 146,
+      "snippet": "converter: SuperConverter;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.extensionService[string]|extensionService: ExtensionService;",
+      "kind": "index",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.extensionService[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 104,
+      "snippet": "extensionService: ExtensionService;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.converter[string]|converter: SuperConverter;",
+      "kind": "index",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.converter[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 146,
+      "snippet": "converter: SuperConverter;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.extensionService[string]|extensionService: ExtensionService;",
+      "kind": "index",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.extensionService[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 104,
+      "snippet": "extensionService: ExtensionService;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|defineNode.<value>(config).editor.converter[string]|converter: SuperConverter;",
+      "kind": "index",
+      "symbolPath": "defineNode.<value>(config).editor.converter[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 146,
+      "snippet": "converter: SuperConverter;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|defineNode.<value>(config).editor.extensionService[string]|extensionService: ExtensionService;",
+      "kind": "index",
+      "symbolPath": "defineNode.<value>(config).editor.extensionService[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 104,
+      "snippet": "extensionService: ExtensionService;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.converter[string]|converter: SuperConverter;",
+      "kind": "index",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.converter[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 146,
+      "snippet": "converter: SuperConverter;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.extensionService[string]|extensionService: ExtensionService;",
+      "kind": "index",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.extensionService[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 104,
+      "snippet": "extensionService: ExtensionService;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.emit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.emit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.off(fn)<0>[number]|fn?: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.off(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 45,
+      "snippet": "fn?: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.on(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.on(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.once(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.once(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 52,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.safeEmit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.safeEmit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.emit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.emit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.off(fn)<0>[number]|fn?: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.off(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 45,
+      "snippet": "fn?: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.on(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.on(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.once(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.once(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 52,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.safeEmit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.safeEmit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.emit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.emit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.on(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.on(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.once(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.once(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 52,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.safeEmit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.safeEmit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.emit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.emit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.off(fn)<0>[number]|fn?: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.off(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 45,
+      "snippet": "fn?: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.on(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.on(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.once(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.once(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 52,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.safeEmit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.safeEmit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.emit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "defineNode.<value>(config).editor.emit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.off(fn)<0>[number]|fn?: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "defineNode.<value>(config).editor.off(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 45,
+      "snippet": "fn?: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.on(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "defineNode.<value>(config).editor.on(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.once(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "defineNode.<value>(config).editor.once(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 52,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.safeEmit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "defineNode.<value>(config).editor.safeEmit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.emit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.emit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.off(fn)<0>[number]|fn?: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.off(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 45,
+      "snippet": "fn?: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.on(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.on(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.once(fn)<0>[number]|fn: EventCallback<EventMap[K]>",
+      "kind": "index",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.once(fn)<0>[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 52,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.safeEmit(args)[number]|...args: EventMap[K]",
+      "kind": "index",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.safeEmit(args)[number]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/helpers/getActiveFormatting.d.ts|getActiveFormatting.<value>(editor)|editor: any",
+      "kind": "param",
+      "symbolPath": "getActiveFormatting.<value>(editor)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/helpers/getActiveFormatting.d.ts",
+      "line": 1,
+      "snippet": "editor: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/super-converter/zipper.d.ts|createZip.<value>(blobs)|blobs: any",
+      "kind": "param",
+      "symbolPath": "createZip.<value>(blobs)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/super-converter/zipper.d.ts",
+      "line": 7,
+      "snippet": "blobs: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/super-converter/zipper.d.ts|createZip.<value>(fileNames)|fileNames: any",
+      "kind": "param",
+      "symbolPath": "createZip.<value>(fileNames)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/super-converter/zipper.d.ts",
+      "line": 7,
+      "snippet": "fileNames: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)|event: any",
+      "kind": "param",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)|event: any",
+      "kind": "param",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)|event: any",
+      "kind": "param",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)|event: any",
+      "kind": "param",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.off(event)|event: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.off(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.on(event)|event: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.on(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.off(event)|event: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.provider.off(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.on(event)|event: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.provider.on(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)|event: any",
+      "kind": "param",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)|event: any",
+      "kind": "param",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)|event: any",
+      "kind": "param",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)|event: any",
+      "kind": "param",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "event: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/composables/use-high-contrast-mode.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.highContrastModeStore.setHighContrastMode(value)|value: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.highContrastModeStore.setHighContrastMode(value)",
+      "file": "node_modules/superdoc/dist/superdoc/src/composables/use-high-contrast-mode.d.ts",
+      "line": 3,
+      "snippet": "value: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/composables/use-high-contrast-mode.d.ts|SuperDoc.highContrastModeStore.setHighContrastMode(value)|value: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.highContrastModeStore.setHighContrastMode(value)",
+      "file": "node_modules/superdoc/dist/superdoc/src/composables/use-high-contrast-mode.d.ts",
+      "line": 3,
+      "snippet": "value: any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 86,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 86,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 105,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 67,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 85,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 91,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 91,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 116,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 95,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 110,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 81,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 81,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 101,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 227,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 227,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 246,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 208,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 226,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 232,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 232,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 257,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 236,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 251,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 222,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 222,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 242,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 368,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 368,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 387,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 349,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 367,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 373,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 373,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 398,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 377,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 392,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 363,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 363,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 383,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 86,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 86,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 105,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 67,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 85,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 91,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 91,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 116,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 95,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 110,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 81,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 81,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 101,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 227,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 227,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 246,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 208,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 226,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 232,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 232,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 257,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 236,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 251,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 222,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 222,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 242,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 368,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 368,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 387,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 349,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 367,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 373,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 373,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 398,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 377,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 392,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 363,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 363,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 383,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.getDocument(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.getDocument(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 468,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.getPageBounds(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.getPageBounds(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 469,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.getPageBounds(page)|page: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.getPageBounds(page)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 469,
+      "snippet": "page: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.handlePageReady(containerBounds)|containerBounds: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.handlePageReady(containerBounds)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 467,
+      "snippet": "containerBounds: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.handlePageReady(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.handlePageReady(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 467,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.handlePageReady(index)|index: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.handlePageReady(index)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 467,
+      "snippet": "index: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.init(config)|config: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.init(config)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 464,
+      "snippet": "config: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.setExceptionHandler(handler)|handler: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<1><0>.setExceptionHandler(handler)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 465,
+      "snippet": "handler: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.getDocument(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.getDocument(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 939,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.getPageBounds(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.getPageBounds(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 940,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.getPageBounds(page)|page: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.getPageBounds(page)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 940,
+      "snippet": "page: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.handlePageReady(containerBounds)|containerBounds: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.handlePageReady(containerBounds)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 938,
+      "snippet": "containerBounds: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.handlePageReady(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.handlePageReady(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 938,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.handlePageReady(index)|index: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.handlePageReady(index)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 938,
+      "snippet": "index: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.init(config)|config: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.init(config)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 935,
+      "snippet": "config: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.setExceptionHandler(handler)|handler: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<2><0>.setExceptionHandler(handler)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 936,
+      "snippet": "handler: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.getDocument(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.getDocument(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1410,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.getPageBounds(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.getPageBounds(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1411,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.getPageBounds(page)|page: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.getPageBounds(page)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1411,
+      "snippet": "page: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.handlePageReady(containerBounds)|containerBounds: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.handlePageReady(containerBounds)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1409,
+      "snippet": "containerBounds: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.handlePageReady(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.handlePageReady(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1409,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.handlePageReady(index)|index: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.handlePageReady(index)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1409,
+      "snippet": "index: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.init(config)|config: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.init(config)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1406,
+      "snippet": "config: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.setExceptionHandler(handler)|handler: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore<3><0>.setExceptionHandler(handler)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1407,
+      "snippet": "handler: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 87,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 87,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 106,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 68,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 86,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 92,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 92,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 117,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 96,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 111,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 82,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 82,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 102,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 228,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 228,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 247,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 209,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 227,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 233,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 233,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 258,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 237,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 252,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 223,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 223,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 243,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 369,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 369,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 388,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 350,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 368,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 374,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 374,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 399,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 378,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 393,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 364,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 364,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 384,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.getDocument(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.getDocument(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 468,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.getPageBounds(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.getPageBounds(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 469,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.getPageBounds(page)|page: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.getPageBounds(page)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 469,
+      "snippet": "page: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.handlePageReady(containerBounds)|containerBounds: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.handlePageReady(containerBounds)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 467,
+      "snippet": "containerBounds: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.handlePageReady(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.handlePageReady(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 467,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.handlePageReady(index)|index: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.handlePageReady(index)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 467,
+      "snippet": "index: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.init(config)|config: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.init(config)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 464,
+      "snippet": "config: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.setExceptionHandler(handler)|handler: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.setExceptionHandler(handler)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 465,
+      "snippet": "handler: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 558,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 558,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 577,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 539,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 557,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 563,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 563,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 588,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 567,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 582,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 553,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 553,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 573,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 699,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 699,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 718,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 680,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 698,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 704,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 704,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 729,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 708,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 723,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 694,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 694,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 714,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 840,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 840,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 859,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 821,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 839,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 845,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 845,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 870,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 849,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 864,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 835,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 835,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 855,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.getDocument(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.getDocument(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 939,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.getPageBounds(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.getPageBounds(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 940,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.getPageBounds(page)|page: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.getPageBounds(page)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 940,
+      "snippet": "page: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.handlePageReady(containerBounds)|containerBounds: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.handlePageReady(containerBounds)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 938,
+      "snippet": "containerBounds: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.handlePageReady(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.handlePageReady(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 938,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.handlePageReady(index)|index: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.handlePageReady(index)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 938,
+      "snippet": "index: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.init(config)|config: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.init(config)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 935,
+      "snippet": "config: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.setExceptionHandler(handler)|handler: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.setExceptionHandler(handler)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 936,
+      "snippet": "handler: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1029,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1029,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1048,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1010,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1028,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1034,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1034,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1059,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1038,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1053,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1024,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1024,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1044,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1170,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1170,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1189,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1151,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1169,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1175,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1175,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1200,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1179,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1194,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1165,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1165,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1185,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.belongsToDocument(activeDocumentId)|activeDocumentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.belongsToDocument(activeDocumentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1311,
+      "snippet": "activeDocumentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.belongsToDocument(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.belongsToDocument(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1311,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.cancelComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.cancelComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1330,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentAliasIds(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentAliasIds(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1292,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentDocumentId(comment)|comment: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentDocumentId(comment)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1310,
+      "snippet": "comment: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentLocation(parent)|parent: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentLocation(parent)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1316,
+      "snippet": "parent: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentLocation(selection)|selection: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentLocation(selection)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1316,
+      "snippet": "selection: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.handleEditorLocationsUpdate(allCommentPositions)|allCommentPositions: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.handleEditorLocationsUpdate(allCommentPositions)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1341,
+      "snippet": "allCommentPositions: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.hasOverlapId(id)|id: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.hasOverlapId(id)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1320,
+      "snippet": "id: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.removePendingComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.removePendingComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1335,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.resolveCommentPositionEntry(commentOrId)|commentOrId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.resolveCommentPositionEntry(commentOrId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1306,
+      "snippet": "commentOrId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.resolveCommentPositionEntry(preferredId)|preferredId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.resolveCommentPositionEntry(preferredId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1306,
+      "snippet": "preferredId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.showAddComment(superdoc)|superdoc: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.showAddComment(superdoc)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1326,
+      "snippet": "superdoc: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.getDocument(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.getDocument(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1410,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.getPageBounds(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.getPageBounds(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1411,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.getPageBounds(page)|page: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.getPageBounds(page)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1411,
+      "snippet": "page: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.handlePageReady(containerBounds)|containerBounds: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.handlePageReady(containerBounds)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1409,
+      "snippet": "containerBounds: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.handlePageReady(documentId)|documentId: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.handlePageReady(documentId)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1409,
+      "snippet": "documentId: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.handlePageReady(index)|index: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.handlePageReady(index)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1409,
+      "snippet": "index: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.init(config)|config: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.init(config)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1406,
+      "snippet": "config: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "param|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.setExceptionHandler(handler)|handler: any",
+      "kind": "param",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.setExceptionHandler(handler)",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1407,
+      "snippet": "handler: any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand(__0).argument|argument?: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand(__0).argument",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 581,
+      "snippet": "argument?: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand(__0).option|option?: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand(__0).option",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 585,
+      "snippet": "option?: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.isDev|isDev: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.isDev",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 140,
+      "snippet": "isDev: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.superdoc",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 141,
+      "snippet": "superdoc: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarContainer|toolbarContainer: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarContainer",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 143,
+      "snippet": "toolbarContainer: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].argument.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].argument.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 434,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].childItem.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].childItem.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 446,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].command(arg0).argument|argument?: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].command(arg0).argument",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 581,
+      "snippet": "argument?: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].command(arg0).option|option?: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].command(arg0).option",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 585,
+      "snippet": "option?: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].defaultLabel.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].defaultLabel.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 482,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].dropdownStyles.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].dropdownStyles.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 464,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].dropdownValueKey.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].dropdownValueKey.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 530,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].icon.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].icon.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 364,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].iconColor.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].iconColor.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 452,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].inputRef.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].inputRef.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 542,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].label.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].label.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 488,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].labelAttr.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].labelAttr.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 518,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].markName.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].markName.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 512,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].minWidth.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].minWidth.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 428,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].parentItem.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].parentItem.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 440,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].selectedValue.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].selectedValue.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 536,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].style.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].style.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 410,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].tooltip.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].tooltip.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 370,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].tooltipTimeout.value|value: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].tooltipTimeout.value",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 476,
+      "snippet": "value: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.isDev|isDev: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.isDev",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 140,
+      "snippet": "isDev: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.superdoc",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 141,
+      "snippet": "superdoc: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.toolbarContainer|toolbarContainer: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.toolbar.toolbarContainer",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 143,
+      "snippet": "toolbarContainer: any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.element|element: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.element",
+      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
+      "line": 9,
+      "snippet": "element: any;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
+      "line": 16,
+      "snippet": "superdoc: any;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.commentsList.element|element: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsList.element",
+      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
+      "line": 9,
+      "snippet": "element: any;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.commentsList.superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsList.superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
+      "line": 16,
+      "snippet": "superdoc: any;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.documentsWithConverations|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.documentsWithConverations",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 189,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingCommentInstances[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingCommentInstances[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 202,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingCommentInstances[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingCommentInstances[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 204,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingCommentInstances[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingCommentInstances[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 206,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingCommentInstances[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingCommentInstances[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 203,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingCommentInstances[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingCommentInstances[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 201,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 407,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 389,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 406,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 390,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 407,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 389,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 406,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 390,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.documentsWithConverations|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore.documentsWithConverations",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 189,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 107,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 108,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 93,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 92,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 61,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 63,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 65,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 62,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 60,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 125,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 124,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 123,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 83,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 135,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 134,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 248,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 249,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 234,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 233,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 202,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 204,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 206,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 203,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 201,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 266,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 265,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 264,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 224,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 276,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 275,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 389,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 390,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 375,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 374,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 343,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 345,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 347,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 344,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 342,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 407,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 406,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 405,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 365,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 417,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 416,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore.$state.commentsStore.documentsWithConverations|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.superdocStore.$state.commentsStore.documentsWithConverations",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 190,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.documentsWithConverations|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.documentsWithConverations",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 190,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getFloatingCommentInstances[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getFloatingCommentInstances[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 203,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getFloatingCommentInstances[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getFloatingCommentInstances[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 205,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getFloatingCommentInstances[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getFloatingCommentInstances[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 207,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getFloatingCommentInstances[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getFloatingCommentInstances[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 204,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getFloatingCommentInstances[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getFloatingCommentInstances[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 202,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 408,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 390,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 407,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 391,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 408,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 390,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 407,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 391,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.documentsWithConverations|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.documentsWithConverations",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 190,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 108,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 109,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 94,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 93,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 62,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 64,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 66,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 63,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 61,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 126,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 125,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 124,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 84,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 136,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 135,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 249,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 250,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 235,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 234,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 203,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 205,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 207,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 204,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 202,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 267,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 266,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 265,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 225,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 277,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 276,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 390,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 391,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 376,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 375,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 344,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 346,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 348,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 345,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 343,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 408,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 407,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 406,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 366,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 418,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 417,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 879,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 861,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 878,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 862,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 879,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 861,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 878,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 862,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.documentsWithConverations|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.documentsWithConverations",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 661,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 579,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 580,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 565,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 564,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 533,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 535,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 537,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 534,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 532,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 597,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 596,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 595,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 555,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 607,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 606,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 720,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 721,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 706,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 705,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 674,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 676,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 678,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 675,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 673,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 738,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 737,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 736,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 696,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 748,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 747,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 861,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 862,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 847,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 846,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 815,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 817,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 819,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 816,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 814,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 879,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 878,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 877,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 837,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 889,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 888,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1350,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1332,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1349,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1333,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1350,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1332,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1349,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1333,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.documentsWithConverations|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.documentsWithConverations",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1132,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1050,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1051,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1036,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1035,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1004,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1006,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1008,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1005,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1003,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1068,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1067,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1066,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1026,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1078,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1077,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1191,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1192,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1177,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1176,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1145,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1147,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1149,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1146,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1144,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1209,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1208,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1207,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1167,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1219,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1218,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.deleteComment(__0).commentId|commentId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.deleteComment(__0).commentId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1332,
+      "snippet": "commentId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.deleteComment(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.deleteComment(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1333,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentLocation=>return.left|left: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentLocation=>return.left",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1318,
+      "snippet": "left: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentLocation=>return.top|top: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentLocation=>return.top",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1317,
+      "snippet": "top: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].comment|comment: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].comment",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1286,
+      "snippet": "comment: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].pageIndex|pageIndex: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].pageIndex",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1288,
+      "snippet": "pageIndex: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionEntry|positionEntry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionEntry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1290,
+      "snippet": "positionEntry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionKey|positionKey: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].positionKey",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1287,
+      "snippet": "positionKey: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].threadId|threadId: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getFloatingCommentInstances<0>[].threadId",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1285,
+      "snippet": "threadId: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).changeIds|changeIds: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).changeIds",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1350,
+      "snippet": "changeIds: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1349,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.refreshTrackedChangeCommentsByIds(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1348,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.resolveCommentPositionEntry=>return.entry|entry: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.resolveCommentPositionEntry=>return.entry",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1308,
+      "snippet": "entry: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).editor|editor: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).editor",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1360,
+      "snippet": "editor: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "property|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).superdoc|superdoc: any;",
+      "kind": "property",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.syncTrackedChangeComments(__0).superdoc",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1359,
+      "snippet": "superdoc: any;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand=>return|emitCommand({ item, argument, option }: CommandItem): any;",
+      "kind": "return",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand=>return",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 229,
+      "snippet": "emitCommand({ item, argument, option }: CommandItem): any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.emitCommand=>return|emitCommand({ item, argument, option }: CommandItem): any;",
+      "kind": "return",
+      "symbolPath": "SuperDoc.toolbar.emitCommand=>return",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 229,
+      "snippet": "emitCommand({ item, argument, option }: CommandItem): any;",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/super-editor/src/editors/v1/core/helpers/getActiveFormatting.d.ts|getActiveFormatting.<value>=>return|export function getActiveFormatting(editor: any): any;",
+      "kind": "return",
+      "symbolPath": "getActiveFormatting.<value>=>return",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/helpers/getActiveFormatting.d.ts",
+      "line": 1,
+      "snippet": "export function getActiveFormatting(editor: any): any;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts|SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>=>return|(...args: any[]) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>=>return",
+      "file": "node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts",
+      "line": 132,
+      "snippet": "(...args: any[]) => any",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 86,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 95,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 227,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 236,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 368,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 377,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 86,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 95,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 227,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 236,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 368,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 377,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 87,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 96,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 228,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 237,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 369,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 378,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 558,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 567,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 699,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 708,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 840,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 849,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1029,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1038,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1170,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1179,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.belongsToDocument=>return|(comment: any, activeDocumentId: any, options?: {}) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.belongsToDocument=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1311,
+      "snippet": "(comment: any, activeDocumentId: any, options?: {}) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "return|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.hasOverlapId=>return|(id: any) => any",
+      "kind": "return",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.hasOverlapId=>return",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1320,
+      "snippet": "(id: any) => any",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.overflowItems<0>|overflowItems: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.overflowItems<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 139,
+      "snippet": "overflowItems: any[];",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.overflowItems[]|overflowItems: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.overflowItems[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 139,
+      "snippet": "overflowItems: any[];",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbar<14>|toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbar<14>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 173,
+      "snippet": "toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarItems<0>|toolbarItems: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarItems<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 138,
+      "snippet": "toolbarItems: any[];",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarItems[]|toolbarItems: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarItems[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 138,
+      "snippet": "toolbarItems: any[];",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].nestedOptions.value<0>|value: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].nestedOptions.value<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 404,
+      "snippet": "value: any[];",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].nestedOptions.value[]|value: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.toolbar.config.customButtons[].nestedOptions.value[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 404,
+      "snippet": "value: any[];",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.overflowItems<0>|overflowItems: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.toolbar.overflowItems<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 139,
+      "snippet": "overflowItems: any[];",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.overflowItems[]|overflowItems: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.toolbar.overflowItems[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 139,
+      "snippet": "overflowItems: any[];",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.toolbar<14>|toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
+      "kind": "type",
+      "symbolPath": "SuperDoc.toolbar.toolbar<14>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 173,
+      "snippet": "toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.toolbarItems<0>|toolbarItems: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.toolbar.toolbarItems<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 138,
+      "snippet": "toolbarItems: any[];",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.toolbarItems[]|toolbarItems: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.toolbar.toolbarItems[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
+      "line": 138,
+      "snippet": "toolbarItems: any[];",
+      "owner": "tier-2-toolbar",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(handlePlugins)(plugin)<0>|plugin: Plugin",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(handlePlugins)(plugin)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugin: Plugin",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(handlePlugins)(plugins)[]<0>|plugins: Plugin[]",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(handlePlugins)(plugins)[]<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugins: Plugin[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(plugin)<0>|plugin: Plugin",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(plugin)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugin: Plugin",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.schema<0>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.schema<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.schema<1>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.schema<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Extensions.<value>.Node.new(config).editor.registerPlugin(handlePlugins)(plugin)<0>|plugin: Plugin",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.registerPlugin(handlePlugins)(plugin)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugin: Plugin",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Extensions.<value>.Node.new(config).editor.registerPlugin(plugin)<0>|plugin: Plugin",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.registerPlugin(plugin)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugin: Plugin",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Extensions.<value>.Node.new(config).editor.schema<0>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.schema<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Extensions.<value>.Node.new(config).editor.schema<1>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.schema<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.registerPlugin(plugin)<0>|plugin: Plugin",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.registerPlugin(plugin)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugin: Plugin",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.schema<0>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.schema<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.schema<1>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.schema<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(handlePlugins)(plugin)<0>|plugin: Plugin",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(handlePlugins)(plugin)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugin: Plugin",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(handlePlugins)(plugins)[]<0>|plugins: Plugin[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(handlePlugins)(plugins)[]<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugins: Plugin[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(plugin)<0>|plugin: Plugin",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(plugin)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugin: Plugin",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.schema<0>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.schema<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.schema<1>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.schema<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|defineNode.<value>(config).editor.registerPlugin(handlePlugins)(plugin)<0>|plugin: Plugin",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.registerPlugin(handlePlugins)(plugin)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugin: Plugin",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|defineNode.<value>(config).editor.registerPlugin(plugin)<0>|plugin: Plugin",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.registerPlugin(plugin)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugin: Plugin",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|defineNode.<value>(config).editor.schema<0>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.schema<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|defineNode.<value>(config).editor.schema<1>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.schema<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.registerPlugin(handlePlugins)(plugin)<0>|plugin: Plugin",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.registerPlugin(handlePlugins)(plugin)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugin: Plugin",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.registerPlugin(plugin)<0>|plugin: Plugin",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.registerPlugin(plugin)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 446,
+      "snippet": "plugin: Plugin",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.schema<0>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.schema<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.schema<1>|schema: Schema;",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.schema<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 113,
+      "snippet": "schema: Schema;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.emit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.emit(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.emit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.emit(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.on(fn)(args)<0>|...args: Args",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.on(fn)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.on(fn)(args)[]|...args: Args",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.on(fn)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.on(fn)<0><0>|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.on(fn)<0><0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.on(fn)<0>[]|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.on(fn)<0>[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.safeEmit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.safeEmit(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.safeEmit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.safeEmit(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.emit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.emit(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.emit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.emit(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.on(fn)(args)<0>|...args: Args",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.on(fn)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.on(fn)(args)[]|...args: Args",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.on(fn)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.on(fn)<0><0>|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.on(fn)<0><0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.on(fn)<0>[]|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.on(fn)<0>[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.safeEmit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.safeEmit(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.safeEmit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.safeEmit(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.emit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.emit(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.emit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.emit(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.on(fn)(args)<0>|...args: Args",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.on(fn)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.on(fn)(args)[]|...args: Args",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.on(fn)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.on(fn)<0><0>|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.on(fn)<0><0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.on(fn)<0>[]|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.on(fn)<0>[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.safeEmit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.safeEmit(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.safeEmit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.presentationEditor.safeEmit(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.presentationEditor.emit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.emit(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.presentationEditor.emit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.emit(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.presentationEditor.on(fn)(args)<0>|...args: Args",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.on(fn)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.presentationEditor.on(fn)(args)[]|...args: Args",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.on(fn)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.presentationEditor.on(fn)<0><0>|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.on(fn)<0><0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.presentationEditor.on(fn)<0>[]|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.on(fn)<0>[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.presentationEditor.safeEmit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.safeEmit(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|defineNode.<value>(config).editor.presentationEditor.safeEmit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.safeEmit(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.emit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.emit(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.emit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.emit(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.on(fn)(args)<0>|...args: Args",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.on(fn)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.on(fn)(args)[]|...args: Args",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.on(fn)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.on(fn)<0><0>|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.on(fn)<0><0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.on(fn)<0>[]|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.on(fn)<0>[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.safeEmit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.safeEmit(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.safeEmit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.safeEmit(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/EventEmitter.d.ts",
+      "line": 37,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|Editor.<value>.new(options)<0>.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
+      "kind": "type",
+      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].config.renderDOM<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
+      "line": 49,
+      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>|addPmPlugins?: MaybeGetter<Plugin[]>;",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
+      "line": 78,
+      "snippet": "addPmPlugins?: MaybeGetter<Plugin[]>;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.options.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.options.extensions[].config.renderDOM<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
+      "line": 49,
+      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|defineNode.<value>(config).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>|addPmPlugins?: MaybeGetter<Plugin[]>;",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
+      "line": 78,
+      "snippet": "addPmPlugins?: MaybeGetter<Plugin[]>;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|defineNode.<value>(config).editor.presentationEditor.options.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.options.extensions[].config.renderDOM<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
+      "line": 49,
+      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>|addPmPlugins?: MaybeGetter<Plugin[]>;",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
+      "line": 78,
+      "snippet": "addPmPlugins?: MaybeGetter<Plugin[]>;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.options.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.options.extensions[].config.renderDOM<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
+      "line": 49,
+      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.off(handler)(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.off(handler)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.off(handler)(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.off(handler)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.on(handler)(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.on(handler)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.on(handler)(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.on(handler)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.off(handler)(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.provider.off(handler)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.off(handler)(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.provider.off(handler)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.on(handler)(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.provider.on(handler)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.on(handler)(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.provider.on(handler)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 205,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
+      "line": 204,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getRichTextExtensions.<value>(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "getRichTextExtensions.<value>(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
+      "line": 1,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getRichTextExtensions.<value>(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "getRichTextExtensions.<value>(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
+      "line": 1,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getRichTextExtensions.<value>=>return<0>|export function getRichTextExtensions(...args: any[]): any[];",
+      "kind": "type",
+      "symbolPath": "getRichTextExtensions.<value>=>return<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
+      "line": 1,
+      "snippet": "export function getRichTextExtensions(...args: any[]): any[];",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getRichTextExtensions.<value>=>return[]|export function getRichTextExtensions(...args: any[]): any[];",
+      "kind": "type",
+      "symbolPath": "getRichTextExtensions.<value>=>return[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
+      "line": 1,
+      "snippet": "export function getRichTextExtensions(...args: any[]): any[];",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getStarterExtensions.<value>(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "getStarterExtensions.<value>(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
+      "line": 2,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getStarterExtensions.<value>(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "getStarterExtensions.<value>(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
+      "line": 2,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getStarterExtensions.<value>=>return<0>|export function getStarterExtensions(...args: any[]): any[];",
+      "kind": "type",
+      "symbolPath": "getStarterExtensions.<value>=>return<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
+      "line": 2,
+      "snippet": "export function getStarterExtensions(...args: any[]): any[];",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getStarterExtensions.<value>=>return[]|export function getStarterExtensions(...args: any[]): any[];",
+      "kind": "type",
+      "symbolPath": "getStarterExtensions.<value>=>return[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
+      "line": 2,
+      "snippet": "export function getStarterExtensions(...args: any[]): any[];",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts|SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>(args)<0>|...args: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>(args)<0>",
+      "file": "node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts",
+      "line": 132,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts|SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>(args)[]|...args: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>(args)[]",
+      "file": "node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts",
+      "line": 132,
+      "snippet": "...args: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.container<14>|container: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, stri",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.container<14>",
+      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
+      "line": 18,
+      "snippet": "container: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, stri",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.commentsList.container<14>|container: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, stri",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsList.container<14>",
+      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
+      "line": 18,
+      "snippet": "container: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, stri",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.emit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.emit(args)<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.emit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.emit(args)[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.on(fn)(args)<0>|...args: Args",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.on(fn)(args)<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.on(fn)(args)[]|...args: Args",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.on(fn)(args)[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.on(fn)<0><0>|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.on(fn)<0><0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.on(fn)<0>[]|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.on(fn)<0>[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.whiteboard.emit(args)<0>|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.emit(args)<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.whiteboard.emit(args)[]|...args: EventMap[K]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.emit(args)[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 31,
+      "snippet": "...args: EventMap[K]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.whiteboard.on(fn)(args)<0>|...args: Args",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.on(fn)(args)<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.whiteboard.on(fn)(args)[]|...args: Args",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.on(fn)(args)[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 11,
+      "snippet": "...args: Args",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.whiteboard.on(fn)<0><0>|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.on(fn)<0><0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts|SuperDoc.whiteboard.on(fn)<0>[]|fn: EventCallback<EventMap[K]>",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.on(fn)<0>[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/EventEmitter.d.ts",
+      "line": 24,
+      "snippet": "fn: EventCallback<EventMap[K]>",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.app<0>|app: import('vue').App;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.app<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts",
+      "line": 63,
+      "snippet": "app: import('vue').App;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts|SuperDoc.app<0>|app: import('vue').App;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.app<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts",
+      "line": 63,
+      "snippet": "app: import('vue').App;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.register(items)<0>|items: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.register(items)<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
+      "line": 30,
+      "snippet": "items: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.register(items)[]|items: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.register(items)[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
+      "line": 30,
+      "snippet": "items: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.whiteboard.getType=>return<0>|getType(type: string): any[] | undefined;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.getType=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
+      "line": 36,
+      "snippet": "getType(type: string): any[] | undefined;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.whiteboard.getType=>return[]|getType(type: string): any[] | undefined;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.getType=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
+      "line": 36,
+      "snippet": "getType(type: string): any[] | undefined;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.whiteboard.register(items)<0>|items: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.register(items)<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
+      "line": 30,
+      "snippet": "items: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.whiteboard.register(items)[]|items: any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.register(items)[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
+      "line": 30,
+      "snippet": "items: any[]",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.stickers<0>|stickers: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.stickers<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
+      "line": 103,
+      "snippet": "stickers: any[];",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.stickers[]|stickers: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.stickers[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
+      "line": 103,
+      "snippet": "stickers: any[];",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.strokes<0>|strokes: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.strokes<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
+      "line": 101,
+      "snippet": "strokes: any[];",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.strokes[]|strokes: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.strokes[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
+      "line": 101,
+      "snippet": "strokes: any[];",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.text<0>|text: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.text<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
+      "line": 102,
+      "snippet": "text: any[];",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.text[]|text: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.text[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
+      "line": 102,
+      "snippet": "text: any[];",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/public/index.d.ts|EditorEventMap[string]<0>|EditorEventMap",
+      "kind": "type",
+      "symbolPath": "EditorEventMap[string]<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/public/index.d.ts",
+      "line": 87,
+      "snippet": "EditorEventMap",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/public/index.d.ts|EditorEventMap[string][]|EditorEventMap",
+      "kind": "type",
+      "symbolPath": "EditorEventMap[string][]",
+      "file": "node_modules/superdoc/dist/superdoc/src/public/index.d.ts",
+      "line": 87,
+      "snippet": "EditorEventMap",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getCommentsByPosition.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getCommentsByPosition.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 195,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getCommentsByPosition.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getCommentsByPosition.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 195,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getCommentsByPosition.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getCommentsByPosition.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 196,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getCommentsByPosition.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getCommentsByPosition.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 196,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingComments<0>|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 198,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingComments[]|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getFloatingComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 198,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getGroupedComments.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getGroupedComments.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 191,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getGroupedComments.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getGroupedComments.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 191,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getGroupedComments.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getGroupedComments.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 192,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getGroupedComments.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore.getGroupedComments.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 192,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<1><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 48,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 189,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<2><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 189,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsStore<3><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 330,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 394,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.filter=>return[].comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 394,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 394,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore.$onAction(callback)(context).args.find=>return.comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 394,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.getFloatingComments<0>|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore.getFloatingComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 198,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore.getFloatingComments[]|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore.getFloatingComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 198,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 48,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 54,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 54,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 55,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 55,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 50,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 50,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 51,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 51,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 112,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 112,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 115,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<1><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<1><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 115,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 189,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 189,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 195,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 195,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 196,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 196,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 191,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 191,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 192,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 192,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 253,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 253,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 256,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<2><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<2><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 256,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 330,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 336,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 336,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 337,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 337,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 332,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 332,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 333,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 333,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 394,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 394,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 397,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts|SuperDoc.commentsStore<3><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.commentsStore<3><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/comments-store.d.ts",
+      "line": 397,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$patch(partialState).commentsStore.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore.$patch(partialState).commentsStore.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 190,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getCommentsByPosition.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getCommentsByPosition.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 196,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getCommentsByPosition.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getCommentsByPosition.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 196,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getCommentsByPosition.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getCommentsByPosition.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 197,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getCommentsByPosition.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getCommentsByPosition.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 197,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getFloatingComments<0>|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getFloatingComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 199,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getFloatingComments[]|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getFloatingComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 199,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getGroupedComments.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getGroupedComments.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 192,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getGroupedComments.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getGroupedComments.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 192,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getGroupedComments.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getGroupedComments.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 193,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore.$state.commentsStore.getGroupedComments.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore.$state.commentsStore.getGroupedComments.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 193,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 395,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 395,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 395,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 395,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.getFloatingComments<0>|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.getFloatingComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 199,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore.getFloatingComments[]|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore.getFloatingComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 199,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 49,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 55,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 55,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 56,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 56,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingComments<0><0>|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingComments<0><0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 58,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingComments<0>[]|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getFloatingComments<0>[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 58,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 51,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 51,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 52,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 52,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 113,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 113,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 116,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<1><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<1><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 116,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 190,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 190,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 196,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 196,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 197,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 197,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 192,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 192,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 193,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 193,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 254,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 254,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 257,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<2><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<2><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 257,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 331,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 337,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 337,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 338,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 338,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 333,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 333,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 334,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 334,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 395,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 395,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 398,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<1><0>.commentsStore<3><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<1><0>.commentsStore<3><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 398,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 866,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 866,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 866,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 866,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.getFloatingComments<0>|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.getFloatingComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 670,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore.getFloatingComments[]|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore.getFloatingComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 670,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 520,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 526,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 526,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 527,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 527,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 522,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 522,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 523,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 523,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 584,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 584,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 587,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<1><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<1><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 587,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 661,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 661,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 667,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 667,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 668,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 668,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 663,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 663,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 664,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 664,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 725,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 725,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 728,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<2><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<2><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 728,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 802,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 808,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 808,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 809,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 809,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 804,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 804,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 805,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 805,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 866,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 866,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 869,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<2><0>.commentsStore<3><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<2><0>.commentsStore<3><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 869,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1337,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.filter=>return[].comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1337,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1337,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.$onAction(callback)(context).args.find=>return.comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1337,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.getFloatingComments<0>|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.getFloatingComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1141,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore.getFloatingComments[]|getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore.getFloatingComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1141,
+      "snippet": "getFloatingComments: import('vue').ComputedRef<any[]>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 991,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 997,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 997,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 998,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 998,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 993,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 993,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 994,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 994,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1055,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1055,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1058,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<1><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<1><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1058,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1132,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1132,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1138,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1138,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1139,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1139,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1134,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1134,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1135,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1135,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1196,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1196,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1199,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<2><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<2><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1199,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.documentsWithConverations<0>|documentsWithConverations: import('vue').ComputedRef<any>;",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.documentsWithConverations<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1273,
+      "snippet": "documentsWithConverations: import('vue').ComputedRef<any>;",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1279,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentsByPosition<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1279,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1280,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getCommentsByPosition<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1280,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments<0>|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1275,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments[]|parentComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getGroupedComments<0>.parentComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1275,
+      "snippet": "parentComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments<0>|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1276,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments[]|resolvedComments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.getGroupedComments<0>.resolvedComments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1276,
+      "snippet": "resolvedComments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments<0>|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1337,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments[]|comments: any[];",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.processLoadedDocxComments(__0).comments[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1337,
+      "snippet": "comments: any[];",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.translateCommentsForExport=>return<0>|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.translateCommentsForExport=>return<0>",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1340,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "type|node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts|SuperDoc.superdocStore<3><0>.commentsStore<3><0>.translateCommentsForExport=>return[]|() => any[]",
+      "kind": "type",
+      "symbolPath": "SuperDoc.superdocStore<3><0>.commentsStore<3><0>.translateCommentsForExport=>return[]",
+      "file": "node_modules/superdoc/dist/superdoc/src/stores/superdoc-store.d.ts",
+      "line": 1340,
+      "snippet": "() => any[]",
+      "owner": "tier-1-pinia",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    }
+  ]
+}


### PR DESCRIPTION
First real public-contract no-new-any gate. Scoped to findings reached from root \`.\` via supported-root exports, against a committed allowlist that represents current known debt (not accepted API). Fails on both new findings (regression) and stale entries (drain landed but allowlist not shrunk).

Extends existing \`deep-type-audit.mjs\` — no new script, no new workflow step. The existing "Deep public-type audit" CI step now invokes \`--strict-supported-root\`, which prints the broad inventory AND runs the gate in one process.

- Allowlist seeded at 950 entries (committed). 832 of those trace to the \`SuperDoc\` root symbol; 713 of those are Pinia stores. Drain PRs start there.
- Top offenders printed on every run so future drain work has a clear queue.
- README adds a "Gate Map" table documenting which existing gate owns which failure class, so future work extends an existing gate rather than accreting new scripts.
- Two stale strings in \`deep-type-audit.mjs\` fixed: the file header's command list and the broad-allowlist-missing message both now match reality.

**Review**: this PR locks current state against regression. It does not drain \`any\`s itself. The 950-entry allowlist is debt. Subsequent PRs drain it (next up: hide internal Pinia stores on \`SuperDoc\`, ~623 findings).

**Verified**: build exit 0; matrix 57/57; gate PASS against seed; FAIL path verified (drop one entry, exit 1, regression flagged).