### PR TITLE
fix(types): exportJsonOnly returns ConvertedXmlPart, not string (SD-3248)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/Editor.exportDocx.types.spec.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.exportDocx.types.spec.ts
@@ -13,14 +13,19 @@
 
 import { describe, it, expect } from 'vitest';
 import type { Editor } from './Editor.js';
+import type { ConvertedXmlPart } from './types/EditorPublicSurfaces.js';
 
-// Never invoked — pure type-level assertions. Wrapped in a function so vitest
+// Never invoked. Pure type-level assertions. Wrapped in a function so vitest
 // doesn't try to execute the assignments at module load time.
 
 function _typeOnlyAssertions(editor: Editor): void {
   // Three narrow overloads.
   const _xmlOnly: Promise<string> = editor.exportDocx({ exportXmlOnly: true });
-  const _jsonOnly: Promise<string> = editor.exportDocx({ exportJsonOnly: true });
+  // SD-3248: exportJsonOnly returns the xml-js intermediate tree, NOT a
+  // JSON string. The original `Promise<string>` overload was a type lie;
+  // runtime always returned an object with a recursive `name` /
+  // `attributes` / `elements` shape.
+  const _jsonOnly: Promise<ConvertedXmlPart> = editor.exportDocx({ exportJsonOnly: true });
   const _updatedDocs: Promise<Record<string, string | null>> = editor.exportDocx({ getUpdatedDocs: true });
 
   // Default overload: T defaults to Blob, so browser consumers get

--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -18,7 +18,11 @@ import { ExtensionService } from './ExtensionService.js';
 import { CommandService } from './CommandService.js';
 import { Attribute } from './Attribute.js';
 import { SuperConverter } from '@core/super-converter/SuperConverter.js';
-import type { EditorConverterSurface, EditorExtensionServiceSurface } from './types/EditorPublicSurfaces.js';
+import type {
+  ConvertedXmlPart,
+  EditorConverterSurface,
+  EditorExtensionServiceSurface,
+} from './types/EditorPublicSurfaces.js';
 import {
   Commands,
   Editable,
@@ -3196,16 +3200,20 @@ export class Editor extends EventEmitter<EditorEventMap> {
    *
    * Return type depends on flags:
    * - `exportXmlOnly: true` → `string` (raw XML)
-   * - `exportJsonOnly: true` → `string` (JSON string)
+   * - `exportJsonOnly: true` → `ConvertedXmlPart` (the xml-js intermediate
+   *   tree; recursive `name` / `attributes` / `elements` shape, NOT a JSON
+   *   string). SD-3248: this overload previously typed as `Promise<string>`,
+   *   which did not match runtime. Consumers should walk the returned tree
+   *   directly; calling `JSON.parse` on it would never have worked.
    * - `getUpdatedDocs: true` → `Record<string, string | null>` (file map)
    * - Default → `Blob` (browser) or `Buffer` (Node.js headless). The runtime
    *   value is determined by the editor's `isHeadless` option at construction
-   *   time, which the type system cannot see — so the default overload is
+   *   time, which the type system cannot see, so the default overload is
    *   generic with `Blob` as the default. Browser consumers get `Blob`
    *   automatically; Node headless consumers opt in with `exportDocx<Buffer>()`.
    */
   async exportDocx(params: ExportDocxParams & { exportXmlOnly: true }): Promise<string>;
-  async exportDocx(params: ExportDocxParams & { exportJsonOnly: true }): Promise<string>;
+  async exportDocx(params: ExportDocxParams & { exportJsonOnly: true }): Promise<ConvertedXmlPart>;
   async exportDocx(params: ExportDocxParams & { getUpdatedDocs: true }): Promise<Record<string, string | null>>;
   async exportDocx<T extends Blob | Buffer = Blob>(
     params?: ExportDocxParams & { exportXmlOnly?: false; exportJsonOnly?: false; getUpdatedDocs?: false },
@@ -3219,7 +3227,9 @@ export class Editor extends EventEmitter<EditorEventMap> {
     getUpdatedDocs = false,
     fieldsHighlightColor = null,
     compression,
-  }: ExportDocxParams = {}): Promise<Blob | Buffer | Record<string, string | null> | string | undefined> {
+  }: ExportDocxParams = {}): Promise<
+    Blob | Buffer | Record<string, string | null> | string | ConvertedXmlPart | undefined
+  > {
     try {
       const exportHostEditor = resolveMainBodyEditor(this);
       commitLiveStorySessionRuntimes(exportHostEditor);
@@ -3255,13 +3265,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
 
       this.#validateDocumentExport();
 
-      // SD-3240: converter surface returns `string | Record<string, unknown>`
-      // (the JSON-only branch returns the intermediate xml-js tree).
-      // The Editor.exportDocx implementation signature here declares the
-      // outer union as `Record<string, string | null>` which is a pre-
-      // existing narrower shape than the runtime JSON tree. Cast at the
-      // bridge so the public surface stays honest.
-      if (exportXmlOnly || exportJsonOnly) return documentXml as string | Record<string, string | null>;
+      if (exportXmlOnly || exportJsonOnly) return documentXml;
 
       const customXml = this.converter.schemaToXml(this.converter.convertedXml['docProps/custom.xml'].elements[0]);
       const styles = this.converter.schemaToXml(this.converter.convertedXml['word/styles.xml'].elements[0]);

--- a/packages/super-editor/src/editors/v1/core/types/EditorPublicSurfaces.ts
+++ b/packages/super-editor/src/editors/v1/core/types/EditorPublicSurfaces.ts
@@ -119,12 +119,12 @@ export interface EditorConverterSurface {
   /**
    * Convert the current document tree to DOCX XML. Returns the
    * exported XML string by default, or the intermediate
-   * `Record<string, unknown>` JSON tree when called with
+   * `ConvertedXmlPart` (xml-js tree) when called with
    * `exportJsonOnly: true`. The `Blob` / `Buffer` wrapping happens
    * upstream in `Editor.exportDocx()` (which feeds the result into
    * a zipper), not here.
    */
-  exportToDocx(...args: unknown[]): Promise<string | Record<string, unknown>>;
+  exportToDocx(...args: unknown[]): Promise<string | ConvertedXmlPart>;
   getBibliographyPartExportPaths(): readonly string[];
   /**
    * ISO-8601 `dcterms:created` timestamp from core.xml (e.g.

--- a/tests/consumer-typecheck/src/customer-scenario.ts
+++ b/tests/consumer-typecheck/src/customer-scenario.ts
@@ -347,7 +347,13 @@ async function testExportDocx(editor: Editor) {
 
   // Specific overloads → narrowed return types
   const xml: string = await editor.exportDocx({ exportXmlOnly: true });
-  const json: string = await editor.exportDocx({ exportJsonOnly: true });
+  // SD-3248: exportJsonOnly returns the xml-js intermediate tree (recursive
+  // `name` / `attributes` / `elements` shape), NOT a JSON string. The
+  // previous `string` annotation was a type lie that did not match runtime
+  // (callers were already walking `.elements[0]` directly in tests).
+  const json: { name?: string; attributes?: Record<string, unknown>; elements?: unknown[] } = await editor.exportDocx({
+    exportJsonOnly: true,
+  });
   const docs: Record<string, string | null> = await editor.exportDocx({ getUpdatedDocs: true });
 }
 

--- a/tests/consumer-typecheck/src/editor-surfaces-not-any.ts
+++ b/tests/consumer-typecheck/src/editor-surfaces-not-any.ts
@@ -85,17 +85,23 @@ void _identifierIsExact;
 // `exportToDocx()` at the converter level returns either the rendered
 // XML string or the intermediate xml-js JSON tree (when called with
 // `exportJsonOnly: true`). Blob / Buffer wrapping happens upstream in
-// `Editor.exportDocx()`, not on the converter. This assertion pins the
-// honest converter shape so a future regression to `any` (or back to
-// the original Blob | Buffer fiction) breaks the typecheck matrix.
-// (Note: `Editor.exportDocx({ exportJsonOnly: true })` is publicly
-// typed as `Promise<string>` but actually returns a JSON tree at
-// runtime; that overload correction is tracked separately and is
-// out of scope for SD-3240.)
-const exported: Promise<string | Record<string, unknown>> = editor.converter.exportToDocx();
-void exported;
-const _exportedIsExact: Equal<
-  ReturnType<typeof editor.converter.exportToDocx>,
-  Promise<string | Record<string, unknown>>
-> = true;
-void _exportedIsExact;
+// `Editor.exportDocx()`, not on the converter. SD-3248 tightened the
+// JSON branch to the recursive `ConvertedXmlPart` shape (was
+// `Record<string, unknown>`) so the runtime tree (`{ name, attributes,
+// elements }`) is named honestly; the `Editor.exportDocx` overload was
+// corrected in the same wave. Structural assertion pins both branches
+// without requiring `ConvertedXmlPart` itself to be a named public
+// export.
+type AwaitedExport = Awaited<ReturnType<typeof editor.converter.exportToDocx>>;
+type StringBranch = Extract<AwaitedExport, string>;
+type TreeBranch = Exclude<AwaitedExport, string>;
+const _hasStringBranch: Equal<StringBranch, string> = true;
+const _treeBranchIsTree: TreeBranch extends {
+  name?: string;
+  attributes?: Record<string, unknown>;
+  elements?: unknown[];
+}
+  ? true
+  : false = true;
+void _hasStringBranch;
+void _treeBranchIsTree;


### PR DESCRIPTION
`Editor.exportDocx({ exportJsonOnly: true })` was publicly typed as `Promise<string>`, but the runtime returns the xml-js intermediate tree (recursive `name` / `attributes` / `elements`). Internal tests already walked the result with `result.elements[0]`; any consumer who trusted the old type and called `JSON.parse(result)` would have failed at runtime.

- `Editor.exportDocx({ exportJsonOnly: true })` overload: `Promise<ConvertedXmlPart>` (was `Promise<string>`)
- JSDoc corrected (was "string (JSON string)")
- `EditorConverterSurface.exportToDocx()` JSON branch tightened from `Record<string, unknown>` to `ConvertedXmlPart`; the bridge cast at the Editor consumer site dropped cleanly
- Type-spec fixture pins the new named type; consumer fixture pins the structural shape

Type-level breaking change for consumers who declared the result as `string`. Runtime behavior is unchanged. Code already walking `.elements` matches the actual return shape and is unaffected.

Discovered during the public TypeScript cleanup after the `any` allowlist reached 0.

**Verified**: type-check clean; pnpm test:editor → 13120 pass; deep-type-audit --pack --strict-supported-root → PASS, 0 entries; typecheck-matrix → 75/75.