### PR TITLE
fix(types): replace ProseMirror DOMOutputSpec on NodeConfig.renderDOM (SD-3213)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/Node.ts
+++ b/packages/super-editor/src/editors/v1/core/Node.ts
@@ -7,7 +7,7 @@ import type { NodeView, EditorView, Decoration, DecorationSource } from 'prosemi
 import type { InputRule } from './InputRule.js';
 import type { Editor } from './Editor.js';
 import type { Command } from './types/ChainedCommands.js';
-import type { AttributeSpec } from './Attribute.js';
+import type { AttributeSpec, AttributeValue } from './Attribute.js';
 
 /**
  * Attribute object accepted inside a `SuperDocDOMOutputSpec` tuple.
@@ -50,6 +50,22 @@ export type SuperDocDOMOutputSpec =
   | globalThis.Node
   | { dom: globalThis.Node; contentDOM?: HTMLElement }
   | SuperDocDOMOutputSpecTuple;
+
+/**
+ * Public function signature for `NodeConfig.renderDOM`. Function-only
+ * (not `MaybeGetter`) because the runtime in
+ * `packages/super-editor/src/editors/v1/core/Schema.js:99` invokes
+ * `renderDOM({ node, htmlAttributes })` directly with no
+ * `callOrGet()` wrapper. Typing it as `MaybeGetter<T>` would
+ * advertise a direct-value form that throws `TypeError` at runtime.
+ *
+ * `htmlAttributes` is the `Record<string, AttributeValue>` that
+ * `Attribute.getAttributesToRender()` returns at runtime.
+ */
+export type RenderDOMFn = (props: {
+  node: PmNode;
+  htmlAttributes: Record<string, AttributeValue>;
+}) => SuperDocDOMOutputSpec;
 
 /**
  * Configuration for Node extensions.
@@ -111,14 +127,20 @@ export interface NodeConfig<
   parseDOM?: MaybeGetter<ParseRule[]>;
 
   /**
-   * The DOM rendering function. Returns a `SuperDocDOMOutputSpec`:
-   * a public local alias mirroring ProseMirror's `DOMOutputSpec`
-   * shape but with an unknown-free tuple branch (the upstream type
-   * uses `readonly [string, ...any[]]`, which leaked `any` into the
-   * SD-3213 supported-root audit). Accepts both readonly and mutable
-   * arrays for JS extension compatibility.
+   * The DOM rendering function for the node. Receives
+   * `{ node, htmlAttributes }` at runtime (see `Schema.js:99`) and
+   * returns a `SuperDocDOMOutputSpec`: a public local alias
+   * mirroring ProseMirror's `DOMOutputSpec` shape but with an
+   * unknown-free tuple branch.
+   *
+   * Typed as a plain function (`RenderDOMFn`) rather than
+   * `MaybeGetter<SuperDocDOMOutputSpec>` because the runtime only
+   * invokes the function form. A direct-value `renderDOM: ['br']`
+   * type-checks under `MaybeGetter<T>` but throws `TypeError` at
+   * runtime. Narrowing the type aligns the public contract with
+   * what the runtime actually supports.
    */
-  renderDOM?: MaybeGetter<SuperDocDOMOutputSpec>;
+  renderDOM?: RenderDOMFn;
 
   /** Function or object to add options to the node */
   addOptions?: MaybeGetter<Options>;

--- a/packages/super-editor/src/editors/v1/core/Node.ts
+++ b/packages/super-editor/src/editors/v1/core/Node.ts
@@ -1,13 +1,55 @@
 import { getExtensionConfigField } from './helpers/getExtensionConfigField.js';
 import { callOrGet } from './utilities/callOrGet.js';
 import type { MaybeGetter } from './utilities/callOrGet.js';
-import type { NodeType, ParseRule, DOMOutputSpec, Node as PmNode } from 'prosemirror-model';
+import type { NodeType, ParseRule, Node as PmNode } from 'prosemirror-model';
 import type { Plugin } from 'prosemirror-state';
 import type { NodeView, EditorView, Decoration, DecorationSource } from 'prosemirror-view';
 import type { InputRule } from './InputRule.js';
 import type { Editor } from './Editor.js';
 import type { Command } from './types/ChainedCommands.js';
 import type { AttributeSpec } from './Attribute.js';
