### PR TITLE
fix(superdoc): enable @ts-check on SuperDoc.js (SD-2916 PR-C)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.js
+++ b/packages/superdoc/src/core/SuperDoc.js
@@ -1,3 +1,4 @@
+// @ts-check
 import '../style.css';
 
 import { EventEmitter } from 'eventemitter3';

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -1335,9 +1335,11 @@ export interface SuperDocExceptionEditorPayload {
  * Consumers can narrow with `'stage' in payload` (store init) or
  * `'code' in payload` (editor lifecycle).
  *
- * SD-2916 tracks a follow-up to normalize these to a single shape; the
- * union exists today because three independent emit sites pre-date a
- * shared error contract.
+ * The union exists today because three independent emit sites
+ * (`initializeDocuments`, the restore path, and the editor lifecycle)
+ * pre-date a shared error contract. Normalizing them to a single
+ * payload shape is a separate follow-up; consumers can narrow with
+ * the `in` checks above in the meantime.
  */
 export type SuperDocExceptionPayload =
   | SuperDocExceptionStorePayload


### PR DESCRIPTION
Closes **SD-2916** by source-checking the main `SuperDoc` public class during build. PR-A (#3466) and PR-B (#3467) made every delayed-init field either field-initialized (`whiteboard`, `version`, `#surfaceManager`) or routed through clear lifecycle guards (`superdocStore`, `commentsStore`, `highContrastModeStore`, `app`, `pinia`, `users`). Verified locally that the file produces zero `@ts-check` errors before opening this PR, so this commit is the one-line enablement plus a small comment cleanup.

## Changes

- **Add `// @ts-check`** to `packages/superdoc/src/core/SuperDoc.js`. `pnpm build` / `tsc --build` now checks the file against its own JSDoc and the public typedefs in `core/types/index.ts`.
- **Fix a stale comment** in `core/types/index.ts`: it attributed the exception-payload union normalization follow-up to SD-2916. SD-2916 is delayed-init field soundness, not error payload normalization. The exception-payload follow-up has no ticket yet; the comment now says so plainly without misattribution.

## Verified

- `pnpm build` → exit 0
- `pnpm --filter superdoc test -- src/core/SuperDoc.test.js` → 105/105, 1054 tests passed
- `pnpm check:public-contract` → PASS (3 stages, 139.8s)

## Milestone

`SuperDoc.js` is now checked during build against its real JSDoc and public typedefs. This PR adds no new suppressions to make the gate pass; the only remaining suppression is the pre-existing `@ts-expect-error` on the `__APP_VERSION__` build-time global at `SuperDoc.js:579`, which should be replaced by an ambient declaration in a follow-up. Future TS migration of this file can land as a separate cleanup; the source-vs-types contract is enforced from now on.