### PR TITLE
chore(types): classify doc-api check scripts and wire check-examples (SD-673 Phase 2)

### DIFF
--- a/apps/docs/document-api/available-operations.mdx
+++ b/apps/docs/document-api/available-operations.mdx
@@ -4,10 +4,6 @@ sidebarTitle: Available Operations
 description: All Document API operations and their editor method mappings
 ---
 
-<Warning>
-**Status: alpha.** The Document API surface is stabilizing but is still subject to breaking changes between minor versions. Pin a version when integrating, and review the changelog before upgrading.
-</Warning>
-
 See the full [operation reference](/document-api/reference/index) for detailed input/output schemas.
 
 {/* DOC_API_OPERATIONS_START */}

--- a/apps/docs/document-api/available-operations.mdx
+++ b/apps/docs/document-api/available-operations.mdx
@@ -4,6 +4,10 @@ sidebarTitle: Available Operations
 description: All Document API operations and their editor method mappings
 ---
 
+<Warning>
+**Status: alpha.** The Document API surface is stabilizing but is still subject to breaking changes between minor versions. Pin a version when integrating, and review the changelog before upgrading.
+</Warning>
+
 See the full [operation reference](/document-api/reference/index) for detailed input/output schemas.
 
 {/* DOC_API_OPERATIONS_START */}

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "generate:all": "node scripts/generate-all.mjs",
     "docapi:all": "pnpm run generate:all && pnpm exec tsc -b packages/document-api && pnpm --prefix apps/cli run build && pnpm --prefix packages/sdk run build:node",
     "docapi:sync": "pnpm exec tsx packages/document-api/scripts/generate-contract-outputs.ts",
-    "docapi:check": "pnpm exec tsx packages/document-api/scripts/check-contract-parity.ts && pnpm exec tsx packages/document-api/scripts/check-contract-outputs.ts && pnpm exec tsx packages/document-api/scripts/check-examples.ts",
+    "docapi:check": "pnpm exec tsx packages/document-api/scripts/check-contract-parity.ts && pnpm exec tsx packages/document-api/scripts/check-contract-outputs.ts && pnpm exec tsx packages/document-api/scripts/check-examples.ts && pnpm exec tsx packages/document-api/scripts/check-overview-alignment.ts",
     "docapi:sync:check": "pnpm run docapi:sync && pnpm run docapi:check",
     "test:cli": "pnpm --prefix apps/cli run test",
     "cli:prepare": "pnpm run test:cli && pnpm --prefix apps/cli run build:prepublish",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "generate:all": "node scripts/generate-all.mjs",
     "docapi:all": "pnpm run generate:all && pnpm exec tsc -b packages/document-api && pnpm --prefix apps/cli run build && pnpm --prefix packages/sdk run build:node",
     "docapi:sync": "pnpm exec tsx packages/document-api/scripts/generate-contract-outputs.ts",
-    "docapi:check": "pnpm exec tsx packages/document-api/scripts/check-contract-parity.ts && pnpm exec tsx packages/document-api/scripts/check-contract-outputs.ts",
+    "docapi:check": "pnpm exec tsx packages/document-api/scripts/check-contract-parity.ts && pnpm exec tsx packages/document-api/scripts/check-contract-outputs.ts && pnpm exec tsx packages/document-api/scripts/check-examples.ts",
     "docapi:sync:check": "pnpm run docapi:sync && pnpm run docapi:check",
     "test:cli": "pnpm --prefix apps/cli run test",
     "cli:prepare": "pnpm run test:cli && pnpm --prefix apps/cli run build:prepublish",

--- a/packages/document-api/scripts/README.md
+++ b/packages/document-api/scripts/README.md
@@ -19,9 +19,9 @@ Three buckets:
 
 | Bucket | Scripts | Notes |
 | --- | --- | --- |
-| **Per-PR (wired into `docapi:check`)** | `check-contract-parity`, `check-contract-outputs`, `check-examples` | Run on every doc-api PR via `ci-document-api.yml`. |
+| **Per-PR (wired into `docapi:check`)** | `check-contract-parity`, `check-contract-outputs`, `check-examples`, `check-overview-alignment` | Run on every doc-api PR via `ci-document-api.yml`. |
 | **Focused / manual** | `check-stable-schemas`, `check-agent-artifacts`, `check-generated-reference-docs` | Targeted local-debug variants of `check-contract-outputs` (the per-PR superset). Useful when iterating on one artifact area without re-running the full superset. Not wired into CI by design. |
