### PR TITLE
ci(sdk): route auto Python publishes to TestPyPI

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -6,9 +6,9 @@
 #   - push to main (auto-release)         -> TestPyPI (Python @next .devN, ephemeral)
 #   - workflow_dispatch, smoke=true       -> TestPyPI only (Python; no npm, no semantic-release)
 #   - workflow_dispatch, smoke=false      -> production PyPI (manual production recovery for stable)
-# TestPyPI Trusted Publishers must be configured for all six projects against this
-# workflow filename and the `testpypi` environment. PyPI TP config is keyed to the
-# workflow filename, so the smoke job lives in this file (not a sibling workflow).
+# TestPyPI auth uses an account-scoped API token stored as TEST_PYPI_TOKEN in
+# the `testpypi` GitHub environment (not OIDC). The smoke job lives in this
+# file so the same token + env scope cover both auto and smoke paths.
 name: "\U0001F4E6 Release SDK"
 
 on:
@@ -74,8 +74,8 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     # Auto path publishes only to TestPyPI to keep production PyPI storage
-    # reserved for stable X.Y.Z releases. Trusted Publisher config for this
-    # workflow filename must exist on TestPyPI for all six projects.
+    # reserved for stable X.Y.Z releases. Auth uses TEST_PYPI_TOKEN from the
+    # `testpypi` GitHub environment (account-scoped TestPyPI API token).
     environment: testpypi
     outputs:
       released: ${{ steps.detect.outputs.released }}
@@ -202,6 +202,7 @@ jobs:
         if: steps.detect.outputs.release_present == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: packages/sdk/langs/python/companion-dist/
           skip-existing: true
@@ -210,6 +211,7 @@ jobs:
         if: steps.detect.outputs.release_present == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: packages/sdk/langs/python/dist/
           skip-existing: true
@@ -447,6 +449,7 @@ jobs:
       - name: Publish companion Python packages to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: packages/sdk/langs/python/companion-dist/
           skip-existing: true
@@ -454,6 +457,7 @@ jobs:
       - name: Publish main Python SDK to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: packages/sdk/langs/python/dist/
           skip-existing: true

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -427,6 +427,20 @@ jobs:
           test -f packages/superdoc/dist/super-editor.es.js \
             || (echo "FATAL: packages/superdoc/dist/super-editor.es.js missing — build:es likely failed silently" && exit 1)
 
+      # Stage CLI native binaries into Python companion packages.
+      # build-python-sdk.mjs has a fail-fast prerequisite check that requires
+      # these binaries; the auto-release path stages them via
+      # sdk-release-publish.mjs --npm-only, which the smoke job bypasses.
+      # These three steps map to steps 2, 3, 5 of sdk-release-publish.mjs.
+      - name: Build CLI native binaries (all platforms)
+        run: pnpm --prefix apps/cli run build:native:all
+
+      - name: Stage CLI artifacts
+        run: pnpm --prefix apps/cli run build:stage
+
+      - name: Stage Python companion binaries
+        run: node packages/sdk/scripts/stage-python-companion-cli.mjs
+
       - name: Build and verify Python SDK
         run: node packages/sdk/scripts/build-python-sdk.mjs
 

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -1,6 +1,14 @@
 # Auto-releases SDK on push to main (@next channel).
 # Stable releases are orchestrated centrally by release-stable.yml.
 # Also supports manual dispatch as a fallback for one-off releases.
+#
+# Python publish routing:
+#   - push to main (auto-release)         -> TestPyPI (Python @next .devN, ephemeral)
+#   - workflow_dispatch, smoke=true       -> TestPyPI only (Python; no npm, no semantic-release)
+#   - workflow_dispatch, smoke=false      -> production PyPI (manual production recovery for stable)
+# TestPyPI Trusted Publishers must be configured for all six projects against this
+# workflow filename and the `testpypi` environment. PyPI TP config is keyed to the
+# workflow filename, so the smoke job lives in this file (not a sibling workflow).
 name: "\U0001F4E6 Release SDK"
 
 on:
@@ -37,6 +45,11 @@ on:
         required: false
         type: string
         default: latest
+      smoke:
+        description: 'TestPyPI smoke test (Python-only, no npm, no semantic-release). Uses 0.0.0-next.${run_number}.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -60,7 +73,10 @@ jobs:
   auto-release:
     if: github.event_name == 'push'
     runs-on: ubuntu-24.04
-    environment: pypi
+    # Auto path publishes only to TestPyPI to keep production PyPI storage
+    # reserved for stable X.Y.Z releases. Trusted Publisher config for this
+    # workflow filename must exist on TestPyPI for all six projects.
+    environment: testpypi
     outputs:
       released: ${{ steps.detect.outputs.released }}
       version: ${{ steps.detect.outputs.version }}
@@ -182,17 +198,19 @@ jobs:
         if: steps.detect.outputs.release_present == 'true'
         run: node packages/sdk/scripts/build-python-sdk.mjs
 
-      - name: Publish companion Python packages to PyPI
+      - name: Publish companion Python packages to TestPyPI
         if: steps.detect.outputs.release_present == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          repository-url: https://test.pypi.org/legacy/
           packages-dir: packages/sdk/langs/python/companion-dist/
           skip-existing: true
 
-      - name: Publish main Python SDK to PyPI
+      - name: Publish main Python SDK to TestPyPI
         if: steps.detect.outputs.release_present == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          repository-url: https://test.pypi.org/legacy/
           packages-dir: packages/sdk/langs/python/dist/
           skip-existing: true
 
@@ -233,7 +251,7 @@ jobs:
   # Manual fallback (workflow_dispatch)
   # -------------------------------------------------------------------
   manual-release:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && !inputs.smoke
     runs-on: ubuntu-24.04
     environment: ${{ inputs.dry-run && '' || 'pypi' }}
     steps:
