### PR TITLE
fix(types): type trackChangesHelpers core via JSDoc (SD-2980 PR B)

### DIFF
--- a/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/documentHelpers.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/documentHelpers.js
@@ -1,4 +1,17 @@
 // https://discuss.prosemirror.net/t/expanding-the-selection-to-the-active-mark/
+
+/**
+ * Expand from `pos` to the full range covered by the mark named
+ * `markName` on the containing parent. Walks left/right while adjacent
+ * siblings share an equivalent mark.
+ *
+ * @param {import('./types.js').PmNode} doc - Document root to resolve against.
+ * @param {number} pos - Cursor position to expand from.
+ * @param {string} markName - Mark type name (e.g. `'link'`, `'bold'`).
+ * @returns {{ from: number; to: number; attrs: import('./types.js').Attrs } | null}
+ *   `{ from, to, attrs }` of the contiguous mark range, or `null` if no
+ *   `markName` mark is at `pos`.
+ */
 export const findMarkPosition = (doc, pos, markName) => {
   const $pos = doc.resolve(pos);
   const parent = $pos.parent;
@@ -34,10 +47,21 @@ export const findMarkPosition = (doc, pos, markName) => {
   };
 };
 
+/**
+ * Flatten a document tree into a list of `{ node, pos }` entries.
+ *
+ * @param {import('./types.js').PmNode} node - Root to flatten.
+ * @param {boolean} [descend=true] - Recurse into matching children.
+ *   When `false`, only the top-level descendants are returned.
+ * @returns {import('./types.js').NodePosEntry[]} Every descendant
+ *   paired with its document position.
+ * @throws {Error} If `node` is missing.
+ */
 export const flatten = (node, descend = true) => {
   if (!node) {
     throw new Error('Invalid "node" parameter');
   }
+  /** @type {import('./types.js').NodePosEntry[]} */
   const result = [];
   node.descendants((child, pos) => {
     result.push({ node: child, pos });
@@ -48,6 +72,20 @@ export const flatten = (node, descend = true) => {
   return result;
 };
 
+/**
+ * Track-changes variant of `findChildren` with optional descend control.
+ * Distinct from `@core/helpers/findChildren` (the 2-arg version without
+ * `descend`); prefer the core helper for the common case.
+ *
+ * @param {import('./types.js').PmNode} node - Root to search.
+ * @param {(child: import('./types.js').PmNode) => boolean} predicate -
+ *   Called per descendant; return `true` to keep the entry.
+ * @param {boolean} [descend] - Recurse into matching children. Forwarded
+ *   to `flatten`.
+ * @returns {import('./types.js').NodePosEntry[]} Matching `{ node, pos }`
+ *   entries.
+ * @throws {Error} If `node` or `predicate` is missing.
+ */
 export const findChildren = (node, predicate, descend) => {
   if (!node) {
     throw new Error('Invalid "node" parameter');
@@ -57,6 +95,13 @@ export const findChildren = (node, predicate, descend) => {
   return flatten(node, descend).filter((child) => predicate(child.node));
 };
 
+/**
+ * Return every inline-typed descendant of `node` as `{ node, pos }`.
+ *
+ * @param {import('./types.js').PmNode} node - Root to search.
+ * @param {boolean} [descend] - Recurse into matching children.
+ * @returns {import('./types.js').NodePosEntry[]} Inline descendants.
+ */
 export const findInlineNodes = (node, descend) => {
   return findChildren(node, (child) => child.isInline, descend);
 };

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/markSnapshotHelpers.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/markSnapshotHelpers.js
@@ -1,9 +1,17 @@
 import { isEqual, isMatch } from 'lodash';
 
+/**
+ * @param {import('./types.js').Attrs} [attrs]
+ * @returns {import('./types.js').Attrs}
+ */
 const normalizeAttrs = (attrs = {}) => {
   return Object.fromEntries(Object.entries(attrs).filter(([, value]) => value !== null && value !== undefined));
 };
 
+/**
+ * @param {import('./types.js').Attrs} [attrs]
+ * @returns {import('./types.js').Attrs}
+ */
 const stripUnsetInternalSnapshotAttrs = (attrs = {}) => {
   const nextAttrs = { ...attrs };
   if (nextAttrs.ooxmlHighlightClear === null || nextAttrs.ooxmlHighlightClear === undefined) {
@@ -12,6 +20,17 @@ const stripUnsetInternalSnapshotAttrs = (attrs = {}) => {
   return nextAttrs;
 };
 
+/**
+ * Create a `MarkSnapshot` from a mark type name and attribute bag.
+ * Internal snapshot attrs (e.g. `ooxmlHighlightClear`) are stripped
+ * when unset so equality checks are stable. The returned snapshot
+ * always has `attrs` set (defaulting to `{}`).
+ *
+ * @param {string} type - The PM mark type name (e.g. `'bold'`).
+ * @param {import('./types.js').Attrs} [attrs] - Attribute bag for the
+ *   snapshot. Defaults to `{}`.
+ * @returns {import('./types.js').MarkSnapshot} Normalized snapshot.
+ */
 export const createMarkSnapshot = (type, attrs = {}) => {
   return {
     type,
@@ -38,20 +57,44 @@ const ATTRIBUTE_ONLY_MARKS = ['textStyle'];
 /**
  * Normalize snapshot attrs for tracked change comparison.
  * Strips null/undefined AND identity values that represent the default visual state.
+ *
+ * @param {import('./types.js').Attrs} [attrs]
+ * @returns {import('./types.js').Attrs}
  */
 const normalizeSnapshotAttrs = (attrs = {}) => {
   const base = normalizeAttrs(attrs);
   return Object.fromEntries(Object.entries(base).filter(([key, value]) => IDENTITY_ATTR_VALUES[key] !== value));
 };
 
+/**
+ * Extract the mark type name from either a live PM `Mark` (where
+ * `.type` is a `MarkType` object) or a `MarkSnapshot` (where `.type`
+ * is already a string).
+ *
+ * @param {import('./types.js').MarkLike | null | undefined} markLike
+ * @returns {string | undefined} The mark type name, or `undefined` if
+ *   the input is missing a `.type`.
+ */
 export const getTypeName = (markLike) => {
   return markLike?.type?.name ?? markLike?.type;
 };
 
 /**
- * Check if a tracked format change is effectively a no-op.
- * Compares before and after snapshots after normalizing identity attribute values.
- * A no-op means the format change has no net visual effect.
+ * Check whether a tracked format change is effectively a no-op.
+ * Compares before/after snapshot lists after normalizing identity
+ * attribute values and removing attribute-only marks (e.g. `textStyle`)
+ * whose normalized attrs are empty.
+ *
+ * Accepts the permissive `SnapshotLike[]` shape because the caller
+ * sources these lists from `formatChangeMark.attrs.before/after`, an
+ * attribute bag that TS infers loosely. Runtime is tolerant of missing
+ * fields (`getTypeName` returns `undefined`, attr merges guard with
+ * `attrs || {}`).
+ *
+ * @param {import('./types.js').SnapshotLike[]} before
+ * @param {import('./types.js').SnapshotLike[]} after
+ * @returns {boolean} `true` when before and after produce the same
+ *   visual state.
  */
 export const isTrackFormatNoOp = (before, after) => {
   const normalize = (entries) =>
@@ -78,12 +121,27 @@ export const isTrackFormatNoOp = (before, after) => {
   );
 };
 
+/**
+ * Compare two attribute bags for exact equality after normalizing
+ * null/undefined entries out of each side.
+ *
+ * @param {import('./types.js').Attrs} [left]
+ * @param {import('./types.js').Attrs} [right]
+ * @returns {boolean}
+ */
 export const attrsExactlyMatch = (left = {}, right = {}) => {
   const normalizedLeft = normalizeAttrs(left);
   const normalizedRight = normalizeAttrs(right);
   return isEqual(normalizedLeft, normalizedRight);
 };
 
+/**
+ * @param {import('./types.js').MarkLike | null | undefined} left
+ * @param {import('./types.js').MarkLike | null | undefined} right
+ * @param {boolean} [exact=true] - When `false`, only type names need to
+ *   match (attrs are ignored).
+ * @returns {boolean}
+ */
 const marksMatch = (left, right, exact = true) => {
   if (!left || !right || getTypeName(left) !== getTypeName(right)) {
     return false;
@@ -96,16 +154,47 @@ const marksMatch = (left, right, exact = true) => {
   return attrsExactlyMatch(left.attrs || {}, right.attrs || {});
 };
 
+/**
+ * Check whether a snapshot matches a step mark (either by full attr
+ * equality or by type name only, depending on `exact`).
+ *
+ * @param {import('./types.js').MarkLike} snapshot
+ * @param {import('./types.js').MarkLike} stepMark
+ * @param {boolean} [exact=true]
+ * @returns {boolean}
+ */
 export const markSnapshotMatchesStepMark = (snapshot, stepMark, exact = true) => {
   return marksMatch(snapshot, stepMark, exact);
 };
 
+/**
+ * Check whether any mark in `marks` matches `stepMark` exactly
+ * (same type name and attrs).
+ *
+ * @param {import('./types.js').MarkLike[]} marks
+ * @param {import('./types.js').MarkLike} stepMark
+ * @returns {boolean}
+ */
 export const hasMatchingMark = (marks, stepMark) => {
   return marks.some((mark) => {
     return marksMatch(mark, stepMark, true);
   });
 };
 
+/**
+ * Insert or update a snapshot in `snapshots` keyed by `type`. Merges
+ * `incoming.attrs` over the existing entry's attrs when a match exists;
+ * otherwise appends a freshly normalized snapshot.
+ *
+ * Accepts the permissive `SnapshotLike[]` input (callers may source
+ * from `formatChangeMark.attrs.*`). Output is the strict
+ * `MarkSnapshot[]` because `createMarkSnapshot` is the only path for
+ * new entries and it always normalizes.
+ *
+ * @param {import('./types.js').SnapshotLike[]} snapshots - Current set.
+ * @param {import('./types.js').MarkSnapshot} incoming - Snapshot to merge in.
+ * @returns {import('./types.js').MarkSnapshot[]} New array (input not mutated).
+ */
 export const upsertMarkSnapshotByType = (snapshots, incoming) => {
   const existing = snapshots.find((mark) => mark.type === incoming.type);
   if (existing) {
@@ -118,10 +207,22 @@ export const upsertMarkSnapshotByType = (snapshots, incoming) => {
   return [...snapshots, createMarkSnapshot(incoming.type, incoming.attrs)];
 };
 
+/**
+ * @param {import('./types.js').MarkLike | null | undefined} mark
+ * @param {import('./types.js').MarkLike | null | undefined} snapshot
+ * @param {boolean} [exact=true]
+ * @returns {boolean}
+ */
 const markMatchesSnapshot = (mark, snapshot, exact = true) => {
   return marksMatch(mark, snapshot, exact);
 };
 
+/**
+ * @param {import('./types.js').PmMark | null | undefined} mark - Live PM mark.
+ * @param {import('./types.js').MarkSnapshot | null | undefined} snapshot
+ * @returns {boolean} `true` when the live mark's attrs are a superset of
+ *   the snapshot's normalized attrs (and snapshot has at least one attr).
+ */
 const markAttrsIncludeSnapshotAttrs = (mark, snapshot) => {
   if (!mark || !snapshot || mark.type.name !== snapshot.type) {
     return false;
@@ -140,6 +241,11 @@ const markAttrsIncludeSnapshotAttrs = (mark, snapshot) => {
 // Attribute-only marks (like textStyle) can be serialized with different attr density
 // between snapshot and live state. This overlap matcher lets reject find the live mark
 // when exact/subset comparisons fail but shared attrs still clearly identify the mark.
+/**
+ * @param {import('./types.js').PmMark | null | undefined} mark
+ * @param {import('./types.js').MarkSnapshot | null | undefined} snapshot
+ * @returns {boolean}
+ */
 const markAttrsMatchOnOverlap = (mark, snapshot) => {
   if (!mark || !snapshot || mark.type.name !== snapshot.type) {
     return false;
@@ -166,6 +272,20 @@ const markAttrsMatchOnOverlap = (mark, snapshot) => {
   return overlapKeys.every((key) => isEqual(normalizedMarkAttrs[key], normalizedSnapshotAttrs[key]));
 };
 
+/**
+ * Find the live PM mark in `[from, to]` that best matches `snapshot`.
+ * Priority: exact attr match → snapshot-subset → attribute overlap →
+ * type-only fallback (only when snapshot has no attrs). Returns `null`
+ * if no candidate is found.
+ *
+ * @param {object} args
+ * @param {import('./types.js').PmNode} args.doc - Document to scan.
+ * @param {number} args.from - Range start position (inclusive).
+ * @param {number} args.to - Range end position (exclusive).
+ * @param {import('./types.js').MarkSnapshot} args.snapshot - Target snapshot.
+ * @returns {import('./types.js').PmMark | null} The matching live mark,
+ *   or `null` if none found.
+ */
 export const findMarkInRangeBySnapshot = ({ doc, from, to, snapshot }) => {
   let exactMatch = null;
   let subsetMatch = null;

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/types.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/types.js
@@ -1,0 +1,47 @@
+/**
+ * Shared JSDoc typedefs for the `trackChangesHelpers` namespace.
+ *
+ * Defined once here so each helper file can reference them via
+ * `@typedef {import('./types.js').X}` without re-declaring (which
+ * would trigger ambiguous `export *` re-exports at the index barrel).
+ *
+ * NOT exported from `index.js`. Reference these types via JSDoc
+ * `import()` only; this module intentionally exports no runtime
+ * symbols.
+ *
+ * @typedef {import('prosemirror-model').Node} PmNode
+ * @typedef {import('prosemirror-model').Mark} PmMark
+ *
+ * @typedef {Record<string, unknown>} Attrs
+ *
+ * @typedef {{ type: string; attrs: Attrs }} MarkSnapshot
+ *   Compact mark descriptor used by the tracked-changes pipeline.
+ *   `type` is the PM mark type name (e.g. `'bold'`); `attrs` is the
+ *   snapshot's attribute bag, always present (`createMarkSnapshot`
+ *   normalizes missing attrs to `{}`).
+ *
+ * @typedef {PmMark | SnapshotLike} MarkLike
+ *   Helpers accept either a live ProseMirror mark or a snapshot-shaped
+ *   object. Code reads `.type?.name ?? .type` to handle both: PM
+ *   `Mark.type` is a `MarkType` object whose `.name` is the string,
+ *   while `MarkSnapshot.type` is the string directly. The snapshot side
+ *   uses the permissive `SnapshotLike` shape so helpers tolerate the
+ *   loose `{ type?, attrs? }` typing that flows through attribute-bag
+ *   channels (e.g. `formatChangeMark.attrs.before`).
+ *
+ * @typedef {{ node: PmNode; pos: number }} NodePosEntry
+ *   The standard `findChildren` / `nodesBetween` result shape.
+ *
+ * @typedef {{ type?: string; attrs?: Attrs }} SnapshotLike
+ *   Permissive snapshot shape for helper inputs that flow through
+ *   loosely-typed channels (e.g. `formatChangeMark.attrs.before`,
+ *   which carries snapshots as a plain attribute bag). Helpers that
+ *   accept `SnapshotLike[]` tolerate missing fields at runtime;
+ *   `getTypeName` returns `undefined` for entries missing `type`, and
+ *   attr-merge sites guard with `attrs || {}` /  `{ ...existing.attrs }`.
+ *   Helpers that PRODUCE snapshots still return strict `MarkSnapshot`.
+ */
+
+// Module marker so TypeScript treats this as a module-scoped declaration
+// file rather than a script. No runtime symbols are exported.
+export {};

--- a/tests/consumer-typecheck/src/track-changes-helpers-typed.ts
+++ b/tests/consumer-typecheck/src/track-changes-helpers-typed.ts
@@ -1,0 +1,146 @@
+/**
+ * Consumer typecheck: `trackChangesHelpers` core helpers (PR B of
+ * SD-2980) return real shapes, not `any` / `any[]`.
+ *
+ * Before this change, every exported helper in `markSnapshotHelpers`
+ * and `documentHelpers` resolved to `(...args: any[]) => any[]` in the
+ * published `.d.ts` (39 audit findings). PR B added JSDoc on every
+ * helper. This fixture pins the visible return / parameter shapes so a
+ * regression breaks the typecheck matrix, not just the inventory count.
+ *
+ * Coverage:
+ * - markSnapshotHelpers: createMarkSnapshot, getTypeName,
+ *   isTrackFormatNoOp, attrsExactlyMatch, markSnapshotMatchesStepMark,
+ *   hasMatchingMark, upsertMarkSnapshotByType, findMarkInRangeBySnapshot
+ * - documentHelpers: findMarkPosition, flatten, findChildren,
+ *   findInlineNodes (the 3-arg track-changes variant, distinct from
+ *   `@core/helpers/findChildren`)
+ */
+
+import { trackChangesHelpers } from 'superdoc/super-editor';
+import type { Node as PmNode, Mark as PmMark } from 'prosemirror-model';
+
+declare const doc: PmNode;
+declare const mark: PmMark;
+declare const liveMarks: PmMark[];
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+// --- MarkSnapshot output shape -------------------------------------------
+
+const snap = trackChangesHelpers.createMarkSnapshot('bold');
+const _snapType: string = snap.type;
+const _snapAttrs: Record<string, unknown> = snap.attrs;
+void _snapType;
+void _snapAttrs;
+
+// `createMarkSnapshot` return is NOT any.
+const _snapNotAny: Equal<typeof snap, any> = false;
+void _snapNotAny;
+
+// --- getTypeName returns string | undefined ------------------------------
+
+const name = trackChangesHelpers.getTypeName(snap);
+const _nameIsStringOrUndefined: Equal<typeof name, string | undefined> = true;
+void _nameIsStringOrUndefined;
+// Accepts a live PM Mark too.
+trackChangesHelpers.getTypeName(mark);
+
+// --- isTrackFormatNoOp / attrsExactlyMatch return boolean ----------------
+
+const _noopReturn: boolean = trackChangesHelpers.isTrackFormatNoOp([snap], [snap]);
+const _attrsMatchReturn: boolean = trackChangesHelpers.attrsExactlyMatch({ a: 1 }, { a: 1 });
+void _noopReturn;
+void _attrsMatchReturn;
+
+// --- hasMatchingMark + markSnapshotMatchesStepMark return boolean -------
+
+const _hasMatch: boolean = trackChangesHelpers.hasMatchingMark(liveMarks, snap);
+const _stepMatch: boolean = trackChangesHelpers.markSnapshotMatchesStepMark(snap, snap, true);
+void _hasMatch;
+void _stepMatch;
+
+// --- upsertMarkSnapshotByType returns MarkSnapshot[] (output strict) -----
+
+const upserted = trackChangesHelpers.upsertMarkSnapshotByType([snap], snap);
+const _upsertedNotAnyArr: Equal<typeof upserted, any[]> = false;
+void _upsertedNotAnyArr;
+// Element members are typed.
+if (upserted[0]) {
+  const _t: string = upserted[0].type;
+  const _a: Record<string, unknown> = upserted[0].attrs;
+  void _t;
+  void _a;
+}
+
+// --- findMarkInRangeBySnapshot returns PmMark | null --------------------
+
+const liveMark = trackChangesHelpers.findMarkInRangeBySnapshot({
+  doc,
+  from: 0,
+  to: 10,
+  snapshot: snap,
+});
+const _liveMarkNotAny: Equal<typeof liveMark, any> = false;
+void _liveMarkNotAny;
+// `null` must be in the union.
+const _nullableLive: null extends typeof liveMark ? true : false = true;
+void _nullableLive;
+if (liveMark) {
+  // PM Mark exposes `.type.name` (MarkType.name), not just `any`.
+  const _typeName: string = liveMark.type.name;
+  void _typeName;
+}
+
+// --- documentHelpers: findMarkPosition returns nullable range -----------
+
+const range = trackChangesHelpers.documentHelpers.findMarkPosition(doc, 5, 'link');
+const _rangeNotAny: Equal<typeof range, any> = false;
+void _rangeNotAny;
+if (range) {
+  const _from: number = range.from;
+  const _to: number = range.to;
+  const _attrs: Record<string, unknown> = range.attrs;
+  void _from;
+  void _to;
+  void _attrs;
+}
+
+// --- documentHelpers: flatten / findChildren / findInlineNodes ----------
+
+type FlattenReturn = ReturnType<typeof trackChangesHelpers.documentHelpers.flatten>;
+type FindChildrenReturn = ReturnType<typeof trackChangesHelpers.documentHelpers.findChildren>;
+type FindInlineReturn = ReturnType<typeof trackChangesHelpers.documentHelpers.findInlineNodes>;
+
+const _flattenNotAnyArr: Equal<FlattenReturn, any[]> = false;
+const _findChildrenNotAnyArr: Equal<FindChildrenReturn, any[]> = false;
+const _findInlineNotAnyArr: Equal<FindInlineReturn, any[]> = false;
+void _flattenNotAnyArr;
+void _findChildrenNotAnyArr;
+void _findInlineNotAnyArr;
+
+// Element shape: { node: PmNode; pos: number }
+function consumeEntry(entry: FlattenReturn[number]): void {
+  const _n: PmNode = entry.node;
+  const _p: number = entry.pos;
+  const _typeName: string = entry.node.type.name;
+  void _n;
+  void _p;
+  void _typeName;
+}
+void consumeEntry;
+
+// 3-arg findChildren is distinct from the simpler core variant.
+trackChangesHelpers.documentHelpers.findChildren(doc, (node) => node.isInline, true);
+trackChangesHelpers.documentHelpers.findChildren(doc, (node) => node.isInline);
+
+// Predicate receives PmNode, not any.
+trackChangesHelpers.documentHelpers.findChildren(doc, (node) => {
+  return node.type.name === 'paragraph';
+});
+
+// @ts-expect-error SD-2980 PR B: predicate must accept a Node, not a string.
+trackChangesHelpers.documentHelpers.findChildren(doc, (s: string) => s.length > 0);
+
+// @ts-expect-error SD-2980 PR B: findMarkPosition needs a string mark name.
+trackChangesHelpers.documentHelpers.findMarkPosition(doc, 5, 42);

--- a/tests/consumer-typecheck/typecheck-matrix.mjs
+++ b/tests/consumer-typecheck/typecheck-matrix.mjs
@@ -394,6 +394,32 @@ const scenarios = [
     files: ['src/field-annotation-helpers-typed.ts'],
     mustPass: true,
   },
+  // SD-2980 PR B: trackChangesHelpers core (markSnapshotHelpers +
+  // documentHelpers) now carry typed JSDoc. The fixture pins each
+  // exported helper's return shape, the MarkSnapshot output type, the
+  // PmMark|null return on findMarkInRangeBySnapshot, and the 3-arg
+  // documentHelpers.findChildren signature (distinct from the simpler
+  // @core/helpers/findChildren).
+  {
+    name: 'bundler / track changes helpers typing (SD-2980 PR B)',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    skipLibCheck: false,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/track-changes-helpers-typed.ts'],
+    mustPass: true,
+  },
+  {
+    name: 'node16 / track changes helpers typing (SD-2980 PR B)',
+    module: 'Node16',
+    moduleResolution: 'node16',
+    skipLibCheck: false,
+    strict: true,
+    noPropertyAccessFromIndexSignature: true,
+    files: ['src/track-changes-helpers-typed.ts'],
+    mustPass: true,
+  },
   // SD-2892: full public-facing surface with skipLibCheck=false. These
   // scenarios pack SuperDoc, install it into the consumer fixture, and compile
   // every public consumer assertion under the resolution modes customers use.


### PR DESCRIPTION
`markSnapshotHelpers.js` and `documentHelpers.js`, both public under `trackChangesHelpers` (via `superdoc/super-editor`), now carry concrete JSDoc and emit real shapes instead of `any` / `any[]`.

Shared types live in a sibling `trackChangesHelpers/types.js` referenced by JSDoc `import()` only (not re-exported from the index barrel, so no `export *` clash):

- `MarkSnapshot` strict output shape `{ type: string; attrs: Attrs }`
- `SnapshotLike` tolerant input shape `{ type?: string; attrs?: Attrs }` for helpers whose callers source data from loosely-typed attribute bags (e.g. `formatChangeMark.attrs.before`)
- `MarkLike = PmMark | SnapshotLike` for helpers that accept either a live ProseMirror mark or a snapshot
- `NodePosEntry = { node: PmNode; pos: number }`

Per the SD-2980 split-plan guidance: inputs are tolerant, outputs are strict. `upsertMarkSnapshotByType` accepts `SnapshotLike[]` but returns `MarkSnapshot[]`. `documentHelpers.findChildren` keeps its 3-arg signature with a one-line JSDoc note that it's distinct from `@core/helpers/findChildren` (2-arg).

- Drains 39 of 39 PR B audit findings (tier-3-helpers 53 → 14, markSnapshotHelpers 21 → 0, documentHelpers 18 → 0)
- Consumer fixture pins every exported helper's return shape, `MarkSnapshot` members, `PmMark | null` return on `findMarkInRangeBySnapshot`, and the 3-arg `documentHelpers.findChildren`
- Scope narrow: no other trackChangesHelpers files touched, no de-dupe, no renames. PR C will drain the remaining 4 helpers.

Stacks on #3438 (PR A). Base is PR A's branch so this review shows only PR B; after PR A merges, this branch can be retargeted/rebased onto main.

**Verified**: type-check clean; pnpm test:editor → 13120 pass; deep-type-audit --pack → 171 findings (was 210); --strict-supported-root → PASS (0 entries); typecheck-matrix → 79/79.