### PR TITLE
fix(types): hide internal Vue mount handles from public TypeScript surface (SD-3213)

### DIFF
--- a/packages/super-editor/src/editors/v1/components/toolbar/super-toolbar.js
+++ b/packages/super-editor/src/editors/v1/components/toolbar/super-toolbar.js
@@ -214,6 +214,21 @@ export class SuperToolbar extends EventEmitter {
   toolbarContainer = null;
 
   /**
+   * Mounted Vue component instance from `this.app.mount(...)`. Not
+   * consumer API: zero docs/examples reference `superdoc.toolbar.toolbar`,
+   * and no .ts or .js cross-file reader exists. The wrapper
+   * `SuperDoc.toolbar` (this class) is the documented public surface;
+   * this nested `.toolbar` field is the internal Vue mount handle.
+   *
+   * Same SD-3213f-style TS surface hide as `commentsList` and
+   * `SuperDoc.app`; not runtime privacy.
+   *
+   * @type {import('vue').ComponentPublicInstance | null}
+   * @private
+   */
+  toolbar = null;
+
+  /**
    * Creates a new SuperToolbar instance
    * @param {ToolbarConfig} config - The configuration for the toolbar
    * @returns {void}

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -330,7 +330,22 @@ export class SuperDoc extends EventEmitter {
    */
   commentsList;
 
-  /** @type {import('vue').App} */
+  /**
+   * Internal Vue app handle created in `#initVueApp()` and used for
+   * mount/unmount, `provide()`, and `config.globalProperties` setup.
+   * Not consumer API: no docs or examples reference `superdoc.app`,
+   * and the only cross-file reader (`SuperComments.createVueApp()`
+   * at `super-comments-list.js:35`) is a `.js` file under
+   * `checkJs: false`, so the `@private` boundary does not break
+   * internal source compilation.
+   *
+   * Same SD-3213f-style TS surface hide as
+   * `superdocStore` / `commentsStore` / `highContrastModeStore` /
+   * `commentsList`; not runtime privacy.
+   *
+   * @type {import('vue').App}
+   * @private
+   */
   app;
 
   /** @type {import('pinia').Pinia} */

--- a/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
+++ b/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "scope": "supported-root",
-  "generatedAt": "2026-05-21T18:04:04.699Z",
+  "generatedAt": "2026-05-21T18:52:37.197Z",
   "entries": [
     {
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.converter[string]|converter: SuperConverter;",
@@ -184,26 +184,6 @@
       "rationale": "auto-seeded from inventory (supported-root scope)"
     },
     {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbar<14>|toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.toolbar.toolbar<14>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 189,
-      "snippet": "toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts|SuperDoc.toolbar.toolbar<14>|toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
-      "kind": "type",
-      "symbolPath": "SuperDoc.toolbar.toolbar<14>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/components/toolbar/super-toolbar.d.ts",
-      "line": 189,
-      "snippet": "toolbar: import('vue').ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, import('vue').ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string",
-      "owner": "tier-2-toolbar",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
       "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|Editor.<value>.new(options)<0>.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
       "kind": "type",
       "symbolPath": "Editor.<value>.new(options)<0>.extensions[].config.renderDOM<1>",
@@ -260,26 +240,6 @@
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
       "line": 49,
       "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts|SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.app<0>|app: import('vue').App;",
-      "kind": "type",
-      "symbolPath": "SuperDoc.<value>.new(config).modules.comments.permissionResolver(params).superdoc.app<0>",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts",
-      "line": 99,
-      "snippet": "app: import('vue').App;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts|SuperDoc.app<0>|app: import('vue').App;",
-      "kind": "type",
-      "symbolPath": "SuperDoc.app<0>",
-      "file": "node_modules/superdoc/dist/superdoc/src/core/SuperDoc.d.ts",
-      "line": 99,
-      "snippet": "app: import('vue').App;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
     }

--- a/tests/consumer-typecheck/src/superdoc-stores-private.ts
+++ b/tests/consumer-typecheck/src/superdoc-stores-private.ts
@@ -57,6 +57,24 @@ void superdoc.highContrastModeStore;
 // handle (SD-3213); not part of the public TypeScript surface.
 void superdoc.commentsList;
 
+// @ts-expect-error app is the internal Vue app handle (SD-3213);
+// not part of the public TypeScript surface. The documented public
+// surface is `superdoc.toolbar` (the SuperToolbar wrapper), not
+// `superdoc.app`.
+void superdoc.app;
+
+// @ts-expect-error toolbar.toolbar is the internal Vue
+// ComponentPublicInstance mounted by SuperToolbar (SD-3213); the
+// documented public surface is `superdoc.toolbar` itself. The
+// nested `.toolbar` field is internal mount state.
+void superdoc.toolbar.toolbar;
+
+// Positive: `superdoc.toolbar` (the SuperToolbar class instance)
+// remains accessible: it is the documented public surface
+// (`apps/docs/editor/built-in-ui/toolbar.mdx` shows multiple
+// `const toolbar = superdoc.toolbar` examples).
+void superdoc.toolbar;
+
 // --- Positive assertions ---------------------------------------------------
 // Documented factories accepting a SuperDoc instance must continue to
 // compile after the hide. These compile because SuperDoc now exposes the


### PR DESCRIPTION
Adds `/** @private */` class-field declarations for two internal Vue mount handles, hiding them from the emitted public type surface:

- **`SuperDoc.app`**: the Vue `App` instance created in `#initVueApp()`, used for `mount()` / unmount, `provide()`, and `config.globalProperties`.
- **`SuperToolbar.toolbar`**: the Vue `ComponentPublicInstance` returned by `this.app.mount(this.toolbarContainer)`. Note this is the **nested** `.toolbar` field inside the `SuperToolbar` class; the wrapper `superdoc.toolbar` (the `SuperToolbar` class instance) remains the documented public surface and is unchanged.

Same SD-3213f-style pattern as `commentsList` / `superdocStore` / `commentsStore` / `highContrastModeStore`. **TypeScript surface hide, not runtime privacy:** `@private` becomes the TS `private` keyword in emit, so the field is invisible to consumers reading the `.d.ts` but remains a normal JS property at runtime.

## Cross-file reach safety

`SuperComments.createVueApp()` (`super-comments-list.js:35`) reads `this.superdoc?.app?._context?.provides` at runtime. This PR only hides the public emitted type; the JS build does not type-check that private cross-file reach today, and runtime behavior is unchanged. If the repo later moves these JS files under `checkJs: true`, an internal accessor for the Vue `provides` / context would be the right next step.

## Audit movement: 28 → 24

- **4 supported-root entries removed** (2 for `SuperDoc.app`, 2 for `SuperToolbar.toolbar`; each across the direct reach + the `comments.permissionResolver` reach)
- **0 new transitives.** Hiding strips the field from the type graph entirely.

## Verified

- `pnpm typecheck:matrix` → 71 passed, 0 failed
- `node deep-type-audit.mjs --strict-supported-root` → PASS (28 → **24**)
- Repo build clean; facade emit clean
- Emitted declarations: `SuperDoc.d.ts` shows `private app;`; `super-toolbar.d.ts` shows `private toolbar;`
- 14,156 unit tests pass (superdoc 1037 + super-editor 13119)
- Fixture asserts both negatives + the positive `superdoc.toolbar` wrapper (documented public, multiple usages in `apps/docs/editor/built-in-ui/toolbar.mdx`)