### PR TITLE
refactor(superdoc): export CanPerformPermissionParams (SD-673)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.ts
+++ b/packages/superdoc/src/core/SuperDoc.ts
@@ -63,6 +63,7 @@ const DEFAULT_AWARENESS_PALETTE = Object.freeze([
 import type {
   AwarenessState,
   AwarenessUser,
+  CanPerformPermissionParams,
   CollaborationProvider,
   Config,
   DocumentMode,
@@ -1561,13 +1562,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
     isInternal = this.config.isInternal,
     comment = null,
     trackedChange = null,
-  }: {
-    permission?: string;
-    role?: string;
-    isInternal?: boolean;
-    comment?: (object & Record<string, unknown>) | null;
-    trackedChange?: ({ id?: string; commentId?: string; comment?: unknown } & Record<string, unknown>) | null;
-  } = {}) {
+  }: CanPerformPermissionParams = {}): boolean {
     if (!permission) return false;
 
     let resolvedComment = comment ?? trackedChange?.comment ?? null;

--- a/packages/superdoc/src/core/SuperDoc.ts
+++ b/packages/superdoc/src/core/SuperDoc.ts
@@ -1542,19 +1542,14 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    * Used by downstream consumers (toolbar, context menu, commands) to keep
    * tracked-change affordances consistent with customer overrides.
    *
-   * `comment` and `trackedChange` carry an open index signature because
-   * the function forwards the full payload to `isAllowed()`; tracked-change
-   * payloads from the editor include `type`, `attrs`, `from`, `to`,
-   * `segments`, and the comment objects passed by consumers vary in shape.
-   * The named fields below are the ones this method reads directly.
+   * The `comment` and `trackedChange` fields on the input carry open
+   * index signatures because the function forwards the full payload to
+   * `isAllowed()`; tracked-change payloads from the editor include
+   * `type`, `attrs`, `from`, `to`, `segments`, and consumer comment
+   * shapes vary. The fields read directly here are documented on the
+   * input type itself.
    *
-   * @param {{
-   *   permission?: string,
-   *   role?: string,
-   *   isInternal?: boolean,
-   *   comment?: (object & Record<string, unknown>) | null,
-   *   trackedChange?: ({ id?: string, commentId?: string, comment?: unknown } & Record<string, unknown>) | null,
-   * }} [params]
+   * @see {@link CanPerformPermissionParams} for the input shape.
    */
   canPerformPermission({
     permission,

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -997,6 +997,31 @@ type PermissionResolverParams = {
   superdoc?: SuperDoc | null;
 };
 
+/**
+ * Input shape for `SuperDoc#canPerformPermission`. All fields are
+ * optional; an empty payload short-circuits to `false`. `role` and
+ * `isInternal` fall back to `Config.role` / `Config.isInternal` when
+ * omitted. `comment` and `trackedChange` carry open index signatures
+ * because the runtime forwards the full payload to the resolver
+ * context, and consumer comment / tracked-change shapes vary; the
+ * named fields below are the ones the method itself reads. Distinct
+ * from the internal `PermissionResolverParams`, which is what the
+ * resolver callback receives (with resolved `currentUser` and
+ * `superdoc` context attached).
+ */
+export interface CanPerformPermissionParams {
+  /** The permission key to check (e.g. `'comment.create'`). Required at runtime; omitting returns `false`. */
+  permission?: string;
+  /** Override `Config.role` for this check. */
+  role?: string;
+  /** Override `Config.isInternal` for this check. */
+  isInternal?: boolean;
+  /** The comment object being acted on, if any. */
+  comment?: (object & Record<string, unknown>) | null;
+  /** The tracked-change payload (as emitted by the editor) being acted on, if any. */
+  trackedChange?: ({ id?: string; commentId?: string; comment?: unknown } & Record<string, unknown>) | null;
+}
+
 /** Modules registered with the SuperDoc instance. */
 export interface Modules {
   /**

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -1005,9 +1005,9 @@ type PermissionResolverParams = {
  * because the runtime forwards the full payload to the resolver
  * context, and consumer comment / tracked-change shapes vary; the
  * named fields below are the ones the method itself reads. Distinct
- * from the internal `PermissionResolverParams`, which is what the
- * resolver callback receives (with resolved `currentUser` and
- * `superdoc` context attached).
+ * from the non-exported `PermissionResolverParams` helper, which
+ * models the resolver callback payload with resolved `currentUser`
+ * and `superdoc` context attached.
  */
 export interface CanPerformPermissionParams {
   /** The permission key to check (e.g. `'comment.create'`). Required at runtime; omitting returns `false`. */

--- a/packages/superdoc/src/public/index.ts
+++ b/packages/superdoc/src/public/index.ts
@@ -61,6 +61,7 @@ export type { AwarenessState } from '../core/types/index.js';
 export type { AwarenessUser } from '../core/types/index.js';
 export type { BlockNavigationAddress } from '../core/types/index.js';
 export type { BookmarkAddress } from '../core/types/index.js';
+export type { CanPerformPermissionParams } from '../core/types/index.js';
 export type { CollaborationConfig } from '../core/types/index.js';
 export type { CommentAddress } from '../core/types/index.js';
 export type { CommentsType } from '../core/types/index.js';

--- a/tests/consumer-typecheck/public-method-coverage-debt-snapshot.json
+++ b/tests/consumer-typecheck/public-method-coverage-debt-snapshot.json
@@ -1,8 +1,6 @@
 {
   "$comment": "Auto-managed by tests/consumer-typecheck/check-public-method-coverage.mjs. Each entry is \"memberName:obligation\" where obligation is one of parameters | returns | call. Refresh with --write after adding fixtures.",
   "knownUnmet": [
-    "canPerformPermission:parameters",
-    "canPerformPermission:returns",
     "lockSuperdoc:parameters",
     "lockSuperdoc:returns",
     "setLocked:parameters",

--- a/tests/consumer-typecheck/snapshots/superdoc-root-classification.json
+++ b/tests/consumer-typecheck/snapshots/superdoc-root-classification.json
@@ -1,14 +1,14 @@
 {
   "generatedAt": "2026-05-19T11:33:50.546Z",
   "summary": {
-    "total": 205,
+    "total": 206,
     "byBucket": {
       "legacy-root": 60,
       "internal-candidate": 8,
-      "supported-root": 137
+      "supported-root": 138
     },
     "byConfidence": {
-      "high": 102,
+      "high": 103,
       "medium": 101,
       "low": 2
     }
@@ -141,6 +141,17 @@
       "rationale": "Editor command typing infrastructure. editor.commands.* is deprecated; Document API (editor.doc.*) is the supported programmatic surface. Keep typed for compat.",
       "confidence": "high",
       "source": "commands",
+      "inDts": true,
+      "inDcts": true,
+      "inEsm": false,
+      "inCjs": false
+    },
+    {
+      "name": "CanPerformPermissionParams",
+      "bucket": "supported-root",
+      "rationale": "Configuration type for a supported feature. Input shape for SuperDoc#canPerformPermission, promoted from an anonymous inline parameter to a named public type so consumers get IDE help and the contract is stable across migrations.",
+      "confidence": "high",
+      "source": "config-supported",
       "inDts": true,
       "inDcts": true,
       "inEsm": false,

--- a/tests/consumer-typecheck/snapshots/superdoc-root-classification.md
+++ b/tests/consumer-typecheck/snapshots/superdoc-root-classification.md
@@ -7,16 +7,16 @@ Input: tests/consumer-typecheck/snapshots/superdoc-root-exports.json (205 names,
 
 | Bucket | Count |
 |---|---|
-| supported-root | 137 |
+| supported-root | 138 |
 | legacy-root | 60 |
 | move-to-subpath | 0 |
 | internal-candidate | 8 |
 | NEEDS-REVIEW | 0 |
-| **total** | **205** |
+| **total** | **206** |
 
-Confidence: high=102, medium=101, needs-review=0.
+Confidence: high=103, medium=101, needs-review=0.
 
-## supported-root (137)
+## supported-root (138)
 
 | Name | Confidence | Source | Rationale |
 |---|---|---|---|
@@ -27,6 +27,7 @@ Confidence: high=102, medium=101, needs-review=0.
 | `BlocksListResult` | high | doc-api | Document API navigation/address/selection type. Promoted into the root facade by SD-3185. |
 | `BookmarkAddress` | high | doc-api | Document API navigation/address/selection type. Promoted into the root facade by SD-3185. |
 | `BookmarkInfo` | high | doc-api | Document API navigation/address/selection type. Promoted into the root facade by SD-3185. |
+| `CanPerformPermissionParams` | high | config-supported | Configuration type for a supported feature. Input shape for SuperDoc#canPerformPermission, promoted from an anonymous inline parameter to a named public type. |
 | `CollaborationConfig` | medium | config-supported | Configuration type for a supported feature. |
 | `CollaborationProvider` | medium | collab | Collaboration/awareness type defined in core/types/index.ts. Customer-facing for collab-provider integrations (e.g., AwarenessState types the documented onAwarenessUpdate callback). |
 | `Comment` | medium | core | Customer-facing core API type or runtime export. Type-reachable through documented config / callback / event / method surfaces; runtime exports are documented utilities. |

--- a/tests/consumer-typecheck/snapshots/superdoc-root-exports.json
+++ b/tests/consumer-typecheck/snapshots/superdoc-root-exports.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-25T11:25:51.224Z",
+  "generatedAt": "2026-05-25T23:10:03.728Z",
   "ticket": "SD-3212 PR A0",
   "package": "superdoc",
   "rootExport": {
@@ -26,6 +26,7 @@
         "BookmarkInfo",
         "BoundingRect",
         "CanObject",
+        "CanPerformPermissionParams",
         "ChainableCommandObject",
         "ChainedCommand",
         "CollaborationConfig",
@@ -237,6 +238,7 @@
         "BookmarkInfo",
         "BoundingRect",
         "CanObject",
+        "CanPerformPermissionParams",
         "ChainableCommandObject",
         "ChainedCommand",
         "CollaborationConfig",
@@ -529,11 +531,11 @@
     }
   },
   "counts": {
-    "types.import": 205,
-    "types.require": 205,
+    "types.import": 206,
+    "types.require": 206,
     "import": 41,
     "require": 41,
-    "union": 205
+    "union": 206
   },
   "divergences": {
     "typesImportVsRequire": {
@@ -555,6 +557,7 @@
         "BookmarkInfo",
         "BoundingRect",
         "CanObject",
+        "CanPerformPermissionParams",
         "ChainableCommandObject",
         "ChainedCommand",
         "CollaborationConfig",

--- a/tests/consumer-typecheck/snapshots/superdoc-root-exports.md
+++ b/tests/consumer-typecheck/snapshots/superdoc-root-exports.md
@@ -1,17 +1,17 @@
 # superdoc root export inventory (SD-3212 PR A0)
 
-Generated: 2026-05-25T11:25:51.224Z
+Generated: 2026-05-25T23:10:03.728Z
 Source: packed and installed `tests/consumer-typecheck/node_modules/superdoc`
 
 ## Counts
 
 | Source | Path | Count |
 |---|---|---|
-| types.import | `./dist/superdoc/src/public/index.d.ts` | 205 |
-| types.require | `./dist/superdoc/src/public/index.d.cts` | 205 |
+| types.import | `./dist/superdoc/src/public/index.d.ts` | 206 |
+| types.require | `./dist/superdoc/src/public/index.d.cts` | 206 |
 | import | `./dist/superdoc.es.js` | 41 |
 | require | `./dist/superdoc.cjs` | 41 |
-| **union** |  | **205** |
+| **union** |  | **206** |
 
 ## Divergences
 
@@ -19,7 +19,7 @@ Source: packed and installed `tests/consumer-typecheck/node_modules/superdoc`
 - types.require only (not in types.import): 0
 - ESM only (not in CJS): 0
 - CJS only (not in ESM): 0
-- typed but no runtime export (phantom risk): 164
+- typed but no runtime export (phantom risk): 165
 - runtime export but not typed (silent shadow on root): 0
 
 ### Type-only names (no runtime)
@@ -33,6 +33,7 @@ Source: packed and installed `tests/consumer-typecheck/node_modules/superdoc`
 - `BookmarkInfo`
 - `BoundingRect`
 - `CanObject`
+- `CanPerformPermissionParams`
 - `ChainableCommandObject`
 - `ChainedCommand`
 - `CollaborationConfig`
@@ -196,7 +197,7 @@ Source: packed and installed `tests/consumer-typecheck/node_modules/superdoc`
 | `AIWriter` | ✓ | ✓ | ✓ | ✓ | 1 |   | 0 | 0 | 4 |   |
 | `AnnotatorHelpers` | ✓ | ✓ | ✓ | ✓ | 1 |   | 0 | 0 | 1 |   |
 | `AwarenessState` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 |   |
-| `AwarenessUser` | ✓ | ✓ |   |   | 0 |   | 0 | 0 | 0 |   |
+| `AwarenessUser` | ✓ | ✓ |   |   | 1 |   | 0 | 0 | 0 |   |
 | `BinaryData` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 |   |
 | `BlankDOCX` | ✓ | ✓ | ✓ | ✓ | 0 |   | 0 | 0 | 1 |   |
 | `BlockNavigationAddress` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
@@ -205,6 +206,7 @@ Source: packed and installed `tests/consumer-typecheck/node_modules/superdoc`
 | `BookmarkInfo` | ✓ | ✓ |   |   | 2 | ✓ | 1 | 0 | 1 | ✓ |
 | `BoundingRect` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 |   |
 | `CanObject` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 | ✓ |
+| `CanPerformPermissionParams` | ✓ | ✓ |   |   | 2 |   | 0 | 0 | 0 |   |
 | `ChainableCommandObject` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 | ✓ |
 | `ChainedCommand` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 | ✓ |
 | `CollaborationConfig` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
@@ -249,7 +251,7 @@ Source: packed and installed `tests/consumer-typecheck/node_modules/superdoc`
 | `ExportDocxParams` | ✓ | ✓ |   |   | 2 | ✓ | 0 | 0 | 0 |   |
 | `ExportFormat` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
 | `ExportOptions` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 |   |
-| `ExportParams` | ✓ | ✓ |   |   | 2 | ✓ | 0 | 0 | 0 |   |
+| `ExportParams` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 |   |
 | `ExportType` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
 | `ExtensionCommandMap` | ✓ | ✓ |   |   | 2 | ✓ | 0 | 0 | 0 | ✓ |
 | `Extensions` | ✓ | ✓ | ✓ | ✓ | 2 |   | 14 | 6 | 3 | ✓ |
@@ -304,7 +306,7 @@ Source: packed and installed `tests/consumer-typecheck/node_modules/superdoc`
 | `PermissionParams` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
 | `PositionHit` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 |   |
 | `PresenceOptions` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 |   |
-| `PresentationEditor` | ✓ | ✓ | ✓ | ✓ | 2 |   | 0 | 0 | 40 | ✓ |
+| `PresentationEditor` | ✓ | ✓ | ✓ | ✓ | 3 |   | 0 | 0 | 40 | ✓ |
 | `PresentationEditorOptions` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 |   |
 | `ProofingCapabilities` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 |   |
 | `ProofingCheckRequest` | ✓ | ✓ |   |   | 3 | ✓ | 0 | 0 | 0 |   |
@@ -341,7 +343,7 @@ Source: packed and installed `tests/consumer-typecheck/node_modules/superdoc`
 | `SlashMenu` | ✓ | ✓ | ✓ | ✓ | 1 |   | 0 | 0 | 1 |   |
 | `StoryLocator` | ✓ | ✓ |   |   | 1 | ✓ | 116 | 0 | 3 |   |
 | `SuperConverter` | ✓ | ✓ | ✓ | ✓ | 1 |   | 0 | 0 | 3 | ✓ |
-| `SuperDoc` | ✓ | ✓ | ✓ | ✓ | 13 |   | 1014 | 180 | 244 | ✓ |
+| `SuperDoc` | ✓ | ✓ | ✓ | ✓ | 19 |   | 1014 | 180 | 244 | ✓ |
 | `SuperDocExceptionEditorPayload` | ✓ | ✓ |   |   | 2 |   | 0 | 0 | 0 |   |
 | `SuperDocExceptionPayload` | ✓ | ✓ |   |   | 2 |   | 0 | 0 | 0 |   |
 | `SuperDocExceptionRestorePayload` | ✓ | ✓ |   |   | 1 |   | 0 | 0 | 0 |   |
@@ -353,10 +355,10 @@ Source: packed and installed `tests/consumer-typecheck/node_modules/superdoc`
 | `SuperToolbar` | ✓ | ✓ | ✓ | ✓ | 2 |   | 0 | 0 | 4 | ✓ |
 | `SurfaceComponentProps` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
 | `SurfaceFloatingPlacement` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
-| `SurfaceHandle` | ✓ | ✓ |   |   | 1 | ✓ | 2 | 0 | 0 |   |
+| `SurfaceHandle` | ✓ | ✓ |   |   | 2 | ✓ | 2 | 0 | 0 |   |
 | `SurfaceMode` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
 | `SurfaceOutcome` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
-| `SurfaceRequest` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
+| `SurfaceRequest` | ✓ | ✓ |   |   | 2 | ✓ | 0 | 0 | 0 |   |
 | `SurfaceResolution` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
 | `SurfaceResolver` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |
 | `SurfacesModuleConfig` | ✓ | ✓ |   |   | 1 | ✓ | 0 | 0 | 0 |   |

--- a/tests/consumer-typecheck/src/all-public-types.ts
+++ b/tests/consumer-typecheck/src/all-public-types.ts
@@ -31,6 +31,7 @@ import type {
   BookmarkInfo,
   BoundingRect,
   CanObject,
+  CanPerformPermissionParams,
   ChainableCommandObject,
   ChainedCommand,
   CollaborationConfig,
@@ -204,6 +205,7 @@ const _real_BookmarkAddress: AssertNotAny<BookmarkAddress> = true;
 const _real_BookmarkInfo: AssertNotAny<BookmarkInfo> = true;
 const _real_BoundingRect: AssertNotAny<BoundingRect> = true;
 const _real_CanObject: AssertNotAny<CanObject> = true;
+const _real_CanPerformPermissionParams: AssertNotAny<CanPerformPermissionParams> = true;
 const _real_ChainableCommandObject: AssertNotAny<ChainableCommandObject> = true;
 const _real_ChainedCommand: AssertNotAny<ChainedCommand> = true;
 const _real_CollaborationConfig: AssertNotAny<CollaborationConfig> = true;

--- a/tests/consumer-typecheck/src/can-perform-permission-apis.ts
+++ b/tests/consumer-typecheck/src/can-perform-permission-apis.ts
@@ -1,0 +1,64 @@
+/**
+ * Consumer typecheck: `canPerformPermission` on `SuperDoc`.
+ *
+ * Locks the parameters and return shape against the emitted `.d.ts`
+ * with strict identity equality. A future migration that narrows or
+ * widens either side will fail the obligation diff rather than
+ * slipping past CI.
+ *
+ * The parameter was previously an anonymous inline literal:
+ *
+ *   {
+ *     permission?: string;
+ *     role?: string;
+ *     isInternal?: boolean;
+ *     comment?: (object & Record<string, unknown>) | null;
+ *     trackedChange?: ({ id?: string; commentId?: string; comment?: unknown }
+ *       & Record<string, unknown>) | null;
+ *   }
+ *
+ * This PR promotes it to a named public type, `CanPerformPermissionParams`,
+ * exported from `superdoc` and used in the method signature. Consumers
+ * now get IDE help on the call site and the contract is stable across
+ * migrations. Distinct from the non-exported `PermissionResolverParams`
+ * helper, which models the resolver callback payload with resolved
+ * `currentUser` and `superdoc` context attached.
+ *
+ * Drained obligations (2):
+ *   - canPerformPermission:parameters
+ *   - canPerformPermission:returns
+ */
+import type { CanPerformPermissionParams, SuperDoc } from 'superdoc';
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type AssertEqual<A, B> = Equal<A, B> extends true ? true : never;
+
+declare const sd: SuperDoc;
+
+// Parameters: tuple of one optional `CanPerformPermissionParams`.
+const _paramsOk: AssertEqual<
+  Parameters<SuperDoc['canPerformPermission']>,
+  [params?: CanPerformPermissionParams]
+> = true;
+
+// Return: boolean. False short-circuits cover the no-permission and
+// no-resolver/default-deny paths.
+const _returnOk: AssertEqual<ReturnType<SuperDoc['canPerformPermission']>, boolean> = true;
+
+// Construct the param object from the named type so the call site
+// proves consumer ergonomics, not just the shape.
+const params: CanPerformPermissionParams = {
+  permission: 'comment.create',
+  role: 'editor',
+  isInternal: true,
+  comment: { id: 'c-1', authorEmail: 'a@x.com' },
+  trackedChange: { id: 'tc-1', commentId: 'c-1' },
+};
+const _allowed: boolean = sd.canPerformPermission(params);
+void _allowed;
+
+// Empty-payload call: typed as the optional tuple.
+const _emptyAllowed: boolean = sd.canPerformPermission();
+void _emptyAllowed;
+
+void [_paramsOk, _returnOk];


### PR DESCRIPTION
Promotes the `canPerformPermission` parameter from a 5-key anonymous inline object to a named public type, `CanPerformPermissionParams`, exported from `superdoc`. The old emit forced consumers to read a long literal in IDE hover and `Parameters<>` extraction; the new emit is `canPerformPermission(...?: CanPerformPermissionParams): boolean`.

Distinct from the non-exported `PermissionResolverParams` helper, which models the resolver callback payload with resolved `currentUser` / `superdoc` context attached. Both shapes overlap on `permission` / `role` / `isInternal` / `comment` / `trackedChange`, but they serve different roles (consumer input vs. resolver context) and stay separate.

Also adds an explicit `: boolean` return type to the method while touching the signature, and replaces the duplicated anonymous-shape JSDoc on the method with prose + a `@see` link to `CanPerformPermissionParams` (keeping the rename from being silently undermined by the comment).

Drains 2 obligations from the public-method coverage gate (`canPerformPermission:parameters` / `:returns`); snapshot drops 9 -> 7. Adds `CanPerformPermissionParams` to the public facade, the `all-public-types` consumer fixture, and the root-classification snapshot as a supported-root entry.

Areas touched: SuperDoc method signature; core/types and public facade; consumer fixture; root-exports + root-classification snapshots; public-method debt snapshot.

**Verified**: `pnpm check:types` -> PASS; `pnpm check:public:superdoc --skip-build` -> PASS (9 ran, 1 skipped, 129.9s).