### PR TITLE
feat(examples): footnote tool agent

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -119,6 +119,7 @@ Document editing through models and agents.
 | [bedrock](./ai/bedrock) | AWS Bedrock Converse API with tool use |
 | [streaming](./ai/streaming) | Stream model output into a visible editor |
 | [redlining](./ai/redlining) | LLM-driven tracked-change review (browser) |
+| [footnote-tool-agent](./ai/footnote-tool-agent) | Real LLM tool-use loop: model picks `addFootnoteCitation`, browser executes against `editor.doc` |
 
 ## Advanced
 

--- a/examples/ai/footnote-tool-agent/.env.example
+++ b/examples/ai/footnote-tool-agent/.env.example
@@ -1,0 +1,5 @@
+OPENAI_API_KEY=sk-...
+# Optional. Defaults to gpt-4o-mini.
+# OPENAI_MODEL=gpt-4o-mini
+# Optional. Defaults to 8093.
+# PORT=8093

--- a/examples/ai/footnote-tool-agent/.gitignore
+++ b/examples/ai/footnote-tool-agent/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/examples/ai/footnote-tool-agent/README.md
+++ b/examples/ai/footnote-tool-agent/README.md
@@ -1,0 +1,61 @@
+# SuperDoc - Footnote tool agent
+
+Real LLM tool-calling against a live SuperDoc document. The user types a natural-language request; the model picks a tool; the browser executes it against the Document API; the document updates. The `OPENAI_API_KEY` never leaves the server.
+
+## Files, in the order you'd read them
+
+1. **`src/tool.ts`** — the Document API wrapper. One function: `addFootnoteCitation(api, { sourceText })`. Wraps `selection.current` + `footnotes.insert` + `footnotes.list` and returns a typed receipt.
+2. **`src/agent.ts`** — the tool-use loop. `runAgentTurn` posts the user message, dispatches any `tool_calls` the model returns to local handlers, sends results back, and emits events to the UI. SDK-agnostic — speaks the Chat Completions message shape but doesn't import any provider SDK.
+3. **`src/App.tsx`** — the UI. Mounts SuperDoc, captures the user prompt, binds `addFootnoteCitation` to the live `editor.doc` as a handler, calls `runAgentTurn`, renders chat rows.
+4. **`server.mjs`** — the proxy. Declares the tool schema (`strict: true`, `parallel_tool_calls: false`), forwards turn requests to `openai.chat.completions.create`, returns the assistant message untouched.
+
+## Architecture
+
+```
+Browser ──POST /api/turn──▶ Node proxy ──▶ OpenAI
+   ▲                            │
+   │       message or         ◀┘
+   │       tool_calls
+   ▼
+editor.doc.* (tool execution lives here)
+   │
+   └── POST /api/turn with the tool result, loop until the model returns text
+```
+
+| Surface  | Owns                                   |
+| -------- | -------------------------------------- |
+| Server   | API key, model client, tool **schema** |
+| Browser  | Editor, Document API, tool **impl**    |
+
+The browser owns tool execution because `editor.doc` lives there. The server has no editor. So the server runs the model conversation; the browser runs the document.
+
+## Adding more tools
+
+1. Add a handler in `src/App.tsx`'s `handlers` map.
+2. Mirror the JSON schema in `server.mjs`'s `TOOLS` array.
+
+That's it. The loop and dispatch in `src/agent.ts` are tool-agnostic.
+
+## Run
+
+```bash
+cp .env.example .env       # then add your OPENAI_API_KEY
+pnpm install
+pnpm dev                   # Node proxy + Vite, run together
+```
+
+Open http://localhost:5181. Click into the paragraph, then send a message like:
+
+> Add a footnote citing Doe's 2024 cloud reliability paper.
+
+The chat shows: user → `used addFootnoteCitation · ok` → one-line assistant confirmation. The doc shows the superscript marker.
+
+## Notes
+
+- Non-streaming: each `/api/turn` call is request/response. For a streaming-token UX layered on top of tool calls, swap to the Responses API or SSE per-event delivery.
+- Each `send` starts a fresh tool loop — prior turns are not preserved. For multi-turn conversations, lift `messages` into app state and append rather than replace.
+- For production, add auth, rate limiting, a stricter iteration cap, and reject tool calls that aren't in the registry.
+
+## See also
+
+- [examples/ai/streaming](../streaming) — SSE token streaming into a document (no tool use).

