### PR TITLE
docs(document-api): wire check-overview-alignment + add status disclaimers (SD-3262)

### DIFF
--- a/apps/docs/document-api/available-operations.mdx
+++ b/apps/docs/document-api/available-operations.mdx
@@ -4,10 +4,6 @@ sidebarTitle: Available Operations
 description: All Document API operations and their editor method mappings
 ---
 
-<Warning>
-**Status: alpha.** The Document API surface is stabilizing but is still subject to breaking changes between minor versions. Pin a version when integrating, and review the changelog before upgrading.
-</Warning>
-
 See the full [operation reference](/document-api/reference/index) for detailed input/output schemas.
 
 {/* DOC_API_OPERATIONS_START */}

--- a/apps/docs/document-api/available-operations.mdx
+++ b/apps/docs/document-api/available-operations.mdx
@@ -4,6 +4,10 @@ sidebarTitle: Available Operations
 description: All Document API operations and their editor method mappings
 ---
 
+<Warning>
+**Status: alpha.** The Document API surface is stabilizing but is still subject to breaking changes between minor versions. Pin a version when integrating, and review the changelog before upgrading.
+</Warning>
+
 See the full [operation reference](/document-api/reference/index) for detailed input/output schemas.
 
 {/* DOC_API_OPERATIONS_START */}

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "generate:all": "node scripts/generate-all.mjs",
     "docapi:all": "pnpm run generate:all && pnpm exec tsc -b packages/document-api && pnpm --prefix apps/cli run build && pnpm --prefix packages/sdk run build:node",
     "docapi:sync": "pnpm exec tsx packages/document-api/scripts/generate-contract-outputs.ts",
-    "docapi:check": "pnpm exec tsx packages/document-api/scripts/check-contract-parity.ts && pnpm exec tsx packages/document-api/scripts/check-contract-outputs.ts && pnpm exec tsx packages/document-api/scripts/check-examples.ts",
+    "docapi:check": "pnpm exec tsx packages/document-api/scripts/check-contract-parity.ts && pnpm exec tsx packages/document-api/scripts/check-contract-outputs.ts && pnpm exec tsx packages/document-api/scripts/check-examples.ts && pnpm exec tsx packages/document-api/scripts/check-overview-alignment.ts",
     "docapi:sync:check": "pnpm run docapi:sync && pnpm run docapi:check",
     "test:cli": "pnpm --prefix apps/cli run test",
     "cli:prepare": "pnpm run test:cli && pnpm --prefix apps/cli run build:prepublish",

--- a/packages/document-api/scripts/README.md
+++ b/packages/document-api/scripts/README.md
@@ -19,9 +19,9 @@ Three buckets:
 
 | Bucket | Scripts | Notes |
 | --- | --- | --- |
-| **Per-PR (wired into `docapi:check`)** | `check-contract-parity`, `check-contract-outputs`, `check-examples` | Run on every doc-api PR via `ci-document-api.yml`. |
+| **Per-PR (wired into `docapi:check`)** | `check-contract-parity`, `check-contract-outputs`, `check-examples`, `check-overview-alignment` | Run on every doc-api PR via `ci-document-api.yml`. |
 | **Focused / manual** | `check-stable-schemas`, `check-agent-artifacts`, `check-generated-reference-docs` | Targeted local-debug variants of `check-contract-outputs` (the per-PR superset). Useful when iterating on one artifact area without re-running the full superset. Not wired into CI by design. |
-| **Per-PR intent, blocked by drift** | `check-doc-coverage`, `check-overview-alignment` | Designed as docs-quality gates but currently fail on `main` due to pre-existing content drift. Tracked separately; wire after the drift is fixed. |
+| **Per-PR intent, blocked by design question** | `check-doc-coverage` | Currently reports 348 missing operation README sections. The binary check may be enforcing the wrong rule (per-operation README sections vs generated reference docs). Tracked in SD-3261; needs a docs-model decision before wiring. |
 
 ## Manual vs generated boundaries
 


### PR DESCRIPTION
Closes SD-3262. `check-overview-alignment.ts` was failing on `main` because `apps/docs/document-api/available-operations.mdx` was missing two required disclaimers (the script checks for `/\balpha\b/i` and `/subject to (?:breaking )?changes?/i`). SD-673 Phase 2 deferred this to a follow-up because the check was blocked by content drift.

**Changes:**

- Add a `<Warning>` block at the top of `available-operations.mdx`:
  > **Status: alpha.** The Document API surface is stabilizing but is still subject to breaking changes between minor versions. Pin a version when integrating, and review the changelog before upgrading.
  
  Honest customer-facing copy (not boilerplate to satisfy the script) and satisfies both required patterns.
- **Wire `check-overview-alignment` into `docapi:check`.** The chain is now: `parity → outputs → examples → overview-alignment`.
- Update `packages/document-api/scripts/README.md`: move `check-overview-alignment` from "blocked by drift" to "Per-PR (wired)". `check-doc-coverage` stays in the "blocked" bucket but the framing is now "blocked by design question" with a pointer to SD-3261 (rescoped after the original 5-op drift turned out to be 348 ops; needs a docs-model decision before wiring).

**Note on file path:** the original SD-3262 description (and the SD-673 Phase 0 audit) referred to `overview.mdx`. The script actually reads `apps/docs/document-api/available-operations.mdx`; the constant `OVERVIEW_PATH` in `lib/reference-docs-artifacts.ts` points there. This PR edits the correct file.

Stacks on #3452 (SD-673 Phase 2). After both merge, `docapi:check` gates 4 sub-checks; the only remaining orphan is `check-doc-coverage` under SD-3261.

**Verified**: `pnpm run docapi:sync:check` → exit 0 (parity: 403 ops; outputs: 446 files; examples: 5 found; overview: 404 member paths).