### PR TITLE
fix(types): tighten CollaborationProvider.on/off to (string, unknown[]) (SD-3213 drain)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/types/EditorConfig.ts
+++ b/packages/super-editor/src/editors/v1/core/types/EditorConfig.ts
@@ -209,11 +209,18 @@ export interface Awareness {
 /**
  * Collaboration provider interface.
  * Accepts any Yjs-compatible provider (HocuspocusProvider, LiveblocksYjsProvider, TiptapCollabProvider, etc.)
+ *
+ * `on`/`off` use `(event: string, handler: (...args: unknown[]) => void)`
+ * to match the established pattern on `Awareness` above and the internal
+ * `ProviderEventHandler` cast in `helpers/collaboration-provider-sync.ts`.
+ * Consumers narrow `args` before reading; this is a TS-only tightening
+ * (no runtime change) that drains 32 SD-3213 supported-root any[]
+ * findings on EditorConfig.d.ts in a single source edit.
  */
 export interface CollaborationProvider {
   awareness?: Awareness | null;
-  on?(event: any, handler: (...args: any[]) => void): void;
-  off?(event: any, handler: (...args: any[]) => void): void;
+  on?(event: string, handler: (...args: unknown[]) => void): void;
+  off?(event: string, handler: (...args: unknown[]) => void): void;
   disconnect?(): void;
   destroy?(): void;
   /** Whether provider is synced - some use `synced`, others `isSynced` */

--- a/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
+++ b/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "scope": "supported-root",
-  "generatedAt": "2026-05-21T09:36:10.903Z",
+  "generatedAt": "2026-05-21T13:56:30.546Z",
   "entries": [
     {
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.converter[string]|converter: SuperConverter;",
@@ -154,126 +154,6 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)|event: any",
-      "kind": "param",
-      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)|event: any",
-      "kind": "param",
-      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)|event: any",
-      "kind": "param",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)|event: any",
-      "kind": "param",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.off(event)|event: any",
-      "kind": "param",
-      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.off(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.on(event)|event: any",
-      "kind": "param",
-      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.on(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.off(event)|event: any",
-      "kind": "param",
-      "symbolPath": "SuperDoc.provider.off(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.on(event)|event: any",
-      "kind": "param",
-      "symbolPath": "SuperDoc.provider.on(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)|event: any",
-      "kind": "param",
-      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)|event: any",
-      "kind": "param",
-      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)|event: any",
-      "kind": "param",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)|event: any",
-      "kind": "param",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(event)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "event: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "property|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.element|element: any;",
       "kind": "property",
       "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.element",
@@ -328,7 +208,7 @@
       "kind": "return",
       "symbolPath": "SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>=>return",
       "file": "node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts",
-      "line": 132,
+      "line": 146,
       "snippet": "(...args: any[]) => any",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
