### PR TITLE
docs(typecheck): refresh release-workflow comments with new stage names

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -115,8 +115,10 @@ jobs:
       # ship to every consumer pinned to `^1` or `latest`. Run identical
       # checks here so the stable lane cannot silently relax the gate.
       - name: SuperDoc public interface check
-        # Wraps typecheck-matrix, deep-type-audit, package-shape-gate,
-        # snapshot --all --check, and check-root-classification-closure.
+        # Wraps the nine wrapper stages: contract-tiers-test,
+        # contract-tiers, jsdoc-ratchet, build (skipped here),
+        # consumer-typecheck-matrix, deep-type-audit-supported-root,
+        # package-shape, export-snapshots, root-classification-closure.
         # Same coverage as PR CI; runs before stable release so any
         # bypass path (manual republish, hotfix) still catches
         # regressions. --skip-build because Build above already ran.

--- a/.github/workflows/release-superdoc.yml
+++ b/.github/workflows/release-superdoc.yml
@@ -132,8 +132,10 @@ jobs:
       # Runs before publishing so a release cannot ship a regression that
       # bypassed PR CI (manual republish, hotfix branch, recovery flow).
       - name: SuperDoc public interface check
-        # Wraps typecheck-matrix, deep-type-audit, package-shape-gate,
-        # snapshot --all --check, and check-root-classification-closure.
+        # Wraps the nine wrapper stages: contract-tiers-test,
+        # contract-tiers, jsdoc-ratchet, build (skipped here),
+        # consumer-typecheck-matrix, deep-type-audit-supported-root,
+        # package-shape, export-snapshots, root-classification-closure.
         # --skip-build because the Build step above already ran
         # `pnpm run build` (which includes build:superdoc).
         run: pnpm check:public:superdoc --skip-build


### PR DESCRIPTION
Comments-only follow-up. PR #3474 renamed the nine `check:public:superdoc` wrapper stage display names and refreshed the inline comments in `.github/workflows/ci-superdoc.yml`. The matching comments in `.github/workflows/release-stable.yml` and `.github/workflows/release-superdoc.yml` were updated too, but the commit landed 42 seconds after #3474 was merged, so it stayed on the source branch as an orphan and never reached `main`.

This PR is just that orphan commit, picked clean onto a fresh branch off `main`.

- `release-stable.yml`: "SuperDoc public interface check" step comment now lists `contract-tiers-test, contract-tiers, jsdoc-ratchet, build (skipped here), consumer-typecheck-matrix, deep-type-audit-supported-root, package-shape, export-snapshots, root-classification-closure`.
- `release-superdoc.yml`: same comment refresh.

No behavior change. Same wrapper command (`pnpm check:public:superdoc --skip-build`), same nine stages, same coverage. The release workflows do not consume these comments as code.
