### PR TITLE
test(typecheck): cover lock/collab-upgrade + tighten return annotations (SD-673)

### DIFF
--- a/packages/superdoc/src/core/SuperDoc.ts
+++ b/packages/superdoc/src/core/SuperDoc.ts
@@ -1052,7 +1052,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
    *
    * @returns {Promise<void>} Resolves once the collaborative runtime is ready
    */
-  async upgradeToCollaboration({ ydoc, provider }: UpgradeToCollaborationOptions) {
+  async upgradeToCollaboration({ ydoc, provider }: UpgradeToCollaborationOptions): Promise<void> {
     this.#validateUpgradePrerequisites({ ydoc, provider });
     this.#isUpgrading = true;
 
@@ -2011,7 +2011,7 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   /**
    * Set the document to locked or unlocked
    */
-  setLocked(lock = true) {
+  setLocked(lock = true): void {
     this.config.documents.forEach((doc: RuntimeDocument) => {
       // setLocked is a collaboration-only API; the surrounding flow only
       // calls it once each document has a Yjs doc attached. Cast away the
@@ -2043,10 +2043,13 @@ export class SuperDoc extends EventEmitter<SuperDocEventMap> {
   }
 
   /**
-   * Lock the current superdoc
-   * @param {User} lockedBy The user who locked the superdoc
+   * Lock the current superdoc and emit the `locked` event.
+   *
+   * @param {boolean} [isLocked] Whether the superdoc is locked. Defaults to `false`.
+   * @param {User | null} [lockedBy] The user who locked the superdoc, or `null`
+   *   when unlocking (or when no user is known). Defaults to `null`.
    */
-  lockSuperdoc(isLocked: boolean = false, lockedBy: User | null = null) {
+  lockSuperdoc(isLocked: boolean = false, lockedBy: User | null = null): void {
     this.isLocked = isLocked;
     this.lockedBy = lockedBy;
     this.#log('🦋 [superdoc] Locking superdoc:', isLocked, lockedBy, '\n\n\n');

--- a/tests/consumer-typecheck/public-method-coverage-debt-snapshot.json
+++ b/tests/consumer-typecheck/public-method-coverage-debt-snapshot.json
@@ -1,12 +1,4 @@
 {
   "$comment": "Auto-managed by tests/consumer-typecheck/check-public-method-coverage.mjs. Each entry is \"memberName:obligation\" where obligation is one of parameters | returns | call. Refresh with --write after adding fixtures.",
-  "knownUnmet": [
-    "lockSuperdoc:parameters",
-    "lockSuperdoc:returns",
-    "setLocked:parameters",
-    "setLocked:returns",
-    "state:returns",
-    "upgradeToCollaboration:parameters",
-    "upgradeToCollaboration:returns"
-  ]
+  "knownUnmet": ["state:returns"]
 }

--- a/tests/consumer-typecheck/src/lock-collab-upgrade-apis.ts
+++ b/tests/consumer-typecheck/src/lock-collab-upgrade-apis.ts
@@ -1,0 +1,84 @@
+/**
+ * Consumer typecheck: locking and collaboration-upgrade public APIs
+ * on `SuperDoc`.
+ *
+ * Locks parameters and returns for `setLocked`, `lockSuperdoc`, and
+ * `upgradeToCollaboration` against the emitted `.d.ts` with strict
+ * identity equality.
+ *
+ * Three source tightenings landed alongside this fixture:
+ *
+ *   - `setLocked`, `lockSuperdoc`: added explicit `: void` return
+ *     types. The emit was already void; the explicit annotation makes
+ *     the source contract match the emit at a glance.
+ *
+ *   - `upgradeToCollaboration`: added explicit `: Promise<void>`
+ *     return type. Same reasoning - the async function already
+ *     resolved to void.
+ *
+ *   - `lockSuperdoc` JSDoc previously documented only `lockedBy` (and
+ *     called it `User`, dropping the runtime-accepted `null` half).
+ *     Rewrote to document both `isLocked` and `lockedBy: User | null`,
+ *     including the `null` default. The runtime has always emitted
+ *     `lockedBy: User | null` through the `locked` event; this PR only
+ *     aligns the doc with that reality.
+ *
+ * Removes 6 debt entries (snapshot 7 -> 1, total tracked obligations
+ * 75 -> 72). The parameter obligations are satisfied by `Parameters<>`
+ * assertions below; the three `:returns` obligations drop out of the
+ * gate's tracking because the source now declares `void` / `Promise<void>`
+ * explicitly (gate's `returnsMeaningful` check treats explicit
+ * void-likes as non-obligation). The fixture still asserts
+ * `ReturnType<>` for each so the return shape stays locked the same
+ * way the parameters are.
+ */
+import type { SuperDoc, UpgradeToCollaborationOptions, User } from 'superdoc';
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type AssertEqual<A, B> = Equal<A, B> extends true ? true : never;
+
+declare const sd: SuperDoc;
+declare const upgradeOpts: UpgradeToCollaborationOptions;
+declare const realUser: User;
+
+// ─── setLocked ──────────────────────────────────────────────────────
+// Writes `locked` and `lockedBy` into each document's Yjs meta map.
+// Default parameter `lock = true` means the emit is `(lock?: boolean)`.
+const _setLockedParamsOk: AssertEqual<Parameters<SuperDoc['setLocked']>, [lock?: boolean]> = true;
+const _setLockedReturnOk: AssertEqual<ReturnType<SuperDoc['setLocked']>, void> = true;
+sd.setLocked(true);
+sd.setLocked();
+
+// ─── lockSuperdoc ───────────────────────────────────────────────────
+// Sets `isLocked` / `lockedBy` on the instance and emits `locked`.
+// `lockedBy` is `User | null` to match the runtime: unlocking (or
+// locking without a known user) passes null.
+const _lockSuperdocParamsOk: AssertEqual<
+  Parameters<SuperDoc['lockSuperdoc']>,
+  [isLocked?: boolean, lockedBy?: User | null]
+> = true;
+const _lockSuperdocReturnOk: AssertEqual<ReturnType<SuperDoc['lockSuperdoc']>, void> = true;
+sd.lockSuperdoc(true, realUser);
+sd.lockSuperdoc(false, null);
+sd.lockSuperdoc();
+
+// ─── upgradeToCollaboration ─────────────────────────────────────────
+// Destructive promotion: overwrites the target collab room with the
+// caller's local state. Limited to single-DOCX + external
+// `{ ydoc, provider }` collaboration (see source for full constraints).
+const _upgradeParamsOk: AssertEqual<
+  Parameters<SuperDoc['upgradeToCollaboration']>,
+  [options: UpgradeToCollaborationOptions]
+> = true;
+const _upgradeReturnOk: AssertEqual<ReturnType<SuperDoc['upgradeToCollaboration']>, Promise<void>> = true;
+const _upgraded: Promise<void> = sd.upgradeToCollaboration(upgradeOpts);
+void _upgraded;
+
+void [
+  _setLockedParamsOk,
+  _setLockedReturnOk,
+  _lockSuperdocParamsOk,
+  _lockSuperdocReturnOk,
+  _upgradeParamsOk,
+  _upgradeReturnOk,
+];


### PR DESCRIPTION
Adds a consumer-typecheck fixture asserting parameters and returns for `setLocked`, `lockSuperdoc`, and `upgradeToCollaboration` against the emitted `.d.ts` with strict `AssertEqual` identity.

Removes 6 debt entries from the public-method coverage snapshot (7 -> 1; only `state:returns` remains). Total gate-tracked obligations drop 75 -> 72: the 3 parameter obligations are satisfied by the fixture, and the 3 `:returns` obligations drop out of the gate's tracking because the source now declares `void` / `Promise<void>` explicitly (the gate's `returnsMeaningful` check treats explicit void-likes as non-obligation). The fixture still asserts `ReturnType<>` for each so the return shape stays locked the same way the parameters are.

Three source cleanups landed alongside the fixture:
- `setLocked`, `lockSuperdoc`: explicit `: void` return annotations.
- `upgradeToCollaboration`: explicit `: Promise<void>` return.
- `lockSuperdoc` JSDoc previously documented only `lockedBy` and called it `User`, dropping the runtime-accepted `null` half. Rewrote to document both `isLocked` and `lockedBy: User | null` with the `null` default. The runtime has always emitted `lockedBy: User | null` through the `locked` event; this only aligns the doc with that reality.

Stacked on #3497; retarget to `main` after that PR merges.

**Verified**: `pnpm check:types` -> PASS; `pnpm check:public:superdoc --skip-build` -> PASS (9 ran, 1 skipped, 127.7s).