+
+/**
+ * Attribute object accepted inside a `SuperDocDOMOutputSpec` tuple.
+ * Runtime `setAttribute` coerces non-string values, so number /
+ * boolean / null / undefined are accepted alongside string.
+ */
+export type RenderDOMAttrs = Record<string, string | number | boolean | null | undefined>;
+
+/**
+ * Tuple branch of `SuperDocDOMOutputSpec`, declared as an interface
+ * to break TypeScript's direct-recursion check (PM's upstream
+ * `readonly [string, ...any[]]` avoids this because `any` swallows
+ * the recursion; we cannot replicate that with `unknown`). The
+ * interface form defers the self-reference through a named type,
+ * which TS accepts.
+ *
+ * The shape mirrors PM's tuple convention: index 0 is the tagName,
+ * subsequent items are an optional attrs object, the literal `0`
+ * (content hole), or nested specs. Both readonly and mutable
+ * arrays satisfy this interface because `ReadonlyArray` is the
+ * supertype of `Array`.
+ */
+export interface SuperDocDOMOutputSpecTuple extends ReadonlyArray<SuperDocDOMOutputSpec | RenderDOMAttrs | 0> {
+  readonly 0: string;
+}
+
+/**
+ * Public DOM rendering output spec for `NodeConfig.renderDOM`.
+ * Mirrors ProseMirror's `DOMOutputSpec` shape but replaces the
+ * upstream `readonly [string, ...any[]]` tuple branch with the
+ * `SuperDocDOMOutputSpecTuple` interface above, so the public type
+ * surface does not leak `any` through the SD-3213 supported-root
+ * audit.
+ *
+ * `globalThis.Node` is used to disambiguate from the editor `Node`
+ * class exported from this same file.
+ */
+export type SuperDocDOMOutputSpec =
+  | string
+  | globalThis.Node
+  | { dom: globalThis.Node; contentDOM?: HTMLElement }
+  | SuperDocDOMOutputSpecTuple;
 
 /**
  * Configuration for Node extensions.
@@ -68,8 +110,15 @@ export interface NodeConfig<
   /** The DOM parsing rules */
   parseDOM?: MaybeGetter<ParseRule[]>;
 
-  /** The DOM rendering function - returns a DOMOutputSpec (allows mutable arrays for JS compatibility) */
-  renderDOM?: MaybeGetter<DOMOutputSpec>;
+  /**
+   * The DOM rendering function. Returns a `SuperDocDOMOutputSpec`:
+   * a public local alias mirroring ProseMirror's `DOMOutputSpec`
+   * shape but with an unknown-free tuple branch (the upstream type
+   * uses `readonly [string, ...any[]]`, which leaked `any` into the
+   * SD-3213 supported-root audit). Accepts both readonly and mutable
+   * arrays for JS extension compatibility.
+   */
+  renderDOM?: MaybeGetter<SuperDocDOMOutputSpec>;
 
   /** Function or object to add options to the node */
   addOptions?: MaybeGetter<Options>;