--- a/examples/ai/footnote-tool-agent/index.html
+++ b/examples/ai/footnote-tool-agent/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SuperDoc - Footnote tool agent</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body { font-family: 'Inter', system-ui, -apple-system, sans-serif; font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/ai/footnote-tool-agent/package.json
+++ b/examples/ai/footnote-tool-agent/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@superdoc-examples/ai-footnote-tool-agent",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "predev": "pnpm --filter superdoc build",
+    "dev": "concurrently -k -n API,WEB -c blue,green \"node server.mjs\" \"vite --host 127.0.0.1 --port 5181 --strictPort\"",
+    "dev:server": "node server.mjs",
+    "dev:web": "vite",
+    "build": "tsc --noEmit && vite build"
+  },
+  "dependencies": {
+    "dotenv": "^17.4.2",
+    "openai": "^6.33.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "superdoc": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "concurrently": "^9.2.1",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/examples/ai/footnote-tool-agent/server.mjs
+++ b/examples/ai/footnote-tool-agent/server.mjs
@@ -1,0 +1,120 @@
+import 'dotenv/config';
+import http from 'node:http';
+import OpenAI from 'openai';
+
+const PORT = Number(process.env.PORT || 8093);
+const MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+
+// Tool schema the model is allowed to call. Mirror any change here in the
+// browser's `handlers` map in src/App.tsx so the model's request can
+// actually be executed.
+const TOOLS = [
+  {
+    type: 'function',
+    function: {
+      name: 'addFootnoteCitation',
+      description:
+        'Insert a footnote at the current cursor position in the document. The footnote body is the provided source text. Word renders the superscript number.',
+      strict: true,
+      parameters: {
+        type: 'object',
+        properties: {
+          sourceText: {
+            type: 'string',
+            description: 'The full source citation text, e.g. "Doe, Cloud Reliability Patterns, 2024".',
+          },
+        },
+        required: ['sourceText'],
+        additionalProperties: false,
+      },
+    },
+  },
+];
+
+// Lazy so the server can still boot and serve a friendly 500 from
+// `handleTurn` when OPENAI_API_KEY is missing. Constructing at module
+// scope would throw before the friendly path runs.
+let _openai;
+function getOpenAI() {
+  return _openai ?? (_openai = new OpenAI());
+}
+
+const server = http.createServer(async (req, res) => {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.writeHead(204).end();
+
+  const url = new URL(req.url || '/', `http://${req.headers.host}`);
+  if (req.method === 'GET' && url.pathname === '/api/health') return sendJson(res, 200, { ok: true, model: MODEL });
+  if (req.method === 'POST' && url.pathname === '/api/turn') return handleTurn(req, res);
+  sendJson(res, 404, { error: 'Not found' });
+});
+
+server.listen(PORT, () => console.log(`[api] footnote tool agent on http://localhost:${PORT}`));
+
+async function handleTurn(req, res) {
+  if (!process.env.OPENAI_API_KEY) {
+    return sendJson(res, 500, { error: 'OPENAI_API_KEY is not set. Copy .env.example to .env first.' });
+  }
+
+  let body;
+  try { body = await readJson(req); }
+  catch (err) { return sendJson(res, 400, { error: err.message }); }
+
+  const messages = Array.isArray(body.messages) ? body.messages : null;
+  const system = typeof body.system === 'string' ? body.system : '';
+  if (!messages) return sendJson(res, 400, { error: 'messages array is required' });
+
+  // Abort upstream if the client disconnects mid-call so we don't burn tokens.
+  const upstream = new AbortController();
+  res.on('close', () => upstream.abort());
+
+  try {
+    const completion = await getOpenAI().chat.completions.create(
+      {
+        model: MODEL,
+        messages: system ? [{ role: 'system', content: system }, ...messages] : messages,
+        tools: TOOLS,
+        tool_choice: 'auto',
+        // One tool call per assistant turn keeps the demo lesson clean.
+        parallel_tool_calls: false,
+      },
+      { signal: upstream.signal },
+    );
+
+    const choice = completion.choices[0];
+    sendJson(res, 200, {
+      type: 'message',
+      message: {
+        content: choice?.message?.content ?? null,
+        tool_calls: choice?.message?.tool_calls,
+      },
+    });
+  } catch (err) {
+    if (upstream.signal.aborted) return;
+    sendJson(res, 502, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+async function readJson(req) {
+  const MAX = 256 * 1024;
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > MAX) throw new Error('Request body too large');
+    chunks.push(chunk);
+  }
+  if (!chunks.length) return {};
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+function sendJson(res, status, payload) {
+  res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(payload));
+}

--- a/examples/ai/footnote-tool-agent/src/App.tsx
+++ b/examples/ai/footnote-tool-agent/src/App.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useRef, useState } from 'react';
+import { SuperDoc } from 'superdoc';
+import type { DocumentApi } from 'superdoc';
+import { addFootnoteCitation } from './tool';
+import { runAgentTurn, type AssistantReply, type ChatMessage, type ToolHandler } from './agent';
+
+const SYSTEM_PROMPT = `You are a writing assistant for a document the user is editing.
+You have one tool, addFootnoteCitation, that inserts a footnote at the user's cursor.
+When the user asks to cite a source or add a footnote, extract the source text from the request and call the tool.
+Use only source details present in the user request. Do not invent authors, titles, publishers, or years. If the request is underspecified, pass the user's wording verbatim as sourceText.
+If the tool returns ok: false, briefly tell the user the reason. If ok: true, confirm in one short sentence.
+Do not narrate what you're about to do. Just call the tool, then summarize the result.`;
+
+const SEED =
+  '# Reliability brief\n\n' +
+  'Cloud-native teams converged on a small set of reliability patterns over the past decade. ' +
+  'Click into this paragraph to position the cursor, then ask the assistant to add a footnote citation.';
+
+const EMPTY_DOC = { type: 'doc', content: [{ type: 'paragraph' }] };
+
+type ChatRow =
+  | { kind: 'user'; text: string }
+  | { kind: 'assistant'; text: string }
+  | { kind: 'tool'; name: string; ok: boolean; reason?: string };
+
+export default function App() {
+  const [prompt, setPrompt] = useState('Add a footnote citing Doe, "Cloud Reliability Patterns," 2024.');
+  const [running, setRunning] = useState(false);
+  const [editorReady, setEditorReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [chat, setChat] = useState<ChatRow[]>([]);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const superdocRef = useRef<SuperDoc | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const sd = new SuperDoc({
+      selector: containerRef.current,
+      documentMode: 'editing',
+      jsonOverride: EMPTY_DOC,
+      modules: { comments: false },
+      telemetry: { enabled: false },
+      onReady: ({ superdoc }) => {
+        const api = (superdoc as SuperDoc).activeEditor?.doc;
+        if (!api) return;
+        const cleared = api.clearContent({});
+        if (!cleared.success && cleared.failure?.code !== 'NO_OP') return;
+        api.insert({ value: SEED, type: 'markdown' });
+        setEditorReady(true);
+      },
+    });
+    superdocRef.current = sd;
+    return () => {
+      abortRef.current?.abort();
+      sd.destroy();
+      superdocRef.current = null;
+    };
+  }, []);
+
+  const send = async () => {
+    const api = superdocRef.current?.activeEditor?.doc;
+    if (!api || running || !prompt.trim()) return;
+
+    const userText = prompt.trim();
+    setPrompt('');
+    setError(null);
+    setChat((c) => [...c, { kind: 'user', text: userText }]);
+    setRunning(true);
+    abortRef.current = new AbortController();
+
+    // Bind editor.doc once so handlers are plain (args) → result functions.
+    // Add more tools by appending entries to this object and mirroring
+    // their JSON schema in server.mjs TOOLS.
+    const handlers: Record<string, ToolHandler> = {
+      addFootnoteCitation: (args) => addFootnoteCitation(api, args as { sourceText: string }),
+    };
+
+    try {
+      await runAgentTurn({
+        userText,
+        handlers,
+        postTurn: (messages, signal) => postTurn(messages, SYSTEM_PROMPT, signal),
+        onEvent: (event) => {
+          setChat((c) =>
+            event.kind === 'assistant'
+              ? [...c, { kind: 'assistant', text: event.text }]
+              : [...c, { kind: 'tool', name: event.name, ok: event.result.ok, reason: event.result.ok ? undefined : event.result.reason }],
+          );
+        },
+        signal: abortRef.current.signal,
+      });
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') return;
+      setError((err as Error).message || String(err));
+    } finally {
+      setRunning(false);
+      abortRef.current = null;
+    }
+  };
+
+  const stop = () => abortRef.current?.abort();
+
+  return (
+    <div style={S.app}>
+      <aside style={S.sidebar}>
+        <header style={S.header}>
+          <div style={S.label}>Available tool</div>
+          <div style={S.chip}>
+            <span style={S.dot} />
+            <span>addFootnoteCitation</span>
+          </div>
+        </header>
+
+        <div style={S.chat}>
+          {chat.length === 0 && (
+            <div style={S.hint}>
+              Place the cursor in the document, then ask in plain language.<br />
+              <em>Add a footnote citing Doe's 2024 cloud reliability paper.</em>
+            </div>
+          )}
+          {chat.map((row, idx) => (
+            <ChatBubble key={idx} row={row} />
+          ))}
+          {error && <div style={S.error}>{error}</div>}
+        </div>
+
+        <div style={S.composer}>
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            disabled={running || !editorReady}
+            rows={2}
+            placeholder="Ask the assistant…"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                void send();
+              }
+            }}
+            style={S.textarea}
+          />
+          {running ? (
+            <button onClick={stop} style={btn('#ef4444')}>Stop</button>
+          ) : (
+            <button onClick={() => void send()} disabled={!editorReady || !prompt.trim()} style={btn('#1355ff', !editorReady || !prompt.trim())}>
+              Send
+            </button>
+          )}
+        </div>
+      </aside>
+
+      <div ref={containerRef} style={S.editorArea} />
+    </div>
+  );
+}
+
+function ChatBubble({ row }: { row: ChatRow }) {
+  if (row.kind === 'user') return <div style={{ ...S.bubble, ...S.user }}>{row.text}</div>;
+  if (row.kind === 'assistant') return <div style={{ ...S.bubble, ...S.assistant }}>{row.text}</div>;
+  return (
+    <div style={S.tool}>
+      <span>used {row.name}</span>
+      {row.ok ? <span style={S.ok}> · ok</span> : <span style={S.fail}> · {row.reason}</span>}
+    </div>
+  );
+}
+
+async function postTurn(messages: ChatMessage[], system: string, signal: AbortSignal): Promise<AssistantReply> {
+  const res = await fetch('/api/turn', {
+    method: 'POST',
+    signal,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messages, system }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => `HTTP ${res.status}`);
+    throw new Error(text);
+  }
+  const data = (await res.json()) as { type: 'message'; message: AssistantReply } | { type: 'error'; error: string };
+  if (data.type === 'error') throw new Error(data.error);
+  return data.message;
+}
+
+function btn(color: string, disabled = false): React.CSSProperties {
+  return {
+    padding: '0 14px',
+    height: 36,
+    background: disabled ? '#dbdbdb' : color,
+    color: '#fff',
+    border: 'none',
+    borderRadius: 4,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    fontSize: 13,
+    fontFamily: 'inherit',
+    fontWeight: 500,
+  };
+}
+
+const S = {
+  app: { display: 'grid', gridTemplateColumns: '380px 1fr', height: '100vh' } as const,
+  sidebar: { display: 'flex', flexDirection: 'column', borderRight: '1px solid #dbdbdb', background: '#fff' } as const,
+  header: { padding: '14px 16px', borderBottom: '1px solid #dbdbdb' } as const,
+  label: { fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#666', marginBottom: 8 } as const,
+  chip: { display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 10px', border: '1px solid #1355ff', borderRadius: 999, fontSize: 13, color: '#1355ff', background: 'rgba(19, 85, 255, 0.06)' } as const,
+  dot: { width: 6, height: 6, borderRadius: '50%', background: '#1355ff' } as const,
+  chat: { flex: 1, overflowY: 'auto', padding: 14, display: 'flex', flexDirection: 'column', gap: 8 } as const,
+  hint: { fontSize: 12, color: '#666', lineHeight: 1.5 } as const,
+  error: { padding: '8px 10px', background: '#fee2e2', color: '#991b1b', fontSize: 12, borderRadius: 4 } as const,
+  composer: { padding: 14, borderTop: '1px solid #dbdbdb', display: 'grid', gridTemplateColumns: '1fr auto', gap: 8 } as const,
+  textarea: { padding: '8px 10px', border: '1px solid #dbdbdb', borderRadius: 4, fontSize: 13, lineHeight: 1.4, resize: 'vertical', fontFamily: 'inherit' } as const,
+  bubble: { maxWidth: '90%', padding: '8px 10px', borderRadius: 6, fontSize: 13, lineHeight: 1.4, whiteSpace: 'pre-wrap' } as const,
+  user: { alignSelf: 'flex-end', maxWidth: '85%', background: '#1355ff', color: '#fff' } as const,
+  assistant: { alignSelf: 'flex-start', background: '#f5f5fa' } as const,
+  tool: { alignSelf: 'flex-start', maxWidth: '90%', padding: '6px 10px', border: '1px dashed #dbdbdb', borderRadius: 6, fontSize: 11, color: '#666', fontFamily: '"JetBrains Mono", ui-monospace, monospace' } as const,
+  ok: { color: '#00853d' } as const,
+  fail: { color: '#c0392b' } as const,
+  editorArea: { overflow: 'auto', padding: 12 } as const,
+} satisfies Record<string, React.CSSProperties>;

--- a/examples/ai/footnote-tool-agent/src/App.tsx
+++ b/examples/ai/footnote-tool-agent/src/App.tsx
@@ -60,15 +60,22 @@ export default function App() {
   }, []);
 
   const send = async () => {
-    const api = superdocRef.current?.activeEditor?.doc;
-    if (!api || running || !prompt.trim()) return;
-
+    // `abortRef.current` is the synchronous in-flight guard. `running` is
+    // React state and is batched, so a fast double-trigger (double-click,
+    // Cmd+Enter twice within one frame) can pass a state-based guard before
+    // setRunning(true) takes effect and start two loops that overwrite each
+    // other's abort controller. The ref check holds because refs update
+    // immediately, not on the next render.
     const userText = prompt.trim();
+    const api = superdocRef.current?.activeEditor?.doc;
+    if (!api || abortRef.current || !userText) return;
+
+    const controller = new AbortController();
+    abortRef.current = controller;
     setPrompt('');
     setError(null);
     setChat((c) => [...c, { kind: 'user', text: userText }]);
     setRunning(true);
-    abortRef.current = new AbortController();
 
     // Bind editor.doc once so handlers are plain (args) → result functions.
     // Add more tools by appending entries to this object and mirroring
@@ -89,14 +96,18 @@ export default function App() {
               : [...c, { kind: 'tool', name: event.name, ok: event.result.ok, reason: event.result.ok ? undefined : event.result.reason }],
           );
         },
-        signal: abortRef.current.signal,
+        signal: controller.signal,
       });
     } catch (err) {
       if ((err as Error).name === 'AbortError') return;
       setError((err as Error).message || String(err));
     } finally {
+      // Clear only if it's still our controller — guards against accidental
+      // clearing if a future edit allows overlapping turns.
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
       setRunning(false);
-      abortRef.current = null;
     }
   };
 

