### PR TITLE
feat(whiteboard): type whiteboard event payloads (SD-3213)

### DIFF
--- a/packages/superdoc/src/core/whiteboard/Whiteboard.js
+++ b/packages/superdoc/src/core/whiteboard/Whiteboard.js
@@ -12,7 +12,32 @@ import { WhiteboardPage } from './WhiteboardPage';
  * or `.x` would be present (runtime gives `pointsN` / `xN`).
  *
  * @typedef {import('./WhiteboardPage.js').WhiteboardStoredPageData} WhiteboardPageData
- * @typedef {{ pages?: Record<string, WhiteboardPageData> }} WhiteboardData
+ *
+ * Per-page size snapshot recorded in `WhiteboardDataMeta.pageSizes`.
+ * `originalWidth` / `originalHeight` are `number | null` because
+ * `getWhiteboardData()` writes `page.originalSize?.width ?? null` when
+ * the original size is unknown.
+ *
+ * @typedef {{ width: number, height: number, originalWidth: number | null, originalHeight: number | null }} WhiteboardPageSizeSnapshot
+ *
+ * @typedef {{ pageSizes: Record<string, WhiteboardPageSizeSnapshot> }} WhiteboardDataMeta
+ *
+ * `WhiteboardData` is the **output** shape: what `getWhiteboardData()`
+ * returns and what the `change` event payload carries. All three
+ * fields are required because the runtime always populates them.
+ * Consumers reading the change payload can write
+ * `data.meta.pageSizes` without optional chaining.
+ *
+ * @typedef {{ pages: Record<string, WhiteboardPageData>, meta: WhiteboardDataMeta, version: 1 }} WhiteboardData
+ *
+ * `WhiteboardDataInput` is the **input** shape accepted by
+ * `setWhiteboardData(json)`. All fields are optional because the
+ * runtime only reads `json?.pages`; callers can pass
+ * `{ pages: {...} }` without supplying `meta` or `version`. A round
+ * trip works (`setWhiteboardData(getWhiteboardData())`) because
+ * `WhiteboardData` is structurally assignable to `WhiteboardDataInput`.
+ *
+ * @typedef {{ pages?: Record<string, WhiteboardPageData>, meta?: WhiteboardDataMeta, version?: number }} WhiteboardDataInput
  *
  * Registry items the host can attach for UI palettes (stickers,
  * comments, etc.). The shape is intentionally extensible: `id` is the
@@ -21,6 +46,22 @@ import { WhiteboardPage } from './WhiteboardPage';
  * don't need a contract change.
  *
  * @typedef {{ id?: string | number, [key: string]: unknown }} WhiteboardRegistryItem
