### PR TITLE
refactor(superdoc-ui): centralize host-bridge cast in one helper (SD-3213g)

### DIFF
--- a/packages/super-editor/src/ui/create-super-doc-ui.ts
+++ b/packages/super-editor/src/ui/create-super-doc-ui.ts
@@ -218,6 +218,36 @@ function deepFreeze<T>(value: T): T {
 }
 
 /**
+ * SD-3213g: single documented bridge between `SuperDocLike` and
+ * `resolveToolbarSources`'s `ToolbarHostShape`. The cast lives here so
+ * callers don't repeat `superdoc as never` at every site.
+ *
+ * Why the cast is intentional, not type-system noise:
+ *
+ * - `SuperDocLike` is intentionally stub-friendly. Its `activeEditor`
+ *   is `SuperDocEditorLike | null` (a UI-level structural type) so
+ *   consumer tests can pass narrow handcrafted hosts without pulling
+ *   in the full `Editor` graph.
+ * - At runtime, a real `SuperDoc` instance's `activeEditor` is always
+ *   a real `Editor` that satisfies `ToolbarHostShape` structurally.
+ *   The two types describe the same runtime value at different
+ *   abstraction levels.
+ * - Custom commands (and other UI paths) require **late-bound** routing
+ *   resolved at execute time, not at controller construction; the
+ *   cached `toolbarSnapshot.context` only reflects state at the last
+ *   subscription event. So fresh `resolveToolbarSources` calls are
+ *   load-bearing for the `'execute receives the routed editor
+ *   late-bound'` contract pinned in `custom-commands.test.ts`.
+ *
+ * Use this helper anywhere the UI needs a fresh resolver walk. Do not
+ * call `resolveToolbarSources(superdoc as never)` elsewhere in this
+ * file.
+ */
+function resolveFreshToolbarSources(superdoc: SuperDocUIOptions['superdoc']) {
+  return resolveToolbarSources(superdoc as never);
+}
+
+/**
  * Resolve the **routed** editor — the body, header, footer, or note
  * editor that PresentationEditor currently routes input/selection to.
  * Falls back to `superdoc.activeEditor` when no presentation layer is
@@ -230,7 +260,7 @@ function deepFreeze<T>(value: T): T {
  */
 function resolveRoutedEditor(superdoc: SuperDocUIOptions['superdoc']): SuperDocEditorLike | null {
   try {
-    const sources = resolveToolbarSources(superdoc as never);
+    const sources = resolveFreshToolbarSources(superdoc);
     return (sources.activeEditor as unknown as SuperDocEditorLike | null) ?? null;
   } catch {
     return (superdoc.activeEditor ?? null) as SuperDocEditorLike | null;
@@ -264,7 +294,7 @@ function resolvePresentationEditor(superdoc: SuperDocUIOptions['superdoc']): {
   off?: (event: string, handler: (...args: unknown[]) => void) => unknown;
 } | null {
   try {
-    const sources = resolveToolbarSources(superdoc as never);
+    const sources = resolveFreshToolbarSources(superdoc);
     return (sources.presentationEditor as never) ?? null;
   } catch {
     return null;
@@ -339,7 +369,7 @@ function readActiveStoryLocator(
 ): import('@superdoc/document-api').StoryLocator | null {
   let presentation: { getActiveStoryLocator?: () => unknown } | null = null;
   try {
-    const sources = resolveToolbarSources(superdoc as never);
+    const sources = resolveFreshToolbarSources(superdoc);
     presentation = (sources.presentationEditor as never) ?? null;
   } catch {
     return null;
@@ -398,6 +428,11 @@ export function createSuperDocUI(options: SuperDocUIOptions): SuperDocUI {
   // same selector substrate as the rest of the controller. Per-command
   // state derivers in the registry are wrapped to default to disabled
   // on throw, so a partial editor never wedges snapshot construction.
+  // SD-3213g: documented bridge cast. Same rationale as the comment on
+  // `resolveFreshToolbarSources` above: SuperDocLike is intentionally
+  // stub-friendly, runtime SuperDoc.activeEditor is a real Editor that
+  // satisfies the host contract structurally. Concentrated here so the
+  // call site stays an obvious boundary, not scattered casts elsewhere.
   const toolbarController: HeadlessToolbarController = createHeadlessToolbar({
     superdoc: superdoc as unknown as HeadlessToolbarSuperdocHost,
     // Pass the full registry so snapshot.commands is populated for


### PR DESCRIPTION
Concentrates the \`SuperDocLike\` → \`HeadlessToolbarSuperdocHost\` / \`ToolbarHostShape\` bridge cast in two documented boundary points:

- \`resolveFreshToolbarSources(superdoc)\` — single helper used by every UI path that needs a fresh resolver walk (\`resolveRoutedEditor\`, \`resolvePresentationEditor\`, \`readActiveStoryLocator\`).
- \`createHeadlessToolbar({ superdoc })\` — single inline cast with a comment cross-referencing the helper's rationale.

The cast is intentional, not type-system noise: \`SuperDocLike\` is stub-friendly so consumer tests don't need the full \`Editor\` graph; runtime \`SuperDoc.activeEditor\` is a real \`Editor\` that satisfies the toolbar contract structurally.

Approaches considered and dropped:

- **Structural \`ToolbarEditorLike\`** (widening \`HeadlessToolbarSuperdocHost.activeEditor\`): blocked by \`Editor.doc\` vs \`SuperDocEditorLike.doc\` being different abstractions named the same field. Any shared type either pulls Editor's graph into SuperDocLike or weakens \`ToolbarTarget.doc\`.
- **Consume \`toolbarSnapshot.context.editor\`** instead of fresh resolution: breaks the late-bound contract pinned in the 'execute receives the routed editor late-bound' test (custom-commands.test.ts). The snapshot is the last subscription event, not a live host view.

The two \`sources.presentationEditor as never\` casts and the \`sources.activeEditor as unknown as SuperDocEditorLike\` cast are return-value narrowing (Cause 2), not host-contract. Tracked separately as SD-3213h follow-up.

**Honest cast math (verified against origin/main)**:

- SD-3213-scope casts in the host/routing helper cluster: **7 → 5**.
- Host bridge casts: 4 scattered sites → 2 documented boundary sites.
- Return narrowing casts: 3 → 3 (unchanged; SD-3213h).
- Repeated scattered resolver casts (\`superdoc as never\` at each call site): 3 → 0.

Other casts elsewhere in the file (unrelated to the host contract, e.g. \`deepClone\` return cast, downstream consumer helper casts) are out of scope.

**Verified**: build exit 0; matrix 59/59; audit PASS (allowlist unchanged at 235 — no \`any\` drained, this is type-quality refactor); super-editor UI tests 314/314 including the late-bound custom-commands test.