### PR TITLE
feat(superdoc): type SuperDoc event payloads (SD-3213)

### DIFF
--- a/apps/docs/extensions/comments.mdx
+++ b/apps/docs/extensions/comments.mdx
@@ -246,8 +246,8 @@ const superdoc = new SuperDoc({
 ## Events
 
 ```javascript
-superdoc.on('commentsUpdate', ({ type, comment }) => {
-  // type: 'ADD' | 'deleted' | 'SELECTED'
+superdoc.on('comments-update', ({ type, comment }) => {
+  // type: 'pending' | 'add' | 'update' | 'deleted' | 'new' | 'resolved' | 'selected' | ...
 });
 ```
 

--- a/packages/super-editor/src/headless-toolbar/types.ts
+++ b/packages/super-editor/src/headless-toolbar/types.ts
@@ -3,18 +3,23 @@ import type { PresentationEditor } from '../editors/v1/core/presentation-editor/
 import type { DocumentApi } from '@superdoc/document-api';
 
 /**
- * Event names a SuperDoc-like host must accept on its `on`/`off`
- * methods to be usable with the headless toolbar and UI controller.
- * Narrow union so a real `SuperDoc` instance (with the SD-3213 closed
+ * Event names the headless toolbar host subscribes to. Narrow union
+ * so a real `SuperDoc` instance (with the SD-3213 closed
  * `SuperDocEventMap`-typed `on`) satisfies the structural host
  * contract. Custom host stubs typed with a wider
  * `on?: (event: string, ...) => void` are still assignable.
  *
- * Owned here (not in `ui/types.ts`) because `ui/types.ts` already
- * imports from this file; reversing the dependency would create a
- * cycle.
+ * Split from the UI controller's narrower
+ * `SuperDocUIHostEvent` (`ui/types.ts`, 3 events) because the toolbar
+ * additionally subscribes to `formatting-marks-change`; requiring the
+ * UI controller's `SuperDocLike` stub to accept that 4th event would
+ * be wider than the UI side actually consumes.
  */
-export type SuperDocHostEvent = 'editorCreate' | 'document-mode-change' | 'formatting-marks-change' | 'zoomChange';
+export type HeadlessToolbarSuperdocHostEvent =
+  | 'editorCreate'
+  | 'document-mode-change'
+  | 'formatting-marks-change'
+  | 'zoomChange';
 
 /**
  * The editable surface that currently owns the toolbar context.
@@ -276,9 +281,9 @@ type HeadlessToolbarSuperdocHostBase = {
   toggleFormattingMarks?: () => void;
   // The toolbar only subscribes to these SuperDoc events; keeping the
   // host event names narrow lets strict event maps satisfy this
-  // structural host contract. See `SuperDocHostEvent` above.
-  on?: (event: SuperDocHostEvent, listener: (...args: any[]) => void) => void;
-  off?: (event: SuperDocHostEvent, listener: (...args: any[]) => void) => void;
+  // structural host contract. See `HeadlessToolbarSuperdocHostEvent` above.
+  on?: (event: HeadlessToolbarSuperdocHostEvent, listener: (...args: any[]) => void) => void;
+  off?: (event: HeadlessToolbarSuperdocHostEvent, listener: (...args: any[]) => void) => void;
 };
 
 /**

--- a/packages/super-editor/src/headless-toolbar/types.ts
+++ b/packages/super-editor/src/headless-toolbar/types.ts
@@ -3,6 +3,20 @@ import type { PresentationEditor } from '../editors/v1/core/presentation-editor/
 import type { DocumentApi } from '@superdoc/document-api';
 
 /**
+ * Event names a SuperDoc-like host must accept on its `on`/`off`
+ * methods to be usable with the headless toolbar and UI controller.
+ * Narrow union so a real `SuperDoc` instance (with the SD-3213 closed
+ * `SuperDocEventMap`-typed `on`) satisfies the structural host
+ * contract. Custom host stubs typed with a wider
+ * `on?: (event: string, ...) => void` are still assignable.
+ *
+ * Owned here (not in `ui/types.ts`) because `ui/types.ts` already
+ * imports from this file; reversing the dependency would create a
+ * cycle.
+ */
+export type SuperDocHostEvent = 'editorCreate' | 'document-mode-change' | 'formatting-marks-change' | 'zoomChange';
+
+/**
  * The editable surface that currently owns the toolbar context.
  *
  * `note` and `endnote` were added in Phase 2 of the unified-history rollout
@@ -260,8 +274,11 @@ type HeadlessToolbarSuperdocHostBase = {
     };
   };
   toggleFormattingMarks?: () => void;
-  on?: (event: string, listener: (...args: any[]) => void) => void;
-  off?: (event: string, listener: (...args: any[]) => void) => void;
+  // The toolbar only subscribes to these SuperDoc events; keeping the
+  // host event names narrow lets strict event maps satisfy this
+  // structural host contract. See `SuperDocHostEvent` above.
+  on?: (event: SuperDocHostEvent, listener: (...args: any[]) => void) => void;
+  off?: (event: SuperDocHostEvent, listener: (...args: any[]) => void) => void;
 };
 
 /**

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -35,17 +35,22 @@ export interface Subscribable<T> {
 }
 
 /**
- * Structural typing for the SuperDoc instance — keeps the UI controller
+ * Event names the UI controller (`createSuperDocUI`) subscribes to on
+ * a SuperDoc-like host. Narrower than
+ * `HeadlessToolbarSuperdocHostEvent` (which adds
+ * `formatting-marks-change`); a custom UI host stub only has to
+ * support the three events the UI controller actually consumes.
+ */
+export type SuperDocUIHostEvent = 'editorCreate' | 'document-mode-change' | 'zoomChange';
+
+/**
+ * Structural typing for the SuperDoc instance. Keeps the UI controller
  * loose from the SuperDoc Vue package's specific class type. The
  * controller only needs an event bus and an `activeEditor` reference.
- *
- * `SuperDocHostEvent` is defined in `headless-toolbar/types.ts` (the
- * canonical owner of the host-shape contract); UI already imports
- * other types from there, so reusing it avoids a circular dependency.
  */
 export interface SuperDocLike {
-  on?(event: import('../headless-toolbar/types.js').SuperDocHostEvent, handler: (...args: unknown[]) => void): unknown;
-  off?(event: import('../headless-toolbar/types.js').SuperDocHostEvent, handler: (...args: unknown[]) => void): unknown;
+  on?(event: SuperDocUIHostEvent, handler: (...args: unknown[]) => void): unknown;
+  off?(event: SuperDocUIHostEvent, handler: (...args: unknown[]) => void): unknown;
   activeEditor?: SuperDocEditorLike | null;
   config?: { documentMode?: 'editing' | 'suggesting' | 'viewing' };
   /**

--- a/packages/super-editor/src/ui/types.ts
+++ b/packages/super-editor/src/ui/types.ts
@@ -38,10 +38,14 @@ export interface Subscribable<T> {
  * Structural typing for the SuperDoc instance — keeps the UI controller
  * loose from the SuperDoc Vue package's specific class type. The
  * controller only needs an event bus and an `activeEditor` reference.
+ *
+ * `SuperDocHostEvent` is defined in `headless-toolbar/types.ts` (the
+ * canonical owner of the host-shape contract); UI already imports
+ * other types from there, so reusing it avoids a circular dependency.
  */
 export interface SuperDocLike {
-  on?(event: string, handler: (...args: unknown[]) => void): unknown;
-  off?(event: string, handler: (...args: unknown[]) => void): unknown;
+  on?(event: import('../headless-toolbar/types.js').SuperDocHostEvent, handler: (...args: unknown[]) => void): unknown;
+  off?(event: import('../headless-toolbar/types.js').SuperDocHostEvent, handler: (...args: unknown[]) => void): unknown;
   activeEditor?: SuperDocEditorLike | null;
   config?: { documentMode?: 'editing' | 'suggesting' | 'viewing' };
   /**

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -75,6 +75,127 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
 /** @typedef {import('./types/index.js').NavigableAddress} NavigableAddress */
 /** @typedef {import('@superdoc/super-editor/ui').SuperDocLike} SuperDocLike */
 
+/** @typedef {import('./types/index.js').AwarenessState} AwarenessState */
+/** @typedef {import('@superdoc/super-editor').Comment} Comment */
+/** @typedef {import('@superdoc/super-editor').FontsResolvedPayload} FontsResolvedPayload */
+/** @typedef {import('@superdoc/super-editor').ListDefinitionsPayload} ListDefinitionsPayload */
+/**
+ * Discriminator for `comments-update` payloads. Inlined rather than
+ * imported from `@superdoc/common` because the dist re-export path for
+ * `CommentEvent` doesn't survive the facade emit; the source values
+ * live in `shared/common/event-types.d.ts` (`comments_module_events`).
+ *
+ * @typedef {'resolved' | 'new' | 'add' | 'update' | 'deleted' | 'pending' | 'selected' | 'comments-list' | 'change-accepted' | 'change-rejected'} CommentEvent
+ */
+/** @typedef {import('./whiteboard/Whiteboard.js').WhiteboardData} WhiteboardData */
+
+/**
+ * Typed event map for `superdoc.on(name, fn)` / `superdoc.emit(name, ...)`.
+ *
+ * The map is closed: unknown event names (e.g. `superdoc.on('reayd', ...)`,
+ * a typo) are TS errors at compile time. This is a **TS-only tightening**.
+ * The runtime `eventemitter3` still accepts any string; it is consumers
+ * relying on dynamic event names who would see new type errors. Verified
+ * no internal SuperDoc code emits or subscribes to dynamic event names
+ * (every emit site is enumerated here).
+ *
+ * `exception` is typed as `SuperDocExceptionPayload`, a union of the three
+ * shapes the runtime currently emits today: `{ error, stage, document }`
+ * from `superdoc-store.js` document-init failures, `{ error, document }`
+ * from the catch in `restoreUnsavedChanges()`, and `{ error, editor?, code?,
+ * documentId? }` from `SuperDoc.vue` editor lifecycle. Normalizing these
+ * is tracked as a separate follow-up; this map types the current reality
+ * so consumers get a union they can narrow with `'stage' in payload` etc.
+ *
+ * `fonts-resolved` uses a **listener-transport pattern**: SuperDoc never
+ * emits it directly. Instead, `SuperDoc.vue:719` reads the registered
+ * `superdoc.listeners('fonts-resolved')[0]` and threads it into the new
+ * editor's `onFontsResolved` option. Cleanup of this transport (relay
+ * through SuperDoc instead) is a follow-up; typing it here matches the
+ * current consumer-visible contract.
+ *
+ * @typedef {{
+ *  ready: [SuperDocReadyPayload],
+ *  editorBeforeCreate: [SuperDocEditorPayload],
+ *  editorCreate: [SuperDocEditorPayload],
+ *  editorDestroy: [],
+ *  'pdf:document-ready': [],
+ *  'sidebar-toggle': [boolean],
+ *  zoomChange: [SuperDocZoomPayload],
+ *  'formatting-marks-change': [SuperDocFormattingMarksPayload],
+ *  'document-mode-change': [SuperDocDocumentModeChangePayload],
+ *  'editor-update': [SuperDocEditorUpdatePayload],
+ *  'content-error': [SuperDocContentErrorPayload],
+ *  'fonts-resolved': [FontsResolvedPayload],
+ *  'pagination-update': [SuperDocPaginationPayload],
+ *  'list-definitions-change': [ListDefinitionsPayload],
+ *  'comments-update': [SuperDocCommentsUpdatePayload],
+ *  'collaboration-ready': [SuperDocEditorPayload],
+ *  'awareness-update': [SuperDocAwarenessUpdatePayload],
+ *  locked: [SuperDocLockedPayload],
+ *  'whiteboard:init': [SuperDocWhiteboardPayload],
+ *  'whiteboard:ready': [SuperDocWhiteboardPayload],
+ *  'whiteboard:change': [WhiteboardData],
+ *  'whiteboard:enabled': [boolean],
+ *  'whiteboard:tool': [string],
+ *  exception: [SuperDocExceptionPayload],
+ * }} SuperDocEventMap
+ *
+ * @typedef {{ superdoc: SuperDoc }} SuperDocReadyPayload
+ * @typedef {{ editor: Editor }} SuperDocEditorPayload
+ * @typedef {{ whiteboard: Whiteboard }} SuperDocWhiteboardPayload
+ * @typedef {{ zoom: number }} SuperDocZoomPayload
+ * @typedef {{ showFormattingMarks: boolean, superdoc: SuperDoc }} SuperDocFormattingMarksPayload
+ * @typedef {{ documentMode: DocumentMode }} SuperDocDocumentModeChangePayload
+ * @typedef {{ totalPages: number, superdoc: SuperDoc }} SuperDocPaginationPayload
+ * @typedef {{ error: unknown, editor: Editor }} SuperDocContentErrorPayload
+ * @typedef {{ isLocked: boolean, lockedBy?: User | null }} SuperDocLockedPayload
+ *
+ * Editor-update envelope produced by `buildEditorPayloadBase` in
+ * `SuperDoc.vue`. `editor` is `effectiveEditor = editor ?? sourceEditor`,
+ * which is `undefined` only when neither was provided.
+ *
+ * @typedef {{
+ *  editor?: Editor,
+ *  sourceEditor?: Editor,
+ *  surface: string,
+ *  headerId: string | null,
+ *  sectionType: string | null,
+ * }} SuperDocEditorUpdatePayload
+ *
+ * Awareness payload from `awarenessHandler` in `collaboration.js`.
+ * `states` is `AwarenessState[]` (the publicly re-exported shape).
+ * `added` and `removed` are Yjs client IDs (numbers).
+ *
+ * @typedef {{
+ *  states: AwarenessState[],
+ *  added: number[],
+ *  removed: number[],
+ *  superdoc: SuperDoc,
+ * }} SuperDocAwarenessUpdatePayload
+ *
+ * Comments-update envelope from `comments-store.js`. `type` is one of the
+ * `CommentEvent` literals; `comment` is present for ADD/UPDATE/DELETED/NEW/
+ * RESOLVED and absent for PENDING. `changes` is present for DELETED to
+ * carry the per-document change record.
+ *
+ * @typedef {{
+ *  type: CommentEvent,
+ *  comment?: Comment,
+ *  changes?: Array<{ key: string, commentId: string, fileId?: string | null }>,
+ * }} SuperDocCommentsUpdatePayload
+ *
+ * Union of the three current `exception` payload shapes (debt: should be
+ * normalized to one shape in a follow-up). Consumers can narrow with
+ * `'stage' in payload` (store init) or `'code' in payload` (Vue editor
+ * lifecycle).
+ *
+ * @typedef {{ error: Error, stage: 'document-init', document: Document | null | undefined }} SuperDocExceptionStorePayload
+ * @typedef {{ error: unknown, document: Document }} SuperDocExceptionRestorePayload
+ * @typedef {{ error: unknown, editor?: Editor, code?: string, documentId?: string | null }} SuperDocExceptionEditorPayload
+ * @typedef {SuperDocExceptionStorePayload | SuperDocExceptionRestorePayload | SuperDocExceptionEditorPayload} SuperDocExceptionPayload
+ */
+
 /**
  * Config callbacks are optional on the public typedef because consumers do
  * not need to pass them. The fields wrapped by this helper (every callback
@@ -99,7 +220,7 @@ function asEventListener(listener) {
  * Expects a config object
  *
  * @class
- * @extends EventEmitter
+ * @extends {EventEmitter<SuperDocEventMap>}
  * @implements {SuperDocLike}
  */
 export class SuperDoc extends EventEmitter {

--- a/tests/consumer-typecheck/src/superdoc-events.ts
+++ b/tests/consumer-typecheck/src/superdoc-events.ts
@@ -242,24 +242,53 @@ superdoc.on('exception', (payload) => {
 // @ts-expect-error SD-3213: SuperDocEventMap is closed; unknown events are not allowed.
 superdoc.on('reayd', () => {});
 
-// --- Host contract: real SuperDoc + broad custom stub both compile ---------
+// --- Host contract: real SuperDoc + narrow + broad stubs all compile -------
 
 // `createHeadlessToolbar({ superdoc })` and `createSuperDocUI({ superdoc })`
 // accept a real SuperDoc instance even after the closed event-map
-// tightening. The host shapes (`HeadlessToolbarSuperdocHost`,
-// `SuperDocLike`) narrowed their `on`/`off` event-name unions to the
-// events the host actually consumes (`SuperDocHostEvent`), so SuperDoc's
-// closed-map `on` is structurally assignable.
+// tightening. The host shapes split their `on`/`off` event-name unions
+// to exactly what each controller subscribes to:
+// `HeadlessToolbarSuperdocHostEvent` (4 events) for the toolbar host,
+// `SuperDocUIHostEvent` (3 events) for the UI controller. SuperDoc's
+// closed `SuperDocEventMap`-typed `on` satisfies both.
 import { createHeadlessToolbar } from 'superdoc/headless-toolbar';
 import { createSuperDocUI } from 'superdoc/ui';
 void createHeadlessToolbar({ superdoc });
 void createSuperDocUI({ superdoc });
 
-// Custom host stubs typed with a wider `on(event: string, ...)` signature
-// remain assignable to the narrower host contract: a stub that accepts
-// any string still accepts the specific events the host will pass.
-declare const customHost: {
+// Custom UI host stub typed precisely to the 3 events the UI
+// controller subscribes to must satisfy `SuperDocLike`. Pinning this
+// so a future widening of `SuperDocUIHostEvent` (e.g. re-adding
+// `formatting-marks-change`) doesn't silently regress this stub
+// shape: such a change would fail this assertion under strict
+// (property-syntax) variance, and would still be a precision loss
+// even under TS method bivariance.
+declare const customUIHost: {
+  on?(event: 'editorCreate' | 'document-mode-change' | 'zoomChange', handler: (...args: unknown[]) => void): unknown;
+  off?(event: 'editorCreate' | 'document-mode-change' | 'zoomChange', handler: (...args: unknown[]) => void): unknown;
+};
+void createSuperDocUI({ superdoc: customUIHost });
+
+// Custom toolbar host stub typed precisely to the 4 events the
+// toolbar subscribes to must satisfy `HeadlessToolbarSuperdocHost`.
+declare const customToolbarHost: {
+  on?: (
+    event: 'editorCreate' | 'document-mode-change' | 'formatting-marks-change' | 'zoomChange',
+    listener: (...args: any[]) => void,
+  ) => void;
+  off?: (
+    event: 'editorCreate' | 'document-mode-change' | 'formatting-marks-change' | 'zoomChange',
+    listener: (...args: any[]) => void,
+  ) => void;
+};
+void createHeadlessToolbar({ superdoc: customToolbarHost });
+
+// Broad string-based custom stubs remain assignable to both host
+// contracts: a function that accepts any string can be called with
+// the specific event names the host will pass.
+declare const broadHost: {
   on?: (event: string, listener: (...args: unknown[]) => void) => void;
   off?: (event: string, listener: (...args: unknown[]) => void) => void;
 };
-void createHeadlessToolbar({ superdoc: customHost });
+void createHeadlessToolbar({ superdoc: broadHost });
+void createSuperDocUI({ superdoc: broadHost });

--- a/tests/consumer-typecheck/src/superdoc-events.ts
+++ b/tests/consumer-typecheck/src/superdoc-events.ts
@@ -1,0 +1,265 @@
+/**
+ * Consumer typecheck: SuperDoc typed event map
+ * (SD-3213 follow-up to the Whiteboard event map #3422).
+ *
+ * Before this change, `SuperDoc` extended `eventemitter3` with no event
+ * map, so every `superdoc.on(name, cb)` gave consumers `(...args: any[])
+ * => void`. The documentation at `apps/docs/editor/superdoc/events.mdx`
+ * advertises ~15 events with specific payload shapes, but none of those
+ * shapes was typed for consumers.
+ *
+ * The event map is **closed**: unknown event names (e.g. typos like
+ * `'reayd'`) are TS errors. This is a TS-only tightening: the runtime
+ * `eventemitter3` still accepts any string, so only consumers relying
+ * on dynamic event names see new errors. Verified internal SuperDoc
+ * code emits/subscribes only to the enumerated events.
+ *
+ * `exception` is typed as a union of three payload shapes the runtime
+ * currently emits today; consumers narrow with `'stage' in payload` etc.
+ * Normalizing the emit sites is tracked as a separate follow-up.
+ *
+ * `whiteboard:change` reuses the `WhiteboardData` typedef from
+ * the stacked SD-3213 Whiteboard PR (#3422); this fixture verifies that
+ * the integration works end-to-end through `superdoc.on('whiteboard:change', ...)`.
+ */
+
+import type { SuperDoc, Editor, User, AwarenessState, Comment, DocumentMode } from 'superdoc';
+
+declare const superdoc: SuperDoc;
+
+// --- Lifecycle events ------------------------------------------------------
+
+superdoc.on('ready', ({ superdoc: instance }) => {
+  const ref: SuperDoc = instance;
+  void ref;
+});
+
+superdoc.on('editorBeforeCreate', ({ editor }) => {
+  const ref: Editor = editor;
+  void ref;
+});
+
+superdoc.on('editorCreate', ({ editor }) => {
+  const ref: Editor = editor;
+  void ref;
+});
+
+superdoc.on('editorDestroy', () => {
+  // No payload.
+});
+
+superdoc.on('pdf:document-ready', () => {
+  // No payload.
+});
+
+// --- UI events -------------------------------------------------------------
+
+superdoc.on('sidebar-toggle', (isOpened) => {
+  const flag: boolean = isOpened;
+  void flag;
+});
+
+superdoc.on('zoomChange', ({ zoom }) => {
+  const value: number = zoom;
+  void value;
+});
+
+superdoc.on('formatting-marks-change', ({ showFormattingMarks, superdoc: instance }) => {
+  const flag: boolean = showFormattingMarks;
+  const ref: SuperDoc = instance;
+  void flag;
+  void ref;
+});
+
+superdoc.on('document-mode-change', ({ documentMode }) => {
+  // `documentMode` narrows to the documented closed union.
+  const mode: DocumentMode = documentMode;
+  void mode;
+  // Negative: any other string must error.
+  // @ts-expect-error SD-3213: DocumentMode is closed; only editing/viewing/suggesting.
+  const bad: DocumentMode = 'reviewing';
+  void bad;
+});
+
+// --- Content events --------------------------------------------------------
+
+superdoc.on('editor-update', (payload) => {
+  // Envelope is required surface/headerId/sectionType; editor and
+  // sourceEditor optional (effectiveEditor may be undefined).
+  const surface: string = payload.surface;
+  const headerId: string | null = payload.headerId;
+  const sectionType: string | null = payload.sectionType;
+  const editor: Editor | undefined = payload.editor;
+  const source: Editor | undefined = payload.sourceEditor;
+  void surface;
+  void headerId;
+  void sectionType;
+  void editor;
+  void source;
+});
+
+superdoc.on('content-error', ({ error, editor }) => {
+  // `error` is `unknown` (the runtime emit accepts arbitrary errors).
+  // Consumers must narrow before reading.
+  void error;
+  const ref: Editor = editor;
+  void ref;
+});
+
+superdoc.on('fonts-resolved', (payload) => {
+  // Payload reuses the existing public `FontsResolvedPayload`.
+  const documentFonts: string[] = payload.documentFonts;
+  const unsupportedFonts: string[] = payload.unsupportedFonts;
+  void documentFonts;
+  void unsupportedFonts;
+});
+
+superdoc.on('pagination-update', ({ totalPages, superdoc: instance }) => {
+  const count: number = totalPages;
+  const ref: SuperDoc = instance;
+  void count;
+  void ref;
+});
+
+superdoc.on('list-definitions-change', (payload) => {
+  // Reuses existing public `ListDefinitionsPayload`. Inner fields are
+  // typed as `unknown` (intentional: deep shape is not part of the
+  // public contract).
+  const change: unknown = payload.change;
+  void change;
+});
+
+// --- Comments events -------------------------------------------------------
+
+superdoc.on('comments-update', (event) => {
+  // `type` is the closed `CommentEvent` union; switching on it lets
+  // consumers narrow per-case.
+  const type: string = event.type;
+  void type;
+  if (event.comment) {
+    const comment: Comment = event.comment;
+    const id: string = comment.commentId;
+    void id;
+  }
+  if (event.changes) {
+    for (const change of event.changes) {
+      const key: string = change.key;
+      const commentId: string = change.commentId;
+      void key;
+      void commentId;
+    }
+  }
+});
+
+// --- Collaboration events --------------------------------------------------
+
+superdoc.on('collaboration-ready', ({ editor }) => {
+  const ref: Editor = editor;
+  void ref;
+});
+
+superdoc.on('awareness-update', ({ states, added, removed, superdoc: instance }) => {
+  for (const state of states) {
+    const s: AwarenessState = state;
+    void s;
+  }
+  for (const id of added) {
+    const n: number = id;
+    void n;
+  }
+  for (const id of removed) {
+    const n: number = id;
+    void n;
+  }
+  const ref: SuperDoc = instance;
+  void ref;
+});
+
+superdoc.on('locked', ({ isLocked, lockedBy }) => {
+  const locked: boolean = isLocked;
+  // `lockedBy` is optional; when present it can be User or null
+  // (runtime initializes as `config.lockedBy || null`).
+  const user: User | null | undefined = lockedBy;
+  void locked;
+  void user;
+});
+
+// --- Whiteboard events (re-uses WhiteboardData from #3422) -----------------
+
+superdoc.on('whiteboard:init', ({ whiteboard }) => {
+  // Whiteboard is the public class; just exercising the binding.
+  void whiteboard;
+});
+
+superdoc.on('whiteboard:ready', ({ whiteboard }) => {
+  void whiteboard;
+});
+
+superdoc.on('whiteboard:change', (data) => {
+  // `WhiteboardData` from the stacked #3422: output shape with required
+  // fields, so no optional chaining needed.
+  const pages = data.pages;
+  void pages;
+  const meta = data.meta;
+  void meta;
+  const version: 1 = data.version;
+  void version;
+});
+
+superdoc.on('whiteboard:enabled', (enabled) => {
+  const flag: boolean = enabled;
+  void flag;
+});
+
+superdoc.on('whiteboard:tool', (tool) => {
+  const name: string = tool;
+  void name;
+});
+
+// --- Exception (union of three current runtime shapes) ---------------------
+
+superdoc.on('exception', (payload) => {
+  // `error` is always present on every union member.
+  void payload.error;
+
+  // The store-init shape is uniquely identified by `stage`. The other
+  // two shapes (restore vs editor lifecycle) overlap structurally and
+  // can't be cleanly discriminated without a tag, so consumers narrow
+  // with `'stage' in payload` for the store case and use `'code' in
+  // payload` or `'document' in payload` for the others.
+  if ('stage' in payload && payload.stage === 'document-init') {
+    const stage: 'document-init' = payload.stage;
+    void stage;
+    void payload.document;
+  }
+});
+
+// --- Closed-map negative assertion -----------------------------------------
+
+// Unknown event names must be a TS error. If a future PR widens the map
+// with an index signature (open fallback), this directive becomes unused
+// and tsc fails (TS2578).
+// @ts-expect-error SD-3213: SuperDocEventMap is closed; unknown events are not allowed.
+superdoc.on('reayd', () => {});
+
+// --- Host contract: real SuperDoc + broad custom stub both compile ---------
+
+// `createHeadlessToolbar({ superdoc })` and `createSuperDocUI({ superdoc })`
+// accept a real SuperDoc instance even after the closed event-map
+// tightening. The host shapes (`HeadlessToolbarSuperdocHost`,
+// `SuperDocLike`) narrowed their `on`/`off` event-name unions to the
+// events the host actually consumes (`SuperDocHostEvent`), so SuperDoc's
+// closed-map `on` is structurally assignable.
+import { createHeadlessToolbar } from 'superdoc/headless-toolbar';
+import { createSuperDocUI } from 'superdoc/ui';
+void createHeadlessToolbar({ superdoc });
+void createSuperDocUI({ superdoc });
+
+// Custom host stubs typed with a wider `on(event: string, ...)` signature
+// remain assignable to the narrower host contract: a stub that accepts
+// any string still accepts the specific events the host will pass.
+declare const customHost: {
+  on?: (event: string, listener: (...args: unknown[]) => void) => void;
+  off?: (event: string, listener: (...args: unknown[]) => void) => void;
+};
+void createHeadlessToolbar({ superdoc: customHost });

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -610,6 +610,33 @@ const scenarios = [
     files: ['src/whiteboard-events.ts'],
     mustPass: true,
   },
+  // SD-3213 SuperDoc event map: typed payloads for the documented
+  // public superdoc.on(...) events. Closed map (typos like
+  // superdoc.on('reayd', ...) are TS errors). Reuses existing public
+  // types (User, Editor, AwarenessState, Comment, DocumentMode,
+  // FontsResolvedPayload, ListDefinitionsPayload, WhiteboardData).
+  // Exception payload is a union of the three current runtime shapes;
+  // normalization is a follow-up.
+  {
+    name: 'bundler / superdoc events (SD-3213)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: true,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/superdoc-events.ts'],
+    mustPass: true,
+  },
+  {
+    name: 'node16 / superdoc events (SD-3213)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: true,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/superdoc-events.ts'],
+    mustPass: true,
+  },
   // SD-2867 phase B: SuperDoc.canPerformPermission forwards `comment` and
   // `trackedChange` to isAllowed() unchanged, so the public contract must
   // accept the wide payloads the editor's permission helper produces


### PR DESCRIPTION
Adds a typed event map to `SuperDoc` so `superdoc.on(name, fn)` gives consumers precise payload types for all ~24 events documented at `apps/docs/editor/superdoc/events.mdx`, instead of the eventemitter3 `any[]` fallback. Reuses existing public types where they exist (`User`, `Editor`, `AwarenessState`, `Comment`, `DocumentMode`, `FontsResolvedPayload`, `ListDefinitionsPayload`, `WhiteboardData`).

To keep `createHeadlessToolbar({ superdoc })` and `createSuperDocUI({ superdoc })` compiling with a real SuperDoc instance after the closed event map narrowed `SuperDoc.on`, this also narrows `HeadlessToolbarSuperdocHost.on/off` and `SuperDocLike.on/off` to a small `SuperDocHostEvent` union (the four events those hosts actually subscribe to). The host types were over-permissive; tightening them to the actual subscription set lets the closed-map SuperDoc satisfy both contracts, and broader custom host stubs typed `(event: string, ...)` remain assignable.

TS-only tightening to flag: the event map is closed (no `DefaultEventMap` fallback), so `superdoc.on('typo', cb)` is now a type error at compile time. The runtime `eventemitter3` still accepts any string. Verified no internal SuperDoc code emits or subscribes to dynamic event names; every emit site is enumerated in the map.

Two debts called out in JSDoc and noted in the fixture, deferred to follow-ups:
- `exception` is typed as a union of the three current runtime payload shapes (store init, restore catch, Vue editor lifecycle). Consumers narrow with `'stage' in payload` etc. Normalizing the emit sites to one shape is a separate PR.
- `fonts-resolved` uses a listener-transport pattern: `SuperDoc` never emits it directly; `SuperDoc.vue` reads `superdoc.listeners('fonts-resolved')[0]` and threads it into the new editor's `onFontsResolved` option. Typed in-place because it is a live consumer-visible event; relay cleanup is a follow-up.

Also fixes `apps/docs/extensions/comments.mdx`: the documented `commentsUpdate` (camelCase) was a typo; the runtime emits `comments-update` (kebab).

**Verified**:
- `pnpm typecheck:matrix` -> 67 passed, 0 failed
- `node deep-type-audit.mjs --strict-supported-root` -> PASS (101 -> 101 unchanged; this is consumer IntelliSense improvement, not allowlist drain)
- Repo build: clean (no TS errors); facade emit clean across 10 entries
- superdoc unit tests: 1037/1037; super-editor unit tests: 13117/13117
- Emitted `SuperDoc.d.ts`: `extends EventEmitter<SuperDocEventMap, any>`; all 24 event names tuple-typed; 13 payload typedefs exported on the public surface
- `createHeadlessToolbar({ superdoc })` + `createSuperDocUI({ superdoc })` still compile with a real SuperDoc (fixture: `superdoc-events.ts`); broader custom host stubs still satisfy (fixture: same file)