### PR TITLE
fix(typecheck): enable @ts-check on packages/superdoc/src/index.js

### DIFF
--- a/packages/superdoc/scripts/jsdoc-debt-snapshot.json
+++ b/packages/superdoc/scripts/jsdoc-debt-snapshot.json
@@ -102,7 +102,6 @@
     "packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/replaceAroundStep.js",
     "packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/replaceStep.js",
     "packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/trackedTransaction.js",
-    "packages/super-editor/src/editors/v1/extensions/underline/underline.js",
-    "packages/superdoc/src/index.js"
+    "packages/super-editor/src/editors/v1/extensions/underline/underline.js"
   ]
 }

--- a/packages/superdoc/src/index.js
+++ b/packages/superdoc/src/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 import {
   SuperConverter,
   Editor,
@@ -34,6 +35,8 @@ import {
   SlashMenu,
 } from '@superdoc/super-editor';
 import { DOCX, PDF, HTML, getFileObject, compareVersions } from '@superdoc/common';
+// @ts-expect-error Vite resolves DOCX asset URL imports; plain tsc does not.
+// Keep local suppression until URL asset imports can be typed without d.ts leaks.
 import BlankDOCX from '@superdoc/common/data/blank.docx?url';
 import { getSchemaIntrospection } from './helpers/schema-introspection.js';
 
@@ -234,7 +237,7 @@ import { getSchemaIntrospection } from './helpers/schema-introspection.js';
 
 // Public exports
 export { SuperDoc } from './core/SuperDoc.js';
-export { createTheme, buildTheme } from './core/theme/create-theme.ts';
+export { createTheme, buildTheme } from './core/theme/create-theme.js';
 export {
   BlankDOCX,
   getFileObject,


### PR DESCRIPTION
First debt drain on the JSDoc ratchet snapshot. `packages/superdoc/src/index.js` was the only file under `packages/superdoc/` on the 103-entry public-reachable debt list; this PR moves it from "tracked debt" to "fully gated by `// @ts-check`". Snapshot count: 103 → 102.

Tight diff: 2 files, +5/-3 lines.

## Two type errors surfaced and got fixed

1. `./core/theme/create-theme.ts` import had an explicit `.ts` extension - TS rejects this without `allowImportingTsExtensions`. Changed to `.js`. The rest of the file already uses `.js` (the canonical convention), and `packages/superdoc/src/public/index.ts:55-56` imports the same module via `.js`.

2. `'@superdoc/common/data/blank.docx?url'` Vite asset import has no static type. Suppressed with `// @ts-expect-error` - same pattern `src/public/index.ts` already uses.

## Why per-file `@ts-expect-error` instead of a global `*?url` ambient shim

I tried the cleaner ambient approach first (`packages/superdoc/src/shims-url.d.ts` declaring `*?url`). It let the import resolve cleanly, but vite-plugin-dts then preserved the `@superdoc/common/data/blank.docx?url` import statement in the emitted `public/index.d.ts`, which tripped `audit-declarations.cjs`'s "private workspace specifier" rule. Per-file suppression keeps the import "unknown" from TS's perspective, which keeps it from leaking into the .d.ts. The longer-term fix (rewriting `?url` specifiers in `ensure-types.cjs` so the ambient shim is safe) is a separate piece of work.

## Verified

- `pnpm check:types` → PASS (`tsc -b` clean across all referenced projects)
- `pnpm check:public:superdoc` → PASS, 9 stages, 156s. The `jsdoc-ratchet` stage now reports `OK 6 CHECKED_FILES clean; ratchet snapshot in sync` with `index.js` properly accounted for via `// @ts-check` rather than the debt snapshot.
- `audit-declarations.cjs` (postbuild) → clean. No `@superdoc/*` specifier leak.

## What this is NOT

- Not a TS migration. The file stays `.js`; just type-checked.
- No intended public-surface change. Same export blocks, same JSDoc typedef re-exports.
- Not "fix everything in src/superdoc". Other files (`stores/superdoc-store.js`, `core/surface-manager.js`, `core/create-app.js`) are not on the public-reachable surface, so adding `// @ts-check` there wouldn't drain the snapshot. Pick those up only if the goal becomes "harden internals", not "drain known debt".

## Snapshot diff

`packages/superdoc/scripts/jsdoc-debt-snapshot.json`: one line removed (`packages/superdoc/src/index.js`). 102 entries remain - all under `packages/super-editor/src/editors/v1/**`.