--- a/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
+++ b/tests/consumer-typecheck/deep-type-audit.supported-root-allowlist.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "scope": "supported-root",
-  "generatedAt": "2026-05-21T18:52:37.197Z",
+  "generatedAt": "2026-05-21T19:18:32.457Z",
   "entries": [
     {
       "key": "index|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Editor.d.ts|Editor.<value>.new(options)<0>.extensions[].editor.converter[string]|converter: SuperConverter;",
@@ -180,66 +180,6 @@
       "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/helpers/getActiveFormatting.d.ts",
       "line": 1,
       "snippet": "export function getActiveFormatting(editor: any): any;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|Editor.<value>.new(options)<0>.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "kind": "type",
-      "symbolPath": "Editor.<value>.new(options)<0>.extensions[].config.renderDOM<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
-      "line": 49,
-      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|Extensions.<value>.Node.new(config).editor.presentationEditor.options.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "kind": "type",
-      "symbolPath": "Extensions.<value>.Node.new(config).editor.presentationEditor.options.extensions[].config.renderDOM<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
-      "line": 49,
-      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|defineNode.<value>(config).editor.presentationEditor.options.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "kind": "type",
-      "symbolPath": "defineNode.<value>(config).editor.presentationEditor.options.extensions[].config.renderDOM<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
-      "line": 49,
-      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|getRichTextExtensions.<value>=>return[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "kind": "type",
-      "symbolPath": "getRichTextExtensions.<value>=>return[].config.renderDOM<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
-      "line": 49,
-      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|getSchemaIntrospection.<value>(options).editor.presentationEditor.options.extensions[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "kind": "type",
-      "symbolPath": "getSchemaIntrospection.<value>(options).editor.presentationEditor.options.extensions[].config.renderDOM<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
-      "line": 49,
-      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "owner": "tier-5-other",
-      "rationale": "auto-seeded from inventory (supported-root scope)"
-    },
-    {
-      "key": "type|node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts|getStarterExtensions.<value>=>return[].config.renderDOM<1>|renderDOM?: MaybeGetter<DOMOutputSpec>;",
-      "kind": "type",
-      "symbolPath": "getStarterExtensions.<value>=>return[].config.renderDOM<1>",
-      "file": "node_modules/superdoc/dist/super-editor/src/editors/v1/core/Node.d.ts",
-      "line": 49,
-      "snippet": "renderDOM?: MaybeGetter<DOMOutputSpec>;",
       "owner": "tier-5-other",
       "rationale": "auto-seeded from inventory (supported-root scope)"
     }

--- a/tests/consumer-typecheck/src/node-render-dom.ts
+++ b/tests/consumer-typecheck/src/node-render-dom.ts
@@ -1,0 +1,88 @@
+/**
+ * Consumer typecheck: NodeConfig.renderDOM no longer leaks `any`
+ * through ProseMirror's DOMOutputSpec tuple branch (SD-3213 drain).
+ *
+ * Before this change, `renderDOM?: MaybeGetter<DOMOutputSpec>` pulled
+ * in PM's upstream `readonly [string, ...any[]]` tuple shape, leaking
+ * `any` into the SD-3213 supported-root audit (6 findings, all reach
+ * paths to this one field).
+ *
+ * After this change, the field is typed with
+ * `MaybeGetter<SuperDocDOMOutputSpec>`, a local public alias that
+ * mirrors PM's shape but uses an `unknown`-free recursive tuple
+ * interface (`SuperDocDOMOutputSpecTuple`).
+ *
+ * This fixture exercises the four shape branches through `defineNode`,
+ * the documented consumer entry point:
+ *   - plain string ("em" — a self-closing inline tag name)
+ *   - plain tuple with attrs and content hole (["span", { class }, 0])
+ *   - nested tuples (["div", ["span", { class }, "text"]])
+ *   - { dom, contentDOM? } form (used for custom DOM mount nodes)
+ *
+ * Plus one negative assertion: a number where an attrs object or
+ * child spec is expected must error.
+ */
+
+import { defineNode } from 'superdoc/super-editor';
+
+// Plain string: tagName-only render. Compiles because `string` is a
+// branch of `SuperDocDOMOutputSpec`.
+defineNode({
+  name: 'plainStringSpec',
+  renderDOM: () => 'em',
+});
+
+// Plain tuple with optional attrs + content hole (0). The most common
+// shape for custom node renderers. Attrs accept string/number/boolean
+// /null/undefined for setAttribute coercion compatibility.
+defineNode({
+  name: 'tupleWithAttrsAndHole',
+  renderDOM: () => ['span', { class: 'my-class', 'data-count': 3, hidden: true }, 0],
+});
+
+// Nested tuples for child renderers. The recursive
+// SuperDocDOMOutputSpecTuple interface defers self-reference so TS
+// doesn't trip on the direct recursion that a plain type alias hits.
+defineNode({
+  name: 'nestedTuple',
+  renderDOM: () => ['div', { class: 'wrap' }, ['span', { class: 'inner' }, 'text']],
+});
+
+// `{ dom, contentDOM? }` form. Used when a custom node needs to
+// distinguish the outer mount node from the editable content node.
+defineNode({
+  name: 'domContentDomShape',
+  renderDOM: () => {
+    const dom = document.createElement('div');
+    const contentDOM = document.createElement('span');
+    dom.appendChild(contentDOM);
+    return { dom, contentDOM };
+  },
+});
+
+// MaybeGetter: renderDOM accepts either a function returning the
+// spec OR the spec directly. Pinning the value form too.
+defineNode({
+  name: 'directValueForm',
+  renderDOM: ['br'],
+});
+
+// --- Negative assertions -------------------------------------------------
+
+// A number can't be an attrs object or child spec. If a future PR
+// widens the tuple element type back to `any` or `unknown`, this
+// `@ts-expect-error` becomes unused and tsc fails (TS2578).
+defineNode({
+  name: 'badTupleElement',
+  // @ts-expect-error SD-3213: tuple elements must be attrs object, nested spec, or 0; not a bare number.
+  renderDOM: () => ['div', 42, 'no'],
+});
+
+// First tuple element must be a string (tagName). Passing a number
+// must error; if a future PR re-widens the tuple, this directive
+// becomes unused and tsc fails (TS2578).
+defineNode({
+  name: 'badTagName',
+  // @ts-expect-error SD-3213: tuple[0] (tagName) must be string.
+  renderDOM: () => [42, { class: 'no' }, 0],
+});

--- a/tests/consumer-typecheck/src/node-render-dom.ts
+++ b/tests/consumer-typecheck/src/node-render-dom.ts
@@ -60,14 +60,21 @@ defineNode({
   },
 });
 
-// MaybeGetter: renderDOM accepts either a function returning the
-// spec OR the spec directly. Pinning the value form too.
+// --- Negative assertions -------------------------------------------------
+
+// renderDOM is function-only at the type level, matching what the
+// runtime in `Schema.js:99` actually supports (`renderDOM({ node,
+// htmlAttributes })`). A direct-value form like `renderDOM: ['br']`
+// would throw `TypeError: renderDOM is not a function` at runtime,
+// so the public type rejects it. If a future PR re-widens the field
+// to `MaybeGetter<SuperDocDOMOutputSpec>` (or back to PM's tuple-
+// containing union), the directive becomes unused and tsc fails
+// (TS2578).
 defineNode({
-  name: 'directValueForm',
+  name: 'directValueRejected',
+  // @ts-expect-error SD-3213: renderDOM is function-only; runtime invokes it as a callable.
   renderDOM: ['br'],
 });
-
-// --- Negative assertions -------------------------------------------------
 
 // A number can't be an attrs object or child spec. If a future PR
 // widens the tuple element type back to `any` or `unknown`, this

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -633,6 +633,32 @@ const scenarios = [
     files: ['src/extensions-helpers.ts'],
     mustPass: true,
   },
+  // SD-3213: NodeConfig.renderDOM uses a local SuperDocDOMOutputSpec
+  // alias instead of PM's DOMOutputSpec (which contains
+  // `readonly [string, ...any[]]`). Pins the four consumer shapes
+  // (string, tuple with attrs+0, nested tuples, { dom, contentDOM? })
+  // plus negative assertions for bad tuple elements and non-string
+  // tagName.
+  {
+    name: 'bundler / node renderDOM (SD-3213)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: true,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/node-render-dom.ts'],
+    mustPass: true,
+  },
+  {
+    name: 'node16 / node renderDOM (SD-3213)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: true,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/node-render-dom.ts'],
+    mustPass: true,
+  },
   // SD-3213 sub 2: ProseMirror generic defaults on Editor + Node
   // public surface. `Editor.schema` becomes `Schema<string, string>`,
   // `Editor.registerPlugin<PluginState>(plugin)` preserves the state


