### PR TITLE
fix(types): correct createZip JSDoc array syntax (SD-3213)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/zipper.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/zipper.js
@@ -1,9 +1,16 @@
 import JSZip from 'jszip';
 
 /**
- * Take a list of blobs and file names and create a zip file
- * @param {Array[Blob]} blobs List of blobs to zip
- * @param {Array[string]} fileNames List of file names to zip
+ * Take a list of blobs and file names and create a zip file.
+ *
+ * The previous `@param {Array[Blob]}` / `@param {Array[string]}`
+ * syntax was invalid JSDoc (the array type expression is `Type[]`
+ * or `Array<Type>`, not `Array[Type]`). TypeScript parsed the
+ * malformed syntax and fell back to `any`, leaking through the
+ * SD-3213 supported-root audit.
+ *
+ * @param {Blob[]} blobs List of blobs to zip
+ * @param {string[]} fileNames List of file names to zip
  * @returns {Promise<Blob>} The zipped file
  */
 export async function createZip(blobs, fileNames) {

--- a/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
+++ b/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "scope": "supported-root",
-  "generatedAt": "2026-05-21T16:00:16.417Z",
+  "generatedAt": "2026-05-21T17:32:34.299Z",
   "entries": [
     {
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.converter[string]|converter: SuperConverter;",
@@ -170,26 +170,6 @@
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/helpers/getActiveFormatting.d.ts",
       "line": 1,
       "snippet": "editor: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/super-converter/zipper.d.ts|createZip.<value>(blobs)|blobs: any",
-      "kind": "param",
-      "symbolPath": "createZip.<value>(blobs)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/super-converter/zipper.d.ts",
-      "line": 7,
-      "snippet": "blobs: any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "param|node_modules/superdoc/dist/super-editor/src/editors/v1/core/super-converter/zipper.d.ts|createZip.<value>(fileNames)|fileNames: any",
-      "kind": "param",
-      "symbolPath": "createZip.<value>(fileNames)",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/super-converter/zipper.d.ts",
-      "line": 7,
-      "snippet": "fileNames: any",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },


### PR DESCRIPTION
The `createZip` JSDoc declared `@param {Array[Blob]} blobs` and `@param {Array[string]} fileNames`. That is **invalid JSDoc syntax**: the array type expression is `Type[]` or `Array<Type>`, not `Array[Type]`. TypeScript parsed the malformed syntax and fell back to `any`, leaking through the SD-3213 supported-root audit as 2 findings (`blobs: any`, `fileNames: any`).

**Fix:** correct to `{Blob[]}` and `{string[]}`. 2-line JSDoc change.

## Audit movement: 39 → 37 net

- 2 stale entries drained (`blobs: any`, `fileNames: any`).
- 0 new entries surfaced. Unlike #3426, this fix doesn't introduce any transitive findings because `Blob` and `string` are leaf types that don't reach into the project's type graph.

## Verified

- `pnpm typecheck:matrix` → 71 passed, 0 failed
- `node deep-type-audit.mjs --strict-supported-root` → PASS (39 → **37**)
- Repo build clean; facade emit clean

## Why no consumer fixture

`createZip` is already covered by the existing `file-zipper subpath` and `docx-zipper subpath` matrix scenarios. The audit gate itself prevents any future regression to `any` (it would surface as a new finding and fail strict mode), so a dedicated fixture would be redundant for a 2-line JSDoc correction.