### PR TITLE
fix(types): tighten Editor ProseMirror generics (SD-3213 drain)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -265,9 +265,17 @@ export class Editor extends EventEmitter<EditorEventMap> {
 
   /**
    * ProseMirror schema for the editor.
+   *
+   * Typed as `Schema<string, string>` rather than bare `Schema` to
+   * drop the implicit `Schema<any, any>` default through the SD-3213
+   * supported-root audit. Node and mark name spaces are typed as
+   * `string` (the established ProseMirror constraint shape); consumer
+   * schemas with literal-typed names like `Schema<'paragraph', 'em'>`
+   * remain assignable.
+   *
    * @deprecated Direct ProseMirror access will be removed in a future version. Use the Document API (`editor.doc`) instead.
    */
-  schema!: Schema;
+  schema!: Schema<string, string>;
 
   /**
    * ProseMirror view instance.
@@ -1947,10 +1955,22 @@ export class Editor extends EventEmitter<EditorEventMap> {
 
   /**
    * Register PM plugin.
+   *
+   * `PluginState` is a call-site generic so the incoming plugin's
+   * state shape is preserved into the `handlePlugins` callback's
+   * `plugin` argument. The existing plugin list is heterogeneous
+   * (each entry can have a different state type) so it stays as
+   * `Plugin<unknown>[]` instead of being inferred under one specific
+   * state. Default `PluginState = unknown` removes the previous
+   * implicit `Plugin<any>` SD-3213 supported-root finding.
+   *
    * @param plugin PM plugin.
    * @param handlePlugins Optional function for handling plugin merge.
    */
-  registerPlugin(plugin: Plugin, handlePlugins?: (plugin: Plugin, plugins: Plugin[]) => Plugin[]): void {
+  registerPlugin<PluginState = unknown>(
+    plugin: Plugin<PluginState>,
+    handlePlugins?: (plugin: Plugin<PluginState>, plugins: Plugin<unknown>[]) => Plugin<unknown>[],
+  ): void {
     if (this.isDestroyed) return;
     if (!this.state?.plugins) return;
     const plugins =

--- a/packages/super-editor/src/editors/v1/core/Node.ts
+++ b/packages/super-editor/src/editors/v1/core/Node.ts
@@ -107,7 +107,7 @@ export interface NodeConfig<
   >;
 
   /** Function to add ProseMirror plugins to the node */
-  addPmPlugins?: MaybeGetter<Plugin[]>;
+  addPmPlugins?: MaybeGetter<Plugin<unknown>[]>;
 
   /** Function to extend the ProseMirror node schema */
   extendNodeSchema?: MaybeGetter<Record<string, unknown>>;

--- a/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
+++ b/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
   "scope": "supported-root",
-  "generatedAt": "2026-05-21T13:56:30.546Z",
+  "generatedAt": "2026-05-21T14:49:39.177Z",
   "entries": [
     {
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.converter[string]|converter: SuperConverter;",
       "kind": "index",
       "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.converter[string]",
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 146,
+      "line": 154,
       "snippet": "converter: SuperConverter;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
@@ -28,7 +28,7 @@
       "kind": "index",
       "symbolPath": "Extensions.<value>.Node.new(config).editor.converter[string]",
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 146,
+      "line": 154,
       "snippet": "converter: SuperConverter;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
@@ -48,7 +48,7 @@
       "kind": "index",
       "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.converter[string]",
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 146,
+      "line": 154,
       "snippet": "converter: SuperConverter;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
@@ -68,7 +68,7 @@
       "kind": "index",
       "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.converter[string]",
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 146,
+      "line": 154,
       "snippet": "converter: SuperConverter;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
@@ -88,7 +88,7 @@
       "kind": "index",
       "symbolPath": "defineNode.<value>(config).editor.converter[string]",
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 146,
+      "line": 154,
       "snippet": "converter: SuperConverter;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
@@ -108,7 +108,7 @@
       "kind": "index",
       "symbolPath": "getSchemaIntrospection.<value>(options).editor.converter[string]",
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 146,
+      "line": 154,
       "snippet": "converter: SuperConverter;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
@@ -234,272 +234,12 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(handlePlugins)(plugin)<0>|plugin: Plugin",
-      "kind": "type",
-      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(handlePlugins)(plugin)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugin: Plugin",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(handlePlugins)(plugins)[]<0>|plugins: Plugin[]",
-      "kind": "type",
-      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(handlePlugins)(plugins)[]<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugins: Plugin[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(plugin)<0>|plugin: Plugin",
-      "kind": "type",
-      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.registerPlugin(plugin)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugin: Plugin",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.schema<0>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.schema<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.schema<1>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].editor.schema<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Extensions.<value>.Node.new(config).editor.registerPlugin(handlePlugins)(plugin)<0>|plugin: Plugin",
-      "kind": "type",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.registerPlugin(handlePlugins)(plugin)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugin: Plugin",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Extensions.<value>.Node.new(config).editor.registerPlugin(plugin)<0>|plugin: Plugin",
-      "kind": "type",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.registerPlugin(plugin)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugin: Plugin",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Extensions.<value>.Node.new(config).editor.schema<0>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.schema<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Extensions.<value>.Node.new(config).editor.schema<1>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.schema<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.registerPlugin(plugin)<0>|plugin: Plugin",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.registerPlugin(plugin)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugin: Plugin",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.schema<0>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.schema<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.schema<1>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.activeEditor.schema<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(handlePlugins)(plugin)<0>|plugin: Plugin",
-      "kind": "type",
-      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(handlePlugins)(plugin)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugin: Plugin",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(handlePlugins)(plugins)[]<0>|plugins: Plugin[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(handlePlugins)(plugins)[]<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugins: Plugin[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(plugin)<0>|plugin: Plugin",
-      "kind": "type",
-      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.registerPlugin(plugin)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugin: Plugin",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.schema<0>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.schema<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|SuperDoc.config.modules.links.popoverResolver(ctx).editor.schema<1>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "SuperDoc.config.modules.links.popoverResolver(ctx).editor.schema<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|defineNode.<value>(config).editor.registerPlugin(handlePlugins)(plugin)<0>|plugin: Plugin",
-      "kind": "type",
-      "symbolPath": "defineNode.<value>(config).editor.registerPlugin(handlePlugins)(plugin)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugin: Plugin",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|defineNode.<value>(config).editor.registerPlugin(plugin)<0>|plugin: Plugin",
-      "kind": "type",
-      "symbolPath": "defineNode.<value>(config).editor.registerPlugin(plugin)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugin: Plugin",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|defineNode.<value>(config).editor.schema<0>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "defineNode.<value>(config).editor.schema<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|defineNode.<value>(config).editor.schema<1>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "defineNode.<value>(config).editor.schema<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.registerPlugin(handlePlugins)(plugin)<0>|plugin: Plugin",
-      "kind": "type",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.registerPlugin(handlePlugins)(plugin)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugin: Plugin",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.registerPlugin(plugin)<0>|plugin: Plugin",
-      "kind": "type",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.registerPlugin(plugin)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 446,
-      "snippet": "plugin: Plugin",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.schema<0>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.schema<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.schema<1>|schema: Schema;",
-      "kind": "type",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.schema<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
-      "line": 113,
-      "snippet": "schema: Schema;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|Editor.<value>.new(options)<0>.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
       "kind": "type",
       "symbolPath": "Editor.<value>.new(options)<0>.extensions[].config.renderDOM<1>",
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
       "line": 49,
       "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>|addPmPlugins?: MaybeGetter<Plugin[]>;",
-      "kind": "type",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
-      "line": 78,
-      "snippet": "addPmPlugins?: MaybeGetter<Plugin[]>;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
@@ -514,32 +254,12 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|defineNode.<value>(config).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>|addPmPlugins?: MaybeGetter<Plugin[]>;",
-      "kind": "type",
-      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
-      "line": 78,
-      "snippet": "addPmPlugins?: MaybeGetter<Plugin[]>;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|defineNode.<value>(config).editor.presentationEditor.options.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
       "kind": "type",
       "symbolPath": "defineNode.<value>(config).editor.presentationEditor.options.extensions[].config.renderDOM<1>",
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
       "line": 49,
       "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>|addPmPlugins?: MaybeGetter<Plugin[]>;",
-      "kind": "type",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.options.extensions[].config.addPmPlugins[]<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
-      "line": 78,
-      "snippet": "addPmPlugins?: MaybeGetter<Plugin[]>;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },

--- a/tests/consumer-typecheck/src/editor-pm-generics.ts
+++ b/tests/consumer-typecheck/src/editor-pm-generics.ts
@@ -1,0 +1,109 @@
+/**
+ * Consumer typecheck: ProseMirror generic defaults on the public
+ * Editor / Node surface (SD-3213 sub 2 drain).
+ *
+ * Before this change, `Editor.schema`, `Editor.registerPlugin`, and
+ * `NodeConfig.addPmPlugins` all exposed bare `Schema` / `Plugin` /
+ * `Plugin[]` without explicit type args. TypeScript filled those in
+ * as `Schema<any, any>` and `Plugin<any>`, leaking `any` through the
+ * SD-3213 supported-root audit (28 findings).
+ *
+ * This fixture pins three contracts:
+ *   1. `editor.schema` is typed `Schema<string, string>` so node/mark
+ *      names are constrained but not collapsed to `any`. Consumer
+ *      schemas with literal-name unions stay assignable.
+ *   2. `editor.registerPlugin<PluginState>(plugin)` preserves the
+ *      incoming plugin's state type into the optional `handlePlugins`
+ *      callback. The existing plugin list parameter stays
+ *      `Plugin<unknown>[]` because the runtime list is heterogeneous.
+ *   3. `NodeConfig.addPmPlugins` accepts `Plugin<unknown>[]` instead
+ *      of the bare `Plugin[]` (= `Plugin<any>[]`) that leaked `any`.
+ *
+ * Also asserts that `EditorState.create({ schema, plugins })` from
+ * raw `prosemirror-state` continues to typecheck against the editor
+ * surface, since SuperDoc's narrowed signatures must not break the
+ * underlying ProseMirror contract (`EditorStateConfig.plugins` is
+ * `readonly Plugin[]`).
+ */
+
+import type { Editor } from 'superdoc';
+import { EditorState, Plugin, PluginKey } from 'prosemirror-state';
+import { Schema } from 'prosemirror-model';
+
+declare const editor: Editor;
+
+// --- 1. editor.schema: Schema<string, string> ------------------------------
+
+// Field type is `Schema<string, string>`. `nodes` / `marks` are indexed
+// by `string`, which is what node lookups across the editor surface use.
+const nodeMap = editor.schema.nodes;
+const markMap = editor.schema.marks;
+void nodeMap;
+void markMap;
+
+// A consumer schema declared with literal-name unions remains assignable
+// to the wider `Schema<string, string>` field. Variance: literal-string
+// types extend `string`, so a `Schema<'paragraph' | 'text', 'em'>` is a
+// subtype of `Schema<string, string>` at this position.
+declare const literalSchema: Schema<'paragraph' | 'text', 'em'>;
+const _schemaAssignableToField: typeof editor.schema = literalSchema;
+void _schemaAssignableToField;
+
+// --- 2. registerPlugin preserves state via generic -------------------------
+
+interface MyPluginState {
+  count: number;
+}
+
+const myPluginKey = new PluginKey<MyPluginState>('my');
+const myPlugin: Plugin<MyPluginState> = new Plugin<MyPluginState>({
+  key: myPluginKey,
+  state: {
+    init: () => ({ count: 0 }),
+    apply: (_tr, value) => value,
+  },
+});
+
+// Without the optional callback: PluginState is inferred from the
+// argument, so the typed plugin flows through without any cast or
+// widening to `any`.
+editor.registerPlugin(myPlugin);
+
+// With the optional callback: the callback's `plugin` argument keeps
+// `MyPluginState`. The list parameter is `Plugin<unknown>[]` because
+// the editor's plugin list is heterogeneous. Returning the typed
+// plugin in that list requires a one-position cast at the boundary
+// because ProseMirror's `Plugin<T>` is invariant in T (verified:
+// `Plugin<MyPluginState>` is not assignable to `Plugin<unknown>`
+// because `EditorProps<P>` uses P in both produces and consumes
+// positions). The cast is honest about PM's variance; there is no
+// `any` introduced here.
+editor.registerPlugin<MyPluginState>(myPlugin, (plugin, plugins) => {
+  // `plugin` keeps `MyPluginState` in the callback.
+  const _typedPlugin: Plugin<MyPluginState> = plugin;
+  void _typedPlugin;
+  return [...plugins, plugin as Plugin<unknown>];
+});
+
+// --- 3. addPmPlugins on NodeConfig accepts Plugin<unknown>[] --------------
+//
+// `NodeConfig.addPmPlugins?: MaybeGetter<Plugin<unknown>[]>`. The
+// list element type is `Plugin<unknown>`. Consumers with typed
+// plugins cast at the list-construction boundary (same Plugin
+// invariance constraint as the registerPlugin callback above).
+type AddPmPluginsReturn = Plugin<unknown>[];
+const pmPluginList: AddPmPluginsReturn = [myPlugin as Plugin<unknown>];
+void pmPluginList;
+
+// --- 4. EditorState.create({ schema, plugins }) round-trip -----------------
+//
+// SuperDoc's narrowed types must not break the underlying ProseMirror
+// contract. `EditorStateConfig.plugins` is `readonly Plugin[]` (= raw
+// `Plugin<any>[]` at the PM boundary), so a typed plugin or our
+// `Plugin<unknown>[]` both flow through to `EditorState.create`
+// without friction (any[] absorbs them).
+const roundTripState = EditorState.create({
+  schema: editor.schema,
+  plugins: [myPlugin],
+});
+void roundTripState;

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -610,6 +610,33 @@ const scenarios = [
     files: ['src/whiteboard-events.ts'],
     mustPass: true,
   },
+  // SD-3213 sub 2: ProseMirror generic defaults on Editor + Node
+  // public surface. `Editor.schema` becomes `Schema<string, string>`,
+  // `Editor.registerPlugin<PluginState>(plugin)` preserves the state
+  // type into the optional handlePlugins callback, and
+  // `NodeConfig.addPmPlugins` accepts `Plugin<unknown>[]`. Includes
+  // an EditorState.create({ schema, plugins }) round-trip to prove
+  // the narrowed types stay compatible with raw prosemirror-state.
+  {
+    name: 'bundler / editor PM generics (SD-3213)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: true,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/editor-pm-generics.ts'],
+    mustPass: true,
+  },
+  {
+    name: 'node16 / editor PM generics (SD-3213)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: true,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/editor-pm-generics.ts'],
+    mustPass: true,
+  },
   // SD-3213 SuperDoc event map: typed payloads for the documented
   // public superdoc.on(...) events. Closed map (typos like
   // superdoc.on('reayd', ...) are TS errors). Reuses existing public


### PR DESCRIPTION
Sub 2 from the SD-3213 EditorConfig + Editor drain spike (sub 1 was #3424, `CollaborationProvider.on/off`). Drops three bare ProseMirror type references that defaulted to `Schema<any, any>` and `Plugin<any>` on the public Editor + Node surface, draining 28 supported-root any-leak findings (69 → **41**) in one source touch.

**Source changes:**
- `Editor.schema`: `Schema` → `Schema<string, string>`. Node/mark name spaces become `string` instead of `any`. Consumer schemas with literal-name unions (e.g. `Schema<'paragraph' \| 'text', 'em'>`) remain assignable because literal-string types extend `string`.
- `Editor.registerPlugin<PluginState = unknown>(plugin, handlePlugins?)`: generic-preserving signature keeps the incoming plugin's state type into the optional callback's first argument. The existing plugin list parameter stays `Plugin<unknown>[]` because the runtime list is heterogeneous.
- `NodeConfig.addPmPlugins?: MaybeGetter<Plugin[]>` → `MaybeGetter<Plugin<unknown>[]>`. Same heterogeneous-list reasoning as `registerPlugin`. This is the tag-along the spike found when sub 2 was first tested in isolation.

**Plugin invariance caveat (called out plainly in the fixture):**

ProseMirror's `Plugin<T>` is effectively invariant in T (verified: `EditorProps<P>` uses P in both produces and consumes positions, so `Plugin<MyState>` is **not** assignable to `Plugin<unknown>`). The incoming plugin's state type is preserved through the signature, but once a typed plugin is merged into the heterogeneous `Plugin<unknown>[]` list (callback return value, or `addPmPlugins` return value), consumers may need an explicit `as Plugin<unknown>` cast at the list-construction boundary.

The new fixture documents this honestly with a single explicit cast at the right place; no `any` is introduced anywhere.

**TS-only tightening; no runtime change.**

**Verified:**
- `pnpm typecheck:matrix` → 69 passed, 0 failed (2 new SD-3213 scenarios added)
- `node deep-type-audit.mjs --strict-supported-root` → PASS (69 → **41**; 28 drained; 0 new)
- Repo build clean; facade emit clean across 10 entries
- New fixture asserts: `Schema<string, string>` accepts literal-name consumer schemas; `registerPlugin(myPlugin)` preserves `Plugin<MyState>` without cast; `registerPlugin<MyState>(myPlugin, cb)` preserves the type into `cb`'s `plugin` arg; the `cb` return uses one `as Plugin<unknown>` cast to satisfy PM invariance; `addPmPlugins` accepts `Plugin<unknown>[]`; `EditorState.create({ schema, plugins })` round-trip typechecks against raw `prosemirror-state`

**Spike status:**
- Sub 1 (#3424, merged): `CollaborationProvider.on/off` — 32 drained
- **Sub 2 (this PR): Editor PM generics — 28 drained**
- Sub 3: `Editor.converter` / `Editor.extensionService` exposure — still deferred. Requires a design decision (narrower public facade types vs `private` keyword, which would break consumers reading `editor.converter`), not a mechanical drain.