--- a/examples/ai/footnote-tool-agent/src/agent.ts
+++ b/examples/ai/footnote-tool-agent/src/agent.ts
@@ -1,0 +1,87 @@
+/**
+ * The tool-use loop. SDK-agnostic: this file doesn't import the OpenAI
+ * SDK. It speaks the Chat Completions message shape that the server
+ * proxy already emits, and routes any `tool_calls` the model returns to
+ * local handlers. Bring your own transport via `postTurn`.
+ *
+ * One pass of `runAgentTurn`:
+ *   1. POST the user message → model returns either text or tool_calls.
+ *   2. Execute each tool call locally, push the result as a `role: 'tool'`
+ *      message, POST again.
+ *   3. Repeat until the model returns plain text, capped at maxIterations.
+ *
+ * The caller supplies `postTurn` so the demo's `/api/turn` contract stays
+ * out of this file. Bring your own transport.
+ */
+
+export type ChatMessage =
+  | { role: 'user'; content: string }
+  | { role: 'assistant'; content: string | null; tool_calls?: ToolCall[] }
+  | { role: 'tool'; tool_call_id: string; content: string };
+
+export type ToolCall = {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+};
+
+export type ToolResult = { ok: true; [key: string]: unknown } | { ok: false; reason: string };
+
+export type ToolHandler = (args: Record<string, unknown>) => ToolResult;
+
+export type AssistantReply = { content: string | null; tool_calls?: ToolCall[] };
+
+export type AgentEvent =
+  | { kind: 'tool'; name: string; result: ToolResult }
+  | { kind: 'assistant'; text: string };
+
+export type RunAgentTurnArgs = {
+  userText: string;
+  handlers: Record<string, ToolHandler>;
+  postTurn: (messages: ChatMessage[], signal: AbortSignal) => Promise<AssistantReply>;
+  onEvent: (event: AgentEvent) => void;
+  signal: AbortSignal;
+  maxIterations?: number;
+};
+
+export async function runAgentTurn(args: RunAgentTurnArgs): Promise<void> {
+  const { userText, handlers, postTurn, onEvent, signal, maxIterations = 6 } = args;
+  const messages: ChatMessage[] = [{ role: 'user', content: userText }];
+
+  for (let i = 0; i < maxIterations; i++) {
+    const reply = await postTurn(messages, signal);
+    messages.push({ role: 'assistant', content: reply.content, tool_calls: reply.tool_calls });
+
+    const toolCalls = reply.tool_calls ?? [];
+    if (toolCalls.length === 0) {
+      if (reply.content) onEvent({ kind: 'assistant', text: reply.content });
+      return;
+    }
+
+    for (const call of toolCalls) {
+      const result = dispatch(handlers, call);
+      onEvent({ kind: 'tool', name: call.function.name, result });
+      messages.push({ role: 'tool', tool_call_id: call.id, content: JSON.stringify(result) });
+    }
+  }
+
+  throw new Error(`Tool loop exceeded ${maxIterations} iterations.`);
+}
+
+function dispatch(handlers: Record<string, ToolHandler>, call: ToolCall): ToolResult {
+  const handler = handlers[call.function.name];
+  if (!handler) return { ok: false, reason: `unknown tool: ${call.function.name}` };
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(call.function.arguments);
+  } catch (err) {
+    return { ok: false, reason: `invalid arguments: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  try {
+    return handler(parsed);
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/examples/ai/footnote-tool-agent/src/main.tsx
+++ b/examples/ai/footnote-tool-agent/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import 'superdoc/style.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/ai/footnote-tool-agent/src/tool.ts
+++ b/examples/ai/footnote-tool-agent/src/tool.ts
@@ -1,0 +1,55 @@
+/**
+ * Custom Document API tool. The model sees a JSON schema for this; the
+ * browser is what actually executes it because `editor.doc` lives here.
+ *
+ * Wraps three `editor.doc.*` calls:
+ *   1. selection.current   - capture where the cursor is
+ *   2. footnotes.insert    - drop the footnote reference + body
+ *   3. footnotes.list      - look up the rendered number, return a receipt
+ *
+ * Adapter exceptions are caught and translated into `{ ok: false, reason }`
+ * so the tool result we send back to the model is always structured.
+ */
+
+import type { DocumentApi } from 'superdoc';
+
+export type FootnoteCitationApi = Pick<DocumentApi, 'selection' | 'footnotes'>;
+
+export type FootnoteCitationReceipt =
+  | { ok: true; noteId: string; displayNumber: string; totalFootnotes: number }
+  | { ok: false; reason: string };
+
+export function addFootnoteCitation(
+  api: FootnoteCitationApi,
+  input: { sourceText: string },
+): FootnoteCitationReceipt {
+  const sourceText = input.sourceText.trim();
+  if (!sourceText) return { ok: false, reason: 'sourceText is empty' };
+
+  try {
+    const selection = api.selection.current({ includeText: true });
+    if (!selection.target) {
+      return { ok: false, reason: 'place the cursor in the document first' };
+    }
+
+    const insertResult = api.footnotes.insert({
+      at: selection.target,
+      type: 'footnote',
+      content: sourceText,
+    });
+    if (!insertResult.success) {
+      return { ok: false, reason: insertResult.failure.message };
+    }
+
+    const list = api.footnotes.list({ type: 'footnote' });
+    const inserted = list.items.find((item) => item.noteId === insertResult.footnote.noteId);
+    return {
+      ok: true,
+      noteId: insertResult.footnote.noteId,
+      displayNumber: inserted?.displayNumber ?? '?',
+      totalFootnotes: list.total,
+    };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/examples/ai/footnote-tool-agent/tsconfig.json
+++ b/examples/ai/footnote-tool-agent/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/examples/ai/footnote-tool-agent/vite.config.ts
+++ b/examples/ai/footnote-tool-agent/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '127.0.0.1',
+    port: 5181,
+    strictPort: true,
+    proxy: {
+      '/api': 'http://127.0.0.1:8093',
+    },
+  },
+});

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -405,6 +405,21 @@
     "ci": false
   },
   {
+    "id": "ai-footnote-tool-agent",
+    "section": "ai",
+    "subsection": "agents",
+    "kind": "minimal-example",
+    "status": "active",
+    "sourceKind": "local",
+    "title": "Footnote tool agent",
+    "category": "AI",
+    "surface": "Agents",
+    "sourceRepo": "superdoc-dev/superdoc",
+    "sourcePath": "examples/ai/footnote-tool-agent",
+    "docs": "https://docs.superdoc.dev/ai/agents/integrations",
+    "ci": false
+  },
+  {
     "id": "ai-redlining",
     "section": "ai",
     "subsection": "agents",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1642,6 +1642,43 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
+  examples/ai/footnote-tool-agent:
+    dependencies:
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      openai:
+        specifier: ^6.33.0
+        version: 6.35.0(ws@8.20.0)(zod@4.3.6)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      superdoc:
+        specifier: workspace:*
+        version: link:../../../packages/superdoc
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(rolldown-vite@7.3.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: npm:rolldown-vite@7.3.1
+        version: rolldown-vite@7.3.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   examples/ai/redlining:
     dependencies:
       react:
@@ -46734,7 +46771,7 @@ snapshots:
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@6.0.1)
+      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
     optionalDependencies:
       esbuild: 0.27.7
 


### PR DESCRIPTION
A minimal example showing how to wire a real LLM into a SuperDoc document via tool calling. The user types a natural-language request, an OpenAI model picks the `addFootnoteCitation` tool, the browser executes it against `editor.doc`, and the document updates. The OpenAI key stays on the server.

The split is: server owns the model conversation, schema, and key. Browser owns the editor, the Document API, and the tool implementation. Adding another tool is two edits, a handler entry in `src/App.tsx` and a schema entry in `server.mjs`.

Mirrors the sibling shape from `examples/ai/streaming` (React + Vite + Node http, `.env` / `.env.example`, `concurrently` in the dev script).

- Browser-side tool dispatch lives in `src/agent.ts`. SDK-agnostic loop, capped at six iterations.
- `src/tool.ts` wraps `selection.current` + `footnotes.insert` + `footnotes.list` into one `addFootnoteCitation(api, { sourceText })` with a typed receipt; adapter exceptions become `{ ok: false, reason }`.
- Server uses `strict: true` and `parallel_tool_calls: false` to keep the lesson clean. OpenAI client is lazy so the server boots without `OPENAI_API_KEY` and serves a friendly 500 on first request instead of crashing.
- Verified end-to-end against `gpt-4o-mini` with a gitignored `.env` (deleted after). `pnpm exec tsc --noEmit && vite build` clean. Missing-key boot path verified: `/api/health` 200, `/api/turn` returns the env-not-set error.