### PR TITLE
fix(superdoc): type superdocStore.documents as RuntimeDocument[] (SD-673)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -632,6 +632,9 @@ export class SuperDoc extends EventEmitter {
     return this.superdocStore.documents.filter((d) => d.type === DOCX).length;
   }
 
+  /**
+   * @returns {{ documents: RuntimeDocument[], users: User[] }}
+   */
   get state() {
     return {
       documents: this.superdocStore.documents,

--- a/packages/superdoc/src/stores/superdoc-store.js
+++ b/packages/superdoc/src/stores/superdoc-store.js
@@ -11,7 +11,7 @@ export const useSuperdocStore = defineStore('superdoc', () => {
   const currentConfig = ref(null);
   let exceptionHandler = null;
   const commentsStore = useCommentsStore();
-  const documents = ref([]);
+  const documents = ref(/** @type {import('@superdoc/core/types/index.js').RuntimeDocument[]} */ ([]));
   const documentBounds = ref([]);
   const pages = reactive({});
   const documentUsers = ref([]);


### PR DESCRIPTION
The store had `documents = ref([])`, which TypeScript inferred as `Ref<never[]>`. Every internal use like `superdocStore.documents.find(d => d.id === ...)` saw `d: never`, which would have produced 25+ type errors once SuperDoc.js opts into `@ts-check`.

The public surface masked the same issue. `SuperDoc.state.documents` emitted as `never[]`, which is technically type-safe but unusable for consumers. After this fix the public emit is `RuntimeDocument[]`.

- Annotate the store ref on its initial value so the type propagates cleanly through Pinia's unwrap.
- Pin `SuperDoc.state` with a `@returns` JSDoc so the public `.d.ts` emit stays `RuntimeDocument[]` regardless of how Pinia's store types resolve at intermediate steps.

Discovered while spiking `@ts-check` on `SuperDoc.js` (SD-673 Phase 4). This PR does not enable `@ts-check` on that file. The remaining ~34 errors after this fix are real prerequisites: SD-2916 owns the delayed-init field group (9 errors with `T | undefined` semantics that need access-site narrowing); the rest are real public-contract drift (`Config` typedef missing fields, `Document` missing `role`, `DocumentMode` literal narrowing, event/callback payload mismatches, `CollaborationProvider` intersection) that needs its own PR before `@ts-check` can be enabled cleanly.

**Verified**: `pnpm check:public-contract` → PASS (3 stages, 140.2s); `pnpm build` → exit 0; `pnpm --filter superdoc test` → 77 files / 1037 tests pass.