### PR TITLE
fix(painters/dom, super-editor): set explicit document text color floor (SD-3456)

### DIFF
--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { ensureSdtContainerStyles, ensureTrackChangeStyles, lineStyles } from './styles.js';
+import {
+  DEFAULT_PAGE_STYLES,
+  ensureSdtContainerStyles,
+  ensureTrackChangeStyles,
+  lineStyles,
+  pageStyles,
+} from './styles.js';
 
 describe('lineStyles', () => {
   it('sets height and lineHeight from the argument', () => {
@@ -11,6 +17,27 @@ describe('lineStyles', () => {
   it('sets fontSize to 0 to eliminate the CSS strut', () => {
     const styles = lineStyles(20);
     expect(styles.fontSize).toBe('0');
+  });
+});
+
+describe('pageStyles', () => {
+  // SD-3456 / IT-1102: auto-numbered list markers (and any other text that
+  // inherits its color rather than carrying an explicit `<w:color>`) render
+  // invisible on dark-themed OSes because the browser default `canvastext`
+  // system color resolves to white on the white page. The page element must
+  // therefore set an explicit text color floor.
+  it('sets an explicit color on the page so document text does not inherit the OS canvastext system color', () => {
+    const styles = pageStyles(816, 1056);
+    expect(styles.color).toBe('var(--sd-layout-page-text, #000)');
+  });
+
+  it('lets consumers override the page color via the pageStyles option', () => {
+    const styles = pageStyles(816, 1056, { color: '#222' });
+    expect(styles.color).toBe('#222');
+  });
+
+  it('exposes the color default through DEFAULT_PAGE_STYLES so consumers and themes can read it', () => {
+    expect(DEFAULT_PAGE_STYLES.color).toBe('var(--sd-layout-page-text, #000)');
   });
 });
 

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -22,6 +22,7 @@ export type PageStyles = {
   boxShadow?: string;
   border?: string;
   margin?: string;
+  color?: string;
 };
 
 export const DEFAULT_PAGE_STYLES: Required<PageStyles> = {
@@ -29,6 +30,12 @@ export const DEFAULT_PAGE_STYLES: Required<PageStyles> = {
   boxShadow: 'var(--sd-layout-page-shadow, 0 4px 20px rgba(15, 23, 42, 0.08))',
   border: '1px solid rgba(15, 23, 42, 0.08)',
   margin: '0 auto',
+  // Without an explicit color, document text inherits the browser default
+  // `canvastext` system color, which resolves to white on dark-themed OSes —
+  // so auto-numbered list markers and any other run without an explicit
+  // `<w:color>` render invisible on the white page (SD-3456 / IT-1102).
+  // Default to black; consumers can override via --sd-layout-page-text.
+  color: 'var(--sd-layout-page-text, #000)',
 };
 
 export const containerStyles: Partial<CSSStyleDeclaration> = {
@@ -75,6 +82,7 @@ export const pageStyles = (width: number, height: number, overrides?: PageStyles
     minHeight: `${height}px`,
     flexShrink: '0',
     background: merged.background,
+    color: merged.color,
     boxShadow: merged.boxShadow,
     border: merged.border,
     margin: merged.margin,

--- a/packages/super-editor/src/editors/v1/assets/styles/elements/prosemirror.css
+++ b/packages/super-editor/src/editors/v1/assets/styles/elements/prosemirror.css
@@ -19,6 +19,14 @@
   font-variant-ligatures: none;
   font-feature-settings: 'liga' 0; /* the above doesn't seem to work in Edge */
   z-index: 0; /* Needed to place images behind text with lower z-index */
+  /* SD-3456: `.sd-editor-scoped` applies `all: revert` to its descendants
+   * (see isolation.css), which reverts text color to the browser default
+   * `canvastext` system color. On dark-themed OSes that resolves to white,
+   * making any document text without an explicit <w:color> (e.g. auto-numbered
+   * list markers, untyped runs) invisible on the white page. Set an explicit
+   * color floor that mirrors the layout-engine page; consumers can override
+   * via --sd-layout-page-text. */
+  color: var(--sd-layout-page-text, #000);
 }
 
 .sd-editor-scoped .ProseMirror pre {

--- a/packages/superdoc/src/assets/styles/elements/editor-scoped-color-floor.test.js
+++ b/packages/superdoc/src/assets/styles/elements/editor-scoped-color-floor.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// SD-3456 (cross-package CSS invariant). `isolation.css` applies `all: revert`
+// to descendants of `.sd-editor-scoped`, which reverts text color to the
+// browser default `canvastext` system color. On dark-themed OSes that
+// resolves to white, making any document text without an explicit <w:color>
+// (e.g. auto-numbered list markers, runs with no rPr) invisible on the white
+// editor surface. This is the editor-mode sibling of the layout-engine
+// `.superdoc-page` fix in `painters/dom/src/styles.ts`. These tests guard
+// the CSS rule that re-establishes the color floor inside the isolation
+// wrapper so the dark-OS bug cannot resurface.
+
+const repoRoot = join(__dirname, '..', '..', '..', '..', '..', '..');
+
+const editorScopedCss = readFileSync(
+  join(repoRoot, 'packages', 'super-editor', 'src', 'editors', 'v1', 'assets', 'styles', 'elements', 'prosemirror.css'),
+  'utf8',
+);
+
+const isolationCss = readFileSync(
+  join(repoRoot, 'packages', 'super-editor', 'src', 'editors', 'v1', 'assets', 'styles', 'helpers', 'isolation.css'),
+  'utf8',
+);
+
+const extractRuleBodies = (css, selector) => {
+  const bodies = [];
+  let cursor = 0;
+  while (cursor < css.length) {
+    const idx = css.indexOf(selector, cursor);
+    if (idx === -1) break;
+    const open = css.indexOf('{', idx);
+    const close = css.indexOf('}', open);
+    if (open === -1 || close === -1) break;
+    bodies.push(css.slice(open + 1, close));
+    cursor = close + 1;
+  }
+  return bodies;
+};
+
+describe('editor-scoped color floor (SD-3456)', () => {
+  it('isolation.css still applies `all: revert` — confirms the canvastext exposure the floor compensates for', () => {
+    expect(isolationCss).toMatch(/all\s*:\s*revert/);
+  });
+
+  it('`.sd-editor-scoped .ProseMirror` declares an explicit `color` so revert cannot bleed canvastext through', () => {
+    const bodies = extractRuleBodies(editorScopedCss, '.sd-editor-scoped .ProseMirror {');
+    expect(bodies.length, 'at least one .sd-editor-scoped .ProseMirror block must exist').toBeGreaterThan(0);
+
+    // At least one of the .sd-editor-scoped .ProseMirror blocks must set color.
+    const hasColor = bodies.some((body) => /\bcolor\s*:/.test(body));
+    expect(hasColor, 'one of the .sd-editor-scoped .ProseMirror blocks must declare `color`').toBe(true);
+  });
+
+  it('the color floor uses the shared `--sd-layout-page-text` token so themes set it once for both surfaces', () => {
+    const bodies = extractRuleBodies(editorScopedCss, '.sd-editor-scoped .ProseMirror {');
+    const usesToken = bodies.some((body) => /color\s*:[^;]*--sd-layout-page-text/.test(body));
+    expect(usesToken, 'color declaration should reference --sd-layout-page-text').toBe(true);
+  });
+
+  it('the floor falls back to #000 when the token is unset so dark-OS users get a sensible default out of the box', () => {
+    const bodies = extractRuleBodies(editorScopedCss, '.sd-editor-scoped .ProseMirror {');
+    const hasBlackFallback = bodies.some((body) =>
+      /color\s*:[^;]*var\(\s*--sd-layout-page-text\s*,\s*#000\s*\)/.test(body),
+    );
+    expect(hasBlackFallback, 'fallback must be #000 to match the layout-engine page default').toBe(true);
+  });
+});

--- a/packages/superdoc/src/assets/styles/helpers/variables.css
+++ b/packages/superdoc/src/assets/styles/helpers/variables.css
@@ -292,6 +292,7 @@
   /* Styles: layout — cascades from semantic tier */
   --sd-layout-page-bg: var(--sd-ui-bg);
   --sd-layout-page-shadow: 0 4px 20px rgba(15, 23, 42, 0.08);
+  --sd-layout-page-text: #000;
   --sd-formatting-mark-color: var(--sd-color-blue-500);
   --sd-formatting-paragraph-mark-gap: 0.2em;
 


### PR DESCRIPTION
Closes #3456.

## Summary

`.superdoc-page` (layout-engine page surface) and `.sd-editor-scoped .ProseMirror` (editor isolation surface) both relied on the browser default `color`. On dark-themed OSes that resolves to the `canvastext` system color (white), so any document text without an explicit `<w:color>` — auto-numbered list markers in particular — rendered invisible on the white page. There is no source CSS rule that sets `color: rgb(255,255,255)` in the repo; the reporter's devtools trace pointed at `.superdoc-page` because that was the highest-up element in the cascade where the color happened to resolve (via the user-agent default), not the rule that set it.

This PR sets an explicit `color: var(--sd-layout-page-text, #000)` floor on both surfaces. OOXML-explicit colors still win (inline `style.color` on runs has higher specificity than the inherited page color). Consumers customize via the `--sd-layout-page-text` token, documented in `variables.css` alongside `--sd-layout-page-bg`/`--sd-layout-page-shadow`.

## Why two surfaces in one PR

`.superdoc-page` covers presentation-mode rendering (where the reported bug manifests). `.sd-editor-scoped .ProseMirror` covers the editor isolation surface for super-editor direct mounts (header/footer section editors, popovers, rich-text Field editors, etc.). Both are reverted to `canvastext` by `isolation.css` (`all: revert`) and both need the same floor. Bundling them avoids shipping the symptom-fix while leaving a sibling surface broken for the same reason.

## Files

| File | Change |
|---|---|
| `packages/layout-engine/painters/dom/src/styles.ts` | `PageStyles.color?: string`; `DEFAULT_PAGE_STYLES.color = 'var(--sd-layout-page-text, #000)'`; `pageStyles()` returns `color: merged.color` in the inline-style payload. |
| `packages/layout-engine/painters/dom/src/styles.test.ts` | 3 new tests: default contract, consumer override path, `DEFAULT_PAGE_STYLES` exposure. |
| `packages/super-editor/src/editors/v1/assets/styles/elements/prosemirror.css` | Adds `color: var(--sd-layout-page-text, #000)` to `.sd-editor-scoped .ProseMirror` with an inline comment linking it to the page-painter fix. |
| `packages/superdoc/src/assets/styles/elements/editor-scoped-color-floor.test.js` | 4 new tests guarding the editor-scoped rule (modeled on existing `search-match-precedence.test.js`). |
| `packages/superdoc/src/assets/styles/helpers/variables.css` | Adds `--sd-layout-page-text: #000;` to the "Styles: layout" section. |

## Test plan

- [x] `pnpm --filter @superdoc/painter-dom test -- styles.test.ts` — 8/8 (3 new + 5 existing)
- [x] `pnpm --filter superdoc test` — 1030/1030 (4 new + 1026 existing)
- [ ] Manual verification on macOS Chrome with system dark mode: open any DOCX with multi-level numbered lists (e.g. a legal MSA). Confirm clause numbers (`1.`, `1.1`, `1.1.1`) are visible against the white page.
- [ ] Manual verification on light mode: confirm no visible change (text was black before via canvastext-on-light, still black after via the explicit floor).
- [ ] Layout-comparison run against published baseline — diff should show only the new `color: ...` property on the page element's inline style, no pixel deltas on Linux CI.

## Reviewer notes / consumer impact

- **Consumers using `.superdoc-page { color: white }` without `!important`** to force dark text on the page will now lose to the inline style. The intended way to customize is `--sd-layout-page-text` (or `pageStyles.color` via the SuperDoc constructor). `!important` overrides still win.
- **Token naming**: `--sd-layout-page-text` is named after the layout page but is reused inside the editor isolation surface. Considered introducing a separate `--sd-editor-text` token but kept one shared token so theme authors set it once for both surfaces.
- **Visual regression test not added**: visual tests run on light-mode Linux CI where `canvastext` is already black, so a pixel-diff baseline would never catch this class. The CSS-content tests added here are the right safety net.

## Follow-ups (not in this PR)

- Consider adding an architecture guard (sibling to Guards D/E in `architecture-boundaries.test.ts`) enforcing "every container hosting inherited document text must declare `color` explicitly in `DEFAULT_*_STYLES`."