@@ -337,3 +355,91 @@ jobs:
           ls -la packages/sdk/langs/python/companion-dist/
           echo "=== Root wheel ==="
           ls -la packages/sdk/langs/python/dist/
+
+  # -------------------------------------------------------------------
+  # TestPyPI smoke (workflow_dispatch, smoke=true)
+  #
+  # Publishes all six Python projects to TestPyPI at a unique
+  # 0.0.0.dev${run_number} version to exercise every Trusted Publisher
+  # config in one shot. No npm publish, no semantic-release tag, no labs
+  # dispatch. Use to validate TestPyPI setup before the first real merge
+  # on the auto path, and any time the publish wiring changes.
+  #
+  # The 0.0.0.dev* versions left on TestPyPI are swept by the retention
+  # workflow (PR1b); they have no stable predecessor so the retention
+  # policy must include them explicitly.
+  # -------------------------------------------------------------------
+  testpypi-smoke:
+    if: github.event_name == 'workflow_dispatch' && inputs.smoke && github.ref_name == 'main'
+    runs-on: ubuntu-24.04
+    environment: testpypi
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          # See auto-release for the bun pin rationale (SD-2784).
+          bun-version: 1.3.11
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install canvas system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential libcairo2-dev libpango1.0-dev \
+            libjpeg-dev libgif-dev librsvg2-dev libpixman-1-dev
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Python build tools
+        run: pip install build
+
+      - name: Compute smoke version
+        id: smoke_version
+        run: |
+          SEMVER="0.0.0-next.${{ github.run_number }}"
+          echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
+          echo "### TestPyPI smoke" >> "$GITHUB_STEP_SUMMARY"
+          echo "Publishing all six Python projects at \`$SEMVER\` (PEP 440: \`0.0.0.dev${{ github.run_number }}\`)." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Set smoke version across SDK packages
+        run: node packages/sdk/scripts/sync-sdk-version.mjs --set "${{ steps.smoke_version.outputs.semver }}"
+
+      - name: Generate all artifacts
+        run: pnpm run generate:all
+
+      - name: Build superdoc package for CLI native bundling
+        run: pnpm --prefix packages/superdoc run build:es
+
+      - name: Verify superdoc build output exists
+        run: |
+          test -f packages/superdoc/dist/super-editor.es.js \
+            || (echo "FATAL: packages/superdoc/dist/super-editor.es.js missing — build:es likely failed silently" && exit 1)
+
+      - name: Build and verify Python SDK
+        run: node packages/sdk/scripts/build-python-sdk.mjs
+
+      - name: Publish companion Python packages to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: packages/sdk/langs/python/companion-dist/
+          skip-existing: true
+
+      - name: Publish main Python SDK to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: packages/sdk/langs/python/dist/
+          skip-existing: true

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -54,7 +54,7 @@ on:
 permissions:
   contents: write
   packages: write
-  id-token: write # PyPI trusted publishing (OIDC)
+  id-token: write # Production PyPI trusted publishing (OIDC) on manual-release; TestPyPI uses TEST_PYPI_TOKEN instead.
 
 concurrency:
   # Release runs never cancel an in-progress release (each merge is a release-worthy
@@ -362,10 +362,14 @@ jobs:
   # TestPyPI smoke (workflow_dispatch, smoke=true)
   #
   # Publishes all six Python projects to TestPyPI at a unique
-  # 0.0.0.dev${run_number} version to exercise every Trusted Publisher
-  # config in one shot. No npm publish, no semantic-release tag, no labs
-  # dispatch. Use to validate TestPyPI setup before the first real merge
-  # on the auto path, and any time the publish wiring changes.
+  # 0.0.0.dev${run_number} version to validate the publish wiring end to
+  # end (account-scoped TEST_PYPI_TOKEN from the `testpypi` environment,
+  # wheel build, all six project names) in one shot. No npm publish, no
+  # semantic-release tag, no labs dispatch. Use before the first real
+  # merge on the auto path, and any time the publish wiring changes.
+  #
+  # First successful run also creates the six TestPyPI projects under
+  # the token owner's account.
   #
   # The 0.0.0.dev* versions left on TestPyPI are swept by the retention
   # workflow (PR1b); they have no stable predecessor so the retention


### PR DESCRIPTION
Routes the auto-release Python publish on push-to-main from production PyPI to TestPyPI, and adds a `workflow_dispatch` smoke job that publishes all six Python projects together so every Trusted Publisher config can be exercised in one shot.

- Auto-release uses a new `testpypi` GitHub environment and `repository-url: https://test.pypi.org/legacy/` on both Python publish steps. npm publish and labs dispatch are unchanged.
- Smoke job is `inputs.smoke == true`, branch-gated to `main`, and publishes at `0.0.0-next.${run_number}` to avoid re-upload collisions. Companion CLI binaries are staged via the canonical steps from `sdk-release-publish.mjs` (`build:native:all` → `build:stage` → `stage-python-companion-cli`) so `build-python-sdk.mjs` prerequisite check passes.
- Manual-release path is preserved for production stable recovery; gated `&& !inputs.smoke`.

Draft until the workflow is disabled in Actions and TestPyPI Trusted Publishers are configured for all six projects against this filename + `testpypi` environment.

**Must stay the same**: manual-release production publish path, sync-labs-agent condition.
**Review**: routing matrix in the header comment matches the three job `if` conditions. Smoke job step order matches steps 1/2/3/5 of `sdk-release-publish.mjs`.
**Verified**: `release-sdk.yml` parses; routing keys match auto=`testpypi`, manual=`pypi`, smoke=`testpypi`; smoke step order checked against `build-python-sdk.mjs` prerequisite check.