+ *
+ * Event map for `whiteboard.on(name, fn)` / `whiteboard.emit(name, ...)`.
+ * Closed map (no DefaultEventMap fallback) because every event the
+ * runtime emits is enumerated here; an unknown event name should be a
+ * type error, not an `unknown[]` payload. SD-3213 follow-up to the
+ * EventEmitter `unknown[]` drain: that change only fixed the
+ * untyped-event fallback; without this map, listeners on Whiteboard
+ * still received `unknown[]` because no event was named.
+ *
+ * @typedef {{
+ *  tool: [string],
+ *  enabled: [boolean],
+ *  opacity: [number],
+ *  setData: [WhiteboardPage[]],
+ *  change: [WhiteboardData],
+ * }} WhiteboardEventMap
  *
  * @typedef {{
  *  Renderer?: any,
@@ -34,6 +75,8 @@ import { WhiteboardPage } from './WhiteboardPage';
 
 /**
  * Whiteboard manager for multi-page annotations.
+ *
+ * @extends {EventEmitter<WhiteboardEventMap>}
  */
 export class Whiteboard extends EventEmitter {
   #Renderer = null;
@@ -243,7 +286,7 @@ export class Whiteboard extends EventEmitter {
 
   /**
    * Load whiteboard data from JSON.
-   * @param {WhiteboardData} json
+   * @param {WhiteboardDataInput} json
    */
   setWhiteboardData(json) {
     this.#pages.clear();

--- a/tests/consumer-typecheck/src/whiteboard-events.ts
+++ b/tests/consumer-typecheck/src/whiteboard-events.ts
@@ -1,0 +1,113 @@
+/**
+ * Consumer typecheck: Whiteboard event-map typed payloads
+ * (SD-3213 follow-up to the EventEmitter `unknown[]` drain).
+ *
+ * Before this change, `Whiteboard` extended `EventEmitter` with no
+ * event map, so every listener received `unknown[]` (post-#3420) or
+ * `any[]` (pre-#3420) regardless of which event was named.
+ * `whiteboard.on('change', cb)` gave consumers no payload type, even
+ * though the runtime always emits `WhiteboardData`.
+ *
+ * The same change splits `WhiteboardData` (output: `getWhiteboardData()`
+ * return + `change` event payload, all fields required) from
+ * `WhiteboardDataInput` (input to `setWhiteboardData(json)`, all
+ * fields optional). Consumers reading the change payload can write
+ * `data.meta.pageSizes` without optional chaining, and existing
+ * `setWhiteboardData({ pages: {...} })` callers keep working through
+ * the looser input type.
+ *
+ * This fixture pins all five typed event payloads, the closed
+ * event-map shape (unknown event names are TS errors), and the
+ * `WhiteboardData` field accessibility.
+ *
+ * Registry shape narrowing via `register<T>` / `getType<T>` is a
+ * separate design decision (caller-asserted shape vs runtime-verified)
+ * tracked as a follow-up; this PR keeps the existing
+ * `WhiteboardRegistryItem` contract.
+ */
+
+import type { SuperDoc } from 'superdoc';
+
+declare const superdoc: SuperDoc;
+
+const whiteboard = superdoc.whiteboard;
+if (whiteboard) {
+  // --- Each typed event payload narrows precisely --------------------------
+
+  whiteboard.on('change', (data) => {
+    // `data.pages` is required (`Record<string, WhiteboardPageData>`).
+    // No optional chaining or null-check needed — the runtime always
+    // populates the field.
+    const pages = data.pages;
+    const firstKey = Object.keys(pages)[0];
+    if (firstKey !== undefined) {
+      const page = pages[firstKey]!;
+      // Stored shape narrows through: `images`, not `stickers`
+      // (pinned separately in whiteboard-data-shape.ts, exercised
+      // here through the event payload entry point).
+      void page.images;
+    }
+
+    // `data.meta` and `data.version` are required on the output
+    // shape (the runtime always sets both). Required on
+    // `WhiteboardData`, optional on `WhiteboardDataInput` — that
+    // split is the point of this PR. Consumers can read these
+    // fields without optional chaining.
+    const pageSizes = data.meta.pageSizes;
+    const firstSizeKey = Object.keys(pageSizes)[0];
+    if (firstSizeKey !== undefined) {
+      const size = pageSizes[firstSizeKey]!;
+      const width: number = size.width;
+      const height: number = size.height;
+      const originalWidth: number | null = size.originalWidth;
+      const originalHeight: number | null = size.originalHeight;
+      void width;
+      void height;
+      void originalWidth;
+      void originalHeight;
+    }
+    // `version` is the literal `1` (current schema version). If a
+    // future schema bump widens this to `number`, this assertion
+    // becomes incompatible and must be revisited alongside consumers.
+    const version: 1 = data.version;
+    void version;
+  });
+
+  whiteboard.on('setData', (pages) => {
+    // `pages` is `WhiteboardPage[]`. `.length` is typed, no cast needed.
+    const count: number = pages.length;
+    void count;
+  });
+
+  whiteboard.on('tool', (tool) => {
+    const name: string = tool;
+    void name;
+  });
+
+  whiteboard.on('enabled', (enabled) => {
+    const flag: boolean = enabled;
+    void flag;
+  });
+
+  whiteboard.on('opacity', (opacity) => {
+    const value: number = opacity;
+    void value;
+  });
+
+  // Unknown event names must be a TS error (closed event map, no
+  // DefaultEventMap fallback). If a future PR widens the map by adding
+  // an index signature, this directive becomes unused and tsc fails
+  // (TS2578).
+  // @ts-expect-error SD-3213: WhiteboardEventMap is closed; unknown events are not allowed.
+  whiteboard.on('not-a-real-event', () => {});
+
+  // --- WhiteboardDataInput round-trip + partial accept ---------------------
+
+  // Round trip: the strict output of getWhiteboardData() must be
+  // assignable to the looser setWhiteboardData() input.
+  whiteboard.setWhiteboardData(whiteboard.getWhiteboardData());
+
+  // Partial input: callers can still pass just `{ pages }` without
+  // supplying `meta` or `version` (the runtime only reads `json?.pages`).
+  whiteboard.setWhiteboardData({ pages: {} });
+}

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -584,6 +584,32 @@ const scenarios = [
     files: ['src/whiteboard-data-shape.ts'],
     mustPass: true,
   },
+  // SD-3213 Whiteboard event map: pin typed payloads for
+  // whiteboard.on(name, fn) across all 5 events plus the runtime
+  // `meta` and `version` fields newly exposed on WhiteboardData.
+  // Closed event map (no DefaultEventMap fallback), so unknown event
+  // names are TS errors. Generic register/getType is a separate
+  // design decision tracked as a follow-up.
+  {
+    name: 'bundler / whiteboard events (SD-3213)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: true,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/whiteboard-events.ts'],
+    mustPass: true,
+  },
+  {
+    name: 'node16 / whiteboard events (SD-3213)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: true,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/whiteboard-events.ts'],
+    mustPass: true,
+  },
   // SD-2867 phase B: SuperDoc.canPerformPermission forwards `comment` and
   // `trackedChange` to isAllowed() unchanged, so the public contract must
   // accept the wide payloads the editor's permission helper produces


### PR DESCRIPTION
Adds a typed event map to `Whiteboard` so `whiteboard.on(name, fn)` gives consumers precise payload types for all five events (`tool`, `enabled`, `opacity`, `setData`, `change`) instead of the `unknown[]` fallback from SD-3213 #3420.

Also splits the `WhiteboardData` shape into output (returned by `getWhiteboardData()`, carried by the `change` event payload; `pages`/`meta`/`version` all required because the runtime always populates them) and `WhiteboardDataInput` (accepted by `setWhiteboardData(json)`; all fields optional because the runtime only reads `json?.pages`). The split lets consumers read `data.meta.pageSizes` and `data.version` from the change payload without optional chaining, while existing `setWhiteboardData({ pages: {...} })` callers keep working through the looser input type. Round-trip is preserved because `WhiteboardData` is structurally assignable to `WhiteboardDataInput`.

`version` is typed as the literal `1` (current schema version) rather than `number`. A future schema bump would require touching this typedef alongside consumers anyway, so being precise now is more useful than abstract.

TS-only tightening to flag: the event map is closed (no `DefaultEventMap` fallback), so `whiteboard.on('custom-event', cb)` is now a type error at compile time. The runtime `EventEmitter` still accepts any string. Verified no internal or test code emits/subscribes to dynamic event names; the five known events cover every actual call site.

Audit count unchanged (101 -> 101). This is consumer IntelliSense improvement, not an allowlist drain - event-listener payloads via callback parameter types aren't paths the supported-root audit traces. Generic `register<T>` / `getType<T>` ergonomics is a separate design decision (caller-asserted shape vs runtime-verified) tracked as a follow-up.

**Verified**:
- `pnpm typecheck:matrix` -> 65 passed, 0 failed
- `node deep-type-audit.mjs --strict-supported-root` -> PASS (101 -> 101)
- Emitted `Whiteboard.d.ts`: `extends EventEmitter<WhiteboardEventMap>`; `getWhiteboardData(): WhiteboardData`; `setWhiteboardData(json: WhiteboardDataInput): void`