### PR TITLE
test(typecheck): drain 5 comments-UI obligations + align addCommentsList JSDoc (SD-673)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.ts
+++ b/packages/superdoc/src/core/SuperDoc.ts
@@ -1642,7 +1642,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /**
    * Add a comments list to the superdoc
    * Requires the comments module to be enabled
-   * @param {Element} element The DOM element to render the comments list in
+   * @param {HTMLElement} element The DOM element to render the comments list in
    */
   addCommentsList(element: HTMLElement) {
     if (!this.config?.modules?.comments || this.config.role === 'viewer') return;

--- a/tests/consumer-typecheck/public-method-coverage-debt-snapshot.json
+++ b/tests/consumer-typecheck/public-method-coverage-debt-snapshot.json
@@ -1,15 +1,10 @@
 {
   "$comment": "Auto-managed by tests/consumer-typecheck/check-public-method-coverage.mjs. Each entry is \"memberName:obligation\" where obligation is one of parameters | returns | call. Refresh with --write after adding fixtures.",
   "knownUnmet": [
-    "addCommentsList:parameters",
-    "addCommentsList:returns",
     "canPerformPermission:parameters",
     "canPerformPermission:returns",
     "lockSuperdoc:parameters",
     "lockSuperdoc:returns",
-    "removeCommentsList:returns",
-    "scrollToComment:parameters",
-    "scrollToComment:returns",
     "setLocked:parameters",
     "setLocked:returns",
     "state:returns",

--- a/tests/consumer-typecheck/src/comments-ui-apis.ts
+++ b/tests/consumer-typecheck/src/comments-ui-apis.ts
@@ -1,0 +1,70 @@
+/**
+ * Consumer typecheck: comments UI helpers on `SuperDoc`.
+ *
+ * Locks the `addCommentsList`, `removeCommentsList`, and
+ * `scrollToComment` contracts against the emitted `.d.ts` with strict
+ * identity equality. A future migration that narrows or widens any
+ * of these signatures will fail the obligation diff rather than
+ * slipping past CI.
+ *
+ * One JSDoc-level cleanup landed alongside this fixture:
+ *
+ *   - `addCommentsList`'s JSDoc said `@param {Element}`, while the
+ *     TS signature is `HTMLElement` (the narrower, more accurate
+ *     type - the runtime stores the element on the comments module
+ *     config and the comments UI relies on the HTML element shape).
+ *     Updated the JSDoc to `@param {HTMLElement}` so doc and signature
+ *     agree. No runtime behavior change.
+ *
+ * Drained obligations (5):
+ *   - addCommentsList:parameters / addCommentsList:returns
+ *   - removeCommentsList:returns
+ *   - scrollToComment:parameters / scrollToComment:returns
+ */
+import type { SuperDoc } from 'superdoc';
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type AssertEqual<A, B> = Equal<A, B> extends true ? true : never;
+
+declare const sd: SuperDoc;
+declare const hostElement: HTMLElement;
+
+// ─── addCommentsList ────────────────────────────────────────────────
+// Mounts the comments side panel into the consumer-provided host
+// element. No-op when the comments module is disabled or role is
+// `viewer`.
+const _addCommentsListParamsOk: AssertEqual<Parameters<SuperDoc['addCommentsList']>, [element: HTMLElement]> = true;
+const _addCommentsListReturnOk: AssertEqual<ReturnType<SuperDoc['addCommentsList']>, void> = true;
+sd.addCommentsList(hostElement);
+
+// ─── removeCommentsList ─────────────────────────────────────────────
+// Tears down the comments side panel mounted by `addCommentsList`.
+// No-op when no list was mounted.
+const _removeCommentsListReturnOk: AssertEqual<ReturnType<SuperDoc['removeCommentsList']>, void> = true;
+
+// ─── scrollToComment ────────────────────────────────────────────────
+// Scrolls the document to the DOM node carrying the given comment id
+// and activates the comment. Returns false on missing module, empty
+// id, or no matching element; otherwise true after triggering
+// scrollIntoView. Options forward to ScrollIntoViewOptions.
+type ScrollOpts = {
+  behavior?: ScrollBehavior;
+  block?: ScrollLogicalPosition;
+};
+const _scrollToCommentParamsOk: AssertEqual<
+  Parameters<SuperDoc['scrollToComment']>,
+  [commentId: string, options?: ScrollOpts]
+> = true;
+const _scrollToCommentReturnOk: AssertEqual<ReturnType<SuperDoc['scrollToComment']>, boolean> = true;
+const _scrolled: boolean = sd.scrollToComment('comment-1', { behavior: 'smooth', block: 'center' });
+void _scrolled;
+const _scrolledNoOpts: boolean = sd.scrollToComment('comment-2');
+void _scrolledNoOpts;
+
+void [
+  _addCommentsListParamsOk,
+  _addCommentsListReturnOk,
+  _removeCommentsListReturnOk,
+  _scrollToCommentParamsOk,
+  _scrollToCommentReturnOk,
+];


### PR DESCRIPTION
Adds a consumer-typecheck fixture asserting parameters and returns for `addCommentsList`, `removeCommentsList`, and `scrollToComment` against the emitted `.d.ts` with strict `AssertEqual` identity. Drops the public-method coverage debt snapshot from 14 to 9.

One JSDoc cleanup landed alongside the fixture: `addCommentsList` had `@param {Element}` while its TS signature is the narrower `HTMLElement`. Updated the JSDoc to match the actual contract. No runtime change.

`removeCommentsList` and `scrollToComment` already had concrete signatures referencing built-in DOM types (`ScrollBehavior`, `ScrollLogicalPosition`); no source change needed beyond the JSDoc tweak above.

Stacked on #3495; retarget to `main` after that PR merges.

**Verified**: `pnpm check:types` -> PASS; `pnpm check:public:superdoc --skip-build` -> PASS (9 ran, 1 skipped, 122.0s); ratchet snapshot in sync at 9 entries.