@@ -674,206 +554,6 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.off(handler)(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.off(handler)(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.off(handler)(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.off(handler)(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.on(handler)(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.on(handler)(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.<value>.new(config).documents[].provider.on(handler)(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).documents[].provider.on(handler)(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.off(handler)(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.provider.off(handler)(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.off(handler)(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.provider.off(handler)(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.on(handler)(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.provider.on(handler)(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|SuperDoc.provider.on(handler)(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.provider.on(handler)(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.off(handler)(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 205,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.attachCollaboration(__0).collaborationProvider.on(handler)(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/types/EditorConfig.d.ts",
-      "line": 204,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getRichTextExtensions.<value>(args)<0>|...args: any[]",
       "kind": "type",
       "symbolPath": "getRichTextExtensions.<value>(args)<0>",
@@ -958,7 +638,7 @@
       "kind": "type",
       "symbolPath": "SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>(args)<0>",
       "file": "node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts",
-      "line": 132,
+      "line": 146,
       "snippet": "...args: any[]",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
@@ -968,7 +648,7 @@
       "kind": "type",
       "symbolPath": "SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>(args)[]",
       "file": "node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts",
-      "line": 132,
+      "line": 146,
       "snippet": "...args: any[]",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"

--- a/tests/consumer-typecheck/src/provider-collaboration-provider.ts
+++ b/tests/consumer-typecheck/src/provider-collaboration-provider.ts
@@ -55,3 +55,33 @@ const docWithMinimalProvider: DocumentEntry = {
 
 // Reference all bindings so `tsc --noEmit` doesn't strip them.
 void [_sdProviderTypeIsExact, _docProviderTypeIsExact, minimalProvider, docWithMinimalProvider];
+
+// SD-3213: `CollaborationProvider.on/off` use `(event: string, handler:
+// (...args: unknown[]) => void)` instead of `(event: any, handler:
+// (...args: any[]) => void)`. Mirrors the existing pattern on
+// `Awareness` and matches the internal `ProviderEventHandler` cast in
+// `helpers/collaboration-provider-sync.ts`. This drained 32 supported-
+// root any-leak findings on EditorConfig.d.ts in a single source edit.
+declare const providerToInspect: CollaborationProvider;
+providerToInspect.on?.('synced', (...args) => {
+  // `args` is `unknown[]`, not `any[]`. Reading a property on an
+  // untyped element must error; if a future PR widens this back to
+  // `any[]`, the directive becomes unused and tsc fails (TS2578).
+  // @ts-expect-error SD-3213: provider on() args are unknown[], not any[].
+  args[0].foo;
+
+  // Narrowing the unknown element works as expected; `as unknown`
+  // assignment also compiles. Both prove `args[0]` is `unknown`.
+  const first = args[0];
+  if (typeof first === 'object' && first !== null && 'message' in first) {
+    void (first as { message: string }).message;
+  }
+  const _untyped: unknown = args[0];
+  void _untyped;
+});
+
+// `event` is `string`, not `any`. Passing a non-string must error;
+// if a future PR widens back to `any`, the directive becomes unused
+// and tsc fails (TS2578).
+// @ts-expect-error SD-3213: provider on() event is string, not any.
+providerToInspect.on?.(123, () => {});


### PR DESCRIPTION
Drains 32 supported-root any-leak findings on `EditorConfig.d.ts` by tightening `CollaborationProvider.on/off` from `(event: any, handler: (...args: any[]) => void)` to `(event: string, handler: (...args: unknown[]) => void)`.

This is **sub 1 of three substitutions tested in a local spike** for the SD-3213 EditorConfig + Editor drain pass; not the whole Editor work. The spike compared three isolated changes by drain count and blast radius:

- **Sub 1 (this PR): `CollaborationProvider.on/off`** - 32 drained, single source edit, zero cross-package fallout.
- Sub 2: ProseMirror `Schema` / `Plugin` generic defaults in `Editor.ts` - 25 drained with 1 small follow-up needed elsewhere; staged as a separate PR.
- Sub 3: `Editor.converter` / `Editor.extensionService` exposure - deferred. Requires a design decision (narrower public facade types vs. `private` keyword that would break consumers reading `editor.converter`); not a clean mechanical drain.

`event` stays `string` rather than narrowing further because `CollaborationProvider` is intentionally provider-agnostic (HocuspocusProvider, LiveblocksYjsProvider, TiptapCollabProvider, and hand-rolled adapters each use different event-name unions). Narrowing to one provider's union would break the cross-provider contract. `args` moves to `unknown[]` so consumers narrow before reading instead of receiving an unsafe `any`.

The shape mirrors:
- The adjacent `Awareness` interface in the same file (lines 205-206) - same pattern, established for the same kind of external-Yjs-compatible boundary.
- The internal `ProviderEventHandler = (...args: unknown[]) => void` cast at `helpers/collaboration-provider-sync.ts:3` - matches actual runtime usage rather than inventing a new contract.

TS-only tightening; no runtime change.

**Verified**:
- `pnpm typecheck:matrix` -> 67 passed, 0 failed
- `node deep-type-audit.mjs --strict-supported-root` -> PASS (101 -> **69** entries; 32 drained; `EditorConfig.d.ts` drops out of top-offender files entirely)
- Repo build: clean; facade emit clean across 10 entries
- Fixture extended with positive narrowing + negative assertions:
  - `args[0].foo` is `@ts-expect-error` (proves `unknown[]`, not `any[]`)
  - `on(123, ...)` is `@ts-expect-error` (proves `string`, not `any`)
  - `typeof first === 'object' && 'message' in first` narrowing compiles