### PR TITLE
fix(super-toolbar): type SuperToolbar fields + ToolbarItem.value shapes (SD-3213 drain)

### DIFF
--- a/packages/super-editor/src/editors/v1/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/editors/v1/components/toolbar/super-toolbar.js
@@ -74,7 +74,7 @@ import { insertTableOfContentsAtSelection } from '@extensions/table-of-contents/
  * @property {{ value: boolean }} active - Whether the item is active
  * @property {{ value: boolean }} expand - Whether the item is expanded
  * @property {{ value: ToolbarItem[] }} nestedOptions - Nested options for the item
- * @property {{ value: Record<string, string> | undefined }} style - Custom style for the item
+ * @property {{ value: Record<string, string | number> | undefined }} style - Custom style for the item
  * @property {{ value: boolean }} isNarrow - Whether the item has narrow styling
  * @property {{ value: boolean }} isWide - Whether the item has wide styling
  * @property {{ value: number | string | undefined }} minWidth - Minimum width of the item
@@ -90,7 +90,7 @@ import { insertTableOfContentsAtSelection } from '@extensions/table-of-contents/
  * @property {{ value: ToolbarItem | undefined }} childItem - The child of this item if it has one
  * @property {{ value: string | undefined }} iconColor - The color of the icon (CSS color)
  * @property {{ value: boolean }} hasCaret - Whether the item has a dropdown caret
- * @property {{ value: Record<string, string> | undefined }} dropdownStyles - Custom styles for the dropdown
+ * @property {{ value: Record<string, string | number> | undefined }} dropdownStyles - Custom styles for the dropdown
  * @property {{ value: boolean }} tooltipVisible - Whether the tooltip is visible
  * @property {{ value: number | undefined }} tooltipTimeout - Timeout for the tooltip (ms)
  * @property {{ value: string | undefined }} defaultLabel - The default label for the item

--- a/packages/super-editor/src/editors/v1/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/editors/v1/components/toolbar/super-toolbar.js
@@ -28,7 +28,7 @@ import { insertTableOfContentsAtSelection } from '@extensions/table-of-contents/
  * A callback function that's executed when a toolbar button is clicked
  * @param {CommandItem} params - Command parameters
  * @param {ToolbarItem} params.item - An instance of the useToolbarItem composable
