### PR TITLE
fix(types): tighten ToolbarTarget.commands to (...args: unknown[]) => unknown (SD-3213)

### DIFF
--- a/packages/super-editor/src/headless-toolbar/types.ts
+++ b/packages/super-editor/src/headless-toolbar/types.ts
@@ -196,8 +196,18 @@ export type ToolbarCommandState = {
 };
 
 // Minimal execution surface for headless toolbar consumers.
+//
+// `commands` is the heterogeneous registry of editor commands documented
+// as an escape hatch for direct access when `execute()` doesn't cover
+// the use case (see headless-toolbar/README.md and apps/docs/advanced/
+// headless-toolbar.mdx). Each command has its own arg shape, so the
+// index-signature value is `(...args: unknown[]) => unknown` instead
+// of the previous `any[] => any`. This mirrors the established
+// `AnyCommand` pattern used by `EditorCommands` (ChainedCommands.ts:31)
+// and drains 3 SD-3213 supported-root any-leak findings. Consumers
+// narrow at the call site for the specific command they're invoking.
 export type ToolbarTarget = {
-  commands: Record<string, (...args: any[]) => any>;
+  commands: Record<string, (...args: unknown[]) => unknown>;
   doc?: DocumentApi;
 };
 

--- a/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
+++ b/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "scope": "supported-root",
-  "generatedAt": "2026-05-21T17:46:27.835Z",
+  "generatedAt": "2026-05-21T18:04:04.699Z",
   "entries": [
     {
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.converter[string]|converter: SuperConverter;",
@@ -184,16 +184,6 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "return|node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts|SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>=>return|(...args: any[]) => any",
-      "kind": "return",
-      "symbolPath": "SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>=>return",
-      "file": "node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts",
-      "line": 146,
-      "snippet": "(...args: any[]) => any",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbar<14>|toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
       "kind": "type",
       "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbar<14>",
@@ -274,31 +264,11 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts|SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>(args)<0>|...args: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>(args)<0>",
-      "file": "node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts",
-      "line": 146,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts|SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>(args)[]|...args: any[]",
-      "kind": "type",
-      "symbolPath": "SuperDoc.toolbar.controller.getSnapshot=>return.context.target.commands<1>(args)[]",
-      "file": "node_modules/superdoc/dist/super-editor/src/headless-toolbar/types.d.ts",
-      "line": 146,
-      "snippet": "...args: any[]",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "type|node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.app<0>|app: import('vue').App;",
       "kind": "type",
       "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.app<0>",
       "file": "node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts",
-      "line": 97,
+      "line": 99,
       "snippet": "app: import('vue').App;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
@@ -308,7 +278,7 @@
       "kind": "type",
       "symbolPath": "SuperDoc.app<0>",
       "file": "node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts",
-      "line": 97,
+      "line": 99,
       "snippet": "app: import('vue').App;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"

--- a/tests/consumer-typecheck/src/imports-headless-toolbar.ts
+++ b/tests/consumer-typecheck/src/imports-headless-toolbar.ts
@@ -48,3 +48,42 @@ const linkValue: string | null | undefined = snapshot.commands['link']?.value;
 
 // Verify ToolbarExecuteFn type
 const execFn: ToolbarExecuteFn = (id, payload?) => true;
+
+// SD-3213: ToolbarTarget.commands is the documented escape hatch for
+// direct command access when execute() doesn't cover the use case
+// (see headless-toolbar/README.md). The index-signature value is
+// `(...args: unknown[]) => unknown`, not `(...args: any[]) => any`,
+// so consumers narrow before reading return values.
+declare const ctx: ToolbarContext;
+const targetCommands = ctx.target.commands;
+const someCommand = targetCommands['someCommand'];
+if (someCommand) {
+  // Return is `unknown`, not `any`. Reading a property without
+  // narrowing must error; if a future PR widens back to `any`, the
+  // directive becomes unused and tsc fails (TS2578).
+  const result = someCommand('arg1', 42);
+  // @ts-expect-error SD-3213: target.commands[id] returns unknown, not any.
+  result.foo;
+  // Narrowing works as expected.
+  const _untyped: unknown = result;
+  void _untyped;
+}
+void targetCommands;
+void execFn;
+
+// SD-3213: a consumer constructing a custom ToolbarTarget (e.g. for
+// tests or a non-Editor command source) can still satisfy the
+// tightened signature by typing their commands with the same
+// `(...args: unknown[]) => unknown` shape. This pins the most common
+// custom-stub construction so a future re-widening or narrowing
+// would surface here.
+const customTarget: ToolbarTarget = {
+  commands: {
+    arbitrary: (...args) => {
+      // `args` is `unknown[]`; reading args[0].foo would error
+      // without narrowing.
+      return args.length;
+    },
+  },
+};
+void customTarget;


### PR DESCRIPTION
`ToolbarTarget.commands` was declared `Record<string, (...args: any[]) => any>`. The `any[] → any` pattern let consumers receive an unsafe `any` when reaching the escape hatch documented at `packages/super-editor/src/headless-toolbar/README.md` and `apps/docs/advanced/headless-toolbar.mdx`:

> Use `target.commands` for direct command access when `execute()` doesn't cover your use case.

**Fix:** change to `Record<string, (...args: unknown[]) => unknown>`. This mirrors the established `AnyCommand` pattern used by `EditorCommands` (`packages/super-editor/src/editors/v1/core/types/ChainedCommands.ts:31`), which is the upstream type of `editor.commands` — the same shape the internal `createEditorToolbarTarget` assigns from. No new public type is exported; the shape is inlined to match the local typedef convention in `headless-toolbar/types.ts`.

**Scope note:** this does **not** introduce precise per-command payload typing. It only tightens the generic fallback command surface from unsafe `any` to `unknown`. Consumers narrow at the call site for specific commands. Precise per-command payloads (if desired) would be a separate design conversation; the typed `execute()` API + `ToolbarPayloadMap` already serve that purpose for built-in commands.

## Audit movement: 31 → 28

- **3 supported-root entries removed** (the value-type any, the args spread, the args element)
- **0 new entries.** Internal callers in `resolve-toolbar-sources.ts` keep working unchanged because `editor.commands` (`EditorCommands`) already uses the same `(...args: unknown[]) => unknown` shape via `Record<string, AnyCommand>`.

## Verified

- `pnpm typecheck:matrix` → 71 passed, 0 failed
- `node deep-type-audit.mjs --strict-supported-root` → PASS (31 → **28**)
- Repo build clean; facade emit clean
- Fixture `imports-headless-toolbar.ts` extended with three pinned assertions:
  - Return type is `unknown`, not `any` (`@ts-expect-error result.foo`)
  - Args remain callable with arbitrary arguments (`someCommand('arg1', 42)` compiles)
  - Custom `ToolbarTarget` construction with the new shape compiles (consumer building test stubs or non-Editor command sources)