### PR TITLE
fix(types): hide SuperDoc.commentsList from public TypeScript surface (SD-3213)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -310,6 +310,26 @@ export class SuperDoc extends EventEmitter {
    */
   highContrastModeStore;
 
+  /**
+   * Internal mount handle for the `SuperComments` Vue component, created
+   * lazily by `addCommentsList()` and torn down by `removeCommentsList()`.
+   * Not consumer API: `SuperComments` is not publicly exported, no docs
+   * or examples reference `superdoc.commentsList`, and the inner fields
+   * (`element`, `superdoc` backref, `container` Vue ComponentPublicInstance)
+   * are internal mount state.
+   *
+   * Typed as `SuperComments | null | undefined` so the runtime states
+   * stay type-clean: `undefined` before `addCommentsList()` runs (e.g.
+   * when the viewer role skips initialization; see SuperDoc.test.js
+   * for the assertion), `SuperComments` after `addCommentsList()`, and
+   * `null` after `removeCommentsList()` tears down. No initializer, to
+   * match the convention used by the adjacent `@private` store fields.
+   *
+   * @type {SuperComments | null | undefined}
+   * @private
+   */
+  commentsList;
+
   /** @type {import('vue').App} */
   app;
 

--- a/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
+++ b/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "scope": "supported-root",
-  "generatedAt": "2026-05-21T17:32:34.299Z",
+  "generatedAt": "2026-05-21T17:46:27.835Z",
   "entries": [
     {
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.converter[string]|converter: SuperConverter;",
@@ -174,46 +174,6 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "property|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.element|element: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.element",
-      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
-      "line": 9,
-      "snippet": "element: any;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.superdoc|superdoc: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.superdoc",
-      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
-      "line": 16,
-      "snippet": "superdoc: any;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.commentsList.element|element: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.commentsList.element",
-      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
-      "line": 9,
-      "snippet": "element: any;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "property|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.commentsList.superdoc|superdoc: any;",
-      "kind": "property",
-      "symbolPath": "SuperDoc.commentsList.superdoc",
-      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
-      "line": 16,
-      "snippet": "superdoc: any;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "return|node_modules/superdoc/dist/super-editor/src/editors/v1/core/helpers/getActiveFormatting.d.ts|getActiveFormatting.<value>=>return|export function getActiveFormatting(editor: any): any;",
       "kind": "return",
       "symbolPath": "getActiveFormatting.<value>=>return",
@@ -334,31 +294,11 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.container<14>|container: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, stri",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.commentsList.container<14>",
-      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
-      "line": 18,
-      "snippet": "container: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, stri",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts|SuperDoc.commentsList.container<14>|container: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, stri",
-      "kind": "type",
-      "symbolPath": "SuperDoc.commentsList.container<14>",
-      "file": "node_modules/superdoc/dist/superdoc/src/components/CommentsLayer/commentsList/super-comments-list.d.ts",
-      "line": 18,
-      "snippet": "container: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, stri",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "type|node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.app<0>|app: import('vue').App;",
       "kind": "type",
       "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.app<0>",
       "file": "node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts",
-      "line": 81,
+      "line": 97,
       "snippet": "app: import('vue').App;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
@@ -368,7 +308,7 @@
       "kind": "type",
       "symbolPath": "SuperDoc.app<0>",
       "file": "node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts",
-      "line": 81,
+      "line": 97,
       "snippet": "app: import('vue').App;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"

--- a/tests/consumer-typecheck/src/superdoc-stores-private.ts
+++ b/tests/consumer-typecheck/src/superdoc-stores-private.ts
@@ -53,6 +53,10 @@ void superdoc.commentsStore;
 // of the public TypeScript surface.
 void superdoc.highContrastModeStore;
 
+// @ts-expect-error commentsList is the internal SuperComments mount
+// handle (SD-3213); not part of the public TypeScript surface.
+void superdoc.commentsList;
+
 // --- Positive assertions ---------------------------------------------------
 // Documented factories accepting a SuperDoc instance must continue to
 // compile after the hide. These compile because SuperDoc now exposes the


### PR DESCRIPTION
Same pattern as SD-3213f (which hid `superdocStore` / `commentsStore` / `highContrastModeStore`). Adds a `/** @private */` class-field declaration for `commentsList` so TS emits it as `private` in `SuperDoc.d.ts`, hiding it from the public type surface.

**This is a TypeScript surface hide, not runtime privacy.** The runtime assignment in `addCommentsList()` (`this.commentsList = new SuperComments(...)`) and tear-down in `removeCommentsList()` (`this.commentsList = null`) keep working unchanged because `@private` is a TS-only marker translated to the TS `private` keyword in the emitted `.d.ts`.

## Why this is safe

- `SuperComments` is **not publicly exported** (verified: no entry in `packages/superdoc/src/public/index.ts` or any other facade)
- **Zero consumer / doc / example references** to `superdoc.commentsList` (verified via grep across `apps/docs`, `examples/`, `tests/consumer-typecheck/src/`)
- The inner fields the audit flagged (`element` HTMLElement, `superdoc` backref, `container` Vue `ComponentPublicInstance`) are all internal mount state from the `SuperComments` Vue component

## Type shape

Field declared as `SuperComments | null | undefined` to keep all three runtime states type-clean:
- `undefined` before `addCommentsList()` runs (e.g. when the viewer role skips initialization; pinned by an existing `SuperDoc.test.js` assertion)
- `SuperComments` after `addCommentsList()`
- `null` after `removeCommentsList()` tears down

No initializer, to match the convention used by the adjacent `@private` store fields.

## Audit movement: 37 → 31

- **6 supported-root entries removed** (3 fields × 2 reach paths each: `commentsList.element`, `commentsList.superdoc`, `commentsList.container<14>` — both directly off `SuperDoc.commentsList` and via the `comments.permissionResolver(params).superdoc` reach)
- **0 new entries.** Hiding the field strips it from the type graph entirely; no transitive surfacing of the kind seen in #3426.

## Verified

- `pnpm typecheck:matrix` → 71 passed, 0 failed
- `node deep-type-audit.mjs --strict-supported-root` → PASS (37 → **31**)
- Repo build clean; facade emit clean
- Emitted `SuperDoc.d.ts:95` now reads `private commentsList;`
- `pnpm --filter superdoc test` → 1032 unit tests pass (collab-server.test.ts suite failure is pre-existing on `main`, unrelated to this change — missing `@superdoc-dev/superdoc-yjs-collaboration` module resolution)
- Fixture extended with `// @ts-expect-error commentsList is the internal SuperComments mount handle (SD-3213)` alongside the three existing store assertions