### PR TITLE
fix(superdoc): internal type-source cleanups for ts-check (SD-673)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -924,9 +924,10 @@ export class SuperDoc extends EventEmitter {
     this.provider = markRaw(provider);
 
     this.#assignUserColor();
-    this._cleanupAwareness = setupAwarenessHandler(provider, this, /** @type {InternalConfig} */ (this.config).user);
+    const internalConfig = /** @type {InternalConfig} */ (this.config);
+    this._cleanupAwareness = setupAwarenessHandler(provider, this, internalConfig.user);
 
-    /** @type {InternalConfig} */ (this.config).documents.forEach((doc) => {
+    internalConfig.documents.forEach((doc) => {
       doc.ydoc = ydoc;
       doc.provider = provider;
       doc.role = this.config.role;

--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -865,7 +865,7 @@ export class SuperDoc extends EventEmitter {
     // Fallback: internal provider creation.
     // Start a socket for all documents and general metaMap for this SuperDoc
     if (collaborationModuleConfig.providerType === 'hocuspocus') {
-      this.config.socket = new HocuspocusProviderWebsocket({
+      /** @type {InternalConfig} */ (this.config).socket = new HocuspocusProviderWebsocket({
         url: /** @type {string} */ (collaborationModuleConfig.url),
       });
     }
@@ -874,10 +874,19 @@ export class SuperDoc extends EventEmitter {
     const processedDocuments = makeDocumentsCollaborative(this);
 
     // Optionally, initialize separate superdoc sync - for comments, view, etc.
-    if (commentsConfig.useInternalExternalComments && !commentsConfig.suppressInternalExternalComments) {
-      const { ydoc: sdYdoc, provider: sdProvider } = initSuperdocYdoc(this);
-      this.ydoc = markRaw(sdYdoc);
-      this.provider = markRaw(sdProvider);
+    if (
+      commentsConfig &&
+      commentsConfig.useInternalExternalComments &&
+      !commentsConfig.suppressInternalExternalComments
+    ) {
+      const sdResult = initSuperdocYdoc(this);
+      if (!sdResult) {
+        throw new Error(
+          'SuperDoc: `modules.comments.useInternalExternalComments` requires `superdocId` to be set in the config.',
+        );
+      }
+      this.ydoc = markRaw(sdResult.ydoc);
+      this.provider = markRaw(sdResult.provider);
     } else {
       this.ydoc = markRaw(processedDocuments[0].ydoc);
       this.provider = markRaw(processedDocuments[0].provider);
@@ -915,7 +924,7 @@ export class SuperDoc extends EventEmitter {
     this.provider = markRaw(provider);
 
     this.#assignUserColor();
-    this._cleanupAwareness = setupAwarenessHandler(provider, this, this.config.user);
+    this._cleanupAwareness = setupAwarenessHandler(provider, this, /** @type {InternalConfig} */ (this.config).user);
 
     /** @type {InternalConfig} */ (this.config).documents.forEach((doc) => {
       doc.ydoc = ydoc;
@@ -1008,7 +1017,7 @@ export class SuperDoc extends EventEmitter {
       // --- Seed the room authoritatively (while editor is still local) ---
       seedEditorStateToYDoc(sourceEditor, ydoc);
       overwriteRoomComments(ydoc, this.commentsStore.commentsList);
-      overwriteRoomLockState(ydoc, { isLocked: this.isLocked, lockedBy: this.lockedBy });
+      overwriteRoomLockState(ydoc, { isLocked: this.isLocked ?? false, lockedBy: this.lockedBy ?? null });
 
       // --- Attach collaboration config (awareness, flags, config.documents) ---
       /** @type {InternalConfig} */ (this.config).modules.collaboration = { ydoc, provider };
@@ -1750,7 +1759,7 @@ export class SuperDoc extends EventEmitter {
   }
 
   #setModeSuggesting() {
-    if (!['editor', 'suggester'].includes(this.config.role)) return this.#setModeViewing();
+    if (!['editor', 'suggester'].includes(this.config.role ?? '')) return this.#setModeViewing();
     if (this.superdocStore.documents.length > 0) {
       const firstEditor = this.superdocStore.documents[0]?.getEditor();
       if (firstEditor) this.setActiveEditor(firstEditor);

--- a/packages/superdoc/src/core/SuperDoc.test.js
+++ b/packages/superdoc/src/core/SuperDoc.test.js
@@ -635,6 +635,41 @@ describe('SuperDoc core', () => {
     expect(instance.ydoc).toBeDefined();
   });
 
+  it('uses a separate SuperDoc ydoc when internal/external comments sync is enabled', async () => {
+    createAppHarness();
+    const superdocYdoc = { destroy: vi.fn() };
+    const superdocProvider = { disconnect: vi.fn(), destroy: vi.fn(), on: vi.fn(), off: vi.fn() };
+    initSuperdocYdocMock.mockImplementationOnce(() => ({
+      ydoc: superdocYdoc,
+      provider: superdocProvider,
+    }));
+
+    const instance = new SuperDoc({
+      selector: '#host',
+      superdocId: 'superdoc-room',
+      document: 'https://example.com/doc.docx',
+      documents: [],
+      modules: {
+        comments: { useInternalExternalComments: true, suppressInternalExternalComments: false },
+        toolbar: {},
+        collaboration: {
+          providerType: 'hocuspocus',
+          url: 'wss://example.com',
+        },
+      },
+      colors: ['red'],
+      user: { name: 'Jane', email: 'jane@example.com' },
+      onException: vi.fn(),
+    });
+    await flushMicrotasks();
+
+    expect(MockHocuspocusProviderWebsocket.instances).toHaveLength(1);
+    expect(instance.config.socket).toBe(MockHocuspocusProviderWebsocket.instances[0]);
+    expect(initSuperdocYdocMock).toHaveBeenCalledWith(instance);
+    expect(instance.ydoc).toBe(superdocYdoc);
+    expect(instance.provider).toBe(superdocProvider);
+  });
+
   // pagination legacy removed; togglePagination test removed
 
   it('broadcasts ready only when all editors resolved', async () => {
@@ -1293,6 +1328,36 @@ describe('SuperDoc core', () => {
     instance.setDocumentMode('editing');
     expect(restoreComments).toHaveBeenCalledTimes(1);
     expect(setDocumentMode).toHaveBeenLastCalledWith('editing');
+  });
+
+  it('falls back to viewing mode when suggesting is requested without a role', async () => {
+    const { superdocStore } = createAppHarness();
+    const removeComments = vi.fn();
+    const setDocumentMode = vi.fn();
+    const docStub = {
+      removeComments,
+      restoreComments: vi.fn(),
+      getEditor: vi.fn(() => ({ setDocumentMode })),
+      getPresentationEditor: vi.fn(() => null),
+    };
+    superdocStore.documents = [docStub];
+
+    const instance = new SuperDoc({
+      selector: '#host',
+      document: 'https://example.com/doc.docx',
+      documents: [],
+      modules: { comments: {}, toolbar: {} },
+      colors: ['red'],
+      role: undefined,
+      user: { name: 'Jane', email: 'jane@example.com' },
+      onException: vi.fn(),
+    });
+    await flushMicrotasks();
+
+    instance.setDocumentMode('suggesting');
+
+    expect(removeComments).toHaveBeenCalledTimes(1);
+    expect(setDocumentMode).toHaveBeenLastCalledWith('viewing');
   });
 
   it('updates viewing comment options for presentation editors', async () => {

--- a/packages/superdoc/src/core/collaboration/helpers.js
+++ b/packages/superdoc/src/core/collaboration/helpers.js
@@ -105,11 +105,12 @@ export const initCollaborationComments = (superdoc) => {
 };
 
 /**
- * Initialize SuperDoc general Y.Doc for high level collaboration
- * Assigns superdoc.ydoc and superdoc.provider in place
+ * Initialize SuperDoc general Y.Doc for high level collaboration.
+ * Returns the pair the caller assigns to `superdoc.ydoc` / `superdoc.provider`,
+ * or `undefined` when there is no `superdocId` to scope the room on.
  *
  * @param {Object} superdoc The SuperDoc instance
- * @returns {void}
+ * @returns {{ ydoc: import('yjs').Doc, provider: import('../types/index.js').CollaborationProvider } | undefined}
  */
 export const initSuperdocYdoc = (superdoc) => {
   const { isInternal } = superdoc.config;

--- a/packages/superdoc/src/stores/superdoc-store.js
+++ b/packages/superdoc/src/stores/superdoc-store.js
@@ -11,7 +11,8 @@ export const useSuperdocStore = defineStore('superdoc', () => {
   const currentConfig = ref(null);
   let exceptionHandler = null;
   const commentsStore = useCommentsStore();
-  const documents = ref(/** @type {import('@superdoc/core/types/index.js').RuntimeDocument[]} */ ([]));
+  /** @type {import('vue').Ref<import('@superdoc/core/types/index.js').RuntimeDocument[]>} */
+  const documents = ref([]);
   const documentBounds = ref([]);
   const pages = reactive({});
   const documentUsers = ref([]);


### PR DESCRIPTION
Continues Phase 4 of the `SuperDoc.js` `@ts-check` enablement work. PR 4B (#3462) covered public typedef alignment; this PR covers internal source-of-truth typing that only surfaces when `@ts-check` is on. None of these change public callbacks, event payloads, or the public `Config` / `Document` / `Modules` shape.

- `superdocStore.documents`: annotate at the binding (`Ref<RuntimeDocument[]>`) rather than via a cast on the initial value. The previous form was technically correct, but Pinia's `defineStore` wrapping erased the type at access sites, leaving 18 internal `.find` / `.filter` / `.forEach` callbacks inferring `doc: any` under `noImplicitAny`. The binding-annotation form propagates through Pinia's unwrap so internal callsites narrow to `RuntimeDocument` cleanly. Public emission is unchanged (`state.documents` stays `RuntimeDocument[]` via the `@returns` annotation on the getter).
- `initSuperdocYdoc`: `@returns` `void` → `{ ydoc, provider } | undefined`. The body returns a pair when the early-return on missing `superdocId` is not hit; the JSDoc was wrong.
- `#initCollaboration`: narrow `commentsConfig` before reading `useInternalExternalComments` / `suppressInternalExternalComments`, and handle the undefined return from `initSuperdocYdoc` with an explicit `Error` instead of an implicit destructure `TypeError`. Same failure condition, clearer error message.
- `socket` assignment: apply the documented `InternalConfig` cast pattern (`types/index.ts:1495` already describes this exact callsite).
- `#attachExternalCollaboration`: extract a local `internalConfig` const so the `setupAwarenessHandler` arg and the `documents.forEach` are both readable on one line. The cast asserts `user` is non-undefined (matches the `InternalConfig` invariant that `#init` normalizes `user`).
- `overwriteRoomLockState`: default `isLocked` and `lockedBy` at the call site so a never-locked SuperDoc instance passes `(boolean, Object | null)` to the helper.
- `#setModeSuggesting`: default `this.config.role` to `''` inside the `includes` check. Same fall-through behavior; the previous `undefined` argument would have failed `Array.includes`' `string` parameter.

This PR does **not** enable `@ts-check` on `SuperDoc.js`. Remaining blockers:
- **SD-2916** (9 delayed-init field errors, separate ticket)
- **PR 4D** (7 errors): public-contract drift for `content-error` / `onContentError` payload, exception event payload, permission resolver context, `CollaborationProvider` intersection, `ToolbarConfig` shape

**Measurement** (with `@ts-check` enabled locally as a measurement tool, reverted before commit): 25 actionable errors → 7 (-18). All 18 TS7006 implicit-any errors eliminated by the store annotation form change.

**Verified**: `pnpm build` → exit 0; `pnpm --filter superdoc test` → 77 files / 1037 tests pass; `pnpm check:public-contract` → PASS (3 stages, 133.6s).