### PR DESCRIPTION
`NodeConfig.renderDOM` was typed `MaybeGetter<DOMOutputSpec>`, importing ProseMirror's `DOMOutputSpec` union. The union's tuple branch is `readonly [string, ...any[]]` — the rest `any[]` leaked through the SD-3213 supported-root audit as 6 findings (all reach paths to this one field).

**Fix:** define a local public alias `SuperDocDOMOutputSpec` in `Node.ts` that mirrors PM's shape but replaces the upstream tuple branch with `SuperDocDOMOutputSpecTuple`, an `unknown`-free recursive interface. `RenderDOMAttrs` accepts `string | number | boolean | null | undefined` to match runtime `setAttribute` coercion. All four new typedefs (`SuperDocDOMOutputSpec`, `SuperDocDOMOutputSpecTuple`, `RenderDOMAttrs`, `RenderDOMFn`) are exported from `Node.ts` so consumers can name them in their own extension helpers.

**Function-only signature for `renderDOM`** (added after bot review caught the runtime mismatch): the field is typed as `RenderDOMFn` rather than `MaybeGetter<SuperDocDOMOutputSpec>` because the runtime in the `Schema.js` `toDOM` path invokes `renderDOM` as a function with no `callOrGet` wrapper. The previous `MaybeGetter<T>` typing allowed a direct-value form (`renderDOM: ['br']`) that would throw `TypeError` at runtime. Narrowing aligns the public contract with what the runtime actually supports.

