### PR TITLE
fix: preserve tab underline via runProperties fallback in collab

### DIFF
--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/tab.test.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/tab.test.ts
@@ -293,5 +293,50 @@ describe('tabNodeToRun', () => {
 
       expect(applyMarksToRunMock).not.toHaveBeenCalled();
     });
+
+    it('hydrates underline from runProperties when tab marks are missing', () => {
+      const tabNode: PMNode = { type: 'tab' };
+      const paragraphAttrs: ParagraphAttrs = {};
+      const positions: PositionMap = new WeakMap();
+      positions.set(tabNode, { start: 0, end: 1 });
+
+      const result = tabNodeToRun({
+        node: tabNode,
+        positions,
+        tabOrdinal: 0,
+        paragraphAttrs,
+        runProperties: {
+          underline: {
+            'w:val': 'single',
+          },
+        } as any,
+      }) as TabRun;
+
+      expect(result.underline).toEqual({ style: 'single' });
+    });
+
+    it('keeps explicit tab mark precedence over runProperties fallback', () => {
+      const tabNode: PMNode = {
+        type: 'tab',
+        marks: [{ type: 'underline', attrs: { underlineType: 'none' } }],
+      };
+      const paragraphAttrs: ParagraphAttrs = {};
+      const positions: PositionMap = new WeakMap();
+      positions.set(tabNode, { start: 0, end: 1 });
+
+      const result = tabNodeToRun({
+        node: tabNode,
+        positions,
+        tabOrdinal: 0,
+        paragraphAttrs,
+        runProperties: {
+          underline: {
+            'w:val': 'single',
+          },
+        } as any,
+      }) as TabRun;
+
+      expect(result.underline).toBeUndefined();
+    });
   });
 });

--- a/packages/layout-engine/pm-adapter/src/converters/inline-converters/tab.ts
+++ b/packages/layout-engine/pm-adapter/src/converters/inline-converters/tab.ts
@@ -1,6 +1,6 @@
 import type { Run, TabRun, TabStop } from '@superdoc/contracts';
 import { applyMarksToRun } from '../../marks/index.js';
-import { type InlineConverterParams } from './common.js';
+import { applyInlineRunProperties, type InlineConverterParams } from './common.js';
 
 /**
  * Converts a tab PM node to a TabRun.
@@ -20,12 +20,15 @@ export function tabNodeToRun({
   paragraphAttrs,
   inheritedMarks,
   sdtMetadata,
+  runProperties,
+  converterContext,
+  inlineRunProperties,
 }: InlineConverterParams): Run | null {
   const pos = positions.get(node);
   if (!pos) return null;
   const tabStops: TabStop[] | undefined = paragraphAttrs.tabs;
   const indent = paragraphAttrs.indent;
-  const run: TabRun = {
+  let run: TabRun = {
     kind: 'tab',
     text: '\t',
     pmStart: pos.start,
@@ -38,6 +41,17 @@ export function tabNodeToRun({
 
   if (sdtMetadata) {
     run.sdt = sdtMetadata;
+  }
+
+  // Align tab formatting with text runs: hydrate from resolved runProperties first.
+  // This survives Yjs element-node mark loss; explicit marks below still override.
+  if (runProperties) {
+    run = applyInlineRunProperties(
+      run as any,
+      runProperties,
+      converterContext,
+      inlineRunProperties,
+    ) as unknown as TabRun;
   }
 
   // Apply marks (e.g., underline) to the tab run


### PR DESCRIPTION
Linear: SD-3103

This PR fixes a collaboration rendering regression where underlined tab runs could lose underline styling after Yjs sync (especially for the second participant joining a session).

#### What changed
- Updated tab conversion in `pm-adapter` to hydrate tab formatting from `runProperties` (same resilience path used by text runs).
- Kept mark precedence intact: explicit tab marks still override fallback formatting.

#### Why
In Yjs collaboration flows, marks on element/atom nodes like `tab` may not always round-trip as reliably as text marks. This fallback ensures tab underline remains stable without changing importer or Yjs behavior.