### PR TITLE
refactor(superdoc): migrate SuperDoc.js to TypeScript

### DIFF
--- a/apps/vscode-ext/__tests__/superdoc-contract.test.ts
+++ b/apps/vscode-ext/__tests__/superdoc-contract.test.ts
@@ -14,7 +14,7 @@ import { resolve } from 'node:path';
 
 const SUPERDOC_PKG = resolve(import.meta.dirname, '..', '..', '..', 'packages', 'superdoc');
 const SUPERDOC_SRC = resolve(SUPERDOC_PKG, 'src');
-const superdocClassSrc = readFileSync(resolve(SUPERDOC_SRC, 'core', 'SuperDoc.js'), 'utf-8');
+const superdocClassSrc = readFileSync(resolve(SUPERDOC_SRC, 'core', 'SuperDoc.ts'), 'utf-8');
 
 describe('SuperDoc API contract', () => {
   describe('package exports', () => {

--- a/packages/superdoc/src/core/SuperDoc.ts
+++ b/packages/superdoc/src/core/SuperDoc.ts
@@ -61,27 +61,28 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
 // The corresponding payload shapes for the SuperDocEventMap are
 // declared as interfaces below.
 import type {
-  User,
-  Document,
-  RuntimeDocument,
-  Modules,
-  Editor,
-  DocumentMode,
-  Config,
-  InternalConfig,
-  ExportParams,
-  UpgradeToCollaborationOptions,
-  SurfaceRequest,
-  SurfaceHandle,
+  AwarenessState,
   CollaborationProvider,
+  Config,
+  DocumentMode,
+  Editor,
+  ExportParams,
+  InternalConfig,
+  Modules,
   NavigableAddress,
+  RuntimeDocument,
   SearchMatch,
+  SuperDocExceptionPayload,
   SuperDocExceptionStorePayload,
+  SurfaceHandle,
+  SurfaceRequest,
+  UpgradeToCollaborationOptions,
+  User,
 } from './types/index.js';
+import type { Comment, FontsResolvedPayload, ListDefinitionsPayload, PresentationEditor } from '@superdoc/super-editor';
 import type * as Y from 'yjs';
-import type { PresentationEditor, FontsResolvedPayload, ListDefinitionsPayload, Comment } from '@superdoc/super-editor';
-import type { AwarenessState, SuperDocExceptionPayload } from './types/index.js';
-// Whiteboard is already imported as a value above (line 19).
+// `Whiteboard` is already imported as a value above (line 19); reuse it
+// as a type here without a separate `import type` declaration.
 import type { WhiteboardData } from './whiteboard/Whiteboard.js';
 
 // Event payload shapes (formerly JSDoc typedefs above the class).

--- a/packages/superdoc/src/core/SuperDoc.ts
+++ b/packages/superdoc/src/core/SuperDoc.ts
@@ -1965,7 +1965,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * @param {string | RegExp} text The text or regex to search for
    * @returns {import('./types/index.js').SearchMatch[] | undefined} The search results
    */
-  search(text: string): SearchMatch[] | undefined {
+  search(text: string | RegExp): SearchMatch[] | undefined {
     return this.activeEditor?.commands.search(text, { searchModel: 'visible' });
   }
 

--- a/packages/superdoc/src/core/SuperDoc.ts
+++ b/packages/superdoc/src/core/SuperDoc.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import '../style.css';
 
 import { EventEmitter } from 'eventemitter3';
@@ -58,6 +57,116 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
   '#F39C12',
 ]);
 
+// TS-native type imports. The JSDoc `@typedef {import(...)}` form below
+// is kept for historical readability and for the few signatures still
+// expressed in JSDoc; the real bindings come from this `import type`.
+import type {
+  User,
+  Document,
+  RuntimeDocument,
+  Modules,
+  Editor,
+  DocumentMode,
+  Config,
+  InternalConfig,
+  ExportParams,
+  UpgradeToCollaborationOptions,
+  SurfaceRequest,
+  SurfaceHandle,
+  CollaborationProvider,
+  NavigableAddress,
+  SearchMatch,
+  SuperDocExceptionStorePayload,
+} from './types/index.js';
+import type * as Y from 'yjs';
+import type { PresentationEditor, FontsResolvedPayload, ListDefinitionsPayload, Comment } from '@superdoc/super-editor';
+import type { AwarenessState, SuperDocExceptionPayload } from './types/index.js';
+// Whiteboard is already imported as a value above (line 19).
+import type { WhiteboardData } from './whiteboard/Whiteboard.js';
+
+// Event payload shapes (formerly JSDoc typedefs above the class).
+interface SuperDocReadyPayload {
+  superdoc: SuperDoc;
+}
+interface SuperDocEditorPayload {
+  editor: Editor;
+}
+interface SuperDocWhiteboardPayload {
+  whiteboard: Whiteboard;
+}
+interface SuperDocZoomPayload {
+  zoom: number;
+}
+interface SuperDocFormattingMarksPayload {
+  showFormattingMarks: boolean;
+  superdoc: SuperDoc;
+}
+interface SuperDocDocumentModeChangePayload {
+  documentMode: DocumentMode;
+}
+interface SuperDocPaginationPayload {
+  totalPages: number;
+  superdoc: SuperDoc;
+}
+interface SuperDocContentErrorPayload {
+  error: unknown;
+  editor: Editor;
+}
+interface SuperDocLockedPayload {
+  isLocked: boolean;
+  lockedBy?: User | null;
+}
+interface SuperDocEditorUpdatePayload {
+  editor?: Editor;
+  sourceEditor?: Editor;
+  surface: string;
+  headerId: string | null;
+  sectionType: string | null;
+}
+interface SuperDocAwarenessUpdatePayload {
+  states: AwarenessState[];
+  added: number[];
+  removed: number[];
+  superdoc: SuperDoc;
+}
+interface SuperDocCommentsUpdatePayload {
+  type: string;
+  comment?: Comment;
+  changes?: Array<{ key: string; commentId: string; fileId?: string | null }>;
+}
+
+/**
+ * SuperDoc lifecycle event registry. Keys are event names emitted via
+ * `this.emit(...)`; each value is the tuple of arguments. Used as the
+ * generic parameter of `EventEmitter<SuperDocEventMap>` so `superdoc.on`
+ * / `superdoc.emit` reject unknown event names at compile time.
+ */
+interface SuperDocEventMap {
+  ready: [SuperDocReadyPayload];
+  editorBeforeCreate: [SuperDocEditorPayload];
+  editorCreate: [SuperDocEditorPayload];
+  editorDestroy: [];
+  'pdf:document-ready': [];
+  'sidebar-toggle': [boolean];
+  zoomChange: [SuperDocZoomPayload];
+  'formatting-marks-change': [SuperDocFormattingMarksPayload];
+  'document-mode-change': [SuperDocDocumentModeChangePayload];
+  'editor-update': [SuperDocEditorUpdatePayload];
+  'content-error': [SuperDocContentErrorPayload];
+  'fonts-resolved': [FontsResolvedPayload];
+  'pagination-update': [SuperDocPaginationPayload];
+  'list-definitions-change': [ListDefinitionsPayload];
+  'comments-update': [SuperDocCommentsUpdatePayload];
+  'collaboration-ready': [SuperDocEditorPayload];
+  'awareness-update': [SuperDocAwarenessUpdatePayload];
+  locked: [SuperDocLockedPayload];
+  'whiteboard:init': [SuperDocWhiteboardPayload];
+  'whiteboard:ready': [SuperDocWhiteboardPayload];
+  'whiteboard:change': [WhiteboardData];
+  'whiteboard:enabled': [boolean];
+  'whiteboard:tool': [string];
+  exception: [SuperDocExceptionPayload];
+}
 /** @typedef {import('./types/index.js').User} User */
 /** @typedef {import('./types/index.js').Document} Document */
 /** @typedef {import('./types/index.js').RuntimeDocument} RuntimeDocument */
@@ -214,8 +323,15 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
  * @param {((...args: any[]) => void) | undefined} listener
  * @returns {(...args: any[]) => void}
  */
-function asEventListener(listener) {
-  return /** @type {(...args: any[]) => void} */ (listener);
+// Accepts any optional Config callback (each has its own narrow signature)
+// and adapts it to EventEmitter's `(...args: any[]) => void`. `any` here
+// matches the runtime contract: EventEmitter dispatches whatever payload
+// the emit site supplies, and the consumer-supplied callback only inspects
+// the args its own signature names. Narrower typing would force every
+// callsite below to cast.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function asEventListener(listener: ((...args: any[]) => void) | undefined): (...args: any[]) => void {
+  return listener as (...args: any[]) => void;
 }
 
 /**
@@ -226,7 +342,7 @@ function asEventListener(listener) {
  * @extends {EventEmitter<SuperDocEventMap>}
  * @implements {SuperDocLike}
  */
-export class SuperDoc extends EventEmitter {
+export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /** @type {Array<string>} */
   static allowedTypes = [DOCX, PDF, HTML];
 
@@ -237,10 +353,10 @@ export class SuperDoc extends EventEmitter {
   #isUpgrading = false;
 
   /** @type {(() => void) | null} — aborts an in-flight upgrade (sync wait or ready wait) */
-  #abortUpgrade = null;
+  #abortUpgrade: (() => void) | null = null;
 
   /** @type {HTMLDivElement | null} */
-  #mountWrapper = null;
+  #mountWrapper: HTMLDivElement | null = null;
 
   /** @type {SurfaceManager} */
   #surfaceManager;
@@ -265,10 +381,10 @@ export class SuperDoc extends EventEmitter {
    * and throw a clear lifecycle error instead.
    * @type {User[]}
    */
-  users = [];
+  users: User[] = [];
 
-  /** @type {import('yjs').Doc | undefined} */
-  ydoc;
+  /** Yjs document for collaboration; set in `#init` when collaboration is enabled, otherwise undefined. */
+  ydoc: Y.Doc | undefined;
 
   /**
    * Provider for the SuperDoc-level collaboration room (separate from
@@ -277,9 +393,8 @@ export class SuperDoc extends EventEmitter {
    * `Config.modules.collaboration.provider`. Consumers needing Hocuspocus-
    * specific members must narrow before use.
    *
-   * @type {import('./types/index.js').CollaborationProvider | undefined}
    */
-  provider;
+  provider: CollaborationProvider | undefined;
 
   /**
    * Whiteboard instance, created by `#initWhiteboard()` after the
@@ -288,7 +403,7 @@ export class SuperDoc extends EventEmitter {
    * a stable null, not `undefined`.
    * @type {Whiteboard | null}
    */
-  whiteboard = null;
+  whiteboard: Whiteboard | null = null;
 
   /**
    * Awareness palette assigned to local users when no explicit color is set.
@@ -296,7 +411,7 @@ export class SuperDoc extends EventEmitter {
    * built-in `DEFAULT_AWARENESS_PALETTE`.
    * @type {string[]}
    */
-  colors = [];
+  colors: string[] = [];
 
   /**
    * Pinia stores and Vue runtime references. Populated by `#initVueApp`
@@ -322,19 +437,19 @@ export class SuperDoc extends EventEmitter {
    * @type {ReturnType<typeof import('../stores/superdoc-store.js').useSuperdocStore> | undefined}
    * @private
    */
-  superdocStore;
+  private declare superdocStore: ReturnType<typeof createSuperdocVueApp>['superdocStore'] | undefined;
 
   /**
    * @type {ReturnType<typeof import('../stores/comments-store.js').useCommentsStore> | undefined}
    * @private
    */
-  commentsStore;
+  private declare commentsStore: ReturnType<typeof createSuperdocVueApp>['commentsStore'] | undefined;
 
   /**
    * @type {ReturnType<typeof import('../composables/use-high-contrast-mode.js').useHighContrastMode> | undefined}
    * @private
    */
-  highContrastModeStore;
+  private declare highContrastModeStore: ReturnType<typeof createSuperdocVueApp>['highContrastModeStore'] | undefined;
 
   /**
    * Internal mount handle for the `SuperComments` Vue component, created
@@ -354,7 +469,13 @@ export class SuperDoc extends EventEmitter {
    * @type {SuperComments | null | undefined}
    * @private
    */
-  commentsList;
+  // `declare` (no runtime initializer): the legacy JS code only sets
+  // `this.commentsList` when role !== 'viewer', and a test asserts the
+  // field is `undefined` in the viewer path. An `= null` initializer
+  // would create an own runtime property up front and flip that to `null`.
+  // `private`: matches the original `@private` JSDoc; not part of the
+  // SuperDoc public type surface (consumer-typecheck fixture asserts this).
+  private declare commentsList: SuperComments | null;
 
   /**
    * Internal Vue app handle created in `#initVueApp()` and used for
@@ -372,10 +493,10 @@ export class SuperDoc extends EventEmitter {
    * @type {import('vue').App | undefined}
    * @private
    */
-  app;
+  private declare app: ReturnType<typeof createSuperdocVueApp>['app'] | undefined;
 
-  /** @type {import('pinia').Pinia | undefined} */
-  pinia;
+  /** Pinia store root for the SuperDoc Vue app. Set in `#initVueApp`. */
+  pinia: ReturnType<typeof createSuperdocVueApp>['pinia'] | undefined;
 
   /** @type {number} Count of editors that have signaled `editorCreate`. */
   readyEditors = 0;
@@ -383,8 +504,38 @@ export class SuperDoc extends EventEmitter {
   /** @type {number} Outstanding async saves waiting for collaboration ack. */
   pendingCollaborationSaves = 0;
 
-  /** @type {Config} */
-  config = {
+  // ─── Runtime fields populated by `#init` ──────────────────────────────
+  // Declared with `declare` so TS knows the field shape without emitting a
+  // runtime own-property initializer. Each is assigned during `#init`
+  // (called synchronously from the constructor), so by the time any
+  // external callsite reads them they exist.
+  declare activeEditor: Editor | null;
+  declare toolbar: SuperToolbar | null;
+  declare toolbarElement: string | HTMLElement | undefined;
+  declare userColorMap: Map<string, string>;
+  declare colorIndex: number;
+  declare isCollaborative: boolean;
+  declare isLocked: boolean;
+  declare lockedBy: User | null;
+  declare isDev: boolean;
+  declare superdocId: string;
+  declare comments: unknown[];
+  declare socket: HocuspocusProviderWebsocket | null;
+  declare user: User;
+  declare _cleanupAwareness: (() => void) | null;
+  declare _commentsCollabInitialized: boolean;
+
+  /**
+   * The active configuration. Typed as `InternalConfig` because `#init` runs
+   * synchronously in the constructor and normalizes the consumer-provided
+   * `Config` into the wider shape (`documents` filled, `modules` defaulted,
+   * `user` spread with `DEFAULT_USER`, etc.). Any callsite reading
+   * `this.config` runs after `#init`, so it sees the normalized shape.
+   *
+   * Public consumer input shape: `Config` (re-exported from `superdoc`).
+   * Internal post-normalize shape: `InternalConfig`.
+   */
+  config: InternalConfig = {
     selector: '#superdoc',
     documentMode: 'editing',
     allowSelectionInViewMode: false,
@@ -401,6 +552,14 @@ export class SuperDoc extends EventEmitter {
     // placeholder was overwritten unconditionally before any consumer
     // could observe it.
     users: [],
+
+    // `user` and `layoutEngineOptions` are also set in `#init` (where `user`
+    // is spread with `DEFAULT_USER` and `layoutEngineOptions` defaults to
+    // `{}` if the consumer passes nothing). Initializing them here too keeps
+    // the field literal satisfying `InternalConfig` directly, with no
+    // pre-init gap.
+    user: { ...DEFAULT_USER },
+    layoutEngineOptions: {},
 
     modules: {}, // Optional: Modules to load. Use modules.ai.{your_key} to pass in your key
 
@@ -474,7 +633,7 @@ export class SuperDoc extends EventEmitter {
   /**
    * @param {Config} config
    */
-  constructor(config) {
+  constructor(config: Config) {
     super();
 
     if (!config.selector) {
@@ -504,7 +663,7 @@ export class SuperDoc extends EventEmitter {
    * @param {Config} config
    * @param {HTMLElement} container
    */
-  async #init(config, container) {
+  async #init(config: Config, container: HTMLElement) {
     this.config = {
       ...this.config,
       ...config,
@@ -571,7 +730,7 @@ export class SuperDoc extends EventEmitter {
       this.config.modules.comments = {};
     }
 
-    this.config.colors = shuffleArray(/** @type {`#${string}`[]} */ (this.config.colors));
+    this.config.colors = shuffleArray(this.config.colors as `#${string}`[]);
     /** @type {Map<unknown, unknown>} */
     this.userColorMap = new Map();
     this.colorIndex = 0;
@@ -621,9 +780,10 @@ export class SuperDoc extends EventEmitter {
     this.lockedBy = this.config.lockedBy || null;
 
     // Mount wrapper created once — Vue apps mount into it on each runtime start
-    this.#mountWrapper = document.createElement('div');
-    this.#mountWrapper.style.display = 'contents';
-    container.appendChild(this.#mountWrapper);
+    const mountWrapper = document.createElement('div');
+    mountWrapper.style.display = 'contents';
+    container.appendChild(mountWrapper);
+    this.#mountWrapper = mountWrapper;
 
     this.#initListeners();
     this.#initWhiteboard();
@@ -668,13 +828,17 @@ export class SuperDoc extends EventEmitter {
    * @returns {number} The number of required editors
    */
   get requiredNumberOfEditors() {
-    return this.#requireSuperdocStore('requiredNumberOfEditors').documents.filter((d) => d.type === DOCX).length;
+    return this.#requireSuperdocStore('requiredNumberOfEditors').documents.filter(
+      (d: RuntimeDocument) => d.type === DOCX,
+    ).length;
   }
 
   /**
-   * @returns {{ documents: RuntimeDocument[], users: User[] }}
+   * Snapshot of the current SuperDoc state. Always reflects the most
+   * recent values from the Pinia store; consumers must re-read on
+   * change rather than caching.
    */
-  get state() {
+  get state(): { documents: RuntimeDocument[]; users: User[] } {
     return {
       documents: this.#requireSuperdocStore('state').documents,
       users: this.users,
@@ -691,10 +855,10 @@ export class SuperDoc extends EventEmitter {
    * @param {string} documentId
    * @returns {import('@superdoc/super-editor').PresentationEditor | null}
    */
-  getPresentationEditorForDocument(documentId) {
+  getPresentationEditorForDocument(documentId: string): PresentationEditor | null {
     if (typeof documentId !== 'string' || documentId.length === 0) return null;
     const documents = this.superdocStore?.documents ?? [];
-    const matched = documents.find((doc) => doc?.getEditor?.()?.options?.documentId === documentId);
+    const matched = documents.find((doc: RuntimeDocument) => doc?.getEditor?.()?.options?.documentId === documentId);
     return matched?.getPresentationEditor?.() ?? null;
   }
 
@@ -708,7 +872,7 @@ export class SuperDoc extends EventEmitter {
    * @param {string} commentId
    * @returns {Record<string, unknown> | null}
    */
-  getComment(commentId) {
+  getComment(commentId: string) {
     if (typeof commentId !== 'string' || commentId.length === 0) return null;
     return this.commentsStore?.getComment?.(commentId) ?? null;
   }
@@ -729,10 +893,10 @@ export class SuperDoc extends EventEmitter {
 
     const originalCreateElement = document.createElement;
     /** @param {string} tagName */
-    document.createElement = function (tagName) {
+    document.createElement = function (tagName: string) {
       const element = originalCreateElement.call(this, tagName);
       if (tagName.toLowerCase() === 'style') {
-        element.setAttribute('nonce', /** @type {string} */ (cspNonce));
+        element.setAttribute('nonce', cspNonce as string);
       }
       return element;
     };
@@ -766,7 +930,7 @@ export class SuperDoc extends EventEmitter {
         {
           id: uuidv4(),
           type: DOCX,
-          url: /** @type {string} */ (this.config.document),
+          url: this.config.document as string,
           name: 'document.docx',
         },
       ];
@@ -827,12 +991,12 @@ export class SuperDoc extends EventEmitter {
     this.commentsStore = commentsStore;
     this.highContrastModeStore = highContrastModeStore;
     if (typeof this.superdocStore.setExceptionHandler === 'function') {
-      this.superdocStore.setExceptionHandler((/** @type {SuperDocExceptionStorePayload} */ payload) =>
+      this.superdocStore.setExceptionHandler((payload: SuperDocExceptionStorePayload) =>
         this.emit('exception', payload),
       );
     }
     this.superdocStore.init(this.config);
-    const commentsModuleConfig = /** @type {InternalConfig} */ (this.config).modules.comments;
+    const commentsModuleConfig = /** @type {InternalConfig} */ this.config.modules.comments;
     // `commentsModuleConfig` is `false | object | undefined`. A truthy
     // check already rules out both `false` and `undefined`, so an
     // explicit `!== false` afterwards is redundant.
@@ -872,7 +1036,9 @@ export class SuperDoc extends EventEmitter {
    * @param {Modules} [modules]
    * @returns {Promise<Document[] | undefined>} The processed documents with collaboration enabled. Caller awaits for side effects; the return value is informational.
    */
-  async #initCollaboration({ collaboration: collaborationModuleConfig, comments: commentsConfig = {} } = {}) {
+  async #initCollaboration(
+    { collaboration: collaborationModuleConfig, comments: commentsConfig = {} }: Modules = {} as Modules,
+  ) {
     if (!collaborationModuleConfig) return this.config.documents;
 
     // Check for external ydoc/provider (provider-agnostic mode)
@@ -906,8 +1072,8 @@ export class SuperDoc extends EventEmitter {
     // Fallback: internal provider creation.
     // Start a socket for all documents and general metaMap for this SuperDoc
     if (collaborationModuleConfig.providerType === 'hocuspocus') {
-      /** @type {InternalConfig} */ (this.config).socket = new HocuspocusProviderWebsocket({
-        url: /** @type {string} */ (collaborationModuleConfig.url),
+      /** @type {InternalConfig} */ this.config.socket = new HocuspocusProviderWebsocket({
+        url: collaborationModuleConfig.url as string,
       });
     }
 
@@ -953,7 +1119,7 @@ export class SuperDoc extends EventEmitter {
    * @param {import('yjs').Doc} ydoc
    * @param {import('./types/index.js').CollaborationProvider} provider
    */
-  #attachExternalCollaboration(ydoc, provider) {
+  #attachExternalCollaboration(ydoc: Y.Doc, provider: CollaborationProvider) {
     this.isCollaborative = true;
 
     // Reset comments observer flag so a new observer is created for the new ydoc
@@ -965,10 +1131,10 @@ export class SuperDoc extends EventEmitter {
     this.provider = markRaw(provider);
 
     this.#assignUserColor();
-    const internalConfig = /** @type {InternalConfig} */ (this.config);
+    const internalConfig = /** @type {InternalConfig} */ this.config;
     this._cleanupAwareness = setupAwarenessHandler(provider, this, internalConfig.user);
 
-    internalConfig.documents.forEach((doc) => {
+    internalConfig.documents.forEach((doc: RuntimeDocument) => {
       doc.ydoc = ydoc;
       doc.provider = provider;
       doc.role = this.config.role;
@@ -991,10 +1157,10 @@ export class SuperDoc extends EventEmitter {
     this._commentsCollabInitialized = false;
     this.ydoc = undefined;
     this.provider = undefined;
-    const cfg = /** @type {InternalConfig} */ (this.config);
+    const cfg = /** @type {InternalConfig} */ this.config;
     delete cfg.modules.collaboration;
 
-    cfg.documents.forEach((doc) => {
+    cfg.documents.forEach((doc: RuntimeDocument) => {
       delete doc.ydoc;
       delete doc.provider;
     });
@@ -1046,7 +1212,7 @@ export class SuperDoc extends EventEmitter {
    * @param {UpgradeToCollaborationOptions} options
    * @returns {Promise<void>} Resolves once the collaborative runtime is ready
    */
-  async upgradeToCollaboration({ ydoc, provider }) {
+  async upgradeToCollaboration({ ydoc, provider }: UpgradeToCollaborationOptions) {
     this.#validateUpgradePrerequisites({ ydoc, provider });
     this.#isUpgrading = true;
 
@@ -1062,7 +1228,7 @@ export class SuperDoc extends EventEmitter {
       overwriteRoomLockState(ydoc, { isLocked: this.isLocked ?? false, lockedBy: this.lockedBy ?? null });
 
       // --- Attach collaboration config (awareness, flags, config.documents) ---
-      /** @type {InternalConfig} */ (this.config).modules.collaboration = { ydoc, provider };
+      /** @type {InternalConfig} */ this.config.modules.collaboration = { ydoc, provider };
       this.#attachExternalCollaboration(ydoc, provider);
 
       // --- Update live store documents in place (no Vue unmount) ---
@@ -1128,7 +1294,7 @@ export class SuperDoc extends EventEmitter {
    * @param {string} methodName The public method name surfaced in
    *   the error so consumers know which call needed the ready state.
    */
-  #requireSuperdocStore(methodName) {
+  #requireSuperdocStore(methodName: string) {
     if (!this.superdocStore) {
       throw new Error(
         `SuperDoc: ${methodName} requires the instance to be ready; wait for the "ready" event before calling.`,
@@ -1145,7 +1311,7 @@ export class SuperDoc extends EventEmitter {
    *
    * @param {string} methodName
    */
-  #requireCommentsStore(methodName) {
+  #requireCommentsStore(methodName: string) {
     if (!this.commentsStore) {
       throw new Error(
         `SuperDoc: ${methodName} requires the instance to be ready; wait for the "ready" event before calling.`,
@@ -1162,7 +1328,7 @@ export class SuperDoc extends EventEmitter {
    *
    * @param {string} methodName
    */
-  #requireReady(methodName) {
+  #requireReady(methodName: string) {
     if (!this.superdocStore) {
       throw new Error(
         `SuperDoc: ${methodName} requires the instance to be ready; wait for the "ready" event before calling.`,
@@ -1184,7 +1350,7 @@ export class SuperDoc extends EventEmitter {
    * @param {import('yjs').Doc | null} ydoc
    * @param {import('./types/index.js').CollaborationProvider | null} provider
    */
-  #setStoreDocumentCollaboration(ydoc, provider) {
+  #setStoreDocumentCollaboration(ydoc: Y.Doc | null, provider: CollaborationProvider | null) {
     const storeDocs = this.superdocStore?.documents;
     if (!Array.isArray(storeDocs)) return;
     for (const doc of storeDocs) {
@@ -1238,7 +1404,7 @@ export class SuperDoc extends EventEmitter {
    * @param {import('@superdoc/super-editor').Editor | import('@superdoc/super-editor').PresentationEditor} editorInstance
    * @returns {Promise<void>}
    */
-  #waitForCollaborationReady(editorInstance) {
+  #waitForCollaborationReady(editorInstance: Editor | PresentationEditor) {
     const TIMEOUT_MS = 10_000;
 
     // PresentationEditor wraps Editor; get the underlying editor for event listening.
@@ -1248,14 +1414,14 @@ export class SuperDoc extends EventEmitter {
     // `.editor` lookup without claiming the field exists on the Editor
     // arm of the union, so the access type-checks once SuperDoc.js is
     // brought under the SD-2863 checkJs gate.
-    const editor = /** @type {Editor} */ (/** @type {{ editor?: Editor }} */ (editorInstance).editor ?? editorInstance);
+    const editor = ((editorInstance as { editor?: Editor }).editor ?? editorInstance) as Editor;
 
     // If collaborationReady already fired (options flag set by collaboration extension)
     if (editor.options?.collaborationIsReady) {
       return Promise.resolve();
     }
 
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       let settled = false;
 
       const cleanup = () => {
@@ -1303,12 +1469,11 @@ export class SuperDoc extends EventEmitter {
    * @param {import('./types/index.js').CollaborationProvider} provider
    * @returns {Promise<void>}
    */
-  #waitForProviderSync(provider) {
+  #waitForProviderSync(provider: CollaborationProvider) {
     const SYNC_TIMEOUT_MS = 10_000;
 
-    return new Promise((resolve, reject) => {
-      /** @type {ReturnType<typeof setTimeout> | undefined} */
-      let timer;
+    return new Promise<void>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
       let settled = false;
       let syncCleanup = () => {};
 
@@ -1351,7 +1516,7 @@ export class SuperDoc extends EventEmitter {
    *
    * @param {{ ydoc: unknown, provider: unknown }} options
    */
-  #validateUpgradePrerequisites({ ydoc, provider }) {
+  #validateUpgradePrerequisites({ ydoc, provider }: UpgradeToCollaborationOptions) {
     if (this.#destroyed) {
       throw new Error('SuperDoc: cannot upgrade a destroyed instance');
     }
@@ -1365,8 +1530,8 @@ export class SuperDoc extends EventEmitter {
       throw new Error('SuperDoc: upgradeToCollaboration() requires both ydoc and provider');
     }
 
-    const cfg = /** @type {InternalConfig} */ (this.config);
-    const docxDocs = cfg.documents.filter((d) => d.type === DOCX);
+    const cfg = /** @type {InternalConfig} */ this.config;
+    const docxDocs = cfg.documents.filter((d: RuntimeDocument) => d.type === DOCX);
     if (docxDocs.length === 0) {
       throw new Error('SuperDoc: no DOCX document found for upgrade');
     }
@@ -1388,10 +1553,10 @@ export class SuperDoc extends EventEmitter {
     // Upstream `#assertCanUpgrade` already verified at least one DOCX
     // document exists; cast the find result to assert non-null without
     // changing runtime behavior.
-    const docxDoc = /** @type {Document} */ (
-      /** @type {InternalConfig} */ (this.config).documents.find((d) => d.type === DOCX)
+    const docxDoc = this.config.documents.find((d: RuntimeDocument) => d.type === DOCX) as RuntimeDocument;
+    const storeDoc = this.#requireSuperdocStore('upgradeToCollaboration').documents.find(
+      (d: RuntimeDocument) => d.id === docxDoc.id,
     );
-    const storeDoc = this.#requireSuperdocStore('upgradeToCollaboration').documents.find((d) => d.id === docxDoc.id);
     const editor = storeDoc?.getEditor?.();
 
     if (!editor) {
@@ -1408,7 +1573,7 @@ export class SuperDoc extends EventEmitter {
    * @param {User} user The user to add
    * @returns {void}
    */
-  addSharedUser(user) {
+  addSharedUser(user: User) {
     this.#requireReady('addSharedUser');
     if (this.users.some((u) => u.email === user.email)) return;
     this.users.push(user);
@@ -1421,7 +1586,7 @@ export class SuperDoc extends EventEmitter {
    * @param {String} email The email of the user to remove
    * @returns {void}
    */
-  removeSharedUser(email) {
+  removeSharedUser(email: string) {
     this.#requireReady('removeSharedUser');
     this.users = this.users.filter((u) => u.email !== email);
   }
@@ -1435,13 +1600,13 @@ export class SuperDoc extends EventEmitter {
    *
    * @param {SuperDocContentErrorPayload} params
    */
-  onContentError({ error, editor }) {
+  onContentError({ error, editor }: { error: unknown; editor: Editor }) {
     const { documentId } = editor.options;
     // The errored editor came from `superdocStore.documents`, so the find
     // by its `documentId` is expected to hit. Cast the find result to a
     // RuntimeDocument to assert non-null at the consumer callback.
-    const doc = /** @type {RuntimeDocument} */ (
-      this.#requireSuperdocStore('onContentError').documents.find((d) => d.id === documentId)
+    const doc = /** @type {RuntimeDocument} */ this.#requireSuperdocStore('onContentError').documents.find(
+      (d: RuntimeDocument) => d.id === documentId,
     );
     // `onContentError` is typed as optional on the public Config typedef
     // because consumers don't have to wire a handler. The class field
@@ -1457,7 +1622,7 @@ export class SuperDoc extends EventEmitter {
     this.config.onContentError?.({
       error,
       editor,
-      documentId: /** @type {string} */ (doc.id),
+      documentId: /** @type {string} */ doc.id,
       file: doc.data,
     });
   }
@@ -1485,7 +1650,7 @@ export class SuperDoc extends EventEmitter {
    * @param {Editor} editor The editor that is about to be created
    * @returns {void}
    */
-  broadcastEditorBeforeCreate(editor) {
+  broadcastEditorBeforeCreate(editor: Editor) {
     this.emit('editorBeforeCreate', { editor: createDeprecatedEditorProxy(editor) });
   }
 
@@ -1494,7 +1659,7 @@ export class SuperDoc extends EventEmitter {
    * @param {Editor} editor The editor that was created
    * @returns {void}
    */
-  broadcastEditorCreate(editor) {
+  broadcastEditorCreate(editor: Editor) {
     this.readyEditors++;
     this.broadcastReady();
     this.emit('editorCreate', { editor: createDeprecatedEditorProxy(editor) });
@@ -1512,12 +1677,12 @@ export class SuperDoc extends EventEmitter {
    * Triggered when the comments sidebar is toggled
    * @param {boolean} isOpened
    */
-  broadcastSidebarToggle(isOpened) {
+  broadcastSidebarToggle(isOpened: boolean) {
     this.emit('sidebar-toggle', isOpened);
   }
 
   /** @param {unknown[]} args */
-  #log(...args) {
+  #log(...args: unknown[]) {
     (console.debug ? console.debug : console.log)('🦋 🦸‍♀️ [superdoc]', ...args);
   }
 
@@ -1526,7 +1691,7 @@ export class SuperDoc extends EventEmitter {
    * @param {Editor} editor The editor to set as active
    * @returns {void}
    */
-  setActiveEditor(editor) {
+  setActiveEditor(editor: Editor) {
     this.activeEditor = editor;
     if (this.toolbar) {
       this.activeEditor.toolbar = this.toolbar;
@@ -1544,7 +1709,7 @@ export class SuperDoc extends EventEmitter {
     // throws without partially flipping the config.
     const store = this.#requireSuperdocStore('toggleRuler');
     this.config.rulers = !this.config.rulers;
-    store.documents.forEach((doc) => {
+    store.documents.forEach((doc: RuntimeDocument) => {
       // In Pinia store, refs are auto-unwrapped, so rulers is a plain boolean
       doc.rulers = this.config.rulers;
     });
@@ -1576,6 +1741,12 @@ export class SuperDoc extends EventEmitter {
     isInternal = this.config.isInternal,
     comment = null,
     trackedChange = null,
+  }: {
+    permission?: string;
+    role?: string;
+    isInternal?: boolean;
+    comment?: (object & Record<string, unknown>) | null;
+    trackedChange?: ({ id?: string; commentId?: string; comment?: unknown } & Record<string, unknown>) | null;
   } = {}) {
     if (!permission) return false;
 
@@ -1595,7 +1766,7 @@ export class SuperDoc extends EventEmitter {
       trackedChange: trackedChange ?? null,
     };
 
-    return isAllowed(permission, /** @type {string} */ (role), /** @type {boolean} */ (isInternal), context);
+    return isAllowed(permission, role as string, isInternal as boolean, context);
   }
 
   #addToolbar() {
@@ -1654,7 +1825,7 @@ export class SuperDoc extends EventEmitter {
    * @param {Element} element The DOM element to render the comments list in
    * @returns {void}
    */
-  addCommentsList(element) {
+  addCommentsList(element: HTMLElement) {
     if (!this.config?.modules?.comments || this.config.role === 'viewer') return;
     if (element) this.config.modules.comments.element = element;
     this.commentsList = new SuperComments(this.config.modules?.comments, this);
@@ -1680,7 +1851,7 @@ export class SuperDoc extends EventEmitter {
    * @param {{ behavior?: ScrollBehavior, block?: ScrollLogicalPosition }} [options]
    * @returns {boolean} Whether a matching element was found
    */
-  scrollToComment(commentId, options = {}) {
+  scrollToComment(commentId: string, options: { behavior?: ScrollBehavior; block?: ScrollLogicalPosition } = {}) {
     const commentsConfig = this.config?.modules?.comments;
     // `commentsConfig` can be `false | object | undefined`; `!commentsConfig`
     // already covers both `false` and `undefined`, so the secondary
@@ -1708,7 +1879,7 @@ export class SuperDoc extends EventEmitter {
    * @param {NavigableAddress} target
    * @returns {Promise<boolean>} Whether the target was found and navigated to.
    */
-  async navigateTo(target) {
+  async navigateTo(target: NavigableAddress): Promise<boolean> {
     /** @type {RuntimeDocument[] | undefined} */
     const storeDocs = this.superdocStore?.documents;
     if (!storeDocs?.length) return false;
@@ -1734,7 +1905,7 @@ export class SuperDoc extends EventEmitter {
    * // Navigate to a comment by its entityId
    * await superdoc.scrollToElement('imported-25def254');
    */
-  async scrollToElement(elementId) {
+  async scrollToElement(elementId: string): Promise<boolean> {
     /** @type {RuntimeDocument[] | undefined} */
     const storeDocs = this.superdocStore?.documents;
     if (!storeDocs?.length) return false;
@@ -1753,7 +1924,7 @@ export class SuperDoc extends EventEmitter {
     if (this.config.disableContextMenu === nextValue) return;
     this.config.disableContextMenu = nextValue;
 
-    this.superdocStore?.documents?.forEach((doc) => {
+    this.superdocStore?.documents?.forEach((doc: RuntimeDocument) => {
       const presentationEditor = doc.getPresentationEditor?.();
       if (presentationEditor?.setContextMenuDisabled) {
         presentationEditor.setContextMenuDisabled(nextValue);
@@ -1778,7 +1949,7 @@ export class SuperDoc extends EventEmitter {
     if (layoutOptions.showBookmarks === nextValue) return;
     layoutOptions.showBookmarks = nextValue;
 
-    this.superdocStore?.documents?.forEach((doc) => {
+    this.superdocStore?.documents?.forEach((doc: RuntimeDocument) => {
       const presentationEditor = doc.getPresentationEditor?.();
       presentationEditor?.setShowBookmarks?.(nextValue);
     });
@@ -1796,7 +1967,7 @@ export class SuperDoc extends EventEmitter {
     if (layoutOptions.showFormattingMarks === nextValue) return;
     layoutOptions.showFormattingMarks = nextValue;
 
-    this.superdocStore?.documents?.forEach((doc) => {
+    this.superdocStore?.documents?.forEach((doc: RuntimeDocument) => {
       const presentationEditor = doc.getPresentationEditor?.();
       presentationEditor?.setShowFormattingMarks?.(nextValue);
     });
@@ -1819,7 +1990,7 @@ export class SuperDoc extends EventEmitter {
    * @param {DocumentMode} type
    * @returns {void}
    */
-  setDocumentMode(type) {
+  setDocumentMode(type: DocumentMode) {
     if (!type) return;
 
     // Guard before mutating `this.config.documentMode` so a pre-ready
@@ -1827,7 +1998,7 @@ export class SuperDoc extends EventEmitter {
     // `#syncViewingVisibility` / tracked-change preference writes.
     this.#requireReady('setDocumentMode');
 
-    type = /** @type {DocumentMode} */ (type.toLowerCase());
+    type = type.toLowerCase() as DocumentMode;
     this.config.documentMode = type;
     this.#syncViewingVisibility();
 
@@ -1849,7 +2020,7 @@ export class SuperDoc extends EventEmitter {
    * @param {RuntimeDocument} doc - The document object
    * @param {DocumentMode} mode - The document mode ('editing', 'viewing', 'suggesting')
    */
-  #applyDocumentMode(doc, mode) {
+  #applyDocumentMode(doc: RuntimeDocument, mode: DocumentMode) {
     const presentationEditor = typeof doc.getPresentationEditor === 'function' ? doc.getPresentationEditor() : null;
     if (presentationEditor) {
       presentationEditor.setDocumentMode(mode);
@@ -1867,13 +2038,13 @@ export class SuperDoc extends EventEmitter {
    *
    * @param {{ mode?: 'review' | 'original' | 'final' | 'off', enabled?: boolean }} [preferences]
    */
-  setTrackedChangesPreferences(preferences) {
+  setTrackedChangesPreferences(preferences?: { mode?: 'review' | 'original' | 'final' | 'off'; enabled?: boolean }) {
     const normalized = preferences && Object.keys(preferences).length ? { ...preferences } : undefined;
     if (!this.config.layoutEngineOptions) {
       this.config.layoutEngineOptions = {};
     }
     this.config.layoutEngineOptions.trackedChanges = normalized;
-    this.superdocStore?.documents?.forEach((doc) => {
+    this.superdocStore?.documents?.forEach((doc: RuntimeDocument) => {
       const presentationEditor = typeof doc.getPresentationEditor === 'function' ? doc.getPresentationEditor() : null;
       if (presentationEditor?.setTrackedChangesOverrides) {
         presentationEditor.setTrackedChangesOverrides(normalized);
@@ -1892,8 +2063,8 @@ export class SuperDoc extends EventEmitter {
     // Enable tracked changes for editing mode
     this.setTrackedChangesPreferences({ mode: 'review', enabled: true });
 
-    store.documents.forEach((doc) => {
-      doc.restoreComments();
+    store.documents.forEach((doc: RuntimeDocument) => {
+      doc.restoreComments?.();
       this.#applyDocumentMode(doc, 'editing');
     });
   }
@@ -1909,8 +2080,8 @@ export class SuperDoc extends EventEmitter {
     // Enable tracked changes for suggesting mode
     this.setTrackedChangesPreferences({ mode: 'review', enabled: true });
 
-    store.documents.forEach((doc) => {
-      doc.restoreComments();
+    store.documents.forEach((doc: RuntimeDocument) => {
+      doc.restoreComments?.();
       this.#applyDocumentMode(doc, 'suggesting');
     });
   }
@@ -1942,11 +2113,11 @@ export class SuperDoc extends EventEmitter {
       this.commentsStore?.clearEditorCommentPositions?.();
     }
 
-    store.documents.forEach((doc) => {
+    store.documents.forEach((doc: RuntimeDocument) => {
       if (commentsVisible || trackChangesVisible) {
-        doc.restoreComments();
+        doc.restoreComments?.();
       } else {
-        doc.removeComments();
+        doc.removeComments?.();
       }
       this.#applyDocumentMode(doc, 'viewing');
     });
@@ -1989,7 +2160,7 @@ export class SuperDoc extends EventEmitter {
    * @param {string | RegExp} text The text or regex to search for
    * @returns {import('./types/index.js').SearchMatch[] | undefined} The search results
    */
-  search(text) {
+  search(text: string): SearchMatch[] | undefined {
     return this.activeEditor?.commands.search(text, { searchModel: 'visible' });
   }
 
@@ -2003,7 +2174,7 @@ export class SuperDoc extends EventEmitter {
    * @param {import('./types/index.js').SearchMatch} match The match object returned by `superdoc.search()`.
    * @returns {boolean | undefined} Whether the command dispatched, or `undefined` if no active editor.
    */
-  goToSearchResult(match) {
+  goToSearchResult(match: SearchMatch) {
     return this.activeEditor?.commands.goToSearchResult(match);
   }
 
@@ -2026,7 +2197,7 @@ export class SuperDoc extends EventEmitter {
    * superdoc.setZoom(150); // Set zoom to 150%
    * superdoc.setZoom(50);  // Set zoom to 50%
    */
-  setZoom(percent) {
+  setZoom(percent: number) {
     if (typeof percent !== 'number' || !Number.isFinite(percent) || percent <= 0) {
       console.warn('[SuperDoc] setZoom expects a positive number representing percentage');
       return;
@@ -2046,12 +2217,12 @@ export class SuperDoc extends EventEmitter {
    * @param {boolean} lock
    */
   setLocked(lock = true) {
-    /** @type {InternalConfig} */ (this.config).documents.forEach((doc) => {
+    /** @type {InternalConfig} */ this.config.documents.forEach((doc: RuntimeDocument) => {
       // setLocked is a collaboration-only API; the surrounding flow only
       // calls it once each document has a Yjs doc attached. Cast away the
       // optional shape on the public Document typedef without changing
       // runtime behavior.
-      const ydoc = /** @type {import('yjs').Doc} */ (doc.ydoc);
+      const ydoc = doc.ydoc as Y.Doc;
       const metaMap = ydoc.getMap('meta');
       ydoc.transact(() => {
         metaMap.set('locked', lock);
@@ -2065,10 +2236,9 @@ export class SuperDoc extends EventEmitter {
    * @returns {Array<string>} The HTML content of all editors
    */
   getHTML(options = {}) {
-    /** @type {Editor[]} */
-    const editors = [];
-    this.#requireSuperdocStore('getHTML').documents.forEach((doc) => {
-      const editor = doc.getEditor();
+    const editors: Editor[] = [];
+    this.#requireSuperdocStore('getHTML').documents.forEach((doc: RuntimeDocument) => {
+      const editor = doc.getEditor?.();
       if (editor) {
         editors.push(editor);
       }
@@ -2082,7 +2252,7 @@ export class SuperDoc extends EventEmitter {
    * @param {Boolean} isLocked
    * @param {User} lockedBy The user who locked the superdoc
    */
-  lockSuperdoc(isLocked = false, lockedBy) {
+  lockSuperdoc(isLocked: boolean = false, lockedBy: User | null = null) {
     this.isLocked = isLocked;
     this.lockedBy = lockedBy;
     this.#log('🦋 [superdoc] Locking superdoc:', isLocked, lockedBy, '\n\n\n');
@@ -2094,18 +2264,20 @@ export class SuperDoc extends EventEmitter {
    * @param {ExportParams} params - Export configuration
    * @returns {Promise<void | Blob>}
    */
-  async export({
-    exportType = ['docx'],
-    commentsType = 'external',
-    exportedName,
-    additionalFiles = [],
-    additionalFileNames = [],
-    isFinalDoc = false,
-    triggerDownload = true,
-    fieldsHighlightColor = null,
-  } = {}) {
+  async export(
+    {
+      exportType = ['docx'],
+      commentsType = 'external',
+      exportedName,
+      additionalFiles = [],
+      additionalFileNames = [],
+      isFinalDoc = false,
+      triggerDownload = true,
+      fieldsHighlightColor = null,
+    }: ExportParams = {} as ExportParams,
+  ) {
     // Get the docx files first
-    const baseFileName = exportedName ? cleanName(exportedName) : cleanName(/** @type {string} */ (this.config.title));
+    const baseFileName = exportedName ? cleanName(exportedName) : cleanName(this.config.title as string);
     const docxFiles = await this.exportEditorsToDOCX({ commentsType, isFinalDoc, fieldsHighlightColor });
     const blobsToZip = [...additionalFiles];
     const filenames = [...additionalFileNames];
@@ -2113,7 +2285,9 @@ export class SuperDoc extends EventEmitter {
     // If we are exporting docx files, add them to the zip
     if (exportType.includes('docx')) {
       docxFiles.forEach((blob) => {
-        blobsToZip.push(blob);
+        // exportDocx default overload returns Blob; the wider `string | Blob | null`
+        // shows up only when callers opt into other export modes (not used here).
+        blobsToZip.push(blob as Blob);
         filenames.push(`${baseFileName}.docx`);
       });
     }
@@ -2141,7 +2315,11 @@ export class SuperDoc extends EventEmitter {
    * @param {{ commentsType?: string, isFinalDoc?: boolean, fieldsHighlightColor?: string | null }} [options]
    * @returns {Promise<Array<Blob>>}
    */
-  async exportEditorsToDOCX({ commentsType, isFinalDoc, fieldsHighlightColor } = {}) {
+  async exportEditorsToDOCX({
+    commentsType,
+    isFinalDoc,
+    fieldsHighlightColor,
+  }: { commentsType?: string; isFinalDoc?: boolean; fieldsHighlightColor?: string | null } = {}) {
     // The export's job is to pick the correct source of truth for
     // comments. There are three branches; the third had a latent
     // ambiguity that resurrected deleted comments and is the
@@ -2170,8 +2348,7 @@ export class SuperDoc extends EventEmitter {
     //    `converter.comments` (which the legacy delete path doesn't
     //    clear today; tracked separately under SD-2839). Pass
     //    whatever the store returns, including `[]`.
-    /** @type {unknown[] | undefined} */
-    let comments;
+    let comments: unknown[] | undefined;
     const commentsModuleConfig = this.config?.modules?.comments;
     const uiStoreHydrated = commentsModuleConfig !== false;
     if (commentsType === 'clean') {
@@ -2189,27 +2366,34 @@ export class SuperDoc extends EventEmitter {
     // else: UI store unhydrated → leave `comments` undefined and
     // let the engine's `converter.comments` fallback fire.
 
-    const docxPromises = this.#requireSuperdocStore('exportEditorsToDOCX').documents.map(async (doc) => {
-      if (!doc || doc.type !== DOCX) return null;
+    const docxPromises = this.#requireSuperdocStore('exportEditorsToDOCX').documents.map(
+      async (doc: RuntimeDocument) => {
+        if (!doc || doc.type !== DOCX) return null;
 
-      const editor = typeof doc.getEditor === 'function' ? doc.getEditor() : null;
-      const fallbackDocx = () => {
-        if (!doc.data) return null;
-        if (doc.data.type && doc.data.type !== DOCX) return null;
-        return doc.data;
-      };
+        const editor = typeof doc.getEditor === 'function' ? doc.getEditor() : null;
+        const fallbackDocx = () => {
+          if (!doc.data) return null;
+          if (doc.data.type && doc.data.type !== DOCX) return null;
+          return doc.data;
+        };
 
-      if (!editor) return fallbackDocx();
+        if (!editor) return fallbackDocx();
 
-      try {
-        const exported = await editor.exportDocx({ isFinalDoc, comments, commentsType, fieldsHighlightColor });
-        if (exported) return exported;
-      } catch (error) {
-        this.emit('exception', { error, document: doc });
-      }
+        try {
+          const exported = await editor.exportDocx({
+            isFinalDoc,
+            comments: comments as import('@superdoc/super-editor').Comment[] | undefined,
+            commentsType,
+            fieldsHighlightColor,
+          });
+          if (exported) return exported;
+        } catch (error) {
+          this.emit('exception', { error, document: doc });
+        }
 
-      return fallbackDocx();
-    });
+        return fallbackDocx();
+      },
+    );
 
     const docxFiles = await Promise.all(docxPromises);
     return docxFiles.filter(Boolean);
@@ -2222,8 +2406,8 @@ export class SuperDoc extends EventEmitter {
   async #triggerCollaborationSaves() {
     this.#log('🦋 [superdoc] Triggering collaboration saves');
     const store = this.#requireSuperdocStore('save');
-    return new Promise((resolve) => {
-      store.documents.forEach((doc, index) => {
+    return new Promise<void>((resolve) => {
+      store.documents.forEach((doc: RuntimeDocument, index: number) => {
         this.#log(`Before reset - Doc ${index}: pending = ${this.pendingCollaborationSaves}`);
         this.pendingCollaborationSaves = 0;
         if (doc.ydoc) {
@@ -2242,7 +2426,7 @@ export class SuperDoc extends EventEmitter {
         }
       });
       this.#log(
-        `FINAL pending = ${this.pendingCollaborationSaves}, but we have ${store.documents.filter((d) => d.ydoc).length} docs!`,
+        `FINAL pending = ${this.pendingCollaborationSaves}, but we have ${store.documents.filter((d: RuntimeDocument) => d.ydoc).length} docs!`,
       );
     });
   }
@@ -2275,7 +2459,7 @@ export class SuperDoc extends EventEmitter {
       this._cleanupAwareness = null;
     }
 
-    const cfg = /** @type {InternalConfig} */ (this.config);
+    const cfg = /** @type {InternalConfig} */ this.config;
     // `cancelWebsocketRetry` is set on `HocuspocusProviderWebsocket` only
     // while a reconnect timer is pending, and Hocuspocus clears it back to
     // `undefined` after firing. Destroy from the "already connected, no
@@ -2289,7 +2473,7 @@ export class SuperDoc extends EventEmitter {
     this.provider?.disconnect?.();
     this.provider?.destroy?.();
 
-    cfg.documents.forEach((doc) => {
+    cfg.documents.forEach((doc: RuntimeDocument) => {
       doc.provider?.disconnect?.();
       doc.provider?.destroy?.();
       doc.ydoc?.destroy();
@@ -2307,15 +2491,15 @@ export class SuperDoc extends EventEmitter {
    * @param {SurfaceRequest} request
    * @returns {SurfaceHandle<TResult>}
    */
-  openSurface(request) {
-    return this.#surfaceManager.open(request);
+  openSurface<TResult = unknown>(request: SurfaceRequest): SurfaceHandle<TResult> {
+    return this.#surfaceManager.open(request) as SurfaceHandle<TResult>;
   }
 
   /**
    * Close a surface by id, or the topmost surface if no id is given.
    * @param {string} [id]
    */
-  closeSurface(id) {
+  closeSurface(id?: string) {
     this.#surfaceManager.close(id);
   }
 
@@ -2372,8 +2556,8 @@ export class SuperDoc extends EventEmitter {
     if (this.activeEditor) {
       this.activeEditor.focus();
     } else {
-      this.#requireSuperdocStore('focus').documents.find((doc) => {
-        const editor = doc.getEditor();
+      this.#requireSuperdocStore('focus').documents.find((doc: RuntimeDocument) => {
+        const editor = doc.getEditor?.();
         if (editor) {
           editor.focus();
         }
@@ -2386,7 +2570,7 @@ export class SuperDoc extends EventEmitter {
    * @param {boolean} isHighContrast
    * @returns {void}
    */
-  setHighContrastMode(isHighContrast) {
+  setHighContrastMode(isHighContrast: boolean) {
     if (!this.activeEditor) return;
     // `setHighContrastMode` is typed as optional on Editor because the
     // method is only present once the editor's mount hooks run. By the

--- a/packages/superdoc/src/core/SuperDoc.ts
+++ b/packages/superdoc/src/core/SuperDoc.ts
@@ -57,9 +57,9 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
   '#F39C12',
 ]);
 
-// TS-native type imports. The JSDoc `@typedef {import(...)}` form below
-// is kept for historical readability and for the few signatures still
-// expressed in JSDoc; the real bindings come from this `import type`.
+// TS-native type imports for the types this file annotates against.
+// The corresponding payload shapes for the SuperDocEventMap are
+// declared as interfaces below.
 import type {
   User,
   Document,
@@ -167,168 +167,41 @@ interface SuperDocEventMap {
   'whiteboard:tool': [string];
   exception: [SuperDocExceptionPayload];
 }
-/** @typedef {import('./types/index.js').User} User */
-/** @typedef {import('./types/index.js').Document} Document */
-/** @typedef {import('./types/index.js').RuntimeDocument} RuntimeDocument */
-/** @typedef {import('./types/index.js').Modules} Modules */
-/** @typedef {import('./types/index.js').Editor} Editor */
-/** @typedef {import('./types/index.js').DocumentMode} DocumentMode */
-/** @typedef {import('./types/index.js').Config} Config */
-/** @typedef {import('./types/index.js').InternalConfig} InternalConfig */
-/** @typedef {import('./types/index.js').ExportParams} ExportParams */
-/** @typedef {import('./types/index.js').UpgradeToCollaborationOptions} UpgradeToCollaborationOptions */
-/** @typedef {import('./types/index.js').SurfaceRequest} SurfaceRequest */
-/**
- * @template [T=unknown]
- * @typedef {import('./types/index.js').SurfaceHandle<T>} SurfaceHandle
- */
-/** @typedef {import('./types/index.js').NavigableAddress} NavigableAddress */
-/** @typedef {import('@superdoc/super-editor/ui').SuperDocLike} SuperDocLike */
-
-/** @typedef {import('./types/index.js').AwarenessState} AwarenessState */
-/** @typedef {import('@superdoc/super-editor').Comment} Comment */
-/** @typedef {import('@superdoc/super-editor').FontsResolvedPayload} FontsResolvedPayload */
-/** @typedef {import('@superdoc/super-editor').ListDefinitionsPayload} ListDefinitionsPayload */
-/**
- * Discriminator for `comments-update` payloads. Inlined rather than
- * imported from `@superdoc/common` because the dist re-export path for
- * `CommentEvent` doesn't survive the facade emit; the source values
- * live in `shared/common/event-types.d.ts` (`comments_module_events`).
- *
- * @typedef {'resolved' | 'new' | 'add' | 'update' | 'deleted' | 'pending' | 'selected' | 'comments-list' | 'change-accepted' | 'change-rejected'} CommentEvent
- */
-/** @typedef {import('./whiteboard/Whiteboard.js').WhiteboardData} WhiteboardData */
+// Notes on the event map above:
+//
+// `exception` is typed as `SuperDocExceptionPayload`, a union of the three
+// shapes the runtime currently emits today: `{ error, stage, document }`
+// from `superdoc-store.js` document-init failures, `{ error, document }`
+// from the catch in `restoreUnsavedChanges()`, and `{ error, editor?,
+// code?, documentId? }` from `SuperDoc.vue` editor lifecycle. Normalizing
+// these is tracked as a separate follow-up; the union types the current
+// reality so consumers can narrow with `'stage' in payload` etc.
+//
+// `fonts-resolved` uses a listener-transport pattern: SuperDoc never
+// emits it directly. `SuperDoc.vue:719` reads
+// `superdoc.listeners('fonts-resolved')[0]` and threads it into the new
+// editor's `onFontsResolved` option. Cleanup of this transport (relay
+// through SuperDoc instead) is a follow-up; typing it here matches the
+// current consumer-visible contract.
 
 /**
- * Typed event map for `superdoc.on(name, fn)` / `superdoc.emit(name, ...)`.
+ * Adapts an optional `Config` callback to EventEmitter's
+ * `(...args: any[]) => void` listener signature.
  *
- * The map is closed: unknown event names (e.g. `superdoc.on('reayd', ...)`,
- * a typo) are TS errors at compile time. This is a **TS-only tightening**.
- * The runtime `eventemitter3` still accepts any string; it is consumers
- * relying on dynamic event names who would see new type errors. Verified
- * no internal SuperDoc code emits or subscribes to dynamic event names
- * (every emit site is enumerated here).
+ * Every callback wrapped by this helper defaults to `() => null` in the
+ * class-field initializer, so EventEmitter receives a function in normal
+ * use. This helper is a runtime identity cast: behavior is unchanged if
+ * that invariant ever breaks (e.g. a consumer explicitly passes
+ * `undefined`), and EventEmitter sees the same value it would have
+ * without the wrapper. Sites with a `null` default (`onFontsResolved`,
+ * `onTrackedChangeBubbleAccept`, `onTrackedChangeBubbleReject`) use a
+ * separate `if`-guard pattern instead of this helper.
  *
- * `exception` is typed as `SuperDocExceptionPayload`, a union of the three
- * shapes the runtime currently emits today: `{ error, stage, document }`
- * from `superdoc-store.js` document-init failures, `{ error, document }`
- * from the catch in `restoreUnsavedChanges()`, and `{ error, editor?, code?,
- * documentId? }` from `SuperDoc.vue` editor lifecycle. Normalizing these
- * is tracked as a separate follow-up; this map types the current reality
- * so consumers get a union they can narrow with `'stage' in payload` etc.
- *
- * `fonts-resolved` uses a **listener-transport pattern**: SuperDoc never
- * emits it directly. Instead, `SuperDoc.vue:719` reads the registered
- * `superdoc.listeners('fonts-resolved')[0]` and threads it into the new
- * editor's `onFontsResolved` option. Cleanup of this transport (relay
- * through SuperDoc instead) is a follow-up; typing it here matches the
- * current consumer-visible contract.
- *
- * @typedef {{
- *  ready: [SuperDocReadyPayload],
- *  editorBeforeCreate: [SuperDocEditorPayload],
- *  editorCreate: [SuperDocEditorPayload],
- *  editorDestroy: [],
- *  'pdf:document-ready': [],
- *  'sidebar-toggle': [boolean],
- *  zoomChange: [SuperDocZoomPayload],
- *  'formatting-marks-change': [SuperDocFormattingMarksPayload],
- *  'document-mode-change': [SuperDocDocumentModeChangePayload],
- *  'editor-update': [SuperDocEditorUpdatePayload],
- *  'content-error': [SuperDocContentErrorPayload],
- *  'fonts-resolved': [FontsResolvedPayload],
- *  'pagination-update': [SuperDocPaginationPayload],
- *  'list-definitions-change': [ListDefinitionsPayload],
- *  'comments-update': [SuperDocCommentsUpdatePayload],
- *  'collaboration-ready': [SuperDocEditorPayload],
- *  'awareness-update': [SuperDocAwarenessUpdatePayload],
- *  locked: [SuperDocLockedPayload],
- *  'whiteboard:init': [SuperDocWhiteboardPayload],
- *  'whiteboard:ready': [SuperDocWhiteboardPayload],
- *  'whiteboard:change': [WhiteboardData],
- *  'whiteboard:enabled': [boolean],
- *  'whiteboard:tool': [string],
- *  exception: [SuperDocExceptionPayload],
- * }} SuperDocEventMap
- *
- * @typedef {{ superdoc: SuperDoc }} SuperDocReadyPayload
- * @typedef {{ editor: Editor }} SuperDocEditorPayload
- * @typedef {{ whiteboard: Whiteboard }} SuperDocWhiteboardPayload
- * @typedef {{ zoom: number }} SuperDocZoomPayload
- * @typedef {{ showFormattingMarks: boolean, superdoc: SuperDoc }} SuperDocFormattingMarksPayload
- * @typedef {{ documentMode: DocumentMode }} SuperDocDocumentModeChangePayload
- * @typedef {{ totalPages: number, superdoc: SuperDoc }} SuperDocPaginationPayload
- * @typedef {{ error: unknown, editor: Editor }} SuperDocContentErrorPayload
- * @typedef {{ isLocked: boolean, lockedBy?: User | null }} SuperDocLockedPayload
- *
- * Editor-update envelope produced by `buildEditorPayloadBase` in
- * `SuperDoc.vue`. `editor` is `effectiveEditor = editor ?? sourceEditor`,
- * which is `undefined` only when neither was provided.
- *
- * @typedef {{
- *  editor?: Editor,
- *  sourceEditor?: Editor,
- *  surface: string,
- *  headerId: string | null,
- *  sectionType: string | null,
- * }} SuperDocEditorUpdatePayload
- *
- * Awareness payload from `awarenessHandler` in `collaboration.js`.
- * `states` is `AwarenessState[]` (the publicly re-exported shape).
- * `added` and `removed` are Yjs client IDs (numbers).
- *
- * @typedef {{
- *  states: AwarenessState[],
- *  added: number[],
- *  removed: number[],
- *  superdoc: SuperDoc,
- * }} SuperDocAwarenessUpdatePayload
- *
- * Comments-update envelope from `comments-store.js`. `type` is one of the
- * `CommentEvent` literals; `comment` is present for ADD/UPDATE/DELETED/NEW/
- * RESOLVED and absent for PENDING. `changes` is present for DELETED to
- * carry the per-document change record.
- *
- * @typedef {{
- *  type: CommentEvent,
- *  comment?: Comment,
- *  changes?: Array<{ key: string, commentId: string, fileId?: string | null }>,
- * }} SuperDocCommentsUpdatePayload
- *
- * Union of the three current `exception` payload shapes (debt: should be
- * normalized to one shape in a follow-up). Consumers can narrow with
- * `'stage' in payload` (store init) or `'code' in payload` (Vue editor
- * lifecycle). The interfaces live in `./types/index.ts` so they can be
- * referenced by both the JSDoc event registry below and the public
- * `Config.onException` callback type.
- *
- * @typedef {import('./types/index.js').SuperDocExceptionStorePayload} SuperDocExceptionStorePayload
- * @typedef {import('./types/index.js').SuperDocExceptionRestorePayload} SuperDocExceptionRestorePayload
- * @typedef {import('./types/index.js').SuperDocExceptionEditorPayload} SuperDocExceptionEditorPayload
- * @typedef {import('./types/index.js').SuperDocExceptionPayload} SuperDocExceptionPayload
+ * The `any[]` here is correct: EventEmitter dispatches whatever payload
+ * each emit site supplies, and the consumer-supplied callback only
+ * inspects the args its own signature names. Narrower typing would force
+ * every callsite below to cast.
  */
-
-/**
- * Config callbacks are optional on the public typedef because consumers do
- * not need to pass them. The fields wrapped by this helper (every callback
- * registered in `#initListeners` plus the toolbar `exception` listener)
- * default to `() => null` in the class-field initializer, so EventEmitter
- * receives a function in normal use. This helper is a runtime identity
- * cast: behavior is unchanged if that invariant is ever broken (e.g. a
- * consumer explicitly passes `undefined`), and EventEmitter sees the same
- * value it would have without the wrapper. Sites with a `null` default
- * (`onFontsResolved`, `onTrackedChangeBubbleAccept`, `onTrackedChangeBubbleReject`)
- * use a separate `if`-guard pattern instead of this helper.
- *
- * @param {((...args: any[]) => void) | undefined} listener
- * @returns {(...args: any[]) => void}
- */
-// Accepts any optional Config callback (each has its own narrow signature)
-// and adapts it to EventEmitter's `(...args: any[]) => void`. `any` here
-// matches the runtime contract: EventEmitter dispatches whatever payload
-// the emit site supplies, and the consumer-supplied callback only inspects
-// the args its own signature names. Narrower typing would force every
-// callsite below to cast.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function asEventListener(listener: ((...args: any[]) => void) | undefined): (...args: any[]) => void {
   return listener as (...args: any[]) => void;
@@ -355,7 +228,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /** @type {(() => void) | null} — aborts an in-flight upgrade (sync wait or ready wait) */
   #abortUpgrade: (() => void) | null = null;
 
-  /** @type {HTMLDivElement | null} */
   #mountWrapper: HTMLDivElement | null = null;
 
   /** @type {SurfaceManager} */
@@ -368,7 +240,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * out of the JSDoc type graph). Consumers reading `superdoc.version`
    * immediately after `new SuperDoc(...)` see the real version because
    * `#init` runs synchronously through the overwrite before returning.
-   * @type {string}
    */
   version = '0.0.0';
 
@@ -379,7 +250,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * `removeSharedUser` mutations would be silently overwritten by the
    * re-seed, so those methods guard with `#requireReady('addSharedUser')`
    * and throw a clear lifecycle error instead.
-   * @type {User[]}
    */
   users: User[] = [];
 
@@ -401,7 +271,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * collaboration await. Initialized to `null` so consumers reading
    * `superdoc.whiteboard` before the `whiteboard:init` event fires get
    * a stable null, not `undefined`.
-   * @type {Whiteboard | null}
    */
   whiteboard: Whiteboard | null = null;
 
@@ -409,7 +278,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * Awareness palette assigned to local users when no explicit color is set.
    * Defaults to an empty array so `#assignUserColor` falls back to the
    * built-in `DEFAULT_AWARENESS_PALETTE`.
-   * @type {string[]}
    */
   colors: string[] = [];
 
@@ -434,19 +302,16 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * `HeadlessToolbarSuperdocHost` directly without exposing
    * `superdocStore` publicly.
    *
-   * @type {ReturnType<typeof import('../stores/superdoc-store.js').useSuperdocStore> | undefined}
    * @private
    */
   private declare superdocStore: ReturnType<typeof createSuperdocVueApp>['superdocStore'] | undefined;
 
   /**
-   * @type {ReturnType<typeof import('../stores/comments-store.js').useCommentsStore> | undefined}
    * @private
    */
   private declare commentsStore: ReturnType<typeof createSuperdocVueApp>['commentsStore'] | undefined;
 
   /**
-   * @type {ReturnType<typeof import('../composables/use-high-contrast-mode.js').useHighContrastMode> | undefined}
    * @private
    */
   private declare highContrastModeStore: ReturnType<typeof createSuperdocVueApp>['highContrastModeStore'] | undefined;
@@ -466,7 +331,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * `null` after `removeCommentsList()` tears down. No initializer, to
    * match the convention used by the adjacent `@private` store fields.
    *
-   * @type {SuperComments | null | undefined}
    * @private
    */
   // `declare` (no runtime initializer): the legacy JS code only sets
@@ -490,7 +354,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * `superdocStore` / `commentsStore` / `highContrastModeStore` /
    * `commentsList`; not runtime privacy.
    *
-   * @type {import('vue').App | undefined}
    * @private
    */
   private declare app: ReturnType<typeof createSuperdocVueApp>['app'] | undefined;
@@ -629,10 +492,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
     // Internal: toggle layout-engine-powered PresentationEditor in dev shells
     useLayoutEngine: true,
   };
-
-  /**
-   * @param {Config} config
-   */
   constructor(config: Config) {
     super();
 
@@ -658,11 +517,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
     this.#init(config, container);
   }
-
-  /**
-   * @param {Config} config
-   * @param {HTMLElement} container
-   */
   async #init(config: Config, container: HTMLElement) {
     this.config = {
       ...this.config,
@@ -852,8 +706,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * `superdoc.superdocStore.documents[].getPresentationEditor()` reach
    * for `superdoc/headless-toolbar` host routing (SD-3213f).
    *
-   * @param {string} documentId
-   * @returns {import('@superdoc/super-editor').PresentationEditor | null}
    */
   getPresentationEditorForDocument(documentId: string): PresentationEditor | null {
     if (typeof documentId !== 'string' || documentId.length === 0) return null;
@@ -869,8 +721,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * intentionally wide (`Record<string, unknown> | null`) so the public
    * surface does not pull the Pinia comment model type graph.
    *
-   * @param {string} commentId
-   * @returns {Record<string, unknown> | null}
    */
   getComment(commentId: string) {
     if (typeof commentId !== 'string' || commentId.length === 0) return null;
@@ -879,7 +729,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Get the SuperDoc container element
-   * @returns {HTMLElement | null}
    */
   get element() {
     if (typeof this.config.selector === 'string') {
@@ -1033,7 +882,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * Initialize collaboration if configured. Accepts the full
    * `Config.modules` block so it can read both the collaboration
    * subkey and the comments subkey at once.
-   * @param {Modules} [modules]
    * @returns {Promise<Document[] | undefined>} The processed documents with collaboration enabled. Caller awaits for side effects; the return value is informational.
    */
   async #initCollaboration(
@@ -1116,8 +964,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * Does NOT initialize collaboration comments — that happens in `#initVueApp()`
    * or explicitly after this call during construction.
    *
-   * @param {import('yjs').Doc} ydoc
-   * @param {import('./types/index.js').CollaborationProvider} provider
    */
   #attachExternalCollaboration(ydoc: Y.Doc, provider: CollaborationProvider) {
     this.isCollaborative = true;
@@ -1209,7 +1055,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * - External `{ ydoc, provider }` collaboration
    * - Overwrite-and-upgrade only (no merge semantics)
    *
-   * @param {UpgradeToCollaborationOptions} options
    * @returns {Promise<void>} Resolves once the collaborative runtime is ready
    */
   async upgradeToCollaboration({ ydoc, provider }: UpgradeToCollaborationOptions) {
@@ -1309,7 +1154,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * non-optional store members. Pre-ready safe paths (`getComment`,
    * `setActiveComment`, etc.) keep their existing `?.` pattern.
    *
-   * @param {string} methodName
    */
   #requireCommentsStore(methodName: string) {
     if (!this.commentsStore) {
@@ -1326,7 +1170,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * The store fields are the most reliable "ready" proxy since they
    * are the last things `#init` populates.
    *
-   * @param {string} methodName
    */
   #requireReady(methodName: string) {
     if (!this.superdocStore) {
@@ -1347,8 +1190,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * shallowRefs on property access, so we must use `toRaw()` to reach the
    * underlying ref objects.
    *
-   * @param {import('yjs').Doc | null} ydoc
-   * @param {import('./types/index.js').CollaborationProvider | null} provider
    */
   #setStoreDocumentCollaboration(ydoc: Y.Doc | null, provider: CollaborationProvider | null) {
     const storeDocs = this.superdocStore?.documents;
@@ -1368,7 +1209,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * Resolve the editor instance that supports `attachCollaboration`.
    * Prefers PresentationEditor (has cursor/layout support); falls back to raw Editor.
    *
-   * @returns {import('@superdoc/super-editor').PresentationEditor | import('@superdoc/super-editor').Editor}
    */
   #resolveUpgradeTarget() {
     const storeDocs = this.superdocStore?.documents;
@@ -1401,19 +1241,16 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * so the editor IS collaborative. A timeout only means secondary setup
    * (cursors, presence) is delayed — rolling back would be worse.
    *
-   * @param {import('@superdoc/super-editor').Editor | import('@superdoc/super-editor').PresentationEditor} editorInstance
-   * @returns {Promise<void>}
    */
   #waitForCollaborationReady(editorInstance: Editor | PresentationEditor) {
     const TIMEOUT_MS = 10_000;
 
-    // PresentationEditor wraps Editor; get the underlying editor for event listening.
-    // PresentationEditor exposes a `get editor(): Editor` accessor; plain
-    // Editor has no such property, so the runtime `??` fallback returns
-    // the instance itself in that case. The cast names the structural
-    // `.editor` lookup without claiming the field exists on the Editor
-    // arm of the union, so the access type-checks once SuperDoc.js is
-    // brought under the SD-2863 checkJs gate.
+    // PresentationEditor wraps Editor; get the underlying editor for event
+    // listening. PresentationEditor exposes a `get editor(): Editor`
+    // accessor; plain Editor has no such property, so the runtime `??`
+    // fallback returns the instance itself in that case. The structural
+    // `{ editor? }` cast names the lookup without claiming the field
+    // exists on the Editor arm of the union.
     const editor = ((editorInstance as { editor?: Editor }).editor ?? editorInstance) as Editor;
 
     // If collaborationReady already fired (options flag set by collaboration extension)
@@ -1466,8 +1303,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * provider that exposes on/off but never emits sync cannot hang forever.
    * destroy() can abort this wait early via #abortUpgrade.
    *
-   * @param {import('./types/index.js').CollaborationProvider} provider
-   * @returns {Promise<void>}
    */
   #waitForProviderSync(provider: CollaborationProvider) {
     const SYNC_TIMEOUT_MS = 10_000;
@@ -1571,7 +1406,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * `this.users = this.config.users || []` re-seed inside `#init`.
    *
    * @param {User} user The user to add
-   * @returns {void}
    */
   addSharedUser(user: User) {
     this.#requireReady('addSharedUser');
@@ -1584,7 +1418,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * to be ready for the same reason as `addSharedUser`.
    *
    * @param {String} email The email of the user to remove
-   * @returns {void}
    */
   removeSharedUser(email: string) {
     this.#requireReady('removeSharedUser');
@@ -1598,7 +1431,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * `Error` consistently (e.g. `insertContentAt` forwards the original
    * caught value).
    *
-   * @param {SuperDocContentErrorPayload} params
    */
   onContentError({ error, editor }: { error: unknown; editor: Editor }) {
     const { documentId } = editor.options;
@@ -1629,7 +1461,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Triggered when the PDF document is ready
-   * @returns {void}
    */
   broadcastPdfDocumentReady() {
     this.emit('pdf:document-ready');
@@ -1637,7 +1468,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Triggered when the superdoc is ready
-   * @returns {void}
    */
   broadcastReady() {
     if (this.readyEditors === this.requiredNumberOfEditors) {
@@ -1648,7 +1478,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /**
    * Triggered before an editor is created
    * @param {Editor} editor The editor that is about to be created
-   * @returns {void}
    */
   broadcastEditorBeforeCreate(editor: Editor) {
     this.emit('editorBeforeCreate', { editor: createDeprecatedEditorProxy(editor) });
@@ -1657,7 +1486,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /**
    * Triggered when an editor is created
    * @param {Editor} editor The editor that was created
-   * @returns {void}
    */
   broadcastEditorCreate(editor: Editor) {
     this.readyEditors++;
@@ -1667,7 +1495,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Triggered when an editor is destroyed
-   * @returns {void}
    */
   broadcastEditorDestroy() {
     this.emit('editorDestroy');
@@ -1675,7 +1502,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Triggered when the comments sidebar is toggled
-   * @param {boolean} isOpened
    */
   broadcastSidebarToggle(isOpened: boolean) {
     this.emit('sidebar-toggle', isOpened);
@@ -1689,7 +1515,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /**
    * Set the active editor
    * @param {Editor} editor The editor to set as active
-   * @returns {void}
    */
   setActiveEditor(editor: Editor) {
     this.activeEditor = editor;
@@ -1702,7 +1527,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /**
    * Toggle the ruler visibility for SuperEditors
    *
-   * @returns {void}
    */
   toggleRuler() {
     // Guard before mutating `this.config.rulers` so a pre-ready call
@@ -1733,7 +1557,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    *   comment?: (object & Record<string, unknown>) | null,
    *   trackedChange?: ({ id?: string, commentId?: string, comment?: unknown } & Record<string, unknown>) | null,
    * }} [params]
-   * @returns {boolean}
    */
   canPerformPermission({
     permission,
@@ -1823,7 +1646,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * Add a comments list to the superdoc
    * Requires the comments module to be enabled
    * @param {Element} element The DOM element to render the comments list in
-   * @returns {void}
    */
   addCommentsList(element: HTMLElement) {
     if (!this.config?.modules?.comments || this.config.role === 'viewer') return;
@@ -1834,7 +1656,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Remove the comments list from the superdoc
-   * @returns {void}
    */
   removeCommentsList() {
     if (this.commentsList) {
@@ -1876,7 +1697,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * Story-aware navigation is currently supported for bookmark and tracked
    * change targets. Block and comment targets are body-only.
    *
-   * @param {NavigableAddress} target
    * @returns {Promise<boolean>} Whether the target was found and navigated to.
    */
   async navigateTo(target: NavigableAddress): Promise<boolean> {
@@ -1917,7 +1737,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /**
    * Toggle the custom context menu globally.
    * Updates both flow editors and PresentationEditor instances so downstream listeners can short-circuit early.
-   * @param {boolean} disabled
    */
   setDisableContextMenu(disabled = true) {
     const nextValue = Boolean(disabled);
@@ -1940,8 +1759,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * SD-2454: Toggle bookmark bracket indicators (opt-in, off by default).
    * Matches Word's "Show bookmarks" option. Triggers a re-layout on change
    * because the brackets are visible characters participating in text flow.
-   * @param {boolean} show
-   * @returns {void}
    */
   setShowBookmarks(show = true) {
     const nextValue = Boolean(show);
@@ -1958,8 +1775,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /**
    * Toggle nonprinting formatting marks (spaces, tabs, paragraph marks) in the
    * rendered layout. This is a view-only setting and is not exported to DOCX.
-   * @param {boolean} show
-   * @returns {void}
    */
   setShowFormattingMarks(show = true) {
     const nextValue = Boolean(show);
@@ -1978,7 +1793,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Toggle nonprinting formatting marks from their current state.
-   * @returns {void}
    */
   toggleFormattingMarks() {
     const currentValue = Boolean(this.config.layoutEngineOptions?.showFormattingMarks);
@@ -1987,8 +1801,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Set the document mode.
-   * @param {DocumentMode} type
-   * @returns {void}
    */
   setDocumentMode(type: DocumentMode) {
     if (!type) return;
@@ -2214,7 +2026,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Set the document to locked or unlocked
-   * @param {boolean} lock
    */
   setLocked(lock = true) {
     /** @type {InternalConfig} */ this.config.documents.forEach((doc: RuntimeDocument) => {
@@ -2249,7 +2060,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Lock the current superdoc
-   * @param {Boolean} isLocked
    * @param {User} lockedBy The user who locked the superdoc
    */
   lockSuperdoc(isLocked: boolean = false, lockedBy: User | null = null) {
@@ -2262,7 +2072,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /**
    * Export the superdoc to a file
    * @param {ExportParams} params - Export configuration
-   * @returns {Promise<void | Blob>}
    */
   async export(
     {
@@ -2313,7 +2122,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /**
    * Export editors to DOCX format.
    * @param {{ commentsType?: string, isFinalDoc?: boolean, fieldsHighlightColor?: string | null }} [options]
-   * @returns {Promise<Array<Blob>>}
    */
   async exportEditorsToDOCX({
     commentsType,
@@ -2449,7 +2257,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Clean up collaboration resources (providers, ydocs, sockets)
-   * @returns {void}
    */
   #cleanupCollaboration() {
     // Remove the awareness listener so the provider cannot emit events
@@ -2488,8 +2295,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * Open a surface (dialog or floating) above the document content.
    *
    * @template [TResult=unknown]
-   * @param {SurfaceRequest} request
-   * @returns {SurfaceHandle<TResult>}
    */
   openSurface<TResult = unknown>(request: SurfaceRequest): SurfaceHandle<TResult> {
     return this.#surfaceManager.open(request) as SurfaceHandle<TResult>;
@@ -2497,7 +2302,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Close a surface by id, or the topmost surface if no id is given.
-   * @param {string} [id]
    */
   closeSurface(id?: string) {
     this.#surfaceManager.close(id);
@@ -2505,7 +2309,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Destroy the superdoc instance
-   * @returns {void}
    */
   destroy() {
     // Mark as destroyed early to prevent in-flight init from mounting
@@ -2550,7 +2353,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Focus the active editor or the first editor in the superdoc
-   * @returns {void}
    */
   focus() {
     if (this.activeEditor) {
@@ -2567,8 +2369,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   /**
    * Set the high contrast mode
-   * @param {boolean} isHighContrast
-   * @returns {void}
    */
   setHighContrastMode(isHighContrast: boolean) {
     if (!this.activeEditor) return;

--- a/packages/superdoc/src/core/SuperDoc.ts
+++ b/packages/superdoc/src/core/SuperDoc.ts
@@ -216,13 +216,10 @@ function asEventListener(listener: ((...args: any[]) => void) | undefined): (...
  * @implements {SuperDocLike}
  */
 export class SuperDoc extends EventEmitter<SuperDocEventMap> {
-  /** @type {Array<string>} */
   static allowedTypes = [DOCX, PDF, HTML];
 
-  /** @type {boolean} */
   #destroyed = false;
 
-  /** @type {boolean} */
   #isUpgrading = false;
 
   /** @type {(() => void) | null} — aborts an in-flight upgrade (sync wait or ready wait) */
@@ -230,7 +227,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
 
   #mountWrapper: HTMLDivElement | null = null;
 
-  /** @type {SurfaceManager} */
   #surfaceManager;
   /**
    * Build-time SuperDoc version string. Initialized to `'0.0.0'` so the
@@ -585,7 +581,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
     }
 
     this.config.colors = shuffleArray(this.config.colors as `#${string}`[]);
-    /** @type {Map<unknown, unknown>} */
     this.userColorMap = new Map();
     this.colorIndex = 0;
 
@@ -593,7 +588,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
     this.version = __APP_VERSION__;
     this.#log('🦋 [superdoc] Using SuperDoc version:', this.version);
 
-    /** @type {string} */
     this.superdocId = config.superdocId || uuidv4();
     // Default to an empty palette when no colors are configured so downstream
     // assignment logic doesn't have to null-check on every access.
@@ -621,13 +615,10 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
     // --- One-time shell setup (survives upgrade) ---
     this.user = this.config.user;
     this.users = this.config.users || [];
-    /** @type {unknown} */
     this.socket = null;
     this.isDev = this.config.isDev || false;
 
-    /** @type {Editor | null | undefined} */
     this.activeEditor = null;
-    /** @type {unknown[]} */
     this.comments = [];
 
     this.isLocked = this.config.isLocked || false;
@@ -845,7 +836,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
       );
     }
     this.superdocStore.init(this.config);
-    const commentsModuleConfig = /** @type {InternalConfig} */ this.config.modules.comments;
+    const commentsModuleConfig = this.config.modules.comments;
     // `commentsModuleConfig` is `false | object | undefined`. A truthy
     // check already rules out both `false` and `undefined`, so an
     // explicit `!== false` afterwards is redundant.
@@ -920,7 +911,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
     // Fallback: internal provider creation.
     // Start a socket for all documents and general metaMap for this SuperDoc
     if (collaborationModuleConfig.providerType === 'hocuspocus') {
-      /** @type {InternalConfig} */ this.config.socket = new HocuspocusProviderWebsocket({
+      this.config.socket = new HocuspocusProviderWebsocket({
         url: collaborationModuleConfig.url as string,
       });
     }
@@ -977,7 +968,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
     this.provider = markRaw(provider);
 
     this.#assignUserColor();
-    const internalConfig = /** @type {InternalConfig} */ this.config;
+    const internalConfig = this.config;
     this._cleanupAwareness = setupAwarenessHandler(provider, this, internalConfig.user);
 
     internalConfig.documents.forEach((doc: RuntimeDocument) => {
@@ -1003,7 +994,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
     this._commentsCollabInitialized = false;
     this.ydoc = undefined;
     this.provider = undefined;
-    const cfg = /** @type {InternalConfig} */ this.config;
+    const cfg = this.config;
     delete cfg.modules.collaboration;
 
     cfg.documents.forEach((doc: RuntimeDocument) => {
@@ -1073,7 +1064,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
       overwriteRoomLockState(ydoc, { isLocked: this.isLocked ?? false, lockedBy: this.lockedBy ?? null });
 
       // --- Attach collaboration config (awareness, flags, config.documents) ---
-      /** @type {InternalConfig} */ this.config.modules.collaboration = { ydoc, provider };
+      this.config.modules.collaboration = { ydoc, provider };
       this.#attachExternalCollaboration(ydoc, provider);
 
       // --- Update live store documents in place (no Vue unmount) ---
@@ -1365,7 +1356,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
       throw new Error('SuperDoc: upgradeToCollaboration() requires both ydoc and provider');
     }
 
-    const cfg = /** @type {InternalConfig} */ this.config;
+    const cfg = this.config;
     const docxDocs = cfg.documents.filter((d: RuntimeDocument) => d.type === DOCX);
     if (docxDocs.length === 0) {
       throw new Error('SuperDoc: no DOCX document found for upgrade');
@@ -1700,7 +1691,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * @returns {Promise<boolean>} Whether the target was found and navigated to.
    */
   async navigateTo(target: NavigableAddress): Promise<boolean> {
-    /** @type {RuntimeDocument[] | undefined} */
     const storeDocs = this.superdocStore?.documents;
     if (!storeDocs?.length) return false;
     const presentationEditor = storeDocs[0].getPresentationEditor?.();
@@ -1726,7 +1716,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * await superdoc.scrollToElement('imported-25def254');
    */
   async scrollToElement(elementId: string): Promise<boolean> {
-    /** @type {RuntimeDocument[] | undefined} */
     const storeDocs = this.superdocStore?.documents;
     if (!storeDocs?.length) return false;
     const presentationEditor = storeDocs[0].getPresentationEditor?.();
@@ -1948,7 +1937,6 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
       });
     }
 
-    /** @type {RuntimeDocument[] | undefined} */
     const docs = this.superdocStore?.documents;
     if (Array.isArray(docs) && docs.length > 0) {
       docs.forEach((doc) => {
@@ -2028,7 +2016,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * Set the document to locked or unlocked
    */
   setLocked(lock = true) {
-    /** @type {InternalConfig} */ this.config.documents.forEach((doc: RuntimeDocument) => {
+    this.config.documents.forEach((doc: RuntimeDocument) => {
       // setLocked is a collaboration-only API; the surrounding flow only
       // calls it once each document has a Yjs doc attached. Cast away the
       // optional shape on the public Document typedef without changing
@@ -2266,7 +2254,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
       this._cleanupAwareness = null;
     }
 
-    const cfg = /** @type {InternalConfig} */ this.config;
+    const cfg = this.config;
     // `cancelWebsocketRetry` is set on `HocuspocusProviderWebsocket` only
     // while a reconnect timer is pending, and Hocuspocus clears it back to
     // `undefined` after firing. Destroy from the "already connected, no

--- a/packages/superdoc/src/core/SuperDoc.ts
+++ b/packages/superdoc/src/core/SuperDoc.ts
@@ -203,10 +203,11 @@ interface SuperDocEventMap {
  * inspects the args its own signature names. Narrower typing would force
  * every callsite below to cast.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/* eslint-disable @typescript-eslint/no-explicit-any */
 function asEventListener(listener: ((...args: any[]) => void) | undefined): (...args: any[]) => void {
   return listener as (...args: any[]) => void;
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 /**
  * SuperDoc class
@@ -1302,6 +1303,9 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
     return new Promise<void>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | undefined;
       let settled = false;
+      // Initial no-op; reassigned below to the real cleanup once the
+      // sync observer is registered.
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       let syncCleanup = () => {};
 
       const settle = () => {

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -181,6 +181,25 @@ export interface RuntimeDocument extends Document {
    * Use the Document API (`editor.doc`) instead.
    */
   getPresentationEditor?: () => SuperEditorPresentationEditor | null | undefined;
+  /**
+   * Runtime-only flag mirrored from `Config.rulers` per document by the
+   * Pinia store. SuperDoc.js writes this on each document during the
+   * setShowRulers flow; not part of consumer-supplied `Document`.
+   */
+  rulers?: boolean;
+  /**
+   * Runtime-only method attached by the comments composable on each
+   * document. Set after the comments store is ready; called during
+   * mode switches. Not part of consumer-supplied `Document`.
+   */
+  restoreComments?: () => void;
+  /**
+   * Runtime-only method attached by the comments composable on each
+   * document. Set after the comments store is ready; called during
+   * DOCX export when comments should be stripped. Not part of
+   * consumer-supplied `Document`.
+   */
+  removeComments?: () => void;
 }
 
 /** Collaboration module configuration. */

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -160,7 +160,7 @@ export interface RuntimeDocument extends Document {
    * silently replacing whatever was passed. SD-2872 removed this from
    * the public `Document` interface so consumers stop trying to use it
    * as a stable per-document override; it lives on `RuntimeDocument`
-   * only so internal SuperDoc.js callsites can type the assignment.
+   * only so internal SuperDoc callsites can type the assignment.
    */
   role?: 'editor' | 'viewer' | 'suggester';
   /**
@@ -183,7 +183,7 @@ export interface RuntimeDocument extends Document {
   getPresentationEditor?: () => SuperEditorPresentationEditor | null | undefined;
   /**
    * Runtime-only flag mirrored from `Config.rulers` per document by the
-   * Pinia store. SuperDoc.js writes this on each document during the
+   * Pinia store. SuperDoc writes this on each document during the
    * setShowRulers flow; not part of consumer-supplied `Document`.
    */
   rulers?: boolean;
@@ -1587,7 +1587,7 @@ export interface Config {
  * call sites cast `this.config` to this type so they can access these
  * invariants without per-site null guards.
  *
- * Use this from internal SuperDoc.js callsites that need the augmented shape
+ * Use this from internal SuperDoc callsites that need the augmented shape
  * (e.g. `/** @type {InternalConfig} *\/ (this.config).socket = ...`).
  */
 export interface InternalConfig extends Config {

--- a/packages/superdoc/src/public/index.ts
+++ b/packages/superdoc/src/public/index.ts
@@ -48,8 +48,8 @@ export { DOCX, PDF, HTML, getFileObject, compareVersions };
 // First-class public API. Documented, advertised, supported long-term.
 // =============================================================================
 
-// Source: ./core/SuperDoc.ts (the .js specifier resolves via
-// `customConditions: ["source"]` + the package exports map).
+// Source: ./core/SuperDoc.ts. The `.js` import specifier is intentional
+// for ESM output and resolves to the .ts source during TypeScript builds.
 export { SuperDoc } from '../core/SuperDoc.js';
 
 // Source: ./core/theme/create-theme.ts

--- a/packages/superdoc/src/public/index.ts
+++ b/packages/superdoc/src/public/index.ts
@@ -48,7 +48,8 @@ export { DOCX, PDF, HTML, getFileObject, compareVersions };
 // First-class public API. Documented, advertised, supported long-term.
 // =============================================================================
 
-// Source: ./core/SuperDoc.js
+// Source: ./core/SuperDoc.ts (the .js specifier resolves via
+// `customConditions: ["source"]` + the package exports map).
 export { SuperDoc } from '../core/SuperDoc.js';
 
 // Source: ./core/theme/create-theme.ts

--- a/tests/consumer-typecheck/src/search-match.ts
+++ b/tests/consumer-typecheck/src/search-match.ts
@@ -17,6 +17,11 @@ import type { SearchMatch, SuperDoc } from 'superdoc';
 declare const sd: SuperDoc;
 
 const results: SearchMatch[] | undefined = sd.search('hello');
+// `search` also accepts a RegExp at runtime; the type must include it.
+// Regression guard: a TS-only narrowing to `string` (e.g. during a JS→TS
+// migration of SuperDoc) would silently break this call until consumer
+// upgrade-time. SD-typecheck-superdoc-ts.
+sd.search(/hello/i);
 
 if (results && results.length > 0) {
   const first: SearchMatch = results[0];
@@ -41,6 +46,7 @@ type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ?
 type AssertEqual<A, B> = Equal<A, B> extends true ? true : never;
 
 const _searchReturnTypeIsExact: AssertEqual<ReturnType<SuperDoc['search']>, SearchMatch[] | undefined> = true;
+const _searchParamTypeIsExact: AssertEqual<Parameters<SuperDoc['search']>[0], string | RegExp> = true;
 const _goToParamTypeIsExact: AssertEqual<Parameters<SuperDoc['goToSearchResult']>[0], SearchMatch> = true;
 
-void [_searchReturnTypeIsExact, _goToParamTypeIsExact, results];
+void [_searchReturnTypeIsExact, _searchParamTypeIsExact, _goToParamTypeIsExact, results];


### PR DESCRIPTION
SuperDoc's main public class is now TypeScript. The runtime is unchanged; the migration moves load-bearing contracts to TS-native syntax so future refactors get real class-shape feedback. Six commits: the migration itself, then five cleanup commits surfaced by review (dead JSDoc removal, dead cast removal, duplicate-import consolidation, lint-warning fixes, source-comment refresh).

## What changed

- **`packages/superdoc/src/core/SuperDoc.{js,ts}`** (2,379 lines). Real `import type { ... }` for the load-bearing types (alphabetized, deduplicated). `config: InternalConfig = { ... }` annotation defeats the literal-shape narrowing TS infers from the default object (the dominant error class on rename, ~140 of the initial 241). 15 `declare` class fields for late-init runtime state (`activeEditor`, `toolbar`, `isCollaborative`, `socket`, etc.) so TS knows the shape without emitting an own-property initializer - matches the previous runtime exactly. The five internal handles (`superdocStore`, `commentsStore`, `highContrastModeStore`, `commentsList`, `app`) are `private declare` so they stay off the public TS surface (consumer-typecheck fixture asserts this). ~60 method/parameter signatures annotated using existing JSDoc as the source of truth. Explicit return types added on `state`, `getPresentationEditorForDocument`, `navigateTo`, `scrollToElement`, and `openSurface` so `deep-type-audit-supported-root` sees no new `any` leaks. `SuperDocEventMap` converted from JSDoc typedef to TS `interface` and applied as `EventEmitter<SuperDocEventMap>` so unknown event names are a compile error.

- **Cleanup commits**: removed the dead JSDoc typedef/event-map blocks now shadowed by TS interfaces/imports, dropped the `/** @type {InternalConfig} */ this.config` JSDoc-style casts (the field is already typed, the prefix was just stray text TS ignores), removed standalone `/** @type {X} */` lines preceding declarations whose TS type is now explicit or trivially inferred. **Some JSDoc tags remain where they still serve documentation purposes** (public API docstrings, `@deprecated` markers, `@example` blocks, multi-line prose); they don't duplicate type information that TS now carries.

- **`packages/superdoc/src/core/types/index.ts`**: added three runtime-only members to `RuntimeDocument` (`rulers?`, `restoreComments?`, `removeComments?`). RuntimeDocument is not re-exported by the public facade; public facade output verified byte-identical to main.

- **`packages/superdoc/src/public/index.ts`**: refreshed the `// Source: ./core/SuperDoc.js` comment to point at the `.ts` source. The `.js` import specifier is intentional for ESM output and resolves to the `.ts` source during TypeScript builds.

## What did NOT change

- No `as any` shortcuts. The one `any` adapter (`asEventListener`) preserves the pre-existing JSDoc behavior and is wrapped in a scoped `eslint-disable @typescript-eslint/no-explicit-any` block with a documenting comment explaining why the looseness is correct (EventEmitter dispatches whatever each emit site supplies).
- No new blanket suppressions. The two existing `@ts-expect-error` lines (`__APP_VERSION__` const-replace + `?url` asset import) are preserved.
- No `// @ts-check` line in the `.ts` file.
- **`packages/superdoc/dist/superdoc/src/public/index.d.ts` and `index.d.cts` are byte-identical to main.** Diff verified via `md5sum` against baseline captured from main before rename.

## Verified

- `pnpm check:types` → PASS. 0 errors. (Baseline after rename was 241; reduced to 0 via the changes above, no shortcuts.)
- `pnpm check:public:superdoc` → PASS, 9 stages, 160.3s. Including:
  - `consumer-typecheck-matrix` (validates published .d.ts across bundler/node16/nodenext × strict × skipLibCheck).
  - `deep-type-audit-supported-root` (no new `any` regressions on supported root).
  - All four destructure-shape fixture tests (`superdoc-stores-private`, `superdoc-events`, `whiteboard-data-shape`, `search-match`) pass.
- `pnpm --filter superdoc test` → 1054/1054 tests pass.
- `pnpm --filter superdoc run lint` → 0 warnings on SuperDoc.ts.
- Public-facing `.d.ts` files byte-identical to main. SuperDoc.d.ts (internal, relocated by ensure-types) changes shape (new EventMap interface block, TS-native type imports) but does not surface `any` on the supported root per the audit.

**Review focus**: the `private declare` choices on the five internal handles and the `declare` (no-initializer) choices on the 15 late-init runtime fields. Both follow the discipline of "TS shape only, no runtime change." If any of these should actually be public, flag the specific field. The `SuperDocEventMap` interface is a direct translation of the prior JSDoc typedef - payload references unchanged.
