### PR TITLE
fix(sdk): include operation id in DOCUMENT_CLOSED error

### DIFF
--- a/packages/sdk/langs/node/src/__tests__/handle-and-tools.test.ts
+++ b/packages/sdk/langs/node/src/__tests__/handle-and-tools.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { BoundDocApi } from '../generated/client.js';
-import { BoundRuntime, SuperDocDocument } from '../index.ts';
+import { SuperDocClient, SuperDocDocument } from '../index.ts';
 import { SuperDocCliError } from '../runtime/errors.js';
-import type { OperationSpec, SuperDocRuntime } from '../runtime/process.js';
 import { dispatchSuperDocTool } from '../tools.ts';
 
 describe('SuperDocDocument', () => {
@@ -21,21 +20,19 @@ describe('SuperDocDocument', () => {
   });
 });
 
-describe('BoundRuntime', () => {
-  test('invoke throws DOCUMENT_CLOSED with operation id after the handle is closed', async () => {
-    const runtime = { invoke: async () => ({}) } as unknown as SuperDocRuntime;
-    const boundRuntime = new BoundRuntime(runtime, 'session-1');
-    const operation: OperationSpec = {
-      operationId: 'doc.save',
-      commandTokens: ['doc', 'save'],
-      params: [],
-    };
+describe('SuperDocClient handle lifecycle', () => {
+  test('invoke after close throws DOCUMENT_CLOSED with the attempted operation id', async () => {
+    const client = new SuperDocClient({ env: { SUPERDOC_CLI_BIN: '/tmp/fake-cli' } });
+    // Bypass the real CLI subprocess by stubbing the internal runtime and rawApi.
+    (client as any).runtime = { invoke: async () => ({}) };
+    (client as any).rawApi = { open: async () => ({ contextId: 'session-1' }) };
 
-    boundRuntime.markClosed();
+    const doc = await client.open({} as any);
+    await doc.close();
 
     try {
-      await boundRuntime.invoke(operation);
-      throw new Error('Expected BoundRuntime.invoke to throw on a closed handle.');
+      await doc.save();
+      throw new Error('Expected doc.save() to throw on a closed handle.');
     } catch (error) {
       expect(error).toBeInstanceOf(SuperDocCliError);
       const cliError = error as SuperDocCliError;

--- a/packages/sdk/langs/node/src/__tests__/handle-and-tools.test.ts
+++ b/packages/sdk/langs/node/src/__tests__/handle-and-tools.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 import type { BoundDocApi } from '../generated/client.js';
-import { SuperDocDocument } from '../index.ts';
+import { BoundRuntime, SuperDocDocument } from '../index.ts';
 import { SuperDocCliError } from '../runtime/errors.js';
+import type { OperationSpec, SuperDocRuntime } from '../runtime/process.js';
 import { dispatchSuperDocTool } from '../tools.ts';
 
 describe('SuperDocDocument', () => {
@@ -17,6 +18,31 @@ describe('SuperDocDocument', () => {
     expect(typeof doc.getMarkdown).toBe('function');
     expect(typeof doc.query.match).toBe('function');
     expect('api' in (doc as unknown as Record<string, unknown>)).toBe(false);
+  });
+});
+
+describe('BoundRuntime', () => {
+  test('invoke throws DOCUMENT_CLOSED with operation id after the handle is closed', async () => {
+    const runtime = { invoke: async () => ({}) } as unknown as SuperDocRuntime;
+    const boundRuntime = new BoundRuntime(runtime, 'session-1');
+    const operation: OperationSpec = {
+      operationId: 'doc.save',
+      commandTokens: ['doc', 'save'],
+      params: [],
+    };
+
+    boundRuntime.markClosed();
+
+    try {
+      await boundRuntime.invoke(operation);
+      throw new Error('Expected BoundRuntime.invoke to throw on a closed handle.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SuperDocCliError);
+      const cliError = error as SuperDocCliError;
+      expect(cliError.code).toBe('DOCUMENT_CLOSED');
+      expect(cliError.message).toContain('doc.save');
+      expect(cliError.details).toEqual({ sessionId: 'session-1', operationId: 'doc.save' });
+    }
   });
 });
 

--- a/packages/sdk/langs/node/src/index.ts
+++ b/packages/sdk/langs/node/src/index.ts
@@ -29,7 +29,7 @@ import { SuperDocCliError } from './runtime/errors.js';
  *
  * @internal
  */
-class BoundRuntime implements RuntimeInvoker {
+export class BoundRuntime implements RuntimeInvoker {
   private readonly runtime: SuperDocRuntime;
   private readonly sessionId: string;
   private closed = false;
@@ -45,9 +45,9 @@ class BoundRuntime implements RuntimeInvoker {
     options: InvokeOptions = {},
   ): Promise<TData> {
     if (this.closed) {
-      throw new SuperDocCliError('Document handle is closed.', {
+      throw new SuperDocCliError(`Document handle is closed; cannot invoke ${operation.operationId}.`, {
         code: 'DOCUMENT_CLOSED',
-        details: { sessionId: this.sessionId },
+        details: { sessionId: this.sessionId, operationId: operation.operationId },
       });
     }
     return this.runtime.invoke<TData>(operation, { ...params, sessionId: this.sessionId }, options);

--- a/packages/sdk/langs/node/src/index.ts
+++ b/packages/sdk/langs/node/src/index.ts
@@ -29,7 +29,7 @@ import { SuperDocCliError } from './runtime/errors.js';
  *
  * @internal
  */
-export class BoundRuntime implements RuntimeInvoker {
+class BoundRuntime implements RuntimeInvoker {
   private readonly runtime: SuperDocRuntime;
   private readonly sessionId: string;
   private closed = false;


### PR DESCRIPTION
When invoke() is called on a closed document handle, the resulting SuperDocCliError now includes the attempted operation id in both the message and the details object. The error code (DOCUMENT_CLOSED) is unchanged so programmatic handling keeps working.

Without this, callers hitting a use-after-close in production see only "Document handle is closed." and have no signal about which operation triggered it.

- `error.message` now reads `Document handle is closed; cannot invoke <operationId>.`
- `error.details.operationId` is added alongside the existing `sessionId`
- Adds a focused unit test through the document handle lifecycle