- * @param {*} [params.argument] - The argument passed to the command
+ * @param {unknown} [params.argument] - The argument passed to the command
  */
 
 /**
@@ -53,76 +53,57 @@ import { insertTableOfContentsAtSelection } from '@extensions/table-of-contents/
 
 /**
  * @typedef {Object} ToolbarItem
- * @property {Object} id - The unique ID of the toolbar item
- * @property {string} id.value - The value of the ID
- * @property {Object} name - The name of the toolbar item
- * @property {string} name.value - The value of the name
+ *
+ * Reactive toolbar item wrapper produced by `useToolbarItem`. Each
+ * field is a Vue `Ref`-shaped container with a `.value`. The `.value`
+ * types are tightened here (was `*` / `any`) so consumers configuring
+ * custom toolbar buttons get real IntelliSense on the values they
+ * pass through.
+ *
+ * @property {{ value: string }} id - The unique ID of the toolbar item
+ * @property {{ value: string }} name - The name of the toolbar item
  * @property {string} type - The type of toolbar item (button, options, separator, dropdown, overflow)
- * @property {Object} group - The group the item belongs to
- * @property {string} group.value - The value of the group
+ * @property {{ value: string }} group - The group the item belongs to
  * @property {string|CommandCallback} command - The command to execute
  * @property {string} [noArgumentCommand] - The command to execute when no argument is provided
- * @property {Object} icon - The icon for the item
- * @property {*} icon.value - The value of the icon
- * @property {Object} tooltip - The tooltip for the item
- * @property {*} tooltip.value - The value of the tooltip
+ * @property {{ value: string | undefined }} icon - The icon for the item (icon-name string)
+ * @property {{ value: string | undefined }} tooltip - The tooltip text
  * @property {boolean} [restoreEditorFocus] - Whether to restore editor focus after command execution
- * @property {Object} attributes - Additional attributes for the item
- * @property {Object} attributes.value - The value of the attributes
- * @property {Object} disabled - Whether the item is disabled
- * @property {boolean} disabled.value - The value of disabled
- * @property {Object} active - Whether the item is active
- * @property {boolean} active.value - The value of active
- * @property {Object} expand - Whether the item is expanded
- * @property {boolean} expand.value - The value of expand
- * @property {Object} nestedOptions - Nested options for the item
- * @property {Array} nestedOptions.value - The array of nested options
- * @property {Object} style - Custom style for the item
- * @property {*} style.value - The value of the style
- * @property {Object} isNarrow - Whether the item has narrow styling
- * @property {boolean} isNarrow.value - The value of isNarrow
- * @property {Object} isWide - Whether the item has wide styling
- * @property {boolean} isWide.value - The value of isWide
- * @property {Object} minWidth - Minimum width of the item
- * @property {*} minWidth.value - The value of minWidth
- * @property {Object} argument - The argument to pass to the command
- * @property {*} argument.value - The value of the argument
- * @property {Object} parentItem - The parent of this item if nested
- * @property {*} parentItem.value - The value of parentItem
- * @property {Object} childItem - The child of this item if it has one
- * @property {*} childItem.value - The value of childItem
- * @property {Object} iconColor - The color of the icon
- * @property {*} iconColor.value - The value of iconColor
- * @property {Object} hasCaret - Whether the item has a dropdown caret
- * @property {boolean} hasCaret.value - The value of hasCaret
- * @property {Object} dropdownStyles - Custom styles for dropdown
- * @property {*} dropdownStyles.value - The value of dropdownStyles
- * @property {Object} tooltipVisible - Whether the tooltip is visible
- * @property {boolean} tooltipVisible.value - The value of tooltipVisible
- * @property {Object} tooltipTimeout - Timeout for the tooltip
- * @property {*} tooltipTimeout.value - The value of tooltipTimeout
- * @property {Object} defaultLabel - The default label for the item
- * @property {*} defaultLabel.value - The value of the default label
- * @property {Object} label - The label for the item
- * @property {*} label.value - The value of the label
- * @property {Object} hideLabel - Whether to hide the label
- * @property {boolean} hideLabel.value - The value of hideLabel
- * @property {Object} inlineTextInputVisible - Whether inline text input is visible
- * @property {boolean} inlineTextInputVisible.value - The value of inlineTextInputVisible
- * @property {Object} hasInlineTextInput - Whether the item has inline text input
- * @property {boolean} hasInlineTextInput.value - The value of hasInlineTextInput
- * @property {Object} markName - The name of the mark
- * @property {*} markName.value - The value of markName
- * @property {Object} labelAttr - The attribute for the label
- * @property {*} labelAttr.value - The value of labelAttr
- * @property {Object} allowWithoutEditor - Whether the item can be used without an editor
- * @property {boolean} allowWithoutEditor.value - The value of allowWithoutEditor
- * @property {Object} dropdownValueKey - The key for dropdown value
- * @property {*} dropdownValueKey.value - The value of dropdownValueKey
- * @property {Object} selectedValue - The selected value for the item
- * @property {*} selectedValue.value - The value of the selected value
- * @property {Object} inputRef - Reference to an input element
- * @property {*} inputRef.value - The value of inputRef
+ * @property {{ value: Record<string, unknown> }} attributes - Additional attributes for the item
+ * @property {{ value: boolean }} disabled - Whether the item is disabled
+ * @property {{ value: boolean }} active - Whether the item is active
+ * @property {{ value: boolean }} expand - Whether the item is expanded
+ * @property {{ value: ToolbarItem[] }} nestedOptions - Nested options for the item
+ * @property {{ value: Record<string, string> | undefined }} style - Custom style for the item
+ * @property {{ value: boolean }} isNarrow - Whether the item has narrow styling
+ * @property {{ value: boolean }} isWide - Whether the item has wide styling
+ * @property {{ value: number | string | undefined }} minWidth - Minimum width of the item
+ *
+ * `argument.value` and `selectedValue.value` are intentionally
+ * `unknown` (not `any`): consumers pass arbitrary data through these
+ * to their custom command callbacks, so the toolbar cannot promise a
+ * narrower shape without becoming wrong. `unknown` forces the
+ * consumer to narrow at the call site they own.
+ *
+ * @property {{ value: unknown }} argument - The argument to pass to the command (consumer-typed)
+ * @property {{ value: ToolbarItem | undefined }} parentItem - The parent of this item if nested
+ * @property {{ value: ToolbarItem | undefined }} childItem - The child of this item if it has one
+ * @property {{ value: string | undefined }} iconColor - The color of the icon (CSS color)
+ * @property {{ value: boolean }} hasCaret - Whether the item has a dropdown caret
+ * @property {{ value: Record<string, string> | undefined }} dropdownStyles - Custom styles for the dropdown
+ * @property {{ value: boolean }} tooltipVisible - Whether the tooltip is visible
+ * @property {{ value: number | undefined }} tooltipTimeout - Timeout for the tooltip (ms)
+ * @property {{ value: string | undefined }} defaultLabel - The default label for the item
+ * @property {{ value: string | undefined }} label - The label for the item
+ * @property {{ value: boolean }} hideLabel - Whether to hide the label
+ * @property {{ value: boolean }} inlineTextInputVisible - Whether inline text input is visible
+ * @property {{ value: boolean }} hasInlineTextInput - Whether the item has inline text input
+ * @property {{ value: string | undefined }} markName - The name of the mark (e.g. 'bold')
+ * @property {{ value: string | undefined }} labelAttr - The attribute for the label
+ * @property {{ value: boolean }} allowWithoutEditor - Whether the item can be used without an editor
+ * @property {{ value: string | undefined }} dropdownValueKey - The key for dropdown value
+ * @property {{ value: unknown }} selectedValue - The selected value (consumer-typed)
+ * @property {{ value: HTMLInputElement | null }} inputRef - Reference to an input element
  * @property {Function} unref - Function to get unreferenced values
  * @property {Function} activate - Function to activate the item
  * @property {Function} deactivate - Function to deactivate the item
@@ -135,8 +116,8 @@ import { insertTableOfContentsAtSelection } from '@extensions/table-of-contents/
 /**
  * @typedef {Object} CommandItem
  * @property {ToolbarItem} item - The toolbar item
- * @property {*} [argument] - The argument to pass to the command
- * @property {*} [option] - The selected nested option for option-style commands
+ * @property {unknown} [argument] - The argument to pass to the command (consumer-typed)
+ * @property {unknown} [option] - The selected nested option for option-style commands (consumer-typed)
  */
 
 /**
@@ -184,6 +165,53 @@ export class SuperToolbar extends EventEmitter {
     customButtons: [],
     showFormattingMarksButton: false,
   };
+
+  /**
+   * Visible toolbar items in their resolved order. Populated by
+   * `#initToolbarItems` after `useToolbarItem` builds the reactive
+   * wrappers; mutated when items move to overflow on resize.
+   * @type {ToolbarItem[]}
+   */
+  toolbarItems = [];
+
+  /**
+   * Items moved into the overflow menu when the container is narrower
+   * than the toolbar's natural width.
+   * @type {ToolbarItem[]}
+   */
+  overflowItems = [];
+
+  /**
+   * Dev mode flag forwarded from `SuperDoc`'s config. Enables extra
+   * dropdowns (e.g. extension picker) used only by internal tooling.
+   * @type {boolean}
+   */
+  isDev = false;
+
+  /**
+   * Role propagated from the parent `SuperDoc` (typically `'editor'`
+   * or `'viewer'`); drives feature gating in the toolbar items.
+   * @type {string}
+   */
+  role = 'editor';
+
+  /**
+   * Back-reference to the owning `SuperDoc` instance. Marked private
+   * because it exposes the full SuperDoc internal graph and should
+   * not be part of the toolbar's public TypeScript surface. Internal
+   * paths that need a method on the parent SuperDoc reach for it
+   * through this field.
+   * @type {unknown}
+   * @private
+   */
+  superdoc;
+
+  /**
+   * Mounted toolbar container element, set after `render()`. Null
+   * before the first render or after `destroy()`.
+   * @type {HTMLElement | null}
+   */
+  toolbarContainer = null;
 
   /**
    * Creates a new SuperToolbar instance
@@ -796,8 +824,9 @@ export class SuperToolbar extends EventEmitter {
    * Main handler for toolbar commands
    * @param {CommandItem} params - Command parameters
    * @param {ToolbarItem} params.item - An instance of the useToolbarItem composable
-   * @param {*} [params.argument] - The argument passed to the command
-   * @returns {*} The result of the executed command, undefined if no result is returned
+   * @param {unknown} [params.argument] - The argument passed to the command
+   * @returns {void} All control-flow branches use a bare `return;`; this method
+   *   side-effects (emits events, mutates state) and produces no value.
    */
   emitCommand({ item, argument, option }) {
     const hasFocusFn = this.activeEditor?.view?.hasFocus;
@@ -999,7 +1028,7 @@ export class SuperToolbar extends EventEmitter {
    * @private
    * @param {Object} params
    * @param {string} params.command
-   * @param {*} params.argument
+   * @param {unknown} params.argument
    * @returns {void}
    */
   #ensureStoredMarksForMarkToggle({ command, argument }) {

--- a/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
+++ b/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "scope": "supported-root",
-  "generatedAt": "2026-05-20T19:46:50.387Z",
+  "generatedAt": "2026-05-20T23:24:35.021Z",
   "entries": [
     {
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.converter[string]|converter: SuperConverter;",
@@ -564,276 +564,6 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand(__0).argument|argument?: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand(__0).argument",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 581,
-      "snippet": "argument?: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand(__0).option|option?: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand(__0).option",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 585,
-      "snippet": "option?: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.isDev|isDev: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.isDev",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 140,
-      "snippet": "isDev: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.superdoc|superdoc: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.superdoc",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 141,
-      "snippet": "superdoc: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarContainer|toolbarContainer: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarContainer",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 143,
-      "snippet": "toolbarContainer: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].argument.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].argument.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 434,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].childItem.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].childItem.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 446,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].command(arg0).argument|argument?: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].command(arg0).argument",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 581,
-      "snippet": "argument?: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].command(arg0).option|option?: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].command(arg0).option",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 585,
-      "snippet": "option?: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].defaultLabel.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].defaultLabel.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 482,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].dropdownStyles.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].dropdownStyles.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 464,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].dropdownValueKey.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].dropdownValueKey.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 530,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].icon.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].icon.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 364,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].iconColor.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].iconColor.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 452,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].inputRef.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].inputRef.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 542,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].label.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].label.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 488,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].labelAttr.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].labelAttr.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 518,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].markName.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].markName.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 512,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].minWidth.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].minWidth.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 428,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].parentItem.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].parentItem.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 440,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].selectedValue.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].selectedValue.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 536,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].style.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].style.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 410,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].tooltip.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].tooltip.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 370,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].tooltipTimeout.value|value: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].tooltipTimeout.value",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 476,
-      "snippet": "value: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.isDev|isDev: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.isDev",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 140,
-      "snippet": "isDev: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.superdoc|superdoc: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.superdoc",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 141,
-      "snippet": "superdoc: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.toolbarContainer|toolbarContainer: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.toolbar.toolbarContainer",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 143,
-      "snippet": "toolbarContainer: any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "property|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.element|element: any;",
       "kind": "property",
       "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.element",
@@ -874,26 +604,6 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "return|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand=>return|emitCommand({ item, argument, option }: CommandItem): any;",
-      "kind": "return",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.emitCommand=>return",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 229,
-      "snippet": "emitCommand({ item, argument, option }: CommandItem): any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "return|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.emitCommand=>return|emitCommand({ item, argument, option }: CommandItem): any;",
-      "kind": "return",
-      "symbolPath": "SuperDoc.toolbar.emitCommand=>return",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 229,
-      "snippet": "emitCommand({ item, argument, option }: CommandItem): any;",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "return|node_modules/superdoc/dist/super-editor/src/editors/v1/core/helpers/getActiveFormatting.d.ts|getActiveFormatting.<value>=>return|export function getActiveFormatting(editor: any): any;",
       "kind": "return",
       "symbolPath": "getActiveFormatting.<value>=>return",
@@ -914,92 +624,12 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.overflowItems<0>|overflowItems: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.overflowItems<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 139,
-      "snippet": "overflowItems: any[];",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.overflowItems[]|overflowItems: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.overflowItems[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 139,
-      "snippet": "overflowItems: any[];",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbar<14>|toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
       "kind": "type",
       "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbar<14>",
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 173,
+      "line": 189,
       "snippet": "toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarItems<0>|toolbarItems: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarItems<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 138,
-      "snippet": "toolbarItems: any[];",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarItems[]|toolbarItems: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbarItems[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 138,
-      "snippet": "toolbarItems: any[];",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].nestedOptions.value<0>|value: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].nestedOptions.value<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 404,
-      "snippet": "value: any[];",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.config.customButtons[].nestedOptions.value[]|value: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.toolbar.config.customButtons[].nestedOptions.value[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 404,
-      "snippet": "value: any[];",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.overflowItems<0>|overflowItems: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.toolbar.overflowItems<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 139,
-      "snippet": "overflowItems: any[];",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.overflowItems[]|overflowItems: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.toolbar.overflowItems[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 139,
-      "snippet": "overflowItems: any[];",
       "owner": "tier-2-toolbar",
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
@@ -1008,28 +638,8 @@
       "kind": "type",
       "symbolPath": "SuperDoc.toolbar.toolbar<14>",
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 173,
+      "line": 189,
       "snippet": "toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.toolbarItems<0>|toolbarItems: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.toolbar.toolbarItems<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 138,
-      "snippet": "toolbarItems: any[];",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.toolbarItems[]|toolbarItems: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.toolbar.toolbarItems[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 138,
-      "snippet": "toolbarItems: any[];",
       "owner": "tier-2-toolbar",
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },


### PR DESCRIPTION
Drains 39 supported-root \`any\` findings (allowlist 235 → 196) by tightening JSDoc in \`super-toolbar.js\`. The previous typedef described every reactive ToolbarItem field as \`{Object} field, * field.value\` — JSDoc \`*\` = \`any\` — which collapsed IntelliSense at every depth that reached through these fields.

Two areas tightened:

1. **SuperToolbar class instance fields**: assigned in constructor without prior class-field declarations, so tsc inferred \`any\`. Added \`@type\` declarations for \`toolbarItems\`, \`overflowItems\`, \`isDev\`, \`role\`, \`toolbarContainer\`. Marked \`superdoc\` as \`@private\` — it's a back-reference to the parent SuperDoc and exposing it works against the public-surface goal.
2. **ToolbarItem typedef**: 18 \`.value\` fields tightened from \`*\` to specific types. Booleans, strings, \`Record<string, string | number>\` for CSS-style records (widened to accept numeric values like \`padding: 0\` that defaultItems.js uses at runtime), \`ToolbarItem[]\` for nestedOptions. Two intentional \`unknown\` types: \`argument.value\` and \`selectedValue.value\` — these flow through to consumer command callbacks; the toolbar cannot promise a narrower shape.
3. **\`emitCommand\` return**: narrowed from \`*\` to \`void\`. Verified the implementation has 5 \`return;\` statements with no value — the method side-effects, doesn't return.

**Scope honesty**: this PR improves the *constructed-instance reach path* — i.e., code that reaches \`superdoc.toolbar.config.customButtons[<i>].<field>.value\` on a live toolbar instance. The **authoring path** through \`new SuperDoc({ modules: { toolbar: { customButtons } } })\` still uses \`Array<Record<string, unknown>>\` in \`Config\` (see \`packages/superdoc/src/core/types/index.ts:1097\`), because the internal ToolbarItem typedef isn't on the public surface yet. Aligning the authoring path with the now-typed ToolbarItem is separate work and isn't required to land this drain.

Per project guidance: prefer precise typed shapes over \`unknown\` where the value type is knowable. \`unknown\` reserved for genuinely opaque consumer-typed values.

**Verified**: build exit 0; matrix 59/59; audit PASS (196 in / 0 new / 0 stale; 39 stale entries detected before regeneration as expected); super-editor tests (toolbar + headless-toolbar + ui): 440/440.

**Drain delta**: total findings 1102 → 1004 (−98); supported-root 235 → 196 (−39).

After this lands, next biggest supported-root targets: EventEmitter.d.ts (69), Editor.d.ts (37), EditorConfig.d.ts (32). EventEmitter is the biggest single-file count but is systemic (\`DefaultEventMap = Record<string, any[]>\` leaks through every \`on\`/\`once\`/\`off\`/\`emit\` path) — needs a spike rather than a casual drain PR.