`RenderDOMFn` is `(props: { node: PmNode; htmlAttributes: Record<string, AttributeValue> }) => SuperDocDOMOutputSpec`. The `htmlAttributes` shape matches what `Attribute.getAttributesToRender()` returns at runtime.

## Recursion via interface, not type alias

ProseMirror gets away with self-recursive tuples because `any` swallows the recursion. We can't replicate that with `unknown` — TS rejects a direct-recursive union type. The `SuperDocDOMOutputSpecTuple` interface defers the self-reference through a named type, which TS accepts. The interface extends `ReadonlyArray` so both readonly and mutable arrays satisfy the type.

`globalThis.Node` is used to disambiguate from the editor `Node` class exported from the same file.

## Audit movement: 24 → 18

- **6 supported-root entries removed** (all reach paths to the single `NodeConfig.renderDOM` field)
- **0 new transitives.** The local alias and `RenderDOMFn` typedef contain no `any`; the function signature doesn't add new public reach paths.

## Why consumer-facing risk is minimal

Verified zero internal Node-level `renderDOM` use: all 123 `renderDOM:` matches in `packages/super-editor/src/editors/v1/extensions/` are at the **attribute-spec level** (different field, returns `Record<string, unknown>`), not the `NodeConfig.renderDOM` field. The field is purely a consumer-facing API; no internal call site forces compatibility with PM's exact tuple shape.

## Verified

- `pnpm typecheck:matrix` → 73 passed, 0 failed
- `node deep-type-audit.mjs --strict-supported-root` → PASS (24 → **18**)
- Repo build clean; facade emit clean across 10 entries
- 13,119 super-editor unit tests pass
- Fixture (`node-render-dom.ts`) exercises through `defineNode()` four positive consumer shapes (plain string, tuple with attrs + content hole, nested tuples, `{ dom, contentDOM? }`) plus three negative assertions:
  - `['div', 42, 'no']` rejects numbers as child specs
  - `[42, ...]` rejects non-string tagName
  - `renderDOM: ['br']` (direct value) rejects — function-only, runtime invokes it as a callable

## Remaining after merge

This is the final confirmed mechanical drain from the current queue. Remaining 18 entries:
- 16 \`editor.converter\` / \`editor.extensionService\` → [SD-3240](https://linear.app/superdocworkspace/issue/SD-3240) (architectural design ticket)
- 2 \`getActiveFormatting\` → [SD-3245](https://linear.app/superdocworkspace/issue/SD-3245) (spike complete; needs internal-caller scope work in headless-toolbar/helpers/formatting.ts, not a clean mechanical drain)