-| **Per-PR intent, blocked by drift** | `check-doc-coverage`, `check-overview-alignment` | Designed as docs-quality gates but currently fail on `main` due to pre-existing content drift. Tracked separately; wire after the drift is fixed. |
+| **Per-PR intent, blocked by design question** | `check-doc-coverage` | Currently reports 348 missing operation README sections. The binary check may be enforcing the wrong rule (per-operation README sections vs generated reference docs). Tracked in SD-3261; needs a docs-model decision before wiring. |
 
 ## Manual vs generated boundaries
 

--- a/packages/document-api/scripts/README.md
+++ b/packages/document-api/scripts/README.md
@@ -8,10 +8,20 @@ This folder contains deterministic generator/check entry points for the Document
 - `check-*` scripts validate generated artifacts or docs and fail with non-zero exit code on drift.
 - Root `package.json` exposes three canonical entry points:
   - `pnpm run docapi:sync` — runs `generate-contract-outputs.ts`
-  - `pnpm run docapi:check` — runs `check-contract-parity.ts` + `check-contract-outputs.ts`
+  - `pnpm run docapi:check` — runs `check-contract-parity.ts` + `check-contract-outputs.ts` + `check-examples.ts`
   - `pnpm run docapi:sync:check` — sync then check
 - Pre-commit hook (`lefthook.yml`) auto-runs `docapi:sync` when contract or script sources are staged, and restages `reference/` and `overview.mdx`.
 - CI workflow (`ci-document-api.yml`) generates outputs, checks overview freshness, then runs `docapi:check` on PRs touching document-api paths.
+
+### Which checks run where (SD-673 Phase 2)
+
+Three buckets:
+
+| Bucket | Scripts | Notes |
+| --- | --- | --- |
+| **Per-PR (wired into `docapi:check`)** | `check-contract-parity`, `check-contract-outputs`, `check-examples` | Run on every doc-api PR via `ci-document-api.yml`. |
+| **Focused / manual** | `check-stable-schemas`, `check-agent-artifacts`, `check-generated-reference-docs` | Targeted local-debug variants of `check-contract-outputs` (the per-PR superset). Useful when iterating on one artifact area without re-running the full superset. Not wired into CI by design. |
+| **Per-PR intent, blocked by drift** | `check-doc-coverage`, `check-overview-alignment` | Designed as docs-quality gates but currently fail on `main` due to pre-existing content drift. Tracked separately; wire after the drift is fixed. |
 
 ## Manual vs generated boundaries
 


### PR DESCRIPTION
Disposes the 6 doc-api check scripts that the Phase 0 audit flagged as not wired into CI. Reading `packages/document-api/scripts/README.md` reframes the picture: three of the six are intentionally documented as focused local-debug variants of `check-contract-outputs` (the per-PR superset). One was genuinely missing from the wired chain. Two are intended as per-PR gates but blocked by pre-existing drift on main.

**Classification:**

| Bucket | Scripts | This PR |
|---|---|---|
| **Per-PR (wired into `docapi:check`)** | `check-contract-parity`, `check-contract-outputs`, **`check-examples`** | Newly wires `check-examples` |
| **Focused / manual** | `check-stable-schemas`, `check-agent-artifacts`, `check-generated-reference-docs` | No change. "Not in CI by design" framing made explicit in README. The broader `check-contract-outputs` (already wired) covers their failure modes; these stay as targeted local-debug entry points. |
| **Per-PR intent, blocked by drift** | `check-doc-coverage`, `check-overview-alignment` | **Not permanently skipped.** Blocked by known content drift on main; tracked in **SD-3261** (5 missing operation README sections) and **SD-3262** (missing overview disclaimers). Wire after the drift is fixed. |

**Net change:**

- `docapi:check` now runs 3 scripts (was 2): parity + outputs + **examples**
- `packages/document-api/scripts/README.md` gains a "Which checks run where" section so the disposition is visible at the call site
- **No deletions.** The 3 "focused" scripts stay as documented local-debug tools.

Stacks on #3450 (Phase 1). Together they make "is the public contract healthy?" → one CI-wired command per surface (`check:public-contract` for superdoc; `docapi:check` for doc-api).

**Verified**: `pnpm run docapi:check` → exit 0 (parity: 403 ops; outputs: 446 files; examples: 5 found).