### PR TITLE
fix(types): tighten extensions helpers signatures (SD-3213)

### DIFF
--- a/packages/super-editor/src/editors/v1/extensions/index.d.ts
+++ b/packages/super-editor/src/editors/v1/extensions/index.d.ts
@@ -1,2 +1,20 @@
-export function getRichTextExtensions(...args: any[]): any[];
-export function getStarterExtensions(...args: any[]): any[];
+import type { EditorExtension } from '../core/types/EditorConfig.js';
+
+/**
+ * Returns the default extension set used for rich-text documents.
+ *
+ * Runtime takes no arguments; the previous `(...args: any[]): any[]`
+ * signature was incorrect on both sides (no call site passes args;
+ * the return is a concrete `EditorExtension[]` from the public
+ * EditorConfig type union). SD-3213 drain.
+ */
+export function getRichTextExtensions(): EditorExtension[];
+
+/**
+ * Returns the default extension set used for DOCX documents (superset
+ * of `getRichTextExtensions`).
+ *
+ * Runtime takes no arguments; see the JSDoc on `getRichTextExtensions`
+ * for the SD-3213 rationale.
+ */
+export function getStarterExtensions(): EditorExtension[];

--- a/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
+++ b/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "scope": "supported-root",
-  "generatedAt": "2026-05-21T14:49:39.177Z",
+  "generatedAt": "2026-05-21T16:00:16.417Z",
   "entries": [
     {
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.converter[string]|converter: SuperConverter;",
@@ -104,6 +104,26 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getRichTextExtensions.<value>=>return[].editor.converter[string]|converter: SuperConverter;",
+      "kind": "index",
+      "symbolPath": "getRichTextExtensions.<value>=>return[].editor.converter[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 154,
+      "snippet": "converter: SuperConverter;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getRichTextExtensions.<value>=>return[].editor.extensionService[string]|extensionService: ExtensionService;",
+      "kind": "index",
+      "symbolPath": "getRichTextExtensions.<value>=>return[].editor.extensionService[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 104,
+      "snippet": "extensionService: ExtensionService;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.converter[string]|converter: SuperConverter;",
       "kind": "index",
       "symbolPath": "getSchemaIntrospection.<value>(options).editor.converter[string]",
@@ -117,6 +137,26 @@
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getSchemaIntrospection.<value>(options).editor.extensionService[string]|extensionService: ExtensionService;",
       "kind": "index",
       "symbolPath": "getSchemaIntrospection.<value>(options).editor.extensionService[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 104,
+      "snippet": "extensionService: ExtensionService;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getStarterExtensions.<value>=>return[].editor.converter[string]|converter: SuperConverter;",
+      "kind": "index",
+      "symbolPath": "getStarterExtensions.<value>=>return[].editor.converter[string]",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
+      "line": 154,
+      "snippet": "converter: SuperConverter;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
+      "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|getStarterExtensions.<value>=>return[].editor.extensionService[string]|extensionService: ExtensionService;",
+      "kind": "index",
+      "symbolPath": "getStarterExtensions.<value>=>return[].editor.extensionService[string]",
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts",
       "line": 104,
       "snippet": "extensionService: ExtensionService;",
@@ -264,6 +304,16 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|getRichTextExtensions.<value>=>return[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
+      "kind": "type",
+      "symbolPath": "getRichTextExtensions.<value>=>return[].config.renderDOM<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
+      "line": 49,
+      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
+      "owner": "tier-5-other",
+      "rationale": "auto-seeded from inventory (supported-root scope)"
+    },
+    {
       "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.options.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
       "kind": "type",
       "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.options.extensions[].config.renderDOM<1>",
@@ -274,82 +324,12 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getRichTextExtensions.<value>(args)<0>|...args: any[]",
+      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|getStarterExtensions.<value>=>return[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
       "kind": "type",
-      "symbolPath": "getRichTextExtensions.<value>(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
-      "line": 1,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getRichTextExtensions.<value>(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "getRichTextExtensions.<value>(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
-      "line": 1,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getRichTextExtensions.<value>=>return<0>|export function getRichTextExtensions(...args: any[]): any[];",
-      "kind": "type",
-      "symbolPath": "getRichTextExtensions.<value>=>return<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
-      "line": 1,
-      "snippet": "export function getRichTextExtensions(...args: any[]): any[];",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getRichTextExtensions.<value>=>return[]|export function getRichTextExtensions(...args: any[]): any[];",
-      "kind": "type",
-      "symbolPath": "getRichTextExtensions.<value>=>return[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
-      "line": 1,
-      "snippet": "export function getRichTextExtensions(...args: any[]): any[];",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getStarterExtensions.<value>(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "getStarterExtensions.<value>(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
-      "line": 2,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getStarterExtensions.<value>(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "getStarterExtensions.<value>(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
-      "line": 2,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getStarterExtensions.<value>=>return<0>|export function getStarterExtensions(...args: any[]): any[];",
-      "kind": "type",
-      "symbolPath": "getStarterExtensions.<value>=>return<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
-      "line": 2,
-      "snippet": "export function getStarterExtensions(...args: any[]): any[];",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts|getStarterExtensions.<value>=>return[]|export function getStarterExtensions(...args: any[]): any[];",
-      "kind": "type",
-      "symbolPath": "getStarterExtensions.<value>=>return[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/extensions/index.d.ts",
-      "line": 2,
-      "snippet": "export function getStarterExtensions(...args: any[]): any[];",
+      "symbolPath": "getStarterExtensions.<value>=>return[].config.renderDOM<1>",
+      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
+      "line": 49,
+      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },

--- a/tests/consumer-typecheck/src/extensions-helpers.ts
+++ b/tests/consumer-typecheck/src/extensions-helpers.ts
@@ -1,0 +1,60 @@
+/**
+ * Consumer typecheck: getStarterExtensions / getRichTextExtensions
+ * return EditorExtension[] (SD-3213 drain).
+ *
+ * Before this change, the hand-written
+ * `packages/super-editor/src/editors/v1/extensions/index.d.ts`
+ * declared both functions as `(...args: any[]): any[]`, doubly wrong:
+ *   - Runtime takes zero args (verified across all internal and
+ *     documented call sites).
+ *   - Return is a concrete `EditorExtension[]`, not `any[]`.
+ *
+ * After this change, consumers passing the result into
+ * `new Editor({ extensions: getStarterExtensions() })` get a typed
+ * array, and any attempt to pass arguments is a TS error.
+ */
+
+import { getStarterExtensions, getRichTextExtensions } from 'superdoc/super-editor';
+import type { EditorExtension } from 'superdoc/super-editor';
+
+// --- Return type is EditorExtension[], not any[] --------------------------
+
+const starter: EditorExtension[] = getStarterExtensions();
+const rich: EditorExtension[] = getRichTextExtensions();
+void starter;
+void rich;
+
+// Strict type-equality assertion. A function silently returning `any[]`
+// would still be assignable to `EditorExtension[]`, masking a regression.
+// `Equal` fails the test if the return type drifts back to `any[]` (or
+// any other shape).
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type AssertEqual<A, B> = Equal<A, B> extends true ? true : never;
+
+const _starterReturnIsExact: AssertEqual<ReturnType<typeof getStarterExtensions>, EditorExtension[]> = true;
+const _richReturnIsExact: AssertEqual<ReturnType<typeof getRichTextExtensions>, EditorExtension[]> = true;
+void _starterReturnIsExact;
+void _richReturnIsExact;
+
+// --- Element type is not any ----------------------------------------------
+
+// If the element type were `any`, this `Equal<typeof first, any>` check
+// would compile to `true`. Asserting it's NOT `any` proves the
+// EditorExtension union is actually applied.
+const first = starter[0];
+if (first) {
+  const _firstIsNotAny: Equal<typeof first, any> = false;
+  void _firstIsNotAny;
+}
+
+// --- Arguments are rejected -----------------------------------------------
+
+// Runtime takes zero arguments. Passing anything must be a TS error;
+// if a future PR widens the signature back to `(...args: any[])`,
+// the directive becomes unused and tsc fails (TS2578).
+
+// @ts-expect-error SD-3213: getStarterExtensions takes no arguments.
+getStarterExtensions('docx');
+
+// @ts-expect-error SD-3213: getRichTextExtensions takes no arguments.
+getRichTextExtensions({ some: 'option' });

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -610,6 +610,29 @@ const scenarios = [
     files: ['src/whiteboard-events.ts'],
     mustPass: true,
   },
+  // SD-3213: getStarterExtensions / getRichTextExtensions return
+  // EditorExtension[], not any[]. Runtime takes no arguments; the
+  // previous hand-written .d.ts was wrong on both sides.
+  {
+    name: 'bundler / extensions helpers (SD-3213)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: true,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/extensions-helpers.ts'],
+    mustPass: true,
+  },
+  {
+    name: 'node16 / extensions helpers (SD-3213)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: true,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/extensions-helpers.ts'],
+    mustPass: true,
+  },
   // SD-3213 sub 2: ProseMirror generic defaults on Editor + Node
   // public surface. `Editor.schema` becomes `Schema<string, string>`,
   // `Editor.registerPlugin<PluginState>(plugin)` preserves the state


### PR DESCRIPTION
Direct `any` removal on the hand-written `packages/super-editor/src/editors/v1/extensions/index.d.ts`. Both helpers were declared `(...args: any[]): any[]` — doubly wrong:

- Runtime takes **zero arguments** (verified across every internal and documented call site).
- Return is a concrete `EditorExtension[]` (the public union type already exported from `@superdoc/super-editor`).

**Source change:** 2-line declaration file fixes both signatures to `(): EditorExtension[]`.

## Audit movement: 41 → 39 net (honest breakdown)

| | Count | Detail |
|---|---|---|
| **Directly removed** | 8 | Helper signatures no longer contain `...args: any[]` or `any[]` return — the original drain target |
| **Transitively surfaced** | 6 | Typing the return as `EditorExtension[]` lets the audit trace through the extension graph for the first time. Surfaced findings are 2× `editor.converter`, 2× `editor.extensionService`, 2× `NodeConfig.renderDOM` |

The 6 surfaced findings are **not new unsafe sources** — they are existing known debt on other reach paths already in the allowlist, just newly reachable via the helper return type. `editor.converter` / `editor.extensionService` hiding is tracked separately as [SD-3240](https://linear.app/superdocworkspace/issue/SD-3240) (design ticket); when that lands, all reach paths drain simultaneously.

This is not a failed drain — it's a more accurate audit graph than before. Previously `any[]` was hiding the helper return type entirely, so the audit could not see the real extension graph behind it. After `(): EditorExtension[]`, consumers get the right type, and the remaining transitive findings are known debt on new reach paths.

## Verified

- `pnpm typecheck:matrix` → 71 passed, 0 failed (2 new SD-3213 scenarios)
- `node deep-type-audit.mjs --strict-supported-root` → PASS (41 → 39)
- Repo build: clean; facade emit clean
- New fixture asserts:
  - `ReturnType<typeof getStarterExtensions>` is **exactly** `EditorExtension[]` (`Equal<>` trick rejects silent collapse to `any[]`)
  - Element type is **not** `any` (`Equal<typeof first, any>` is `false`)
  - `getStarterExtensions('docx')` and `getRichTextExtensions({ some: 'option' })` are both `@ts-expect-error` (runtime is zero-arg)