### PR TITLE
test(typecheck): drain 2 PresentationEditor-lookup obligations (SD-673)

### DIFF
--- a/tests/consumer-typecheck/public-method-coverage-debt-snapshot.json
+++ b/tests/consumer-typecheck/public-method-coverage-debt-snapshot.json
@@ -9,8 +9,6 @@
     "export:returns",
     "exportEditorsToDOCX:parameters",
     "exportEditorsToDOCX:returns",
-    "getPresentationEditorForDocument:parameters",
-    "getPresentationEditorForDocument:returns",
     "lockSuperdoc:parameters",
     "lockSuperdoc:returns",
     "removeCommentsList:returns",

--- a/tests/consumer-typecheck/src/presentation-editor-lookup-apis.ts
+++ b/tests/consumer-typecheck/src/presentation-editor-lookup-apis.ts
@@ -1,0 +1,41 @@
+/**
+ * Consumer typecheck: PresentationEditor lookup on `SuperDoc`.
+ *
+ * Locks the `getPresentationEditorForDocument` contract (parameters
+ * and returns) against the emitted `.d.ts` with strict identity
+ * equality. A future migration that narrows or widens the signature
+ * will fail the obligation diff rather than slipping past CI.
+ *
+ * Both halves of the contract reference publicly exported types:
+ *   - parameter is `[documentId: string]`
+ *   - return is `PresentationEditor | null` (PresentationEditor is
+ *     re-exported from `@superdoc/super-editor` via the facade and is
+ *     classified as `legacy-root` - typed for backward compatibility,
+ *     not the recommended public path, but still part of the surface)
+ *
+ * Runtime behavior the typedef does not capture: the method returns
+ * null on empty/non-string ids before walking the document store.
+ * That's a runtime concern; the type signature does not (and should
+ * not) encode it.
+ *
+ * Drained obligations (2):
+ *   - getPresentationEditorForDocument:parameters
+ *   - getPresentationEditorForDocument:returns
+ */
+import type { PresentationEditor, SuperDoc } from 'superdoc';
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type AssertEqual<A, B> = Equal<A, B> extends true ? true : never;
+
+declare const sd: SuperDoc;
+
+const _paramsOk: AssertEqual<Parameters<SuperDoc['getPresentationEditorForDocument']>, [documentId: string]> = true;
+const _returnOk: AssertEqual<
+  ReturnType<SuperDoc['getPresentationEditorForDocument']>,
+  PresentationEditor | null
+> = true;
+
+const _looked: PresentationEditor | null = sd.getPresentationEditorForDocument('doc-id-1');
+void _looked;
+
+void [_paramsOk, _returnOk];


### PR DESCRIPTION
Adds a consumer-typecheck fixture asserting parameters and returns for `getPresentationEditorForDocument` against the emitted `.d.ts` with strict `AssertEqual` identity. Drops the public-method coverage debt snapshot from 21 to 19. Fixture-only - no source changes.

Both halves of the signature reference publicly-exported types: `documentId` is a string; the return is `PresentationEditor | null`. `PresentationEditor` is re-exported through the facade from `@superdoc/super-editor` and classified as `legacy-root` (typed for backward compatibility, not the recommended public path, but still part of the surface). That means `SuperDoc` (supported-root) referencing `PresentationEditor` (legacy-root) is fine under the root-classification closure gate - not a `state:returns`-style internal leak.

Stacked on #3492; retarget to `main` after that PR merges.

**Verified**: `pnpm check:types` -> PASS; `pnpm check:public:superdoc --skip-build` -> PASS (9 ran, 1 skipped, 132.0s); ratchet snapshot in sync at 19 entries.