### PR TITLE
fix(superdoc): align typedefs and JSDoc with runtime (SD-673)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -613,8 +613,8 @@ export class SuperDoc extends EventEmitter {
   }
 
   #initWhiteboard() {
-    const config = this.config.modules?.whiteboard ?? {};
-    const enabled = config.enabled ?? false;
+    const config = this.config.modules?.whiteboard;
+    const enabled = config !== false && (config?.enabled ?? false);
 
     this.whiteboard = new Whiteboard({
       Renderer: WhiteboardRenderer,
@@ -1448,7 +1448,8 @@ export class SuperDoc extends EventEmitter {
     const commentId = trackedChange?.commentId || trackedChange?.id;
     if (!resolvedComment && commentId && this.commentsStore?.getComment) {
       const storeComment = this.commentsStore.getComment(commentId);
-      resolvedComment = storeComment?.getValues ? storeComment.getValues() : storeComment;
+      const getValues = storeComment?.getValues;
+      resolvedComment = typeof getValues === 'function' ? getValues.call(storeComment) : storeComment;
     }
 
     const context = {
@@ -1678,7 +1679,7 @@ export class SuperDoc extends EventEmitter {
   setDocumentMode(type) {
     if (!type) return;
 
-    type = type.toLowerCase();
+    type = /** @type {DocumentMode} */ (type.toLowerCase());
     this.config.documentMode = type;
     this.#syncViewingVisibility();
 
@@ -1845,7 +1846,7 @@ export class SuperDoc extends EventEmitter {
    * tracker ids.
    *
    * @param {import('./types/index.js').SearchMatch} match The match object returned by `superdoc.search()`.
-   * @returns {void}
+   * @returns {boolean | undefined} Whether the command dispatched, or `undefined` if no active editor.
    */
   goToSearchResult(match) {
     return this.activeEditor?.commands.goToSearchResult(match);

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -186,7 +186,7 @@ export interface RuntimeDocument extends Document {
 /** Collaboration module configuration. */
 export interface CollaborationConfig {
   /** External Yjs document (provider-agnostic mode). */
-  ydoc?: object;
+  ydoc?: YDoc;
   /** External collaboration provider (provider-agnostic mode). */
   provider?: CollaborationProvider;
   /** Internal provider type (deprecated). */
@@ -1294,6 +1294,12 @@ export interface Config {
   selector: string | HTMLElement;
   /** The mode of the document (default: 'editing'). */
   documentMode?: DocumentMode;
+  /**
+   * When `documentMode` is `'viewing'`, allow the user to make text
+   * selections even though editing is disabled. Defaults to `false`.
+   * Forwarded to the underlying editor as `options.allowSelectionInViewMode`.
+   */
+  allowSelectionInViewMode?: boolean;
   /** The role of the user in this SuperDoc. */
   role?: 'editor' | 'viewer' | 'suggester';
   /**
@@ -1495,8 +1501,15 @@ export interface InternalConfig extends Config {
    * not part of the public Config surface.
    */
   socket?: HocuspocusProviderWebsocket;
-  /** Normalized to `[]` by `#init` if the consumer passes nothing or `undefined`. */
-  documents: Document[];
+  /**
+   * Normalized to `[]` by `#init` if the consumer passes nothing or
+   * `undefined`. Narrowed to `RuntimeDocument[]` because once `#init`
+   * runs, each entry has been augmented with the runtime-only fields
+   * (`role`, `getEditor`, `getPresentationEditor`, etc.). Consumers
+   * still pass `Document[]` via the public `Config` interface; this
+   * override only describes the post-init shape internal callsites see.
+   */
+  documents: RuntimeDocument[];
   /** Normalized to `{}` by `#init` if the consumer passes nothing or `undefined`. */
   modules: Modules;
   /** Spread of `DEFAULT_USER` over consumer input by `#init`; `name` always present. */

--- a/packages/superdoc/src/stores/comments-store.js
+++ b/packages/superdoc/src/stores/comments-store.js
@@ -105,7 +105,7 @@ export const useCommentsStore = defineStore('comments', () => {
    * Get a comment by either ID or imported ID
    *
    * @param {string} id The comment ID
-   * @returns {Object} The comment object
+   * @returns {Record<string, unknown> | null | undefined} The comment object, `null` if no id was provided, or `undefined` if not found.
    */
   const getComment = (id) => {
     if (id === undefined || id === null) return null;


### PR DESCRIPTION
Found while spiking `@ts-check` on `SuperDoc.js`. Each fix is either a public typedef extension, a JSDoc tightening, or a literal narrowing. One real runtime bug, one explicit narrowing, the rest are type-correctness alignment.

- `Config`: add `allowSelectionInViewMode`. Already exercised by `tests/behavior/tests/selection/viewing-mode-selection.spec.ts` and forwarded to the editor as `options.allowSelectionInViewMode`.
- `CollaborationConfig.ydoc`: `object` → `YDoc`. Tightens to what consumers actually pass; matches the existing `Document.ydoc` and `UpgradeToCollaborationOptions.ydoc` types.
- `InternalConfig.documents`: `Document[]` → `RuntimeDocument[]`. Matches the post-`#init` runtime shape (each entry has been augmented with `role`, `getEditor`, `getPresentationEditor`, etc.). The public `Config` surface is unchanged - consumers still pass `Document[]`.
- `commentsStore.getComment` `@returns`: `Object` → `Record<string, unknown> | null | undefined`. Matches the actual three-way return.
- `SuperDoc.setDocumentMode`: cast `type.toLowerCase()` to `DocumentMode`.
- `SuperDoc.goToSearchResult` `@returns`: `void` → `boolean | undefined`. The body always returned a value; the JSDoc was wrong.

One runtime bug surfaced and fixed:
- `canPerformPermission`: guard `storeComment.getValues` with `typeof === 'function'`. The previous truthy check would attempt to call any truthy non-function value.

One boolean-config narrowing was made explicit:
- `#initWhiteboard`: narrow `whiteboard` config before reading `.enabled`, so `modules: { whiteboard: false }` is handled intentionally and type-checks cleanly.

This PR does **not** enable `@ts-check` on `SuperDoc.js`. Remaining blockers for that gate are tracked separately: SD-2916 (delayed-init field soundness, 9 errors) plus follow-up PRs 4C (runtime narrowing) and 4D (structural mismatches: CollaborationProvider intersection, ToolbarConfig shape, permission resolver shape, content-error callback registry).

**Verified**: `pnpm build` → exit 0; `pnpm --filter superdoc test` → 77 files / 1037 tests pass; `pnpm check:public-contract` → PASS (3 stages, 129.8s).