### PR TITLE
fix(types): type fieldAnnotationHelpers via JSDoc (SD-2980 PR A)

### DIFF
--- a/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findFieldAnnotations.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findFieldAnnotations.js
@@ -1,5 +1,14 @@
 import { getAllFieldAnnotations } from './getAllFieldAnnotations.js';
 
+/**
+ * Find field annotations matching a predicate.
+ *
+ * @param {(node: import('./types.js').PmNode) => boolean} predicate -
+ *   Called with each `fieldAnnotation` node; return `true` to keep the entry.
+ * @param {import('./types.js').EditorState} state - The editor state to search.
+ * @returns {import('./types.js').FieldAnnotationEntry[]} Matching
+ *   `{ node, pos }` entries.
+ */
 export function findFieldAnnotations(predicate, state) {
   let allFieldAnnotations = getAllFieldAnnotations(state);
   let fieldAnnotations = [];

--- a/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findFieldAnnotationsBetween.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findFieldAnnotationsBetween.js
@@ -1,9 +1,11 @@
 /**
- * Find all field annotations between positions.
- * @param from From position.
- * @param to To position.
- * @param doc Document.
- * @returns The array of field annotations (node and pos).
+ * Find all field annotations between two document positions.
+ *
+ * @param {number} from - Start position (inclusive).
+ * @param {number} to - End position (exclusive).
+ * @param {import('./types.js').PmNode} doc - Document node to scan.
+ * @returns {import('./types.js').FieldAnnotationEntry[]} `{ node, pos }`
+ *   per annotation in range.
  */
 export function findFieldAnnotationsBetween(from, to, doc) {
   let fieldAnnotations = [];

--- a/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findFieldAnnotationsByFieldId.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findFieldAnnotationsByFieldId.js
@@ -2,9 +2,12 @@ import { findChildren } from '@core/helpers/findChildren.js';
 
 /**
  * Find field annotations by field ID or array of field IDs.
- * @param fieldIdOrArray The field ID or array of field IDs.
- * @param state The editor state.
- * @returns The field annotations array.
+ *
+ * @param {string | string[]} fieldIdOrArray - Single field ID or array
+ *   of IDs to match against `node.attrs.fieldId`.
+ * @param {import('./types.js').EditorState} state - The editor state to search.
+ * @returns {import('./types.js').FieldAnnotationEntry[]} Matching
+ *   `{ node, pos }` entries.
  */
 export function findFieldAnnotationsByFieldId(fieldIdOrArray, state) {
   let fieldAnnotations = findChildren(state.doc, (node) => {

--- a/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findFirstFieldAnnotationByFieldId.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findFirstFieldAnnotationByFieldId.js
@@ -1,8 +1,10 @@
 /**
- * Find first field annotation by field ID.
- * @param fieldId The field ID.
- * @param state The editor state.
- * @returns The field annotation or null.
+ * Find the first field annotation matching the given field ID.
+ *
+ * @param {string} fieldId - The field ID to match against `node.attrs.fieldId`.
+ * @param {import('./types.js').EditorState} state - The editor state to search.
+ * @returns {import('./types.js').FieldAnnotationEntry | null} The first
+ *   match, or `null` if none.
  */
 export function findFirstFieldAnnotationByFieldId(fieldId, state) {
   let fieldAnnotation = findNode(state.doc, (node) => {
@@ -12,7 +14,13 @@ export function findFirstFieldAnnotationByFieldId(fieldId, state) {
   return fieldAnnotation;
 }
 
+/**
+ * @param {import('./types.js').PmNode} node
+ * @param {(node: import('./types.js').PmNode) => boolean} predicate
+ * @returns {import('./types.js').FieldAnnotationEntry | null}
+ */
 function findNode(node, predicate) {
+  /** @type {import('./types.js').FieldAnnotationEntry | null} */
   let found = null;
   node.descendants((node, pos) => {
     if (predicate(node)) found = { node, pos };

--- a/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findHeaderFooterAnnotationsByFieldId.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findHeaderFooterAnnotationsByFieldId.js
@@ -2,10 +2,20 @@ import { findChildren } from '@core/helpers/findChildren.js';
 import { getAllHeaderFooterEditors } from '../../../core/helpers/annotator.js';
 
 /**
- * Find field annotations in headers and footers by field ID or array of field IDs.
- * @param fieldIdOrArray The field ID or array of field IDs.
- * @param editor The editor state.
- * @returns The field annotations array.
+ * Find field annotations across all header / footer sub-editors that
+ * match the given field ID(s). If the active section editor's
+ * `documentId` matches a sub-editor, that sub-editor's live state is
+ * used instead of its snapshot state.
+ *
+ * @param {string | string[]} fieldIdOrArray - Field ID or array of IDs
+ *   to match against `node.attrs.fieldId`.
+ * @param {import('./types.js').Editor} editor - The main editor whose
+ *   registered headers / footers are walked.
+ * @param {import('./types.js').Editor} activeSectionEditor - The
+ *   currently-focused section sub-editor; its `state` overrides the
+ *   snapshot state for a matching `documentId`.
+ * @returns {import('./types.js').FieldAnnotationEntry[]} `{ node, pos }`
+ *   per match across all header / footer sub-editors.
  */
 export function findHeaderFooterAnnotationsByFieldId(fieldIdOrArray, editor, activeSectionEditor) {
   const sectionEditors = getAllHeaderFooterEditors(editor);

--- a/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findRemovedFieldAnnotations.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/findRemovedFieldAnnotations.js
@@ -1,7 +1,25 @@
 import { ReplaceStep } from 'prosemirror-transform';
 import { findChildren } from '@core/helpers/findChildren';
 
+/**
+ * Find field annotations that were removed by a transaction.
+ *
+ * Inspects the transaction's `ReplaceStep`s against `tr.before` and
+ * returns annotations whose positions were deleted (and that didn't
+ * reappear elsewhere in `tr.doc` under the same `fieldId`).
+ *
+ * Skips when:
+ * - the transaction has no steps,
+ * - it carries unexpected meta keys,
+ * - it's an undo / redo / drop / fieldAnnotationUpdate / tableGeneration tx.
+ *
+ * @param {import('./types.js').Transaction} tr - The transaction to inspect.
+ * @returns {import('./types.js').FieldAnnotationEntry[]} Removed
+ *   `{ node, pos }` entries. Empty array when nothing was removed or the
+ *   transaction is skipped.
+ */
 export function findRemovedFieldAnnotations(tr) {
+  /** @type {import('./types.js').FieldAnnotationEntry[]} */
   let removedNodes = [];
 
   if (
@@ -49,6 +67,10 @@ export function findRemovedFieldAnnotations(tr) {
   return removedNodes;
 }
 
+/**
+ * @param {import('./types.js').Transaction} tr
+ * @returns {boolean}
+ */
 function transactionDeletedAnything(tr) {
   return tr.steps.some((step) => {
     if (step instanceof ReplaceStep || step instanceof ReplaceAroundStep) {

--- a/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/getAllFieldAnnotations.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/getAllFieldAnnotations.js
@@ -1,9 +1,12 @@
 import { findChildren } from '@core/helpers/findChildren.js';
 
 /**
- * Get all field annotations in the doc.
- * @param state The editor state.
- * @returns The array of field annotations.
+ * Get all field annotations in the document.
+ *
+ * @param {import('./types.js').EditorState} state - The editor state to search.
+ * @returns {import('./types.js').FieldAnnotationEntry[]} Array of
+ *   `{ node, pos }` entries where `node.type.name === 'fieldAnnotation'`.
+ *   Empty array if none.
  */
 export function getAllFieldAnnotations(state) {
   let fieldAnnotations = findChildren(state.doc, (node) => node.type.name === 'fieldAnnotation');

--- a/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/getAllFieldAnnotationsWithRect.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/getAllFieldAnnotationsWithRect.js
@@ -2,10 +2,15 @@ import { posToDOMRect } from '@core/helpers/index.js';
 import { getAllFieldAnnotations } from './getAllFieldAnnotations.js';
 
 /**
- * Get all field annotations with rects in the doc.
- * @param view The editor view.
- * @param state The editor state.
- * @returns The array of field annotations with rects.
+ * Get all field annotations in the document, paired with their DOM
+ * bounding rect from the current view.
+ *
+ * @param {import('./types.js').EditorView} view - The editor view; used
+ *   to compute DOM rects.
+ * @param {import('./types.js').EditorState} state - The editor state to search.
+ * @returns {import('./types.js').FieldAnnotationEntryWithRect[]}
+ *   `{ node, pos, rect }` per annotation. `rect` is the bounding rect
+ *   from `view.coordsAtPos`.
  */
 export function getAllFieldAnnotationsWithRect(view, state) {
   let fieldAnnotations = getAllFieldAnnotations(state).map(({ node, pos }) => {

--- a/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/getHeaderFooterAnnotations.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/getHeaderFooterAnnotations.js
@@ -2,8 +2,12 @@ import { getAllHeaderFooterEditors } from '@core/helpers/annotator.js';
 import { getAllFieldAnnotations } from './index.js';
 
 /**
- * Get all field annotations in the header and footer.
- * @returns {Object[]} An array of field annotations, and which editor they belong to.
+ * Get all field annotations across every header / footer sub-editor.
+ *
+ * @param {import('./types.js').Editor} editor - The main editor whose
+ *   registered headers / footers are walked.
+ * @returns {import('./types.js').FieldAnnotationEntry[]} `{ node, pos }`
+ *   per annotation, flattened across all sub-editors.
  */
 export const getHeaderFooterAnnotations = (editor) => {
   const editors = getAllHeaderFooterEditors(editor);

--- a/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/trackFieldAnnotationsDeletion.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/trackFieldAnnotationsDeletion.js
@@ -1,6 +1,20 @@
 import { findRemovedFieldAnnotations } from './findRemovedFieldAnnotations.js';
 
+/**
+ * Detect field annotations removed by the transaction and emit a
+ * `fieldAnnotationDeleted` event on the editor (deferred via
+ * `setTimeout(0)` so the dispatch settles before subscribers run).
+ *
+ * Failures inside `findRemovedFieldAnnotations` are swallowed so a
+ * transaction-shape edge case can't crash the editor.
+ *
+ * @param {import('./types.js').Editor} editor - The editor instance to
+ *   emit the event on.
+ * @param {import('./types.js').Transaction} tr - The transaction to inspect.
+ * @returns {void}
+ */
 export function trackFieldAnnotationsDeletion(editor, tr) {
+  /** @type {import('./types.js').FieldAnnotationEntry[]} */
   let removedAnnotations = [];
   try {
     removedAnnotations = findRemovedFieldAnnotations(tr);

--- a/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/types.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-annotation/fieldAnnotationHelpers/types.js
@@ -1,0 +1,20 @@
+/**
+ * Shared JSDoc typedefs for the `fieldAnnotationHelpers` namespace.
+ *
+ * Defined once here so each helper file can reference them via
+ * `@typedef {import('./types.js').X}` without re-declaring (which
+ * would trigger ambiguous `export *` re-exports at the index barrel).
+ *
+ * @typedef {import('prosemirror-state').EditorState} EditorState
+ * @typedef {import('prosemirror-state').Transaction} Transaction
+ * @typedef {import('prosemirror-view').EditorView} EditorView
+ * @typedef {import('prosemirror-model').Node} PmNode
+ * @typedef {import('../../../core/Editor.js').Editor} Editor
+ *
+ * @typedef {{ node: PmNode; pos: number }} FieldAnnotationEntry
+ * @typedef {{ node: PmNode; pos: number; rect: DOMRect }} FieldAnnotationEntryWithRect
+ */
+
+// Module marker so TypeScript treats this as a module-scoped declaration
+// file rather than a script. No runtime symbols are exported.
+export {};

--- a/tests/consumer-typecheck/src/field-annotation-helpers-typed.ts
+++ b/tests/consumer-typecheck/src/field-annotation-helpers-typed.ts
@@ -1,0 +1,132 @@
+/**
+ * Consumer typecheck: `fieldAnnotationHelpers` namespace returns
+ * typed `{ node, pos }` entries, not `any[]` (SD-2980 PR A).
+ *
+ * Before this change, every helper in `fieldAnnotationHelpers` resolved
+ * to `(...args: any[]) => any[]` in the published `.d.ts` because the
+ * source files were JavaScript without `@param` / `@returns` JSDoc.
+ * 34 audit findings tracked the leak. After PR A, JSDoc is in place;
+ * this fixture pins each helper's return so a regression breaks the
+ * typecheck matrix, not just the inventory count.
+ *
+ * Element shape pinned: `{ node, pos }` where `pos` is a number and
+ * `node` exposes the ProseMirror Node API (`type.name`, `attrs`,
+ * `nodeSize`). One helper adds a `rect: DOMRect` field.
+ */
+
+import { Editor, fieldAnnotationHelpers } from 'superdoc/super-editor';
+import type { EditorState, Transaction } from 'prosemirror-state';
+import type { EditorView } from 'prosemirror-view';
+import type { Node as PmNode } from 'prosemirror-model';
+
+declare const state: EditorState;
+declare const view: EditorView;
+declare const doc: PmNode;
+declare const tr: Transaction;
+declare const editor: Editor;
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+// --- Each helper's return is NOT any[] -----------------------------------
+
+type GetAllReturn = ReturnType<typeof fieldAnnotationHelpers.getAllFieldAnnotations>;
+const _getAllNotAnyArr: Equal<GetAllReturn, any[]> = false;
+void _getAllNotAnyArr;
+
+type FindReturn = ReturnType<typeof fieldAnnotationHelpers.findFieldAnnotations>;
+const _findNotAnyArr: Equal<FindReturn, any[]> = false;
+void _findNotAnyArr;
+
+type FindByIdReturn = ReturnType<typeof fieldAnnotationHelpers.findFieldAnnotationsByFieldId>;
+const _findByIdNotAnyArr: Equal<FindByIdReturn, any[]> = false;
+void _findByIdNotAnyArr;
+
+type FindBetweenReturn = ReturnType<typeof fieldAnnotationHelpers.findFieldAnnotationsBetween>;
+const _findBetweenNotAnyArr: Equal<FindBetweenReturn, any[]> = false;
+void _findBetweenNotAnyArr;
+
+type WithRectReturn = ReturnType<typeof fieldAnnotationHelpers.getAllFieldAnnotationsWithRect>;
+const _withRectNotAnyArr: Equal<WithRectReturn, any[]> = false;
+void _withRectNotAnyArr;
+
+// --- Element shape: { node: PmNode; pos: number } ------------------------
+
+// Structural pin. If the element ever degrades to `any` or loses the
+// `node`/`pos` fields, this assignment breaks.
+function consumeEntry(entry: GetAllReturn[number]): void {
+  const n: PmNode = entry.node;
+  const p: number = entry.pos;
+  void n;
+  void p;
+  // `node` must expose ProseMirror Node members, not just be `any`.
+  const _typeName: string = entry.node.type.name;
+  const _nodeSize: number = entry.node.nodeSize;
+  void _typeName;
+  void _nodeSize;
+}
+void consumeEntry;
+
+// --- getAllFieldAnnotationsWithRect carries a real DOMRect ---------------
+
+function consumeWithRect(entry: WithRectReturn[number]): void {
+  const _rect: DOMRect = entry.rect;
+  // DOMRect has typed top/left/width/height. Asserting `number` proves
+  // the rect didn't degrade to `any`.
+  const _top: number = entry.rect.top;
+  const _width: number = entry.rect.width;
+  void _rect;
+  void _top;
+  void _width;
+}
+void consumeWithRect;
+
+// --- Predicate parameter is typed Node, not any --------------------------
+
+// If `predicate` were `(...args: any[]) => any`, this `@ts-expect-error`
+// would become unused and tsc would fail with TS2578.
+fieldAnnotationHelpers.findFieldAnnotations((node) => {
+  // Real PmNode members must work:
+  return node.type.name === 'fieldAnnotation';
+}, state);
+
+// @ts-expect-error SD-2980: predicate receives a Node, not a string.
+fieldAnnotationHelpers.findFieldAnnotations((s: string) => s.length > 0, state);
+
+// --- findFirstFieldAnnotationByFieldId returns nullable entry, not any --
+
+type FirstReturn = ReturnType<typeof fieldAnnotationHelpers.findFirstFieldAnnotationByFieldId>;
+const _firstNotAny: Equal<FirstReturn, any> = false;
+void _firstNotAny;
+// Must include `null` in the union (no match case).
+const _firstHandlesNull: null extends FirstReturn ? true : false = true;
+void _firstHandlesNull;
+
+// --- Argument types are real, not any ------------------------------------
+
+// state: EditorState (not any). If it were any, this `@ts-expect-error`
+// would not fire and tsc would catch the unused directive.
+fieldAnnotationHelpers.getAllFieldAnnotations(state);
+// @ts-expect-error SD-2980: getAllFieldAnnotations needs an EditorState.
+fieldAnnotationHelpers.getAllFieldAnnotations('not a state');
+
+// view: EditorView (not any).
+fieldAnnotationHelpers.getAllFieldAnnotationsWithRect(view, state);
+// @ts-expect-error SD-2980: getAllFieldAnnotationsWithRect needs an EditorView first arg.
+fieldAnnotationHelpers.getAllFieldAnnotationsWithRect('not a view', state);
+
+// tr: Transaction (not any).
+fieldAnnotationHelpers.findRemovedFieldAnnotations(tr);
+// @ts-expect-error SD-2980: findRemovedFieldAnnotations needs a Transaction.
+fieldAnnotationHelpers.findRemovedFieldAnnotations('not a tr');
+
+// doc: PmNode (not any).
+fieldAnnotationHelpers.findFieldAnnotationsBetween(0, 10, doc);
+// @ts-expect-error SD-2980: findFieldAnnotationsBetween needs a Node as doc.
+fieldAnnotationHelpers.findFieldAnnotationsBetween(0, 10, 'not a doc');
+
+// editor: Editor (not any).
+fieldAnnotationHelpers.getHeaderFooterAnnotations(editor);
+// @ts-expect-error SD-2980: getHeaderFooterAnnotations needs an Editor.
+fieldAnnotationHelpers.getHeaderFooterAnnotations('not an editor');
+
+fieldAnnotationHelpers.trackFieldAnnotationsDeletion(editor, tr);

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -370,6 +370,30 @@ const scenarios = [
     files: ['src/track-changes-helpers.ts'],
     mustPass: true,
   },
+  // SD-2980 PR A: fieldAnnotationHelpers exported under `superdoc/super-editor`
+  // now carry typed JSDoc on every helper. The fixture pins each helper's
+  // return shape (`{ node, pos }`, plus DOMRect for the rect variant) and
+  // proves arguments are real ProseMirror types, not `any`.
+  {
+    name: 'bundler / field annotation helper typing (SD-2980)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: false,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/field-annotation-helpers-typed.ts'],
+    mustPass: true,
+  },
+  {
+    name: 'node16 / field annotation helper typing (SD-2980)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: false,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/field-annotation-helpers-typed.ts'],
+    mustPass: true,
+  },
   // SD-2892: full public-facing surface with skipLibCheck=false. These
   // scenarios pack SuperDoc, install it into the consumer fixture, and compile
   // every public consumer assertion under the resolution modes customers use.


### PR DESCRIPTION
All 10 helpers exported under `fieldAnnotationHelpers` (public via `superdoc/super-editor`) now carry concrete JSDoc and emit real return types instead of `any` / `any[]`. The shared `{ node, pos }` entry shape and ProseMirror parameter types (`EditorState`, `EditorView`, `Transaction`, `Node`, `Editor`) live in a sibling `types.js` so each helper can reference them via `import('./types.js').*` without re-declaring at module scope. Re-declaring would trigger `export *` ambiguity at the index barrel.

- Drains 34 of 34 `fieldAnnotationHelpers` audit findings (tier-3-helpers 87 → 53)
- Consumer fixture pins each helper's return shape, the element members (`node.type.name`, `nodeSize`, `rect.top`, etc.), and rejects bad-shape args via `@ts-expect-error`
- Approach: JSDoc on `.js`, not `.ts` rename. Matches the SD-3245 precedent on `getActiveFormatting.js`. Cheaper, preserves import paths, avoids test churn.

Scope intentionally narrow per the SD-2980 PR split plan: no `trackChangesHelpers` files touched, no helper de-dupe, no file renames. Follow-ups: PR B (`markSnapshotHelpers` + `documentHelpers`), PR C (remaining trackChanges helpers).

**Verified**: type-check clean; pnpm test:editor → 13120 pass; deep-type-audit --pack --strict-supported-root → PASS (0 entries); typecheck-matrix → 77/77 (2 new SD-2980 scenarios).