### PR TITLE
fix(whiteboard): type stored shapes + register/getType, fix stickers->images JSDoc (SD-3213 drain)

### DIFF
--- a/packages/superdoc/src/core/whiteboard/Whiteboard.js
+++ b/packages/superdoc/src/core/whiteboard/Whiteboard.js
@@ -3,8 +3,25 @@ import { WhiteboardPage } from './WhiteboardPage';
 
 /**
  * @typedef {{ width: number, height: number, originalWidth?: number, originalHeight?: number }} WhiteboardPageSize
- * @typedef {{ strokes?: any[], text?: any[], images?: any[] }} WhiteboardPageData
+ *
+ * The page-level serialized shape is the normalized one (matches what
+ * `WhiteboardPage.toJSON()` actually returns). SD-3213 follow-up:
+ * the previous `any[]` typing meant consumers reading
+ * `whiteboard.getWhiteboardData().pages[0].strokes` had no
+ * IntelliSense — and a wrong assumption that fields like `.points`
+ * or `.x` would be present (runtime gives `pointsN` / `xN`).
+ *
+ * @typedef {import('./WhiteboardPage.js').WhiteboardStoredPageData} WhiteboardPageData
  * @typedef {{ pages?: Record<string, WhiteboardPageData> }} WhiteboardData
+ *
+ * Registry items the host can attach for UI palettes (stickers,
+ * comments, etc.). The shape is intentionally extensible: `id` is the
+ * one field the runtime actually relies on (filter, dedup); everything
+ * else is consumer-typed via `unknown` so palettes for new domains
+ * don't need a contract change.
+ *
+ * @typedef {{ id?: string | number, [key: string]: unknown }} WhiteboardRegistryItem
+ *
  * @typedef {{
  *  Renderer?: any,
  *  superdoc?: any,
@@ -65,7 +82,7 @@ export class Whiteboard extends EventEmitter {
   /**
    * Register items for a UI palette type (e.g. stickers, comments).
    * @param {string} type
-   * @param {any[]} items
+   * @param {WhiteboardRegistryItem[]} items
    */
   register(type, items) {
     this.#registry.set(type, items);
@@ -74,7 +91,7 @@ export class Whiteboard extends EventEmitter {
   /**
    * Get registered items by type.
    * @param {string} type
-   * @returns {any[] | undefined}
+   * @returns {WhiteboardRegistryItem[] | undefined}
    */
   getType(type) {
     return this.#registry.get(type);

--- a/packages/superdoc/src/core/whiteboard/WhiteboardPage.js
+++ b/packages/superdoc/src/core/whiteboard/WhiteboardPage.js
@@ -7,9 +7,39 @@ const DEFAULT_TEXT_FONT_SIZE = 18;
 /**
  * @typedef {{ width: number, height: number, originalWidth?: number, originalHeight?: number }} WhiteboardPageSize
  * @typedef {{ x: number, y: number }} Point
+ *
+ * Authored input shapes — what `addStroke`/`addText`/`addImage` accept
+ * from a consumer (pixel-space coordinates, optional ids). The
+ * add* methods normalize these into the stored shapes below.
+ *
  * @typedef {{ points: number[][], color?: string, width?: number, type?: 'draw'|'erase' }} WhiteboardStroke
  * @typedef {{ id?: string|number, x: number, y: number, content: string, fontSize?: number, width?: number }} WhiteboardTextItem
  * @typedef {{ id?: string|number, stickerId?: string, x: number, y: number, src: string, width?: number, height?: number, type?: string }} WhiteboardImageItem
+ *
+ * Stored / normalized shapes — what the page actually holds in
+ * `this.strokes` / `this.text` / `this.images` and what gets
+ * serialized via `toJSON()` and re-applied via `applyData()`. Fields
+ * suffixed with `N` (pointsN, xN, yN, widthN, heightN, fontSizeN) are
+ * normalized to the page's 0..1 coordinate space; raw `width`/`height`
+ * pairs are kept where consumers expect pixel sizes.
+ *
+ * SD-3213 follow-up: the public types were previously `any[]` for the
+ * fields and the toJSON / applyData signatures; consumers reading
+ * `page.strokes[0].points` would have hit pointsN at runtime with no
+ * IntelliSense. The named shapes below restore typing without
+ * over-committing the authored shapes (which the add* methods
+ * normalize away).
+ *
+ * @typedef {{ pointsN: number[][], widthN?: number, color?: string, type?: 'draw'|'erase' }} WhiteboardStoredStroke
+ * @typedef {{ id: string|number, xN: number, yN: number, content: string, fontSizeN?: number, widthN?: number | null }} WhiteboardStoredTextItem
+ * @typedef {{ id: string|number, stickerId?: string | number | null, xN: number, yN: number, src: string, widthN?: number | null, heightN?: number | null, type?: string }} WhiteboardStoredImageItem
+ *
+ * @typedef {{
+ *  strokes?: WhiteboardStoredStroke[],
+ *  text?: WhiteboardStoredTextItem[],
+ *  images?: WhiteboardStoredImageItem[],
+ * }} WhiteboardStoredPageData
+ *
  * @typedef {{
  *  pageIndex: number,
  *  enabled: boolean,
@@ -26,13 +56,13 @@ export class WhiteboardPage {
   /** @type {number|null} */
   pageIndex = null;
 
-  /** @type {WhiteboardStroke[]} */
+  /** @type {WhiteboardStoredStroke[]} */
   strokes = [];
 
-  /** @type {WhiteboardTextItem[]} */
+  /** @type {WhiteboardStoredTextItem[]} */
   text = [];
 
-  /** @type {WhiteboardImageItem[]} */
+  /** @type {WhiteboardStoredImageItem[]} */
   images = [];
 
   /** @type {WhiteboardPageSize|null} */
@@ -681,7 +711,12 @@ export class WhiteboardPage {
 
   /**
    * Serialize page data.
-   * @returns {{ strokes: any[], text: any[], stickers: any[] }}
+   * Returns the page's serializable shape. SD-3213 follow-up: fixed
+   * stale JSDoc that said `stickers` (which never existed on the
+   * runtime return) and typed the values as the stored normalized
+   * shapes instead of `any[]`.
+   *
+   * @returns {{ strokes: WhiteboardStoredStroke[], text: WhiteboardStoredTextItem[], images: WhiteboardStoredImageItem[] }}
    */
   toJSON() {
     return {
@@ -693,7 +728,7 @@ export class WhiteboardPage {
 
   /**
    * Apply data to this page and re-render.
-   * @param {{ strokes?: any[], text?: any[], images?: any[] }} data
+   * @param {WhiteboardStoredPageData} data
    */
   applyData(data = {}) {
     const strokes = Array.isArray(data.strokes) ? data.strokes : [];

--- a/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
+++ b/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "scope": "supported-root",
-  "generatedAt": "2026-05-21T00:16:58.891Z",
+  "generatedAt": "2026-05-21T09:36:10.903Z",
   "entries": [
     {
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.converter[string]|converter: SuperConverter;",
@@ -1010,126 +1010,6 @@
       "file": "node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts",
       "line": 81,
       "snippet": "app: import('vue').App;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.register(items)<0>|items: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.register(items)<0>",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
-      "line": 30,
-      "snippet": "items: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.register(items)[]|items: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.whiteboard.register(items)[]",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
-      "line": 30,
-      "snippet": "items: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.whiteboard.getType=>return<0>|getType(type: string): any[] | undefined;",
-      "kind": "type",
-      "symbolPath": "SuperDoc.whiteboard.getType=>return<0>",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
-      "line": 36,
-      "snippet": "getType(type: string): any[] | undefined;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.whiteboard.getType=>return[]|getType(type: string): any[] | undefined;",
-      "kind": "type",
-      "symbolPath": "SuperDoc.whiteboard.getType=>return[]",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
-      "line": 36,
-      "snippet": "getType(type: string): any[] | undefined;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.whiteboard.register(items)<0>|items: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.whiteboard.register(items)<0>",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
-      "line": 30,
-      "snippet": "items: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts|SuperDoc.whiteboard.register(items)[]|items: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.whiteboard.register(items)[]",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/Whiteboard.d.ts",
-      "line": 30,
-      "snippet": "items: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.stickers<0>|stickers: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.stickers<0>",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
-      "line": 103,
-      "snippet": "stickers: any[];",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.stickers[]|stickers: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.stickers[]",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
-      "line": 103,
-      "snippet": "stickers: any[];",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.strokes<0>|strokes: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.strokes<0>",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
-      "line": 101,
-      "snippet": "strokes: any[];",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.strokes[]|strokes: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.strokes[]",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
-      "line": 101,
-      "snippet": "strokes: any[];",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.text<0>|text: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.text<0>",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
-      "line": 102,
-      "snippet": "text: any[];",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts|SuperDoc.whiteboard.getPages=>return[].toJSON=>return.text[]|text: any[];",
-      "kind": "type",
-      "symbolPath": "SuperDoc.whiteboard.getPages=>return[].toJSON=>return.text[]",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/whiteboard/WhiteboardPage.d.ts",
-      "line": 102,
-      "snippet": "text: any[];",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
     }

--- a/tests/consumer-typecheck/src/whiteboard-data-shape.ts
+++ b/tests/consumer-typecheck/src/whiteboard-data-shape.ts
@@ -1,0 +1,125 @@
+/**
+ * Consumer typecheck: Whiteboard data shape contracts (SD-3213 follow-up).
+ *
+ * Pre-PR, the public types for Whiteboard / WhiteboardPage carried
+ * three any-leak categories that all hurt consumers reading whiteboard
+ * data:
+ *
+ *   1. `WhiteboardPage.toJSON()` declared `{ strokes: any[]; text: any[];
+ *      stickers: any[] }` — the type said `stickers`, but the runtime
+ *      always returned `images`. Consumers reading the typed return
+ *      would have written `result.stickers` and silently gotten
+ *      `undefined`.
+ *   2. `WhiteboardPage.{strokes, text, images}` were typed as the
+ *      *authored* shapes (e.g. `{ points, x, y }`), but the runtime
+ *      stores *normalized* shapes (`{ pointsN, xN, yN }`). Consumers
+ *      reaching for `page.strokes[0].points` would have hit
+ *      `pointsN` at runtime with no IntelliSense.
+ *   3. `Whiteboard.register` / `Whiteboard.getType` accepted /
+ *      returned `any[]`, giving consumers no IntelliSense for the
+ *      stable `id` field the runtime relies on.
+ *
+ * This fixture pins all three: the serialized field is `images` (not
+ * `stickers`); stored items use normalized field names; registry items
+ * expose `id` typed.
+ */
+
+import type { SuperDoc } from 'superdoc';
+
+declare const superdoc: SuperDoc;
+
+const whiteboard = superdoc.whiteboard;
+if (whiteboard) {
+  // --- 1. getWhiteboardData() returns the normalized page shape with
+  //        `images`, not `stickers` -----------------------------------------
+  const data = whiteboard.getWhiteboardData();
+  const pages = data.pages ?? {};
+  const firstKey = Object.keys(pages)[0];
+  if (firstKey !== undefined) {
+    const page = pages[firstKey]!;
+
+    // `images` exists and is typed
+    const images = page.images;
+    void images;
+
+    // `stickers` was a stale JSDoc artifact; it must NOT appear on the
+    // public shape. If it slips back, this @ts-expect-error stops
+    // erroring and tsc fails (TS2578).
+    // @ts-expect-error SD-3213: toJSON() return uses `images`, not `stickers`.
+    void page.stickers;
+  }
+
+  // --- 2. Stored items use normalized field names (not authored) -----------
+  const allPages = whiteboard.getPages();
+  const firstPage = allPages[0];
+  if (firstPage) {
+    const firstStroke = firstPage.strokes[0];
+    if (firstStroke) {
+      // Normalized field: `pointsN`, not `points`.
+      const pointsN: number[][] = firstStroke.pointsN;
+      const widthN: number | undefined = firstStroke.widthN;
+      void pointsN;
+      void widthN;
+
+      // `points` was the authored input field, normalized away on store.
+      // @ts-expect-error SD-3213: stored strokes have `pointsN`, not `points`.
+      void firstStroke.points;
+    }
+
+    const firstText = firstPage.text[0];
+    if (firstText) {
+      // Stored text uses normalized coordinates and font size.
+      // widthN includes null because #toNormalizedText falls back to
+      // null when the input width is non-finite.
+      const xN: number = firstText.xN;
+      const yN: number = firstText.yN;
+      const content: string = firstText.content;
+      const fontSizeN: number | undefined = firstText.fontSizeN;
+      const textWidthN: number | null | undefined = firstText.widthN;
+      void xN;
+      void yN;
+      void content;
+      void fontSizeN;
+      void textWidthN;
+    }
+
+    const firstImage = firstPage.images[0];
+    if (firstImage) {
+      // Stored images use normalized coordinates/sizes plus the source URL.
+      // widthN / heightN include null (#toNormalizedImage fallback).
+      // stickerId is `string | number | null` because addImage() forwards
+      // item.id (which is `string | number`) when type === 'sticker'.
+      const xN: number = firstImage.xN;
+      const imageWidthN: number | null | undefined = firstImage.widthN;
+      const imageHeightN: number | null | undefined = firstImage.heightN;
+      const src: string = firstImage.src;
+      const stickerId: string | number | null | undefined = firstImage.stickerId;
+      void xN;
+      void imageWidthN;
+      void imageHeightN;
+      void src;
+      void stickerId;
+    }
+  }
+
+  // --- 3. Registry items expose `id` typed, arbitrary fields are unknown --
+  whiteboard.register('stickers', [{ id: 's1', label: 'sticker' }]);
+  const items = whiteboard.getType('stickers');
+  if (items) {
+    const first = items[0];
+    if (first) {
+      // `id` is typed.
+      const id: string | number | undefined = first.id;
+      void id;
+
+      // Arbitrary fields are `unknown`, not `any`. Reading them without
+      // narrowing must error. Bracket access is required under
+      // `noPropertyAccessFromIndexSignature` (which the strict
+      // "all public surface" scenario enables); same intent either way.
+      const label = first['label'];
+      // @ts-expect-error SD-3213: arbitrary registry fields are unknown, not any.
+      label.toUpperCase();
+      void label;
+    }
+  }
+}

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -562,6 +562,28 @@ const scenarios = [
     files: ['src/event-emitter-contract.ts'],
     mustPass: true,
   },
+  // SD-3213 Whiteboard data-shape typing: pin the three contracts
+  // tightened in this PR — toJSON returns `images` not `stickers`,
+  // stored items use normalized field names (pointsN/xN/yN/widthN),
+  // and registry items expose `id` typed with `unknown` for extras.
+  {
+    name: 'bundler / whiteboard data shape (SD-3213)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: true,
+    strict: true,
+    files: ['src/whiteboard-data-shape.ts'],
+    mustPass: true,
+  },
+  {
+    name: 'node16 / whiteboard data shape (SD-3213)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: true,
+    strict: true,
+    files: ['src/whiteboard-data-shape.ts'],
+    mustPass: true,
+  },
   // SD-2867 phase B: SuperDoc.canPerformPermission forwards `comment` and
   // `trackedChange` to isAllowed() unchanged, so the public contract must
   // accept the wide payloads the editor's permission helper produces


### PR DESCRIPTION
Drains 12 supported-root \`any\` findings (allowlist 113 → 101) by typing the Whiteboard data contract that consumers reach through \`superdoc.whiteboard.getWhiteboardData()\`, the \`Whiteboard.register\`/\`getType\` registry, and the per-page \`strokes\`/\`text\`/\`images\` storage.

Pre-PR there were three real consumer-side problems, not just type leaks:

1. **\`WhiteboardPage.toJSON()\` had stale JSDoc**: declared \`{ strokes, text, stickers }\` but runtime returns \`{ strokes, text, images }\`. Typed-and-wrong, not just loose — a consumer reading the return wrote \`result.stickers\` and silently got undefined.
2. **\`WhiteboardPage.{strokes, text, images}\` typed as authored shapes**: typed as \`WhiteboardStroke[]\` (= \`{ points, color, ... }\`), but runtime stores normalized shapes (\`{ pointsN, widthN, color, type }\`). Typed surface and runtime surface disagreed.
3. **\`Whiteboard.register\` / \`getType\` used \`any[]\`**: no IntelliSense for the stable \`id\` field consumers rely on.

This PR keeps authored vs stored typedefs distinct so \`add*\` methods accept authored inputs while fields/serializers expose stored normalized shapes:

- **WhiteboardPage.js**: adds \`WhiteboardStoredStroke\` / \`WhiteboardStoredTextItem\` / \`WhiteboardStoredImageItem\` / \`WhiteboardStoredPageData\` typedefs alongside the existing authored typedefs. Types \`this.strokes/text/images\` as stored shapes. Fixes \`toJSON()\`'s stale \`stickers\` → \`images\` and types the values. Types \`applyData()\` param.
- **Whiteboard.js**: adds \`WhiteboardRegistryItem\` (\`{ id?: string | number, [key: string]: unknown }\`). Types register/getType. Updates \`WhiteboardPageData\` via cross-file JSDoc import.

**Type-shape precision** (verified against the normalization helpers):
- \`WhiteboardStoredStroke.widthN\`: \`number | undefined\` (#toNormalizedStroke returns undefined when input width is non-finite).
- \`WhiteboardStoredTextItem.widthN\`: \`number | null | undefined\` (#toNormalizedText returns null fallback).
- \`WhiteboardStoredImageItem.widthN\`/\`heightN\`: \`number | null | undefined\` (#toNormalizedImage returns null fallback).
- \`WhiteboardStoredImageItem.stickerId\`: \`string | number | null\` (addImage forwards \`item.id\`, which is \`string|number\`, when \`type === 'sticker'\`).

**New consumer fixture** (\`src/whiteboard-data-shape.ts\`) pins all three contracts:
- \`getWhiteboardData()\` page shape exposes \`images\`, NOT \`stickers\` (@ts-expect-error proves \`stickers\` is no longer typed).
- Stored items use normalized field names. Old authored fields are @ts-expect-error. Null variants for widthN/heightN/stickerId pinned.
- Registry items: \`id\` typed; arbitrary fields are \`unknown\` (bracket access under \`noPropertyAccessFromIndexSignature\`), \`.toUpperCase()\` without narrowing is @ts-expect-error.

**Verified**: build exit 0; matrix 63/63 (+2 new SD-3213 scenarios); audit PASS (101 in, 0 new, 0 stale; was 113 in with 12 stale pre-regen); whiteboard tests 83/83 pass.

**Follow-up**: WhiteboardEventMap (typed event payloads for \`whiteboard.on/off\` — small PR, ~30 lines) can now use the corrected \`WhiteboardData\` type as the change/setData payload.