### PR TITLE
fix(sdt): empty SDT placeholder text + cursor/keyboard interactions (SD-3237)

### DIFF
--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -290,6 +290,10 @@ export type FlowRunLink = {
   history?: boolean;
 };
 
+export const EMPTY_SDT_PLACEHOLDER_TEXT = 'Click or tap here to enter text';
+
+export type SdtVisualPlaceholder = 'emptyInlineSdt' | 'emptyBlockSdt';
+
 /**
  * Common formatting marks that can be applied to any run type.
  * Used by TextRun, TabRun, and other run types that support inline formatting.
@@ -343,7 +347,7 @@ export type TextRun = RunMarks & {
   dataAttrs?: Record<string, string>;
   sdt?: SdtMetadata;
   /** Layout-only placeholder for visual affordances that do not represent document text. */
-  visualPlaceholder?: 'emptyInlineSdt';
+  visualPlaceholder?: SdtVisualPlaceholder;
   link?: FlowRunLink;
   /** Token annotations for dynamic content (page numbers, etc.). */
   token?: 'pageNumber' | 'totalPageCount' | 'pageReference';
@@ -2199,6 +2203,11 @@ export { isResolvedTableItem, isResolvedImageItem, isResolvedDrawingItem } from 
 
 // Pure transformations on inline-run shapes (used by pm-adapter, layout-bridge,
 // and painter-dom). Located in contracts to avoid reverse stage dependencies.
-export { expandRunsForInlineNewlines, isEmptyInlineSdtPlaceholderRun, sliceRunsForLine } from './run-helpers.js';
+export {
+  expandRunsForInlineNewlines,
+  isEmptyInlineSdtPlaceholderRun,
+  isEmptySdtPlaceholderRun,
+  sliceRunsForLine,
+} from './run-helpers.js';
 
 export * as Engines from './engines/index.js';

--- a/packages/layout-engine/contracts/src/pm-range.ts
+++ b/packages/layout-engine/contracts/src/pm-range.ts
@@ -1,4 +1,5 @@
 import type { FlowBlock, Line, ParagraphBlock, ParagraphMeasure } from './index.js';
+import { isEmptySdtPlaceholderRun } from './run-helpers.js';
 
 /**
  * Represents a ProseMirror position range for a line or fragment.
@@ -92,6 +93,15 @@ export function computeLinePmRange(block: FlowBlock, line: Line): LinePmRange {
 
     const runPmStart = coercePmStart(run);
     if (runPmStart == null) continue;
+
+    if (isEmptySdtPlaceholderRun(run)) {
+      const runPmEnd = coercePmEnd(run) ?? runPmStart;
+      if (pmStart == null) {
+        pmStart = runPmStart;
+      }
+      pmEnd = runPmEnd;
+      continue;
+    }
 
     if (isAtomicRunKind((run as { kind?: unknown }).kind) || isImageLikeRun(run)) {
       const runPmEnd = coercePmEnd(run) ?? runPmStart + 1;

--- a/packages/layout-engine/contracts/src/run-helpers.test.ts
+++ b/packages/layout-engine/contracts/src/run-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { FlowBlock, Line, ParagraphBlock, Run, TabRun, TextRun, TrackedChangeMeta } from './index.js';
-import { expandRunsForInlineNewlines, sliceRunsForLine } from './run-helpers.js';
+import { expandRunsForInlineNewlines, isEmptySdtPlaceholderRun, sliceRunsForLine } from './run-helpers.js';
 
 describe('expandRunsForInlineNewlines', () => {
   const makeRun = (text: string, pmStart = 0): TextRun => ({
@@ -152,5 +152,18 @@ describe('sliceRunsForLine', () => {
     const line = makeLine({ fromRun: 0, fromChar: 0, toRun: 0, toChar: 0 });
 
     expect(sliceRunsForLine(block, line)).toEqual([run]);
+  });
+
+  it('recognizes block SDT visual placeholders', () => {
+    const run: TextRun = {
+      kind: 'text',
+      text: '',
+      fontFamily: 'Arial',
+      fontSize: 12,
+      visualPlaceholder: 'emptyBlockSdt',
+      sdt: { type: 'structuredContent', scope: 'block', id: 'sdt-block-1' },
+    };
+
+    expect(isEmptySdtPlaceholderRun(run)).toBe(true);
   });
 });

--- a/packages/layout-engine/contracts/src/run-helpers.ts
+++ b/packages/layout-engine/contracts/src/run-helpers.ts
@@ -9,12 +9,18 @@
 
 import type { FlowBlock, Line, Run, TextRun } from './index.js';
 
-export function isEmptyInlineSdtPlaceholderRun(run: Run): run is TextRun & { visualPlaceholder: 'emptyInlineSdt' } {
+export function isEmptySdtPlaceholderRun(
+  run: Run,
+): run is TextRun & { visualPlaceholder: 'emptyInlineSdt' | 'emptyBlockSdt' } {
   return (
     (run.kind === 'text' || run.kind === undefined) &&
     'text' in run &&
-    (run as TextRun).visualPlaceholder === 'emptyInlineSdt'
+    ((run as TextRun).visualPlaceholder === 'emptyInlineSdt' || (run as TextRun).visualPlaceholder === 'emptyBlockSdt')
   );
+}
+
+export function isEmptyInlineSdtPlaceholderRun(run: Run): run is TextRun & { visualPlaceholder: 'emptyInlineSdt' } {
+  return isEmptySdtPlaceholderRun(run) && run.visualPlaceholder === 'emptyInlineSdt';
 }
 
 /**
@@ -90,7 +96,7 @@ export function sliceRunsForLine(block: FlowBlock, line: Line): Run[] {
     }
 
     const text = run.text ?? '';
-    if (isEmptyInlineSdtPlaceholderRun(run)) {
+    if (isEmptySdtPlaceholderRun(run)) {
       result.push(run);
       continue;
     }

--- a/packages/layout-engine/layout-bridge/src/remeasure.ts
+++ b/packages/layout-engine/layout-bridge/src/remeasure.ts
@@ -10,7 +10,7 @@ import type {
   ParagraphIndent,
   LeaderDecoration,
 } from '@superdoc/contracts';
-import { Engines } from '@superdoc/contracts';
+import { EMPTY_SDT_PLACEHOLDER_TEXT, Engines, isEmptySdtPlaceholderRun } from '@superdoc/contracts';
 import type { WordParagraphLayoutOutput } from '@superdoc/word-layout';
 import {
   LIST_MARKER_GAP as _LIST_MARKER_GAP,
@@ -126,6 +126,10 @@ function fontString(run: Run): string {
  * @returns Text content of the run, or empty string for non-text runs
  */
 function runText(run: Run): string {
+  if (isEmptySdtPlaceholderRun(run)) {
+    return run.sdt?.type === 'structuredContent' && run.sdt.appearance === 'hidden' ? '' : EMPTY_SDT_PLACEHOLDER_TEXT;
+  }
+
   return 'src' in run ||
     run.kind === 'lineBreak' ||
     run.kind === 'break' ||

--- a/packages/layout-engine/layout-bridge/src/remeasure.ts
+++ b/packages/layout-engine/layout-bridge/src/remeasure.ts
@@ -1384,6 +1384,17 @@ export function remeasureParagraph(
       if (text.length > 0 && isTextRun(run)) {
         lineMaxTextFontSize = Math.max(lineMaxTextFontSize, run.fontSize ?? 16);
       }
+      if (isEmptySdtPlaceholderRun(run)) {
+        const placeholderWidth = text.length > 0 ? measureRunSliceWidth(run, 0, text.length) : 0;
+        if (width > 0 && width + placeholderWidth > effectiveMaxWidth - WIDTH_FUDGE_PX) {
+          didBreakInThisLine = true;
+          break;
+        }
+        width += placeholderWidth;
+        endRun = r;
+        endChar = text.length > 0 ? text.length : start + 1;
+        continue;
+      }
       for (let c = start; c < text.length; c += 1) {
         const ch = text[c];
         if (ch === '\t') {

--- a/packages/layout-engine/layout-bridge/test/remeasure.test.ts
+++ b/packages/layout-engine/layout-bridge/test/remeasure.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
-import type { ParagraphBlock, Run, TabStop } from '@superdoc/contracts';
+import { EMPTY_SDT_PLACEHOLDER_TEXT, type ParagraphBlock, type Run, type TabStop } from '@superdoc/contracts';
 import { remeasureParagraph } from '../src/remeasure.ts';
 
 /**
@@ -214,6 +214,34 @@ describe('remeasureParagraph', () => {
       expect(measure.kind).toBe('paragraph');
       expect(measure.lines).toHaveLength(0);
       expect(measure.totalHeight).toBe(0);
+    });
+
+    it('measures visible empty SDT placeholders using the placeholder prompt width', () => {
+      const block = createBlock([
+        textRun('', {
+          kind: 'text',
+          visualPlaceholder: 'emptyBlockSdt',
+          sdt: { type: 'structuredContent', scope: 'block', id: 'empty-block-sdt' },
+        }),
+      ]);
+      const measure = remeasureParagraph(block, 500);
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.lines[0].width).toBe(EMPTY_SDT_PLACEHOLDER_TEXT.length * CHAR_WIDTH);
+    });
+
+    it('keeps hidden empty SDT placeholders zero-width during remeasurement', () => {
+      const block = createBlock([
+        textRun('', {
+          kind: 'text',
+          visualPlaceholder: 'emptyBlockSdt',
+          sdt: { type: 'structuredContent', scope: 'block', id: 'hidden-block-sdt', appearance: 'hidden' },
+        }),
+      ]);
+      const measure = remeasureParagraph(block, 500);
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.lines[0].width).toBe(0);
     });
 
     it('handles single character per line when maxWidth is very narrow', () => {

--- a/packages/layout-engine/layout-bridge/test/remeasure.test.ts
+++ b/packages/layout-engine/layout-bridge/test/remeasure.test.ts
@@ -230,6 +230,22 @@ describe('remeasureParagraph', () => {
       expect(measure.lines[0].width).toBe(EMPTY_SDT_PLACEHOLDER_TEXT.length * CHAR_WIDTH);
     });
 
+    it('keeps a visible empty SDT placeholder atomic when it is wider than the line', () => {
+      const block = createBlock([
+        textRun('', {
+          kind: 'text',
+          visualPlaceholder: 'emptyBlockSdt',
+          sdt: { type: 'structuredContent', scope: 'block', id: 'narrow-empty-block-sdt' },
+        }),
+      ]);
+      const measure = remeasureParagraph(block, 60);
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.lines[0].fromRun).toBe(0);
+      expect(measure.lines[0].toRun).toBe(0);
+      expect(measure.lines[0].width).toBe(EMPTY_SDT_PLACEHOLDER_TEXT.length * CHAR_WIDTH);
+    });
+
     it('keeps hidden empty SDT placeholders zero-width during remeasurement', () => {
       const block = createBlock([
         textRun('', {

--- a/packages/layout-engine/layout-bridge/test/remeasure.test.ts
+++ b/packages/layout-engine/layout-bridge/test/remeasure.test.ts
@@ -11,7 +11,13 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
-import { EMPTY_SDT_PLACEHOLDER_TEXT, type ParagraphBlock, type Run, type TabStop } from '@superdoc/contracts';
+import {
+  EMPTY_SDT_PLACEHOLDER_TEXT,
+  computeLinePmRange,
+  type ParagraphBlock,
+  type Run,
+  type TabStop,
+} from '@superdoc/contracts';
 import { remeasureParagraph } from '../src/remeasure.ts';
 
 /**
@@ -222,12 +228,15 @@ describe('remeasureParagraph', () => {
           kind: 'text',
           visualPlaceholder: 'emptyBlockSdt',
           sdt: { type: 'structuredContent', scope: 'block', id: 'empty-block-sdt' },
+          pmStart: 12,
+          pmEnd: 12,
         }),
       ]);
       const measure = remeasureParagraph(block, 500);
 
       expect(measure.lines).toHaveLength(1);
       expect(measure.lines[0].width).toBe(EMPTY_SDT_PLACEHOLDER_TEXT.length * CHAR_WIDTH);
+      expect(computeLinePmRange(block, measure.lines[0])).toEqual({ pmStart: 12, pmEnd: 12 });
     });
 
     it('keeps a visible empty SDT placeholder atomic when it is wider than the line', () => {

--- a/packages/layout-engine/measuring/dom/src/index.test.ts
+++ b/packages/layout-engine/measuring/dom/src/index.test.ts
@@ -9,6 +9,7 @@ import type {
   DrawingBlock,
   TableMeasure,
 } from '@superdoc/contracts';
+import { EMPTY_SDT_PLACEHOLDER_TEXT } from '@superdoc/contracts';
 
 const expectParagraphMeasure = (measure: Measure): ParagraphMeasure => {
   expect(measure.kind).toBe('paragraph');
@@ -712,6 +713,39 @@ describe('measureBlock', () => {
       expect(measure.lines[0].segments).toHaveLength(1);
       expect(measure.lines[0].segments[0]).toMatchObject({ runIndex: 0, fromChar: 0, toChar: 0 });
       expect(measure.lines[0].segments[0].width).toBe(measure.lines[0].width);
+    });
+
+    it('applies textTransform when measuring empty SDT placeholder text', async () => {
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d');
+      expect(ctx).not.toBeNull();
+      ctx!.font = '16px Arial';
+      const transformedPlaceholderText = EMPTY_SDT_PLACEHOLDER_TEXT.toUpperCase();
+      const transformedWidth = ctx!.measureText(transformedPlaceholderText).width;
+      const untransformedWidth = ctx!.measureText(EMPTY_SDT_PLACEHOLDER_TEXT).width;
+      expect(transformedWidth).not.toBeCloseTo(untransformedWidth, 2);
+
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'empty-inline-sdt-uppercase',
+        runs: [
+          {
+            kind: 'text',
+            text: '',
+            fontFamily: 'Arial',
+            fontSize: 16,
+            textTransform: 'uppercase',
+            visualPlaceholder: 'emptyInlineSdt',
+            sdt: { type: 'structuredContent', scope: 'inline', id: 'sdt-empty-uppercase' },
+          },
+        ],
+        attrs: {},
+      };
+
+      const measure = expectParagraphMeasure(await measureBlock(block, 1000));
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.lines[0].width).toBeCloseTo(transformedWidth, 2);
     });
   });
 

--- a/packages/layout-engine/measuring/dom/src/index.test.ts
+++ b/packages/layout-engine/measuring/dom/src/index.test.ts
@@ -685,7 +685,7 @@ describe('measureBlock', () => {
       });
     });
 
-    it('measures empty inline SDT placeholders as a small inline box', async () => {
+    it('measures empty inline SDT placeholders using the visible placeholder text width', async () => {
       const block: FlowBlock = {
         kind: 'paragraph',
         id: 'empty-inline-sdt',
@@ -707,14 +707,11 @@ describe('measureBlock', () => {
       const measure = expectParagraphMeasure(await measureBlock(block, 1000));
 
       expect(measure.lines).toHaveLength(1);
-      expect(measure.lines[0]).toMatchObject({
-        fromRun: 0,
-        fromChar: 0,
-        toRun: 0,
-        toChar: 0,
-        width: 8,
-        segments: [{ runIndex: 0, fromChar: 0, toChar: 0, width: 8 }],
-      });
+      expect(measure.lines[0]).toMatchObject({ fromRun: 0, fromChar: 0, toRun: 0, toChar: 0 });
+      expect(measure.lines[0].width).toBeGreaterThan(8);
+      expect(measure.lines[0].segments).toHaveLength(1);
+      expect(measure.lines[0].segments[0]).toMatchObject({ runIndex: 0, fromChar: 0, toChar: 0 });
+      expect(measure.lines[0].segments[0].width).toBe(measure.lines[0].width);
     });
   });
 

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -61,8 +61,9 @@ import {
   type CellSpacing,
   type TableBorders,
   type TableBorderValue,
+  EMPTY_SDT_PLACEHOLDER_TEXT,
   effectiveTableCellSpacing,
-  isEmptyInlineSdtPlaceholderRun,
+  isEmptySdtPlaceholderRun,
   LeaderDecoration,
   resolveBaseFontSizeForVerticalText,
 } from '@superdoc/contracts';
@@ -209,8 +210,6 @@ const FIELD_ANNOTATION_VERTICAL_PADDING = 6; // Vertical padding/border for pill
 const DEFAULT_FIELD_ANNOTATION_FONT_SIZE = 16; // Default font size for field annotations
 const DEFAULT_PARAGRAPH_FONT_SIZE = 12;
 const DEFAULT_PARAGRAPH_FONT_FAMILY = 'Arial';
-const EMPTY_INLINE_SDT_PLACEHOLDER_WIDTH = 8;
-
 const isValidFontSize = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value) && value > 0;
 
@@ -1036,7 +1035,7 @@ async function measureParagraphBlock(block: ParagraphBlock, maxWidth: number): P
   const emptyParagraphRun =
     normalizedRuns.length === 1 &&
     isEmptyTextRun(normalizedRuns[0] as Run) &&
-    !isEmptyInlineSdtPlaceholderRun(normalizedRuns[0] as Run)
+    !isEmptySdtPlaceholderRun(normalizedRuns[0] as Run)
       ? (normalizedRuns[0] as TextRun)
       : null;
   if (emptyParagraphRun) {
@@ -2018,11 +2017,19 @@ async function measureParagraphBlock(block: ParagraphBlock, maxWidth: number): P
       continue;
     }
 
-    if (isEmptyInlineSdtPlaceholderRun(run)) {
+    if (isEmptySdtPlaceholderRun(run)) {
+      const placeholderFont = buildFontString(run).font;
+      const measuredPlaceholderWidth = getMeasuredTextWidth(
+        EMPTY_SDT_PLACEHOLDER_TEXT,
+        placeholderFont,
+        run.letterSpacing ?? 0,
+        ctx,
+      );
+      const fallbackPlaceholderWidth = EMPTY_SDT_PLACEHOLDER_TEXT.length * run.fontSize * 0.45;
       const placeholderWidth =
         run.sdt?.type === 'structuredContent' && run.sdt.appearance === 'hidden'
           ? 0
-          : EMPTY_INLINE_SDT_PLACEHOLDER_WIDTH;
+          : Math.max(measuredPlaceholderWidth, fallbackPlaceholderWidth);
 
       if (!currentLine) {
         currentLine = {

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -2029,7 +2029,9 @@ async function measureParagraphBlock(block: ParagraphBlock, maxWidth: number): P
       const placeholderWidth =
         run.sdt?.type === 'structuredContent' && run.sdt.appearance === 'hidden'
           ? 0
-          : Math.max(measuredPlaceholderWidth, fallbackPlaceholderWidth);
+          : measuredPlaceholderWidth > 0
+            ? measuredPlaceholderWidth
+            : fallbackPlaceholderWidth;
 
       if (!currentLine) {
         currentLine = {

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -2019,13 +2019,14 @@ async function measureParagraphBlock(block: ParagraphBlock, maxWidth: number): P
 
     if (isEmptySdtPlaceholderRun(run)) {
       const placeholderFont = buildFontString(run).font;
+      const placeholderText = applyTextTransform(EMPTY_SDT_PLACEHOLDER_TEXT, run);
       const measuredPlaceholderWidth = getMeasuredTextWidth(
-        EMPTY_SDT_PLACEHOLDER_TEXT,
+        placeholderText,
         placeholderFont,
         run.letterSpacing ?? 0,
         ctx,
       );
-      const fallbackPlaceholderWidth = EMPTY_SDT_PLACEHOLDER_TEXT.length * run.fontSize * 0.45;
+      const fallbackPlaceholderWidth = placeholderText.length * run.fontSize * 0.45;
       const placeholderWidth =
         run.sdt?.type === 'structuredContent' && run.sdt.appearance === 'hidden'
           ? 0

--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -3019,12 +3019,12 @@ describe('DomPainter', () => {
     const painter = createTestPainter({ blocks: [block], measures: [measure] });
     painter.paint(layout, mount);
 
-    const fragment = mount.querySelector(
-      '.superdoc-structured-content-block[data-sdt-id="sc-block-hidden-empty-1"]',
-    ) as HTMLElement | null;
+    const fragment = mount.querySelector('[data-sdt-id="sc-block-hidden-empty-1"]') as HTMLElement | null;
 
     expect(fragment).toBeTruthy();
     expect(fragment?.dataset.appearance).toBe('hidden');
+    expect(fragment?.classList.contains('superdoc-structured-content-block')).toBe(false);
+    expect(fragment?.querySelector('.superdoc-structured-content__label')).toBeNull();
   });
 
   it('keeps inline SDT wrapper font-size in sync when run font-size changes', () => {

--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -2880,8 +2880,82 @@ describe('DomPainter', () => {
     expect(wrapper?.dataset.empty).toBe('true');
     expect(wrapper?.dataset.pmStart).toBe('8');
     expect(wrapper?.dataset.pmEnd).toBe('8');
-    expect(wrapper?.querySelector('.superdoc-empty-inline-sdt-placeholder')).toBeTruthy();
+    const placeholder = wrapper?.querySelector('.superdoc-empty-inline-sdt-placeholder') as HTMLElement | null;
+    expect(placeholder).toBeTruthy();
+    expect(placeholder?.classList.contains('superdoc-empty-sdt-placeholder')).toBe(true);
+    expect(placeholder?.dataset.placeholderText).toBe('Click or tap here to enter text');
     expect(wrapper?.textContent).not.toContain('old content');
+    expect(wrapper?.textContent).not.toContain('Click or tap here to enter text');
+  });
+
+  it('renders placeholder chrome for an empty block SDT without adding document text', () => {
+    const sdt = {
+      type: 'structuredContent',
+      scope: 'block',
+      id: 'sc-block-empty-1',
+      alias: 'Empty block',
+    } as const;
+    const block: FlowBlock = {
+      kind: 'paragraph',
+      id: 'block-sc-empty',
+      runs: [
+        {
+          kind: 'text',
+          text: '',
+          fontFamily: 'Arial',
+          fontSize: 16,
+          pmStart: 4,
+          pmEnd: 4,
+          visualPlaceholder: 'emptyBlockSdt',
+          sdt,
+        },
+      ],
+      attrs: { sdt },
+    };
+
+    const measure: Measure = {
+      kind: 'paragraph',
+      lines: [{ fromRun: 0, fromChar: 0, toRun: 0, toChar: 0, width: 220, ascent: 12, descent: 4, lineHeight: 20 }],
+      totalHeight: 20,
+    };
+
+    const layout: Layout = {
+      pageSize: { w: 612, h: 792 },
+      pages: [
+        {
+          number: 1,
+          fragments: [
+            {
+              kind: 'para',
+              blockId: 'block-sc-empty',
+              fromLine: 0,
+              toLine: 1,
+              x: 30,
+              y: 40,
+              width: 552,
+              pmStart: 3,
+              pmEnd: 5,
+            },
+          ],
+        },
+      ],
+    };
+
+    const painter = createTestPainter({ blocks: [block], measures: [measure] });
+    painter.paint(layout, mount);
+
+    const fragment = mount.querySelector(
+      '.superdoc-structured-content-block[data-sdt-id="sc-block-empty-1"]',
+    ) as HTMLElement | null;
+    const placeholder = fragment?.querySelector('.superdoc-empty-block-sdt-placeholder') as HTMLElement | null;
+
+    expect(fragment).toBeTruthy();
+    expect(placeholder).toBeTruthy();
+    expect(placeholder?.classList.contains('superdoc-empty-sdt-placeholder')).toBe(true);
+    expect(placeholder?.dataset.placeholderText).toBe('Click or tap here to enter text');
+    expect(placeholder?.dataset.pmStart).toBe('4');
+    expect(placeholder?.dataset.pmEnd).toBe('4');
+    expect(fragment?.textContent).not.toContain('Click or tap here to enter text');
   });
 
   it('keeps inline SDT wrapper font-size in sync when run font-size changes', () => {

--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -2955,6 +2955,8 @@ describe('DomPainter', () => {
     expect(placeholder?.dataset.placeholderText).toBe('Click or tap here to enter text');
     expect(placeholder?.dataset.pmStart).toBe('4');
     expect(placeholder?.dataset.pmEnd).toBe('4');
+    expect(placeholder?.style.fontFamily).toBe('Arial');
+    expect(placeholder?.style.fontSize).toBe('16px');
     expect(fragment?.textContent).not.toContain('Click or tap here to enter text');
   });
 

--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -2962,6 +2962,71 @@ describe('DomPainter', () => {
     expect(fragment?.textContent).not.toContain('Click or tap here to enter text');
   });
 
+  it('marks hidden empty block SDT wrappers so placeholder chrome can be suppressed', () => {
+    const sdt = {
+      type: 'structuredContent',
+      scope: 'block',
+      id: 'sc-block-hidden-empty-1',
+      alias: 'Hidden empty block',
+      appearance: 'hidden',
+    } as const;
+    const block: FlowBlock = {
+      kind: 'paragraph',
+      id: 'block-sc-hidden-empty',
+      runs: [
+        {
+          kind: 'text',
+          text: '',
+          fontFamily: 'Arial',
+          fontSize: 16,
+          pmStart: 4,
+          pmEnd: 4,
+          visualPlaceholder: 'emptyBlockSdt',
+          sdt,
+        },
+      ],
+      attrs: { sdt },
+    };
+
+    const measure: Measure = {
+      kind: 'paragraph',
+      lines: [{ fromRun: 0, fromChar: 0, toRun: 0, toChar: 0, width: 0, ascent: 12, descent: 4, lineHeight: 20 }],
+      totalHeight: 20,
+    };
+
+    const layout: Layout = {
+      pageSize: { w: 612, h: 792 },
+      pages: [
+        {
+          number: 1,
+          fragments: [
+            {
+              kind: 'para',
+              blockId: 'block-sc-hidden-empty',
+              fromLine: 0,
+              toLine: 1,
+              x: 30,
+              y: 40,
+              width: 552,
+              pmStart: 3,
+              pmEnd: 5,
+            },
+          ],
+        },
+      ],
+    };
+
+    const painter = createTestPainter({ blocks: [block], measures: [measure] });
+    painter.paint(layout, mount);
+
+    const fragment = mount.querySelector(
+      '.superdoc-structured-content-block[data-sdt-id="sc-block-hidden-empty-1"]',
+    ) as HTMLElement | null;
+
+    expect(fragment).toBeTruthy();
+    expect(fragment?.dataset.appearance).toBe('hidden');
+  });
+
   it('keeps inline SDT wrapper font-size in sync when run font-size changes', () => {
     const block: FlowBlock = {
       kind: 'paragraph',

--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -2957,6 +2957,8 @@ describe('DomPainter', () => {
     expect(placeholder?.dataset.pmEnd).toBe('4');
     expect(placeholder?.style.fontFamily).toBe('Arial');
     expect(placeholder?.style.fontSize).toBe('16px');
+    expect(fragment?.style.getPropertyValue('--sd-sdt-chrome-left')).toBe('0px');
+    expect(fragment?.style.getPropertyValue('--sd-sdt-chrome-width')).toBe('220px');
     expect(fragment?.textContent).not.toContain('Click or tap here to enter text');
   });
 

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -60,6 +60,7 @@ import type {
 } from '@superdoc/contracts';
 import {
   LAYOUT_BOUNDARY_SCHEMA,
+  EMPTY_SDT_PLACEHOLDER_TEXT,
   adjustAvailableWidthForTextIndent,
   buildLayoutSourceIdentityForFragment,
   calculateJustifySpacing,
@@ -68,6 +69,7 @@ import {
   getCellSpacingPx,
   getParagraphInlineDirection,
   isEmptyInlineSdtPlaceholderRun,
+  isEmptySdtPlaceholderRun,
   normalizeColumnLayout,
   normalizeBaselineShift,
   resolveBaseFontSizeForVerticalText,
@@ -5705,11 +5707,17 @@ export class DomPainter {
     }
   }
 
-  private renderEmptyInlineSdtPlaceholderRun(run: TextRun): HTMLElement | null {
+  private renderEmptySdtPlaceholderRun(run: TextRun): HTMLElement | null {
     if (!this.doc) return null;
     const elem = this.doc.createElement('span');
-    elem.classList.add('superdoc-empty-inline-sdt-placeholder');
+    elem.classList.add('superdoc-empty-sdt-placeholder');
+    if (run.visualPlaceholder === 'emptyInlineSdt') {
+      elem.classList.add('superdoc-empty-inline-sdt-placeholder');
+    } else if (run.visualPlaceholder === 'emptyBlockSdt') {
+      elem.classList.add('superdoc-empty-block-sdt-placeholder');
+    }
     elem.setAttribute('aria-hidden', 'true');
+    elem.dataset.placeholderText = EMPTY_SDT_PLACEHOLDER_TEXT;
     elem.dataset.layoutEpoch = String(this.layoutEpoch);
     if (run.pmStart != null) elem.dataset.pmStart = String(run.pmStart);
     if (run.pmEnd != null) elem.dataset.pmEnd = String(run.pmEnd);
@@ -5854,8 +5862,8 @@ export class DomPainter {
       return null;
     }
 
-    if (isEmptyInlineSdtPlaceholderRun(run)) {
-      return this.renderEmptyInlineSdtPlaceholderRun(run);
+    if (isEmptySdtPlaceholderRun(run)) {
+      return this.renderEmptySdtPlaceholderRun(run);
     }
 
     // Handle TextRun

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -7622,6 +7622,7 @@ export class DomPainter {
     'sdtScope',
     'sdtTag',
     'sdtAlias',
+    'appearance',
     'lockMode',
     'sdtSectionTitle',
     'sdtSectionType',
@@ -7752,6 +7753,7 @@ export class DomPainter {
       this.setDatasetString(el, 'sdtScope', metadata.scope);
       this.setDatasetString(el, 'sdtTag', metadata.tag);
       this.setDatasetString(el, 'sdtAlias', metadata.alias);
+      this.setDatasetString(el, 'appearance', metadata.appearance);
       // Always set lockMode (defaulting to 'unlocked') so CSS can target all SDTs uniformly.
       this.setDatasetString(el, 'lockMode', metadata.lockMode || 'unlocked');
     } else if (metadata.type === 'documentSection') {

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -5537,6 +5537,10 @@ export class DomPainter {
       let hasVisibleContent = false;
       for (const run of runsForLine) {
         if (run.kind === 'lineBreak' || run.kind === 'break') continue;
+        if (isEmptySdtPlaceholderRun(run)) {
+          hasVisibleContent = true;
+          break;
+        }
         if ((run.kind === 'text' || run.kind === undefined) && 'text' in run) {
           if ((run.text ?? '').trim().length === 0) continue;
         }

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -5722,6 +5722,7 @@ export class DomPainter {
     if (run.pmStart != null) elem.dataset.pmStart = String(run.pmStart);
     if (run.pmEnd != null) elem.dataset.pmEnd = String(run.pmEnd);
     this.applySdtDataset(elem, run.sdt);
+    applyRunStyles(elem, run);
     return elem;
   }
 

--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -167,6 +167,17 @@ describe('ensureSdtContainerStyles', () => {
     expect(viewingPlaceholderRule).toContain("content: '';");
   });
 
+  it('suppresses empty SDT placeholder text in print mode', () => {
+    ensureSdtContainerStyles(document);
+
+    const styleEl = document.querySelector('[data-superdoc-sdt-container-styles="true"]');
+    const cssText = styleEl?.textContent ?? '';
+    const printPlaceholderRule =
+      cssText.match(/@media print\s*\{[\s\S]*?\.superdoc-empty-sdt-placeholder::before\s*\{([^}]*)\}/)?.[1] ?? '';
+
+    expect(printPlaceholderRule).toContain("content: '';");
+  });
+
   it('suppresses structured-content hover backgrounds in viewing mode, including grouped hover', () => {
     ensureSdtContainerStyles(document);
 

--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -164,8 +164,8 @@ describe('ensureSdtContainerStyles', () => {
     const viewingPlaceholderRule =
       cssText.match(/\.presentation-editor--viewing \.superdoc-empty-sdt-placeholder::before\s*\{([^}]*)\}/)?.[1] ?? '';
 
-    expect(viewingPlaceholderRule).toContain('visibility: hidden;');
-    expect(viewingPlaceholderRule).not.toContain('content:');
+    expect(viewingPlaceholderRule).toContain("content: '';");
+    expect(viewingPlaceholderRule).not.toContain('visibility: hidden;');
   });
 
   it('suppresses empty SDT placeholder text in print mode', () => {
@@ -176,8 +176,8 @@ describe('ensureSdtContainerStyles', () => {
     const printPlaceholderRule =
       cssText.match(/@media print\s*\{[\s\S]*?\.superdoc-empty-sdt-placeholder::before\s*\{([^}]*)\}/)?.[1] ?? '';
 
-    expect(printPlaceholderRule).toContain('visibility: hidden;');
-    expect(printPlaceholderRule).not.toContain('content:');
+    expect(printPlaceholderRule).toContain("content: '';");
+    expect(printPlaceholderRule).not.toContain('visibility: hidden;');
   });
 
   it('suppresses structured-content hover backgrounds in viewing mode, including grouped hover', () => {

--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -136,6 +136,26 @@ describe('ensureSdtContainerStyles', () => {
     expect(selectedRule).not.toMatch(/(^|\n)\s*color\s*:/);
   });
 
+  it('suppresses empty block SDT placeholder text when the SDT appearance is hidden', () => {
+    ensureSdtContainerStyles(document);
+
+    const styleEl = document.querySelector('[data-superdoc-sdt-container-styles="true"]');
+    const cssText = styleEl?.textContent ?? '';
+    const hiddenPlaceholderRule =
+      cssText.match(
+        /\.superdoc-structured-content-inline\[data-appearance='hidden'\] \.superdoc-empty-inline-sdt-placeholder,\s*\.superdoc-structured-content-block\[data-appearance='hidden'\] \.superdoc-empty-block-sdt-placeholder\s*\{([^}]*)\}/,
+      )?.[1] ?? '';
+    const hiddenPlaceholderBeforeRule =
+      cssText.match(
+        /\.superdoc-structured-content-inline\[data-appearance='hidden'\] \.superdoc-empty-inline-sdt-placeholder::before,\s*\.superdoc-structured-content-block\[data-appearance='hidden'\] \.superdoc-empty-block-sdt-placeholder::before\s*\{([^}]*)\}/,
+      )?.[1] ?? '';
+
+    expect(hiddenPlaceholderRule).toContain('width: 0;');
+    expect(hiddenPlaceholderRule).toContain('min-width: 0;');
+    expect(hiddenPlaceholderRule).toContain('overflow: hidden;');
+    expect(hiddenPlaceholderBeforeRule).toContain("content: '';");
+  });
+
   it('suppresses structured-content hover backgrounds in viewing mode, including grouped hover', () => {
     ensureSdtContainerStyles(document);
 

--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -143,11 +143,11 @@ describe('ensureSdtContainerStyles', () => {
     const cssText = styleEl?.textContent ?? '';
     const hiddenPlaceholderRule =
       cssText.match(
-        /\.superdoc-structured-content-inline\[data-appearance='hidden'\] \.superdoc-empty-inline-sdt-placeholder,\s*\.superdoc-structured-content-block\[data-appearance='hidden'\] \.superdoc-empty-block-sdt-placeholder\s*\{([^}]*)\}/,
+        /\.superdoc-structured-content-inline\[data-appearance='hidden'\] \.superdoc-empty-inline-sdt-placeholder,\s*\.superdoc-structured-content-block\[data-appearance='hidden'\] \.superdoc-empty-block-sdt-placeholder,\s*\.superdoc-empty-sdt-placeholder\[data-appearance='hidden'\]\s*\{([^}]*)\}/,
       )?.[1] ?? '';
     const hiddenPlaceholderBeforeRule =
       cssText.match(
-        /\.superdoc-structured-content-inline\[data-appearance='hidden'\] \.superdoc-empty-inline-sdt-placeholder::before,\s*\.superdoc-structured-content-block\[data-appearance='hidden'\] \.superdoc-empty-block-sdt-placeholder::before\s*\{([^}]*)\}/,
+        /\.superdoc-structured-content-inline\[data-appearance='hidden'\] \.superdoc-empty-inline-sdt-placeholder::before,\s*\.superdoc-structured-content-block\[data-appearance='hidden'\] \.superdoc-empty-block-sdt-placeholder::before,\s*\.superdoc-empty-sdt-placeholder\[data-appearance='hidden'\]::before\s*\{([^}]*)\}/,
       )?.[1] ?? '';
 
     expect(hiddenPlaceholderRule).toContain('width: 0;');
@@ -164,7 +164,8 @@ describe('ensureSdtContainerStyles', () => {
     const viewingPlaceholderRule =
       cssText.match(/\.presentation-editor--viewing \.superdoc-empty-sdt-placeholder::before\s*\{([^}]*)\}/)?.[1] ?? '';
 
-    expect(viewingPlaceholderRule).toContain("content: '';");
+    expect(viewingPlaceholderRule).toContain('visibility: hidden;');
+    expect(viewingPlaceholderRule).not.toContain('content:');
   });
 
   it('suppresses empty SDT placeholder text in print mode', () => {
@@ -175,7 +176,8 @@ describe('ensureSdtContainerStyles', () => {
     const printPlaceholderRule =
       cssText.match(/@media print\s*\{[\s\S]*?\.superdoc-empty-sdt-placeholder::before\s*\{([^}]*)\}/)?.[1] ?? '';
 
-    expect(printPlaceholderRule).toContain("content: '';");
+    expect(printPlaceholderRule).toContain('visibility: hidden;');
+    expect(printPlaceholderRule).not.toContain('content:');
   });
 
   it('suppresses structured-content hover backgrounds in viewing mode, including grouped hover', () => {

--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -105,9 +105,12 @@ describe('ensureSdtContainerStyles', () => {
     expect(inlineLabelRule).toContain('border-radius: 4px 4px 0 0;');
     expect(blockLabelRule).toContain('white-space: nowrap;');
     expect(blockLabelRule).toContain('top: -18px;');
-    expect(blockLabelRule).toContain('width: calc(var(--sd-sdt-chrome-width, 100%) - 4px);');
+    expect(blockLabelRule).toContain('width: max-content;');
     expect(blockLabelRule).toContain('max-width: 130px;');
     expect(blockLabelRule).toContain('min-width: 0;');
+    expect(blockLabelRule).not.toContain('width: calc(var(--sd-sdt-chrome-width, 100%) - 4px);');
+    expect(cssText).toContain('.superdoc-structured-content__label span');
+    expect(cssText).toContain('flex: 1 1 auto;');
     expect(cssText).toContain('bottom: calc(100% + 1px);');
   });
 

--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -156,6 +156,17 @@ describe('ensureSdtContainerStyles', () => {
     expect(hiddenPlaceholderBeforeRule).toContain("content: '';");
   });
 
+  it('suppresses empty SDT placeholder text in viewing mode', () => {
+    ensureSdtContainerStyles(document);
+
+    const styleEl = document.querySelector('[data-superdoc-sdt-container-styles="true"]');
+    const cssText = styleEl?.textContent ?? '';
+    const viewingPlaceholderRule =
+      cssText.match(/\.presentation-editor--viewing \.superdoc-empty-sdt-placeholder::before\s*\{([^}]*)\}/)?.[1] ?? '';
+
+    expect(viewingPlaceholderRule).toContain("content: '';");
+  });
+
   it('suppresses structured-content hover backgrounds in viewing mode, including grouped hover', () => {
     ensureSdtContainerStyles(document);
 

--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -111,19 +111,26 @@ describe('ensureSdtContainerStyles', () => {
     expect(cssText).toContain('bottom: calc(100% + 1px);');
   });
 
-  it('reserves empty inline SDT width without adding line-box height', () => {
+  it('renders empty SDT placeholder text and active selection styling', () => {
     ensureSdtContainerStyles(document);
 
     const styleEl = document.querySelector('[data-superdoc-sdt-container-styles="true"]');
     const cssText = styleEl?.textContent ?? '';
-    const placeholderRule = cssText.match(/\.superdoc-empty-inline-sdt-placeholder\s*\{([^}]*)\}/)?.[1] ?? '';
+    const placeholderRule = cssText.match(/\.superdoc-empty-sdt-placeholder\s*\{([^}]*)\}/)?.[1] ?? '';
+    const placeholderBeforeRule = cssText.match(/\.superdoc-empty-sdt-placeholder::before\s*\{([^}]*)\}/)?.[1] ?? '';
+    const selectedRule =
+      cssText.match(
+        /\.superdoc-structured-content-inline\.ProseMirror-selectednode \.superdoc-empty-sdt-placeholder::before,\s*\.superdoc-structured-content-block\.ProseMirror-selectednode \.superdoc-empty-sdt-placeholder::before\s*\{([^}]*)\}/,
+      )?.[1] ?? '';
 
     expect(placeholderRule).toContain('display: inline-block;');
-    expect(placeholderRule).toContain('width: 8px;');
-    expect(placeholderRule).toContain('height: 0;');
-    expect(placeholderRule).toContain('line-height: 0;');
+    expect(placeholderRule).toContain('line-height: normal;');
     expect(placeholderRule).toContain('vertical-align: baseline;');
-    expect(placeholderRule).not.toContain('height: 1em;');
+    expect(placeholderRule).toContain('white-space: nowrap;');
+    expect(placeholderBeforeRule).toContain('content: attr(data-placeholder-text);');
+    expect(placeholderBeforeRule).toContain('color: var(--sd-content-controls-placeholder-text, #a6a6a6);');
+    expect(selectedRule).toContain('background-color: var(--sd-content-controls-placeholder-selected-bg, Highlight);');
+    expect(selectedRule).not.toMatch(/(^|\n)\s*color\s*:/);
   });
 
   it('suppresses structured-content hover backgrounds in viewing mode, including grouped hover', () => {

--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -156,7 +156,7 @@ describe('ensureSdtContainerStyles', () => {
     expect(hiddenPlaceholderBeforeRule).toContain("content: '';");
   });
 
-  it('suppresses empty SDT placeholder text in viewing mode', () => {
+  it('keeps empty SDT placeholder text visible in viewing mode', () => {
     ensureSdtContainerStyles(document);
 
     const styleEl = document.querySelector('[data-superdoc-sdt-container-styles="true"]');
@@ -164,11 +164,11 @@ describe('ensureSdtContainerStyles', () => {
     const viewingPlaceholderRule =
       cssText.match(/\.presentation-editor--viewing \.superdoc-empty-sdt-placeholder::before\s*\{([^}]*)\}/)?.[1] ?? '';
 
-    expect(viewingPlaceholderRule).toContain("content: '';");
+    expect(viewingPlaceholderRule).toBe('');
     expect(viewingPlaceholderRule).not.toContain('visibility: hidden;');
   });
 
-  it('suppresses empty SDT placeholder text in print mode', () => {
+  it('keeps empty SDT placeholder text visible in print mode', () => {
     ensureSdtContainerStyles(document);
 
     const styleEl = document.querySelector('[data-superdoc-sdt-container-styles="true"]');
@@ -176,7 +176,7 @@ describe('ensureSdtContainerStyles', () => {
     const printPlaceholderRule =
       cssText.match(/@media print\s*\{[\s\S]*?\.superdoc-empty-sdt-placeholder::before\s*\{([^}]*)\}/)?.[1] ?? '';
 
-    expect(printPlaceholderRule).toContain("content: '';");
+    expect(printPlaceholderRule).toBe('');
     expect(printPlaceholderRule).not.toContain('visibility: hidden;');
   });
 

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -703,13 +703,15 @@ const SDT_CONTAINER_STYLES = `
   background-color: var(--sd-content-controls-placeholder-selected-bg, Highlight);
 }
 
-.superdoc-structured-content-inline[data-appearance='hidden'] .superdoc-empty-inline-sdt-placeholder {
+.superdoc-structured-content-inline[data-appearance='hidden'] .superdoc-empty-inline-sdt-placeholder,
+.superdoc-structured-content-block[data-appearance='hidden'] .superdoc-empty-block-sdt-placeholder {
   width: 0;
   min-width: 0;
   overflow: hidden;
 }
 
-.superdoc-structured-content-inline[data-appearance='hidden'] .superdoc-empty-inline-sdt-placeholder::before {
+.superdoc-structured-content-inline[data-appearance='hidden'] .superdoc-empty-inline-sdt-placeholder::before,
+.superdoc-structured-content-block[data-appearance='hidden'] .superdoc-empty-block-sdt-placeholder::before {
   content: '';
 }
 

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -848,6 +848,10 @@ const SDT_CONTAINER_STYLES = `
   .superdoc-structured-content-inline__label {
     display: none !important;
   }
+
+  .superdoc-empty-sdt-placeholder::before {
+    content: '';
+  }
 }
 `;
 

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -683,18 +683,31 @@ const SDT_CONTAINER_STYLES = `
   border-color: var(--sd-content-controls-inline-border, #629be7);
 }
 
-.superdoc-empty-inline-sdt-placeholder {
+.superdoc-empty-sdt-placeholder {
   display: inline-block;
-  width: 8px;
-  height: 0;
-  line-height: 0;
+  line-height: normal;
   vertical-align: baseline;
-  overflow: hidden;
+  white-space: nowrap;
+}
+
+.superdoc-empty-sdt-placeholder::before {
+  content: attr(data-placeholder-text);
+  color: var(--sd-content-controls-placeholder-text, #a6a6a6);
+}
+
+.superdoc-structured-content-inline.ProseMirror-selectednode .superdoc-empty-sdt-placeholder::before,
+.superdoc-structured-content-block.ProseMirror-selectednode .superdoc-empty-sdt-placeholder::before {
+  background-color: var(--sd-content-controls-placeholder-selected-bg, Highlight);
 }
 
 .superdoc-structured-content-inline[data-appearance='hidden'] .superdoc-empty-inline-sdt-placeholder {
   width: 0;
   min-width: 0;
+  overflow: hidden;
+}
+
+.superdoc-structured-content-inline[data-appearance='hidden'] .superdoc-empty-inline-sdt-placeholder::before {
+  content: '';
 }
 
 /* Inline structured content label - shown when active */

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -590,7 +590,7 @@ const SDT_CONTAINER_STYLES = `
   position: absolute;
   left: calc(var(--sd-sdt-chrome-left, 0px) + 2px);
   top: -18px;
-  width: calc(var(--sd-sdt-chrome-width, 100%) - 4px);
+  width: max-content;
   max-width: 130px;
   min-width: 0;
   border-bottom: none;
@@ -600,6 +600,9 @@ const SDT_CONTAINER_STYLES = `
 }
 
 .superdoc-structured-content__label span {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
   max-width: 100%;
   overflow: hidden;
   white-space: nowrap;

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -823,7 +823,7 @@ const SDT_CONTAINER_STYLES = `
 }
 
 .presentation-editor--viewing .superdoc-empty-sdt-placeholder::before {
-  visibility: hidden;
+  content: '';
 }
 
 .presentation-editor--viewing .superdoc-structured-content__label,
@@ -852,7 +852,7 @@ const SDT_CONTAINER_STYLES = `
   }
 
   .superdoc-empty-sdt-placeholder::before {
-    visibility: hidden;
+    content: '';
   }
 }
 `;

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -822,10 +822,6 @@ const SDT_CONTAINER_STYLES = `
   border: none;
 }
 
-.presentation-editor--viewing .superdoc-empty-sdt-placeholder::before {
-  content: '';
-}
-
 .presentation-editor--viewing .superdoc-structured-content__label,
 .presentation-editor--viewing .superdoc-structured-content-inline__label {
   display: none !important;
@@ -849,10 +845,6 @@ const SDT_CONTAINER_STYLES = `
   .superdoc-structured-content__label,
   .superdoc-structured-content-inline__label {
     display: none !important;
-  }
-
-  .superdoc-empty-sdt-placeholder::before {
-    content: '';
   }
 }
 `;

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -704,14 +704,16 @@ const SDT_CONTAINER_STYLES = `
 }
 
 .superdoc-structured-content-inline[data-appearance='hidden'] .superdoc-empty-inline-sdt-placeholder,
-.superdoc-structured-content-block[data-appearance='hidden'] .superdoc-empty-block-sdt-placeholder {
+.superdoc-structured-content-block[data-appearance='hidden'] .superdoc-empty-block-sdt-placeholder,
+.superdoc-empty-sdt-placeholder[data-appearance='hidden'] {
   width: 0;
   min-width: 0;
   overflow: hidden;
 }
 
 .superdoc-structured-content-inline[data-appearance='hidden'] .superdoc-empty-inline-sdt-placeholder::before,
-.superdoc-structured-content-block[data-appearance='hidden'] .superdoc-empty-block-sdt-placeholder::before {
+.superdoc-structured-content-block[data-appearance='hidden'] .superdoc-empty-block-sdt-placeholder::before,
+.superdoc-empty-sdt-placeholder[data-appearance='hidden']::before {
   content: '';
 }
 
@@ -821,7 +823,7 @@ const SDT_CONTAINER_STYLES = `
 }
 
 .presentation-editor--viewing .superdoc-empty-sdt-placeholder::before {
-  content: '';
+  visibility: hidden;
 }
 
 .presentation-editor--viewing .superdoc-structured-content__label,
@@ -850,7 +852,7 @@ const SDT_CONTAINER_STYLES = `
   }
 
   .superdoc-empty-sdt-placeholder::before {
-    content: '';
+    visibility: hidden;
   }
 }
 `;

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -820,6 +820,10 @@ const SDT_CONTAINER_STYLES = `
   border: none;
 }
 
+.presentation-editor--viewing .superdoc-empty-sdt-placeholder::before {
+  content: '';
+}
+
 .presentation-editor--viewing .superdoc-structured-content__label,
 .presentation-editor--viewing .superdoc-structured-content-inline__label {
   display: none !important;

--- a/packages/layout-engine/painters/dom/src/utils/sdt-helpers.ts
+++ b/packages/layout-engine/painters/dom/src/utils/sdt-helpers.ts
@@ -224,6 +224,12 @@ export function applySdtContainerStyling(
     config = getSdtContainerConfig(containerSdt);
   }
   if (!config) return;
+  if (
+    (isStructuredContentMetadata(sdt) && sdt.appearance === 'hidden') ||
+    (isStructuredContentMetadata(containerSdt) && containerSdt.appearance === 'hidden')
+  ) {
+    return;
+  }
 
   const isStart = boundaryOptions?.isStart ?? config.isStart;
   const isEnd = boundaryOptions?.isEnd ?? config.isEnd;

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
@@ -347,6 +347,51 @@ describe('structured-content-block', () => {
         expect(recordBlockKind).toHaveBeenCalledWith('pageBreak');
       });
 
+      it('should not synthesize a placeholder when tracked-change filtering removes an empty paragraph child', () => {
+        const emptyParagraph: PMNode = {
+          type: 'paragraph',
+          attrs: {
+            paragraphProperties: {
+              runProperties: {},
+            },
+          },
+          content: [],
+        };
+        const node: PMNode = {
+          type: 'structuredContentBlock',
+          attrs: { id: 'scb-1' },
+          content: [emptyParagraph],
+        };
+
+        const blocks: FlowBlock[] = [];
+        const recordBlockKind = vi.fn();
+
+        vi.mocked(metadataModule.resolveNodeSdtMetadata).mockReturnValue(scbMetadata);
+        const paragraphToFlowBlocks = vi.fn().mockReturnValue([]);
+
+        const context: NodeHandlerContext = {
+          blocks,
+          recordBlockKind,
+          nextBlockId: mockBlockIdGenerator,
+          positions: mockPositionMap,
+          defaultFont: 'Arial',
+          defaultSize: 12,
+          trackedChangesConfig: { enabled: true, mode: 'final' },
+          bookmarks: mockBookmarks,
+          hyperlinkConfig: mockHyperlinkConfig,
+          enableComments: mockEnableComments,
+          converterContext: mockConverterContext,
+          converters: {
+            paragraphToFlowBlocks,
+          },
+        };
+
+        handleStructuredContentBlockNode(node, context);
+
+        expect(blocks).toHaveLength(0);
+        expect(recordBlockKind).not.toHaveBeenCalled();
+      });
+
       it('should process a single paragraph child', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
@@ -393,6 +393,79 @@ describe('structured-content-block', () => {
         expect(recordBlockKind).toHaveBeenCalledWith('paragraph');
       });
 
+      it('should emit a placeholder paragraph when the empty paragraph only has permission range markers', () => {
+        const emptyParagraph: PMNode = {
+          type: 'paragraph',
+          content: [
+            { type: 'permStart', attrs: { id: 'perm-1', edGrp: 'everyone' } },
+            { type: 'permEnd', attrs: { id: 'perm-1' } },
+          ],
+        };
+        const node: PMNode = {
+          type: 'structuredContentBlock',
+          attrs: { id: 'scb-1' },
+          content: [emptyParagraph],
+        };
+
+        const blocks: FlowBlock[] = [];
+        const recordBlockKind = vi.fn();
+
+        mockPositionMap.set(node, { start: 10, end: 16 });
+        mockPositionMap.set(emptyParagraph, { start: 11, end: 15 });
+        vi.mocked(metadataModule.resolveNodeSdtMetadata).mockReturnValue(scbMetadata);
+        const paragraphToFlowBlocks = vi.fn().mockReturnValue([
+          {
+            kind: 'paragraph',
+            id: 'converted-permission-only-paragraph',
+            attrs: { sdt: scbMetadata },
+            runs: [
+              {
+                text: '',
+                fontFamily: 'Aptos',
+                fontSize: 14,
+                pmStart: 12,
+                pmEnd: 12,
+              },
+            ],
+          },
+        ] satisfies ParagraphBlock[]);
+
+        const context: NodeHandlerContext = {
+          blocks,
+          recordBlockKind,
+          nextBlockId: mockBlockIdGenerator,
+          positions: mockPositionMap,
+          defaultFont: 'Arial',
+          defaultSize: 12,
+          trackedChangesConfig: mockTrackedChangesConfig,
+          bookmarks: mockBookmarks,
+          hyperlinkConfig: mockHyperlinkConfig,
+          enableComments: mockEnableComments,
+          converterContext: mockConverterContext,
+          converters: {
+            paragraphToFlowBlocks,
+          },
+        };
+
+        handleStructuredContentBlockNode(node, context);
+
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toMatchObject({
+          kind: 'paragraph',
+          attrs: { sdt: scbMetadata },
+          runs: [
+            {
+              text: '',
+              sdt: scbMetadata,
+              visualPlaceholder: 'emptyBlockSdt',
+              pmStart: 12,
+              pmEnd: 12,
+            },
+          ],
+        });
+        expect(recordBlockKind).toHaveBeenCalledWith('paragraph');
+      });
+
       it('should not emit a placeholder for a vanished empty paragraph child', () => {
         const emptyParagraph: PMNode = {
           type: 'paragraph',

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
@@ -247,6 +247,79 @@ describe('structured-content-block', () => {
         expect(recordBlockKind).toHaveBeenCalledWith('paragraph');
       });
 
+      it('should emit a placeholder paragraph when the empty paragraph only has bookmark markers', () => {
+        const emptyParagraph: PMNode = {
+          type: 'paragraph',
+          content: [
+            { type: 'bookmarkStart', attrs: { id: '1', name: 'EmptySdtBookmark' } },
+            { type: 'bookmarkEnd', attrs: { id: '1' } },
+          ],
+        };
+        const node: PMNode = {
+          type: 'structuredContentBlock',
+          attrs: { id: 'scb-1' },
+          content: [emptyParagraph],
+        };
+
+        const blocks: FlowBlock[] = [];
+        const recordBlockKind = vi.fn();
+
+        mockPositionMap.set(node, { start: 10, end: 16 });
+        mockPositionMap.set(emptyParagraph, { start: 11, end: 15 });
+        vi.mocked(metadataModule.resolveNodeSdtMetadata).mockReturnValue(scbMetadata);
+        const paragraphToFlowBlocks = vi.fn().mockReturnValue([
+          {
+            kind: 'paragraph',
+            id: 'converted-bookmark-only-paragraph',
+            attrs: { sdt: scbMetadata },
+            runs: [
+              {
+                text: '',
+                fontFamily: 'Aptos',
+                fontSize: 14,
+                pmStart: 12,
+                pmEnd: 12,
+              },
+            ],
+          },
+        ] satisfies ParagraphBlock[]);
+
+        const context: NodeHandlerContext = {
+          blocks,
+          recordBlockKind,
+          nextBlockId: mockBlockIdGenerator,
+          positions: mockPositionMap,
+          defaultFont: 'Arial',
+          defaultSize: 12,
+          trackedChangesConfig: mockTrackedChangesConfig,
+          bookmarks: mockBookmarks,
+          hyperlinkConfig: mockHyperlinkConfig,
+          enableComments: mockEnableComments,
+          converterContext: mockConverterContext,
+          converters: {
+            paragraphToFlowBlocks,
+          },
+        };
+
+        handleStructuredContentBlockNode(node, context);
+
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toMatchObject({
+          kind: 'paragraph',
+          attrs: { sdt: scbMetadata },
+          runs: [
+            {
+              text: '',
+              sdt: scbMetadata,
+              visualPlaceholder: 'emptyBlockSdt',
+              pmStart: 12,
+              pmEnd: 12,
+            },
+          ],
+        });
+        expect(recordBlockKind).toHaveBeenCalledWith('paragraph');
+      });
+
       it('should not emit a placeholder for a vanished empty paragraph child', () => {
         const emptyParagraph: PMNode = {
           type: 'paragraph',

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
@@ -35,6 +35,10 @@ describe('structured-content-block', () => {
       scope: 'block',
       id: 'scb-1',
     };
+    const nonEmptyParagraph = (text = 'Text'): PMNode => ({
+      type: 'paragraph',
+      content: [{ type: 'text', text }],
+    });
 
     beforeEach(() => {
       vi.clearAllMocks();
@@ -96,7 +100,7 @@ describe('structured-content-block', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
-          content: [{ type: 'paragraph', content: [] }],
+          content: [nonEmptyParagraph()],
         };
 
         const blocks: FlowBlock[] = [];
@@ -163,6 +167,83 @@ describe('structured-content-block', () => {
             },
           ],
         });
+        expect(recordBlockKind).toHaveBeenCalledWith('paragraph');
+      });
+
+      it('should emit a placeholder paragraph for a single empty paragraph child', () => {
+        const emptyParagraph: PMNode = { type: 'paragraph', content: [] };
+        const node: PMNode = {
+          type: 'structuredContentBlock',
+          attrs: { id: 'scb-1' },
+          content: [emptyParagraph],
+        };
+
+        const blocks: FlowBlock[] = [];
+        const recordBlockKind = vi.fn();
+
+        mockPositionMap.set(node, { start: 10, end: 14 });
+        mockPositionMap.set(emptyParagraph, { start: 11, end: 13 });
+        vi.mocked(metadataModule.resolveNodeSdtMetadata).mockReturnValue(scbMetadata);
+        const paragraphToFlowBlocks = vi.fn().mockReturnValue([
+          {
+            kind: 'paragraph',
+            id: 'converted-empty-paragraph',
+            attrs: { sdt: scbMetadata },
+            runs: [
+              {
+                text: '',
+                fontFamily: 'Aptos',
+                fontSize: 14,
+                color: '#123456',
+                pmStart: 12,
+                pmEnd: 12,
+              },
+            ],
+          },
+        ] satisfies ParagraphBlock[]);
+
+        const context: NodeHandlerContext = {
+          blocks,
+          recordBlockKind,
+          nextBlockId: mockBlockIdGenerator,
+          positions: mockPositionMap,
+          defaultFont: 'Arial',
+          defaultSize: 12,
+          trackedChangesConfig: mockTrackedChangesConfig,
+          bookmarks: mockBookmarks,
+          hyperlinkConfig: mockHyperlinkConfig,
+          enableComments: mockEnableComments,
+          converterContext: mockConverterContext,
+          converters: {
+            paragraphToFlowBlocks,
+          },
+        };
+
+        handleStructuredContentBlockNode(node, context);
+
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toMatchObject({
+          kind: 'paragraph',
+          attrs: { sdt: scbMetadata },
+          runs: [
+            {
+              text: '',
+              sdt: scbMetadata,
+              visualPlaceholder: 'emptyBlockSdt',
+              fontFamily: 'Aptos',
+              fontSize: 14,
+              color: '#123456',
+              pmStart: 12,
+              pmEnd: 12,
+            },
+          ],
+        });
+        expect(paragraphToFlowBlocks).toHaveBeenCalledWith(
+          expect.objectContaining({
+            para: emptyParagraph,
+            positions: mockPositionMap,
+          }),
+        );
         expect(recordBlockKind).toHaveBeenCalledWith('paragraph');
       });
 
@@ -263,7 +344,7 @@ describe('structured-content-block', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
-          content: [{ type: 'paragraph', content: [] }],
+          content: [nonEmptyParagraph()],
         };
 
         const blocks: FlowBlock[] = [];
@@ -302,7 +383,7 @@ describe('structured-content-block', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
-          content: [{ type: 'paragraph', content: [] }],
+          content: [nonEmptyParagraph()],
         };
 
         const blocks: FlowBlock[] = [];
@@ -351,7 +432,7 @@ describe('structured-content-block', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
-          content: [{ type: 'paragraph', content: [] }],
+          content: [nonEmptyParagraph()],
         };
 
         const blocks: FlowBlock[] = [];
@@ -392,7 +473,7 @@ describe('structured-content-block', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
-          content: [{ type: 'paragraph', content: [] }],
+          content: [nonEmptyParagraph()],
         };
 
         const blocks: FlowBlock[] = [];
@@ -431,7 +512,7 @@ describe('structured-content-block', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
-          content: [{ type: 'paragraph', content: [] }],
+          content: [nonEmptyParagraph()],
         };
 
         const blocks: FlowBlock[] = [];
@@ -481,7 +562,7 @@ describe('structured-content-block', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
-          content: [{ type: 'paragraph', content: [] }],
+          content: [nonEmptyParagraph()],
         };
 
         const blocks: FlowBlock[] = [];
@@ -517,7 +598,7 @@ describe('structured-content-block', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: {},
-          content: [{ type: 'paragraph', content: [] }],
+          content: [nonEmptyParagraph()],
         };
 
         const blocks: FlowBlock[] = [];
@@ -723,7 +804,7 @@ describe('structured-content-block', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
-          content: [{ type: 'paragraph', content: [] }],
+          content: [nonEmptyParagraph()],
         };
 
         const blocks: FlowBlock[] = [];
@@ -806,7 +887,7 @@ describe('structured-content-block', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
-          content: [{ type: 'paragraph', content: [] }],
+          content: [nonEmptyParagraph()],
         };
 
         const blocks: FlowBlock[] = [];

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
@@ -294,6 +294,59 @@ describe('structured-content-block', () => {
         expect(recordBlockKind).not.toHaveBeenCalled();
       });
 
+      it('should preserve non-paragraph converter output for a vanished empty paragraph child', () => {
+        const emptyParagraph: PMNode = {
+          type: 'paragraph',
+          attrs: {
+            pageBreakBefore: true,
+            paragraphProperties: {
+              runProperties: {
+                vanish: true,
+              },
+            },
+          },
+          content: [],
+        };
+        const node: PMNode = {
+          type: 'structuredContentBlock',
+          attrs: { id: 'scb-1' },
+          content: [emptyParagraph],
+        };
+
+        const pageBreakBlock: FlowBlock = {
+          kind: 'pageBreak',
+          id: 'page-break-before-hidden-paragraph',
+          attrs: { source: 'pageBreakBefore' },
+        };
+        const blocks: FlowBlock[] = [];
+        const recordBlockKind = vi.fn();
+
+        vi.mocked(metadataModule.resolveNodeSdtMetadata).mockReturnValue(scbMetadata);
+        const paragraphToFlowBlocks = vi.fn().mockReturnValue([pageBreakBlock]);
+
+        const context: NodeHandlerContext = {
+          blocks,
+          recordBlockKind,
+          nextBlockId: mockBlockIdGenerator,
+          positions: mockPositionMap,
+          defaultFont: 'Arial',
+          defaultSize: 12,
+          trackedChangesConfig: mockTrackedChangesConfig,
+          bookmarks: mockBookmarks,
+          hyperlinkConfig: mockHyperlinkConfig,
+          enableComments: mockEnableComments,
+          converterContext: mockConverterContext,
+          converters: {
+            paragraphToFlowBlocks,
+          },
+        };
+
+        handleStructuredContentBlockNode(node, context);
+
+        expect(blocks).toEqual([pageBreakBlock]);
+        expect(recordBlockKind).toHaveBeenCalledWith('pageBreak');
+      });
+
       it('should process a single paragraph child', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
@@ -320,6 +320,79 @@ describe('structured-content-block', () => {
         expect(recordBlockKind).toHaveBeenCalledWith('paragraph');
       });
 
+      it('should emit a placeholder paragraph when the empty paragraph only has comment range markers', () => {
+        const emptyParagraph: PMNode = {
+          type: 'paragraph',
+          content: [
+            { type: 'commentRangeStart', attrs: { 'w:id': 'comment-1' } },
+            { type: 'commentRangeEnd', attrs: { 'w:id': 'comment-1' } },
+          ],
+        };
+        const node: PMNode = {
+          type: 'structuredContentBlock',
+          attrs: { id: 'scb-1' },
+          content: [emptyParagraph],
+        };
+
+        const blocks: FlowBlock[] = [];
+        const recordBlockKind = vi.fn();
+
+        mockPositionMap.set(node, { start: 10, end: 16 });
+        mockPositionMap.set(emptyParagraph, { start: 11, end: 15 });
+        vi.mocked(metadataModule.resolveNodeSdtMetadata).mockReturnValue(scbMetadata);
+        const paragraphToFlowBlocks = vi.fn().mockReturnValue([
+          {
+            kind: 'paragraph',
+            id: 'converted-comment-only-paragraph',
+            attrs: { sdt: scbMetadata },
+            runs: [
+              {
+                text: '',
+                fontFamily: 'Aptos',
+                fontSize: 14,
+                pmStart: 12,
+                pmEnd: 12,
+              },
+            ],
+          },
+        ] satisfies ParagraphBlock[]);
+
+        const context: NodeHandlerContext = {
+          blocks,
+          recordBlockKind,
+          nextBlockId: mockBlockIdGenerator,
+          positions: mockPositionMap,
+          defaultFont: 'Arial',
+          defaultSize: 12,
+          trackedChangesConfig: mockTrackedChangesConfig,
+          bookmarks: mockBookmarks,
+          hyperlinkConfig: mockHyperlinkConfig,
+          enableComments: mockEnableComments,
+          converterContext: mockConverterContext,
+          converters: {
+            paragraphToFlowBlocks,
+          },
+        };
+
+        handleStructuredContentBlockNode(node, context);
+
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toMatchObject({
+          kind: 'paragraph',
+          attrs: { sdt: scbMetadata },
+          runs: [
+            {
+              text: '',
+              sdt: scbMetadata,
+              visualPlaceholder: 'emptyBlockSdt',
+              pmStart: 12,
+              pmEnd: 12,
+            },
+          ],
+        });
+        expect(recordBlockKind).toHaveBeenCalledWith('paragraph');
+      });
+
       it('should not emit a placeholder for a vanished empty paragraph child', () => {
         const emptyParagraph: PMNode = {
           type: 'paragraph',

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
@@ -31,17 +31,19 @@ describe('structured-content-block', () => {
     const mockConverterContext = { docx: {} } as never;
 
     const scbMetadata: SdtMetadata = {
-      type: 'structuredContentBlock',
+      type: 'structuredContent',
+      scope: 'block',
       id: 'scb-1',
     };
 
     beforeEach(() => {
       vi.clearAllMocks();
+      mockPositionMap.clear();
     });
 
     // ==================== Basic Functionality Tests ====================
     describe('Basic functionality', () => {
-      it('should return early if node.content is not an array', () => {
+      it('should emit a placeholder paragraph if node.content is not an array', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
@@ -50,6 +52,8 @@ describe('structured-content-block', () => {
 
         const blocks: FlowBlock[] = [];
         const recordBlockKind = vi.fn();
+        mockPositionMap.set(node, { start: 10, end: 12 });
+        vi.mocked(metadataModule.resolveNodeSdtMetadata).mockReturnValue(scbMetadata);
 
         const context: NodeHandlerContext = {
           blocks,
@@ -70,8 +74,22 @@ describe('structured-content-block', () => {
 
         handleStructuredContentBlockNode(node, context);
 
-        expect(blocks).toHaveLength(0);
-        expect(recordBlockKind).not.toHaveBeenCalled();
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toMatchObject({
+          kind: 'paragraph',
+          id: 'paragraph-test-id',
+          attrs: { sdt: scbMetadata },
+          runs: [
+            {
+              text: '',
+              sdt: scbMetadata,
+              visualPlaceholder: 'emptyBlockSdt',
+              pmStart: 11,
+              pmEnd: 11,
+            },
+          ],
+        });
+        expect(recordBlockKind).toHaveBeenCalledWith('paragraph');
       });
 
       it('should throw if paragraphToFlowBlocks is not provided', () => {
@@ -102,7 +120,7 @@ describe('structured-content-block', () => {
         expect(() => handleStructuredContentBlockNode(node, context)).toThrow();
       });
 
-      it('should handle empty children array', () => {
+      it('should emit a placeholder paragraph for empty children array', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
@@ -133,8 +151,19 @@ describe('structured-content-block', () => {
 
         handleStructuredContentBlockNode(node, context);
 
-        expect(blocks).toHaveLength(0);
-        expect(recordBlockKind).not.toHaveBeenCalled();
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toMatchObject({
+          kind: 'paragraph',
+          attrs: { sdt: scbMetadata },
+          runs: [
+            {
+              text: '',
+              sdt: scbMetadata,
+              visualPlaceholder: 'emptyBlockSdt',
+            },
+          ],
+        });
+        expect(recordBlockKind).toHaveBeenCalledWith('paragraph');
       });
 
       it('should process a single paragraph child', () => {
@@ -735,7 +764,7 @@ describe('structured-content-block', () => {
 
     // ==================== Edge Cases ====================
     describe('Edge cases', () => {
-      it('should handle node with null content', () => {
+      it('should emit a placeholder paragraph for null content', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',
           attrs: { id: 'scb-1' },
@@ -744,6 +773,7 @@ describe('structured-content-block', () => {
 
         const blocks: FlowBlock[] = [];
         const recordBlockKind = vi.fn();
+        vi.mocked(metadataModule.resolveNodeSdtMetadata).mockReturnValue(scbMetadata);
 
         const context: NodeHandlerContext = {
           blocks,
@@ -764,7 +794,12 @@ describe('structured-content-block', () => {
 
         handleStructuredContentBlockNode(node, context);
 
-        expect(blocks).toHaveLength(0);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toMatchObject({
+          kind: 'paragraph',
+          attrs: { sdt: scbMetadata },
+          runs: [{ visualPlaceholder: 'emptyBlockSdt', sdt: scbMetadata }],
+        });
       });
 
       it('should handle converter returning empty array', () => {

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.test.ts
@@ -247,6 +247,53 @@ describe('structured-content-block', () => {
         expect(recordBlockKind).toHaveBeenCalledWith('paragraph');
       });
 
+      it('should not emit a placeholder for a vanished empty paragraph child', () => {
+        const emptyParagraph: PMNode = {
+          type: 'paragraph',
+          attrs: {
+            paragraphProperties: {
+              runProperties: {
+                vanish: true,
+              },
+            },
+          },
+          content: [],
+        };
+        const node: PMNode = {
+          type: 'structuredContentBlock',
+          attrs: { id: 'scb-1' },
+          content: [emptyParagraph],
+        };
+
+        const blocks: FlowBlock[] = [];
+        const recordBlockKind = vi.fn();
+
+        vi.mocked(metadataModule.resolveNodeSdtMetadata).mockReturnValue(scbMetadata);
+        const paragraphToFlowBlocks = vi.fn().mockReturnValue([]);
+
+        const context: NodeHandlerContext = {
+          blocks,
+          recordBlockKind,
+          nextBlockId: mockBlockIdGenerator,
+          positions: mockPositionMap,
+          defaultFont: 'Arial',
+          defaultSize: 12,
+          trackedChangesConfig: mockTrackedChangesConfig,
+          bookmarks: mockBookmarks,
+          hyperlinkConfig: mockHyperlinkConfig,
+          enableComments: mockEnableComments,
+          converterContext: mockConverterContext,
+          converters: {
+            paragraphToFlowBlocks,
+          },
+        };
+
+        handleStructuredContentBlockNode(node, context);
+
+        expect(blocks).toHaveLength(0);
+        expect(recordBlockKind).not.toHaveBeenCalled();
+      });
+
       it('should process a single paragraph child', () => {
         const node: PMNode = {
           type: 'structuredContentBlock',

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
@@ -149,13 +149,11 @@ export function handleStructuredContentBlockNode(node: PMNode, context: NodeHand
         });
         return;
       }
-      if (isVanishedParagraph) {
-        paragraphBlocks.forEach((block) => {
-          blocks.push(block);
-          recordBlockKind?.(block.kind);
-        });
-        return;
-      }
+      paragraphBlocks.forEach((block) => {
+        blocks.push(block);
+        recordBlockKind?.(block.kind);
+      });
+      return;
     }
 
     if (isVanishedParagraph) return;

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
@@ -9,7 +9,13 @@ import type { FlowBlock, ParagraphBlock, TableBlock, TextRun } from '@superdoc/c
 import type { PMNode, NodeHandlerContext } from '../types.js';
 import { resolveNodeSdtMetadata, applySdtMetadataToParagraphBlocks, applySdtMetadataToTableBlock } from './metadata.js';
 
-const NON_RENDERED_STRUCTURAL_INLINE_TYPES = new Set(['bookmarkEnd', 'commentRangeStart', 'commentRangeEnd']);
+const NON_RENDERED_STRUCTURAL_INLINE_TYPES = new Set([
+  'bookmarkEnd',
+  'commentRangeStart',
+  'commentRangeEnd',
+  'permStart',
+  'permEnd',
+]);
 
 function isVisuallyEmptyInlineNode(node: PMNode): boolean {
   if (node.type === 'text') {

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
@@ -9,19 +9,23 @@ import type { FlowBlock, ParagraphBlock, TableBlock, TextRun } from '@superdoc/c
 import type { PMNode, NodeHandlerContext } from '../types.js';
 import { resolveNodeSdtMetadata, applySdtMetadataToParagraphBlocks, applySdtMetadataToTableBlock } from './metadata.js';
 
+function isVisuallyEmptyInlineNode(node: PMNode): boolean {
+  if (node.type === 'text') {
+    return (node.text ?? '').length === 0;
+  }
+
+  if (node.type === 'run' || node.type === 'bookmarkStart') {
+    return !Array.isArray(node.content) || node.content.every(isVisuallyEmptyInlineNode);
+  }
+
+  return node.type === 'bookmarkEnd';
+}
+
 function isEmptyParagraphNode(node: PMNode): boolean {
   if (node.type !== 'paragraph') return false;
   if (!Array.isArray(node.content) || node.content.length === 0) return true;
 
-  return node.content.every((child) => {
-    if (child.type === 'run') {
-      return !Array.isArray(child.content) || child.content.length === 0;
-    }
-    if (child.type === 'text') {
-      return (child.text ?? '').length === 0;
-    }
-    return false;
-  });
+  return node.content.every(isVisuallyEmptyInlineNode);
 }
 
 function isVanishedParagraphNode(node: PMNode): boolean {

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
@@ -5,9 +5,55 @@
  * paragraphs and tables while preserving their content structure.
  */
 
-import type { ParagraphBlock, TableBlock, TextRun } from '@superdoc/contracts';
+import type { FlowBlock, ParagraphBlock, TableBlock, TextRun } from '@superdoc/contracts';
 import type { PMNode, NodeHandlerContext } from '../types.js';
 import { resolveNodeSdtMetadata, applySdtMetadataToParagraphBlocks, applySdtMetadataToTableBlock } from './metadata.js';
+
+function isEmptyParagraphNode(node: PMNode): boolean {
+  if (node.type !== 'paragraph') return false;
+  if (!Array.isArray(node.content) || node.content.length === 0) return true;
+
+  return node.content.every((child) => {
+    if (child.type === 'run') {
+      return !Array.isArray(child.content) || child.content.length === 0;
+    }
+    if (child.type === 'text') {
+      return (child.text ?? '').length === 0;
+    }
+    return false;
+  });
+}
+
+function asEmptyTextRun(run: unknown): TextRun | undefined {
+  if (!run || typeof run !== 'object') return undefined;
+  const candidate = run as TextRun;
+  if (!('text' in candidate) || candidate.text !== '') return undefined;
+  const kind = (candidate as { kind?: unknown }).kind;
+  return kind == null || kind === 'text' ? candidate : undefined;
+}
+
+function applyPlaceholderToEmptyParagraphBlocks(
+  paragraphBlocks: FlowBlock[],
+  metadata: TextRun['sdt'],
+  contentPos?: number,
+): boolean {
+  let applied = false;
+  paragraphBlocks.forEach((block) => {
+    if (block.kind !== 'paragraph') return;
+    const run = block.runs.map(asEmptyTextRun).find(Boolean);
+    if (!run) return;
+    run.kind = 'text';
+    run.text = '';
+    run.sdt = metadata;
+    run.visualPlaceholder = 'emptyBlockSdt';
+    if (contentPos != null) {
+      run.pmStart = contentPos;
+      run.pmEnd = contentPos;
+    }
+    applied = true;
+  });
+  return applied;
+}
 
 /**
  * Handle structured content block nodes.
@@ -35,10 +81,8 @@ export function handleStructuredContentBlockNode(node: PMNode, context: NodeHand
   const structuredContentMetadata = resolveNodeSdtMetadata(node, 'structuredContentBlock');
   const paragraphToFlowBlocks = converters?.paragraphToFlowBlocks;
 
-  if (!Array.isArray(node.content) || node.content.length === 0) {
+  const emitPlaceholderBlock = (contentPos?: number): void => {
     if (!structuredContentMetadata) return;
-    const pos = positions.get(node);
-    const contentPos = pos ? pos.start + 1 : undefined;
     const placeholderRun: TextRun = {
       kind: 'text',
       text: '',
@@ -56,6 +100,47 @@ export function handleStructuredContentBlockNode(node: PMNode, context: NodeHand
     };
     blocks.push(placeholderBlock);
     recordBlockKind?.(placeholderBlock.kind);
+  };
+
+  if (!Array.isArray(node.content) || node.content.length === 0) {
+    const pos = positions.get(node);
+    emitPlaceholderBlock(pos ? pos.start + 1 : undefined);
+    return;
+  }
+
+  if (node.content.length === 1 && isEmptyParagraphNode(node.content[0])) {
+    const paragraphPos = positions.get(node.content[0]);
+    const blockPos = positions.get(node);
+    const contentPos = paragraphPos ? paragraphPos.start + 1 : blockPos ? blockPos.start + 1 : undefined;
+
+    if (paragraphToFlowBlocks) {
+      const convertedBlocks = paragraphToFlowBlocks({
+        para: node.content[0],
+        nextBlockId,
+        positions,
+        trackedChangesConfig,
+        bookmarks,
+        hyperlinkConfig,
+        themeColors,
+        enableComments,
+        converters,
+        converterContext,
+      });
+      const paragraphBlocks = Array.isArray(convertedBlocks) ? convertedBlocks : [];
+      applySdtMetadataToParagraphBlocks(
+        paragraphBlocks.filter((b) => b.kind === 'paragraph') as ParagraphBlock[],
+        structuredContentMetadata,
+      );
+      if (applyPlaceholderToEmptyParagraphBlocks(paragraphBlocks, structuredContentMetadata, contentPos)) {
+        paragraphBlocks.forEach((block) => {
+          blocks.push(block);
+          recordBlockKind?.(block.kind);
+        });
+        return;
+      }
+    }
+
+    emitPlaceholderBlock(contentPos);
     return;
   }
 

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
@@ -119,10 +119,7 @@ export function handleStructuredContentBlockNode(node: PMNode, context: NodeHand
   }
 
   if (node.content.length === 1 && isEmptyParagraphNode(node.content[0])) {
-    if (isVanishedParagraphNode(node.content[0])) {
-      return;
-    }
-
+    const isVanishedParagraph = isVanishedParagraphNode(node.content[0]);
     const paragraphPos = positions.get(node.content[0]);
     const blockPos = positions.get(node);
     const contentPos = paragraphPos ? paragraphPos.start + 1 : blockPos ? blockPos.start + 1 : undefined;
@@ -152,8 +149,16 @@ export function handleStructuredContentBlockNode(node: PMNode, context: NodeHand
         });
         return;
       }
+      if (isVanishedParagraph) {
+        paragraphBlocks.forEach((block) => {
+          blocks.push(block);
+          recordBlockKind?.(block.kind);
+        });
+        return;
+      }
     }
 
+    if (isVanishedParagraph) return;
     emitPlaceholderBlock(contentPos);
     return;
   }

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
@@ -9,6 +9,8 @@ import type { FlowBlock, ParagraphBlock, TableBlock, TextRun } from '@superdoc/c
 import type { PMNode, NodeHandlerContext } from '../types.js';
 import { resolveNodeSdtMetadata, applySdtMetadataToParagraphBlocks, applySdtMetadataToTableBlock } from './metadata.js';
 
+const NON_RENDERED_STRUCTURAL_INLINE_TYPES = new Set(['bookmarkEnd', 'commentRangeStart', 'commentRangeEnd']);
+
 function isVisuallyEmptyInlineNode(node: PMNode): boolean {
   if (node.type === 'text') {
     return (node.text ?? '').length === 0;
@@ -18,7 +20,7 @@ function isVisuallyEmptyInlineNode(node: PMNode): boolean {
     return !Array.isArray(node.content) || node.content.every(isVisuallyEmptyInlineNode);
   }
 
-  return node.type === 'bookmarkEnd';
+  return NON_RENDERED_STRUCTURAL_INLINE_TYPES.has(node.type);
 }
 
 function isEmptyParagraphNode(node: PMNode): boolean {

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
@@ -24,6 +24,16 @@ function isEmptyParagraphNode(node: PMNode): boolean {
   });
 }
 
+function isVanishedParagraphNode(node: PMNode): boolean {
+  const paragraphProperties = node.attrs?.paragraphProperties;
+  if (!paragraphProperties || typeof paragraphProperties !== 'object') return false;
+
+  const runProperties = (paragraphProperties as { runProperties?: unknown }).runProperties;
+  if (!runProperties || typeof runProperties !== 'object') return false;
+
+  return (runProperties as { vanish?: unknown }).vanish === true;
+}
+
 function asEmptyTextRun(run: unknown): TextRun | undefined {
   if (!run || typeof run !== 'object') return undefined;
   const candidate = run as TextRun;
@@ -109,6 +119,10 @@ export function handleStructuredContentBlockNode(node: PMNode, context: NodeHand
   }
 
   if (node.content.length === 1 && isEmptyParagraphNode(node.content[0])) {
+    if (isVanishedParagraphNode(node.content[0])) {
+      return;
+    }
+
     const paragraphPos = positions.get(node.content[0]);
     const blockPos = positions.get(node);
     const contentPos = paragraphPos ? paragraphPos.start + 1 : blockPos ? blockPos.start + 1 : undefined;

--- a/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
+++ b/packages/layout-engine/pm-adapter/src/sdt/structured-content-block.ts
@@ -5,7 +5,7 @@
  * paragraphs and tables while preserving their content structure.
  */
 
-import type { ParagraphBlock, TableBlock } from '@superdoc/contracts';
+import type { ParagraphBlock, TableBlock, TextRun } from '@superdoc/contracts';
 import type { PMNode, NodeHandlerContext } from '../types.js';
 import { resolveNodeSdtMetadata, applySdtMetadataToParagraphBlocks, applySdtMetadataToTableBlock } from './metadata.js';
 
@@ -17,13 +17,13 @@ import { resolveNodeSdtMetadata, applySdtMetadataToParagraphBlocks, applySdtMeta
  * @param context - Shared handler context
  */
 export function handleStructuredContentBlockNode(node: PMNode, context: NodeHandlerContext): void {
-  if (!Array.isArray(node.content)) return;
-
   const {
     blocks,
     recordBlockKind,
     nextBlockId,
     positions,
+    defaultFont,
+    defaultSize,
     trackedChangesConfig,
     bookmarks,
     hyperlinkConfig,
@@ -33,7 +33,31 @@ export function handleStructuredContentBlockNode(node: PMNode, context: NodeHand
     themeColors,
   } = context;
   const structuredContentMetadata = resolveNodeSdtMetadata(node, 'structuredContentBlock');
-  const paragraphToFlowBlocks = converters.paragraphToFlowBlocks;
+  const paragraphToFlowBlocks = converters?.paragraphToFlowBlocks;
+
+  if (!Array.isArray(node.content) || node.content.length === 0) {
+    if (!structuredContentMetadata) return;
+    const pos = positions.get(node);
+    const contentPos = pos ? pos.start + 1 : undefined;
+    const placeholderRun: TextRun = {
+      kind: 'text',
+      text: '',
+      fontFamily: defaultFont,
+      fontSize: defaultSize,
+      sdt: structuredContentMetadata,
+      visualPlaceholder: 'emptyBlockSdt',
+      ...(contentPos != null ? { pmStart: contentPos, pmEnd: contentPos } : {}),
+    };
+    const placeholderBlock: ParagraphBlock = {
+      kind: 'paragraph',
+      id: nextBlockId('paragraph'),
+      runs: [placeholderRun],
+      attrs: { sdt: structuredContentMetadata },
+    };
+    blocks.push(placeholderBlock);
+    recordBlockKind?.(placeholderBlock.kind);
+    return;
+  }
 
   // SD-1333: a documentPartObject is a transparent SDT wrapper. When it sits
   // as a direct child of a structuredContentBlock (e.g. a Signature SDT
@@ -42,6 +66,9 @@ export function handleStructuredContentBlockNode(node: PMNode, context: NodeHand
   // outer SDT metadata to them.
   const visitChild = (child: PMNode): void => {
     if (child.type === 'paragraph') {
+      if (!paragraphToFlowBlocks) {
+        throw new Error('paragraphToFlowBlocks converter is required for structuredContentBlock paragraphs');
+      }
       const paragraphBlocks = paragraphToFlowBlocks({
         para: child,
         nextBlockId,

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/pointer-events/EditorInputManager.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/pointer-events/EditorInputManager.ts
@@ -72,6 +72,7 @@ const COMMENT_THREAD_HIT_TOLERANCE_PX = 3;
 const INLINE_SDT_LABEL_SELECTOR = `.${DOM_CLASS_NAMES.INLINE_SDT_LABEL}`;
 const BLOCK_SDT_LABEL_SELECTOR = `.${DOM_CLASS_NAMES.BLOCK_SDT_LABEL}`;
 const SDT_LABEL_SELECTOR = `${INLINE_SDT_LABEL_SELECTOR}, ${BLOCK_SDT_LABEL_SELECTOR}`;
+const EMPTY_SDT_PLACEHOLDER_SELECTOR = '.superdoc-empty-sdt-placeholder';
 const COMMENT_THREAD_HIT_SAMPLE_OFFSETS: ReadonlyArray<readonly [number, number]> = [
   [0, 0],
   [-COMMENT_THREAD_HIT_TOLERANCE_PX, 0],
@@ -1719,13 +1720,14 @@ export class EditorInputManager {
         let nextSelection: Selection;
         let inlineSdtBoundaryPos: number | null = null;
         let inlineSdtBoundaryDirection: 'before' | 'after' | null = null;
+        const clickedEmptySdtPlaceholder = target?.closest?.(EMPTY_SDT_PLACEHOLDER_SELECTOR) != null;
         const inlineSdt = clickDepth === 1 ? findStructuredContentInlineAtPos(doc, hit.pos) : null;
-        if (inlineSdt && hit.pos >= inlineSdt.end) {
+        if (!clickedEmptySdtPlaceholder && inlineSdt && hit.pos >= inlineSdt.end) {
           const afterInlineSdt = inlineSdt.pos + inlineSdt.node.nodeSize;
           inlineSdtBoundaryPos = afterInlineSdt;
           inlineSdtBoundaryDirection = 'after';
           nextSelection = TextSelection.create(doc, afterInlineSdt);
-        } else if (inlineSdt && hit.pos <= inlineSdt.start) {
+        } else if (!clickedEmptySdtPlaceholder && inlineSdt && hit.pos <= inlineSdt.start) {
           inlineSdtBoundaryPos = inlineSdt.pos;
           inlineSdtBoundaryDirection = 'before';
           nextSelection = TextSelection.create(doc, inlineSdt.pos);

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/DomSelectionGeometry.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/DomSelectionGeometry.test.ts
@@ -1652,6 +1652,38 @@ describe('computeDomCaretPageLocal', () => {
       });
     });
 
+    it('positions caret at the left edge of an empty block SDT placeholder', () => {
+      painterHost.innerHTML = `
+        <div class="superdoc-page" data-page-index="0">
+          <div class="superdoc-line">
+            <span class="superdoc-structured-content-block" data-pm-start="5" data-pm-end="5" data-empty="true">
+              <span class="superdoc-empty-block-sdt-placeholder" data-pm-start="5" data-pm-end="5"></span>
+            </span>
+          </div>
+        </div>
+      `;
+
+      domPositionIndex.rebuild(painterHost);
+
+      const pageEl = painterHost.querySelector('.superdoc-page') as HTMLElement;
+      const lineEl = painterHost.querySelector('.superdoc-line') as HTMLElement;
+      const placeholderEl = painterHost.querySelector('.superdoc-empty-block-sdt-placeholder') as HTMLElement;
+
+      pageEl.getBoundingClientRect = vi.fn(() => createRect(0, 0, 612, 792));
+      lineEl.getBoundingClientRect = vi.fn(() => createRect(10, 20, 100, 16));
+      placeholderEl.getBoundingClientRect = vi.fn(() => createRect(10, 34, 205, 16));
+
+      const options = createCaretOptions();
+      const caret = computeDomCaretPageLocal(options, 5);
+
+      expect(caret).not.toBe(null);
+      expect(caret).toMatchObject({
+        pageIndex: 0,
+        x: 10,
+        y: 20,
+      });
+    });
+
     it('positions caret at the right edge when it is after an empty inline SDT placeholder', () => {
       painterHost.innerHTML = `
         <div class="superdoc-page" data-page-index="0">

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/DomSelectionGeometry.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/DomSelectionGeometry.test.ts
@@ -1651,6 +1651,40 @@ describe('computeDomCaretPageLocal', () => {
         y: 20,
       });
     });
+
+    it('positions caret at the right edge when it is after an empty inline SDT placeholder', () => {
+      painterHost.innerHTML = `
+        <div class="superdoc-page" data-page-index="0">
+          <div class="superdoc-line">
+            <span data-pm-start="2" data-pm-end="7">Lead </span>
+            <span class="superdoc-structured-content-inline" data-pm-start="9" data-pm-end="9" data-empty="true">
+              <span class="superdoc-empty-inline-sdt-placeholder" data-pm-start="9" data-pm-end="9"></span>
+            </span>
+            <span data-pm-start="14" data-pm-end="20"> trail.</span>
+          </div>
+        </div>
+      `;
+
+      domPositionIndex.rebuild(painterHost);
+
+      const pageEl = painterHost.querySelector('.superdoc-page') as HTMLElement;
+      const lineEl = painterHost.querySelector('.superdoc-line') as HTMLElement;
+      const placeholderEl = painterHost.querySelector('.superdoc-empty-inline-sdt-placeholder') as HTMLElement;
+
+      pageEl.getBoundingClientRect = vi.fn(() => createRect(0, 0, 612, 792));
+      lineEl.getBoundingClientRect = vi.fn(() => createRect(10, 20, 250, 16));
+      placeholderEl.getBoundingClientRect = vi.fn(() => createRect(60, 20, 205, 16));
+
+      const options = createCaretOptions();
+      const caret = computeDomCaretPageLocal(options, 10);
+
+      expect(caret).not.toBe(null);
+      expect(caret).toMatchObject({
+        pageIndex: 0,
+        x: 265,
+        y: 20,
+      });
+    });
   });
 
   describe('index rebuild for disconnected elements', () => {

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/EditorInputManager.structuredContent.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/EditorInputManager.structuredContent.test.ts
@@ -58,7 +58,9 @@ function getPointerEventImpl(): typeof PointerEvent | typeof MouseEvent {
   );
 }
 
-function createMockDoc(mode: 'tableInSdt' | 'plainSdt' | 'inlineSdtAfterBoundary' | 'nestedInlineInBlock') {
+function createMockDoc(
+  mode: 'tableInSdt' | 'plainSdt' | 'inlineSdtAfterBoundary' | 'emptyInlineSdt' | 'nestedInlineInBlock',
+) {
   return {
     content: { size: 200 },
     nodeAt: vi.fn(() => ({ nodeSize: 20 })),
@@ -87,6 +89,19 @@ function createMockDoc(mode: 'tableInSdt' | 'plainSdt' | 'inlineSdtAfterBoundary
           before: (depth: number) => (depth === 2 ? 10 : 0),
           start: (depth: number) => (depth === 2 ? 11 : 1),
           end: (depth: number) => (depth === 2 ? 12 : 199),
+        };
+      }
+      if (mode === 'emptyInlineSdt') {
+        return {
+          depth: 2,
+          node: (depth: number) => {
+            if (depth === 2) return { type: { name: 'structuredContent' }, nodeSize: 2 };
+            if (depth === 1) return { type: { name: 'paragraph' } };
+            return { type: { name: 'doc' } };
+          },
+          before: (depth: number) => (depth === 2 ? 8 : 0),
+          start: (depth: number) => (depth === 2 ? 9 : 1),
+          end: (depth: number) => (depth === 2 ? 9 : 199),
         };
       }
       if (mode === 'nestedInlineInBlock') {
@@ -175,7 +190,9 @@ describe('EditorInputManager structured content clicks', () => {
   let getEditor: Mock;
   let mockHitTestTable: Mock;
 
-  function mountWithDoc(mode: 'tableInSdt' | 'plainSdt' | 'inlineSdtAfterBoundary' | 'nestedInlineInBlock') {
+  function mountWithDoc(
+    mode: 'tableInSdt' | 'plainSdt' | 'inlineSdtAfterBoundary' | 'emptyInlineSdt' | 'nestedInlineInBlock',
+  ) {
     mockEditor.state.doc = createMockDoc(mode);
   }
 
@@ -240,7 +257,7 @@ describe('EditorInputManager structured content clicks', () => {
       getEditor,
       getLayoutState: vi.fn(() => ({ layout: {} as any, blocks: [], measures: [] })),
       getEpochMapper: vi.fn(() => ({
-        mapPosFromLayoutToCurrentDetailed: vi.fn(() => ({ ok: true, pos: 12, toEpoch: 1 })),
+        mapPosFromLayoutToCurrentDetailed: vi.fn((pos: number) => ({ ok: true, pos, toEpoch: 1 })),
       })),
       getViewportHost: vi.fn(() => viewportHost),
       getVisibleHost: vi.fn(() => visibleHost),
@@ -368,6 +385,38 @@ describe('EditorInputManager structured content clicks', () => {
     expect(resolvePointerPositionHit as unknown as Mock).toHaveBeenCalled();
     expect(mockTextSelectionCreate).toHaveBeenCalledWith(mockEditor.state.doc, 13);
     expect(mockApplyEditableSlotAtInlineBoundary).toHaveBeenCalledWith(mockEditor.state.tr, 13, 'after');
+    expect(mockNodeSelectionCreate).not.toHaveBeenCalled();
+  });
+
+  it('keeps placeholder clicks inside an empty inline structured content node', () => {
+    mountWithDoc('emptyInlineSdt');
+    (resolvePointerPositionHit as unknown as Mock).mockReturnValueOnce({
+      pos: 9,
+      layoutEpoch: 1,
+      pageIndex: 0,
+      blockId: 'body-1',
+      column: 0,
+      lineIndex: 0,
+    });
+    const target = document.createElement('span');
+    target.className = 'superdoc-empty-sdt-placeholder superdoc-empty-inline-sdt-placeholder';
+    viewportHost.appendChild(target);
+
+    const PointerEventImpl = getPointerEventImpl();
+    target.dispatchEvent(
+      new PointerEventImpl('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 1,
+        clientX: 28,
+        clientY: 28,
+      } as PointerEventInit),
+    );
+
+    expect(resolvePointerPositionHit as unknown as Mock).toHaveBeenCalled();
+    expect(mockTextSelectionCreate).toHaveBeenCalledWith(mockEditor.state.doc, 9);
+    expect(mockApplyEditableSlotAtInlineBoundary).not.toHaveBeenCalled();
     expect(mockNodeSelectionCreate).not.toHaveBeenCalled();
   });
 

--- a/packages/super-editor/src/editors/v1/dom-observer/DomPointerMapping.test.ts
+++ b/packages/super-editor/src/editors/v1/dom-observer/DomPointerMapping.test.ts
@@ -282,6 +282,40 @@ describe('DomPointerMapping', () => {
         }
       }
     });
+
+    it('maps clicks on empty SDT placeholder chrome to the SDT content position', () => {
+      container.innerHTML = `
+        <div class="superdoc-page" data-page-index="0">
+          <div class="superdoc-fragment" data-block-id="block1">
+            <div class="superdoc-line" data-pm-start="10" data-pm-end="12">
+              <span
+                class="superdoc-empty-sdt-placeholder superdoc-empty-inline-sdt-placeholder"
+                data-pm-start="11"
+                data-pm-end="11"
+                data-placeholder-text="Click or tap here to enter text"
+              ></span>
+            </div>
+          </div>
+        </div>
+      `;
+
+      const page = container.querySelector('.superdoc-page') as HTMLElement;
+      const fragment = container.querySelector('.superdoc-fragment') as HTMLElement;
+      const line = container.querySelector('.superdoc-line') as HTMLElement;
+      const placeholder = container.querySelector('.superdoc-empty-sdt-placeholder') as HTMLElement;
+
+      mockRect(page, { left: 100, top: 10, width: 300, height: 30 });
+      mockRect(fragment, { left: 100, top: 10, width: 300, height: 30 });
+      mockRect(line, { left: 110, top: 10, width: 250, height: 20 });
+      mockRect(placeholder, { left: 110, top: 10, width: 220, height: 20 });
+
+      withMockedElementsFromPoint(
+        [placeholder, line, fragment, page, container, document.body, document.documentElement],
+        () => {
+          expect(clickToPositionDom(container, 310, 18)).toBe(11);
+        },
+      );
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/packages/super-editor/src/editors/v1/dom-observer/DomPointerMapping.ts
+++ b/packages/super-editor/src/editors/v1/dom-observer/DomPointerMapping.ts
@@ -38,6 +38,7 @@ const CLASS = {
   line: DOM_CLASS_NAMES.LINE,
   tableFragment: DOM_CLASS_NAMES.TABLE_FRAGMENT,
   inlineSdtWrapper: DOM_CLASS_NAMES.INLINE_SDT_WRAPPER,
+  emptySdtPlaceholder: 'superdoc-empty-sdt-placeholder',
 } as const;
 
 /** Augmented Document type for the `elementsFromPoint` API. */
@@ -488,6 +489,11 @@ function resolvePositionInLine(
 
   const { start: spanStart, end: spanEnd } = readPmRange(targetEl);
   if (!Number.isFinite(spanStart) || !Number.isFinite(spanEnd)) return null;
+
+  if (targetEl.classList.contains(CLASS.emptySdtPlaceholder)) {
+    return spanStart;
+  }
+
   const rightCaretBoundary = resolveRightCaretBoundary(spanEls, targetIndex, spanStart, spanEnd);
 
   // Non-text or empty element → snap to nearest edge

--- a/packages/super-editor/src/editors/v1/dom-observer/DomSelectionGeometry.ts
+++ b/packages/super-editor/src/editors/v1/dom-observer/DomSelectionGeometry.ts
@@ -578,9 +578,12 @@ export function computeDomCaretPageLocal(
     const elRect = targetEl.getBoundingClientRect();
     // For non-text elements (images, math), position caret at the right edge
     // when pos matches pmEnd (cursor after the element)
-    const isEmptyInlineSdtPlaceholder = targetEl.classList.contains('superdoc-empty-inline-sdt-placeholder');
-    const atEnd = isEmptyInlineSdtPlaceholder ? pos > entry.pmEnd : pos >= entry.pmEnd;
-    const lineEl = isEmptyInlineSdtPlaceholder ? (targetEl.closest('.superdoc-line') as HTMLElement | null) : null;
+    const isEmptySdtPlaceholder =
+      targetEl.classList.contains('superdoc-empty-sdt-placeholder') ||
+      targetEl.classList.contains('superdoc-empty-inline-sdt-placeholder') ||
+      targetEl.classList.contains('superdoc-empty-block-sdt-placeholder');
+    const atEnd = isEmptySdtPlaceholder ? pos > entry.pmEnd : pos >= entry.pmEnd;
+    const lineEl = isEmptySdtPlaceholder ? (targetEl.closest('.superdoc-line') as HTMLElement | null) : null;
     const yRect = lineEl?.getBoundingClientRect() ?? elRect;
     return {
       pageIndex: Number(page.dataset.pageIndex ?? '0'),

--- a/packages/super-editor/src/editors/v1/dom-observer/DomSelectionGeometry.ts
+++ b/packages/super-editor/src/editors/v1/dom-observer/DomSelectionGeometry.ts
@@ -579,7 +579,7 @@ export function computeDomCaretPageLocal(
     // For non-text elements (images, math), position caret at the right edge
     // when pos matches pmEnd (cursor after the element)
     const isEmptyInlineSdtPlaceholder = targetEl.classList.contains('superdoc-empty-inline-sdt-placeholder');
-    const atEnd = !isEmptyInlineSdtPlaceholder && pos >= entry.pmEnd;
+    const atEnd = isEmptyInlineSdtPlaceholder ? pos > entry.pmEnd : pos >= entry.pmEnd;
     const lineEl = isEmptyInlineSdtPlaceholder ? (targetEl.closest('.superdoc-line') as HTMLElement | null) : null;
     const yRect = lineEl?.getBoundingClientRect() ?? elRect;
     return {

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.js
@@ -173,7 +173,7 @@ export function createStructuredContentLockPlugin() {
             inlineSdtAncestor &&
             inlineSdtAncestor.lockMode !== 'contentLocked' &&
             inlineSdtAncestor.lockMode !== 'sdtContentLocked';
-          if (inlineSdtContentEditable && selection.$from.parent.type.name === 'run') {
+          if ((isBackspace || isDelete) && inlineSdtContentEditable && selection.$from.parent.type.name === 'run') {
             const deleteFrom = isBackspace ? from - 1 : from;
             const deleteTo = isBackspace ? from : from + 1;
             const staysInsideInlineSdt = deleteFrom > inlineSdtAncestor.pos && deleteTo < inlineSdtAncestor.end;

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.js
@@ -229,6 +229,11 @@ export function createStructuredContentLockPlugin() {
         return true;
       }
 
+      const inputType = tr.getMeta?.('inputType');
+      if (inputType === 'historyUndo' || inputType === 'historyRedo') {
+        return true;
+      }
+
       if (tr.getMeta?.(BLOCK_NODE_METADATA_UPDATE_META)) {
         return true;
       }

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.js
@@ -1,4 +1,4 @@
-import { NodeSelection, Plugin, PluginKey } from 'prosemirror-state';
+import { NodeSelection, Plugin, PluginKey, TextSelection } from 'prosemirror-state';
 import { ySyncPluginKey } from 'y-prosemirror';
 import { BLOCK_NODE_METADATA_UPDATE_META } from '../block-node/block-node.js';
 
@@ -122,6 +122,13 @@ export function createStructuredContentLockPlugin() {
               exactContentSDT.lockMode === 'contentLocked' || exactContentSDT.lockMode === 'sdtContentLocked';
             const isWrapperDeletable =
               exactContentSDT.lockMode !== 'sdtLocked' && exactContentSDT.lockMode !== 'sdtContentLocked';
+            const isFullyLocked = exactContentSDT.lockMode === 'sdtContentLocked';
+            if (isFullyLocked && exactContentSDT.type === 'structuredContent' && (isBackspace || isDelete)) {
+              const collapsePos = isBackspace ? exactContentSDT.pos : exactContentSDT.end;
+              view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, collapsePos)));
+              event.preventDefault();
+              return true;
+            }
             if (isContentLocked && isWrapperDeletable) {
               if (isCut) {
                 const tr = state.tr.setSelection(NodeSelection.create(state.doc, exactContentSDT.pos));

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.js
@@ -166,6 +166,26 @@ export function createStructuredContentLockPlugin() {
             return true;
           }
 
+          const inlineSdtAncestor = sdtNodes.find(
+            (s) => s.type === 'structuredContent' && from > s.pos && from < s.end,
+          );
+          const inlineSdtContentEditable =
+            inlineSdtAncestor &&
+            inlineSdtAncestor.lockMode !== 'contentLocked' &&
+            inlineSdtAncestor.lockMode !== 'sdtContentLocked';
+          if (inlineSdtContentEditable && selection.$from.parent.type.name === 'run') {
+            const deleteFrom = isBackspace ? from - 1 : from;
+            const deleteTo = isBackspace ? from : from + 1;
+            const staysInsideInlineSdt = deleteFrom > inlineSdtAncestor.pos && deleteTo < inlineSdtAncestor.end;
+            const staysInsideRun = isBackspace ? from > selection.$from.start() : from < selection.$from.end();
+
+            if (staysInsideInlineSdt && staysInsideRun) {
+              view.dispatch(state.tr.delete(deleteFrom, deleteTo).scrollIntoView());
+              event.preventDefault();
+              return true;
+            }
+          }
+
           if (isBackspace && from > 0) {
             affectedFrom = from - 1;
             // Path 2 — caret is exactly at the trailing wrapper boundary of an

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.test.js
@@ -656,6 +656,35 @@ describe('StructuredContentLockPlugin', () => {
         expect(editor.state.selection.empty).toBe(true);
         expect(editor.state.selection.from).toBe(nextSdtInfo.pos + 1);
       });
+
+      it('sdtLocked + collapsed Cmd+X inside typed inline SDT text does not delete content', () => {
+        const beforeText = schema.text('Before ');
+        const sdtRun = schema.nodes.run.create(null, schema.text('abc'));
+        const sdt = schema.nodes.structuredContent.create({ id: 'test-123', lockMode: 'sdtLocked' }, sdtRun);
+        const afterText = schema.text(' After');
+        const paragraph = schema.nodes.paragraph.create(null, [beforeText, sdt, afterText]);
+        const doc = schema.nodes.doc.create(null, [paragraph]);
+        const state = applyDocToEditor(doc);
+        const originalText = state.doc.textContent;
+
+        let runPos = null;
+        state.doc.descendants((node, pos) => {
+          if (node.type.name === 'run' && node.textContent === 'abc') {
+            runPos = pos;
+            return false;
+          }
+          return true;
+        });
+        expect(runPos).not.toBeNull();
+
+        placeCaretAt(state, runPos + 2);
+
+        const result = invokeLockHandleKeyDown('x', { metaKey: true });
+
+        expect(result.handled).toBe(false);
+        expect(result.prevented).toBe(false);
+        expect(editor.state.doc.textContent).toBe(originalText);
+      });
     });
 
     describe('Path 1 — selection covers SDT content (label selection / triple-click)', () => {

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.test.js
@@ -790,6 +790,33 @@ describe('StructuredContentLockPlugin', () => {
         expect(finalState.doc.textContent).not.toBe(originalContent);
         expect(sdtNodeExists(finalState.doc, 'structuredContent')).toBe(true);
       });
+
+      it('sdtLocked: undo restores inline SDT content deleted by Backspace', () => {
+        const leadingRun = schema.nodes.run.create(null, schema.text('Lead '));
+        const sdtRun = schema.nodes.run.create(null, schema.text('inline value'));
+        const sdt = schema.nodes.structuredContent.create({ id: 'test-123', lockMode: 'sdtLocked' }, sdtRun);
+        const trailingRun = schema.nodes.run.create(null, schema.text('ail.'));
+        const paragraph = schema.nodes.paragraph.create(null, [leadingRun, sdt, trailingRun]);
+        const doc = schema.nodes.doc.create(null, [paragraph]);
+        const state = applyDocToEditor(doc);
+        const sdtInfo = findSDTNode(state.doc, 'structuredContent');
+
+        placeCaretAt(state, sdtInfo.end);
+        handleBackspace(editor);
+        handleBackspace(editor);
+
+        let sdtAfterDelete = findSDTNode(editor.state.doc, 'structuredContent');
+        expect(sdtAfterDelete).not.toBeNull();
+        expect(sdtAfterDelete.node.textContent).toBe('');
+
+        expect(editor.commands.undo()).toBe(true);
+
+        sdtAfterDelete = findSDTNode(editor.state.doc, 'structuredContent');
+        expect(sdtAfterDelete).not.toBeNull();
+        expect(sdtAfterDelete.node.attrs.lockMode).toBe('sdtLocked');
+        expect(sdtAfterDelete.node.textContent).toBe('inline value');
+        expect(editor.state.doc.textContent).toBe('Lead inline valueail.');
+      });
     });
   });
 

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.test.js
@@ -650,6 +650,11 @@ describe('StructuredContentLockPlugin', () => {
 
           if (shouldDeleteWrapper) {
             expect(sdtNodeExists(editor.state.doc, 'structuredContent')).toBe(false);
+          } else if (lockMode === 'sdtContentLocked') {
+            const sel = editor.state.selection;
+            expect(sel).toBeInstanceOf(TextSelection);
+            expect(sel.empty).toBe(true);
+            expect(sel.from).toBe(sdtInfo.pos);
           } else {
             // No wrapper deletion: selection unchanged.
             const sel = editor.state.selection;
@@ -696,6 +701,36 @@ describe('StructuredContentLockPlugin', () => {
         expect(sdtNodeExists(editor.state.doc, 'structuredContent')).toBe(false);
       });
 
+      it('sdtContentLocked: exact content selection + Backspace collapses before inline SDT, then deletes preceding text', () => {
+        const leadingRun = schema.nodes.run.create(null, schema.text('Lead '));
+        const sdtRun = schema.nodes.run.create(null, schema.text('inline value'));
+        const sdt = schema.nodes.structuredContent.create({ id: 'test-123', lockMode: 'sdtContentLocked' }, sdtRun);
+        const trailingRun = schema.nodes.run.create(null, schema.text('ail.'));
+        const paragraph = schema.nodes.paragraph.create(null, [leadingRun, sdt, trailingRun]);
+        const doc = schema.nodes.doc.create(null, [paragraph]);
+        const state = applyDocToEditor(doc);
+        const sdtInfo = findSDTNode(state.doc, 'structuredContent');
+
+        setSelection(state, TextSelection.create(state.doc, sdtInfo.pos + 1, sdtInfo.end - 1));
+
+        const result = invokeLockHandleKeyDown('Backspace');
+
+        expect(result.handled).toBe(true);
+        expect(result.prevented).toBe(true);
+        expect(editor.state.selection).toBeInstanceOf(TextSelection);
+        expect(editor.state.selection.empty).toBe(true);
+        expect(editor.state.selection.from).toBe(sdtInfo.pos);
+        expect(findSDTNode(editor.state.doc, 'structuredContent').node.textContent).toBe('inline value');
+
+        handleBackspace(editor);
+
+        const sdtAfter = findSDTNode(editor.state.doc, 'structuredContent');
+        expect(sdtAfter).not.toBeNull();
+        expect(sdtAfter.node.attrs.lockMode).toBe('sdtContentLocked');
+        expect(sdtAfter.node.textContent).toBe('inline value');
+        expect(editor.state.doc.textContent).toBe('Leadinline valueail.');
+      });
+
       it.each([
         ['unlocked', false, true],
         ['sdtLocked', false, true],
@@ -719,6 +754,11 @@ describe('StructuredContentLockPlugin', () => {
           } else {
             expect(sdtAfter).not.toBeNull();
             expect(sdtAfter.node.textContent === '').toBe(deletesContent);
+            if (lockMode === 'sdtContentLocked') {
+              expect(editor.state.selection).toBeInstanceOf(TextSelection);
+              expect(editor.state.selection.empty).toBe(true);
+              expect(editor.state.selection.from).toBe(sdtAfter.end);
+            }
           }
         },
       );

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.test.js
@@ -621,6 +621,41 @@ describe('StructuredContentLockPlugin', () => {
         expect(result.prevented).toBe(true);
         expect(sdtNodeExists(editor.state.doc, 'structuredContent')).toBe(!shouldDeleteWrapper);
       });
+
+      it('sdtLocked + Delete before typed inline SDT text deletes the text and preserves the wrapper', () => {
+        const beforeText = schema.text('Before ');
+        const sdtRun = schema.nodes.run.create(null, schema.text('a'));
+        const sdt = schema.nodes.structuredContent.create({ id: 'test-123', lockMode: 'sdtLocked' }, sdtRun);
+        const afterText = schema.text(' After');
+        const paragraph = schema.nodes.paragraph.create(null, [beforeText, sdt, afterText]);
+        const doc = schema.nodes.doc.create(null, [paragraph]);
+        const state = applyDocToEditor(doc);
+        const sdtInfo = findSDTNode(state.doc, 'structuredContent');
+
+        let runPos = null;
+        state.doc.descendants((node, pos) => {
+          if (node.type.name === 'run' && node.textContent === 'a') {
+            runPos = pos;
+            return false;
+          }
+          return true;
+        });
+        expect(sdtInfo).not.toBeNull();
+        expect(runPos).not.toBeNull();
+
+        placeCaretAt(state, runPos + 1);
+
+        const result = invokeLockHandleKeyDown('Delete');
+
+        expect(result.handled).toBe(true);
+        expect(result.prevented).toBe(true);
+        const nextSdtInfo = findSDTNode(editor.state.doc, 'structuredContent');
+        expect(nextSdtInfo).not.toBeNull();
+        expect(nextSdtInfo.node.textContent).toBe('');
+        expect(editor.state.doc.textContent).toBe('Before  After');
+        expect(editor.state.selection.empty).toBe(true);
+        expect(editor.state.selection.from).toBe(nextSdtInfo.pos + 1);
+      });
     });
 
     describe('Path 1 — selection covers SDT content (label selection / triple-click)', () => {

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-select-plugin.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-select-plugin.js
@@ -25,6 +25,7 @@ export function createStructuredContentSelectPlugin(editor) {
         const isEditableSlotText = (text) => text.replace(/\u200B/g, '').length === 0;
 
         const resolveAdjacentEmptyInlineSdtEntry = () => {
+          if (event.key !== 'ArrowLeft') return null;
           if (!selection.empty) return null;
 
           let targetPos = null;

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-select-plugin.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-select-plugin.js
@@ -1,4 +1,4 @@
-import { Plugin } from 'prosemirror-state';
+import { Plugin, TextSelection } from 'prosemirror-state';
 
 import { applyEditableSlotAtInlineBoundary } from '@helpers/ensure-editable-slot-inline-boundary.js';
 import { SELECT_INLINE_SDT_BEFORE_RUN_START_META } from '@core/commands/selectInlineSdtBeforeRunStart.js';
@@ -23,6 +23,25 @@ export function createStructuredContentSelectPlugin(editor) {
         const { state } = view;
         const { selection } = state;
         const isEditableSlotText = (text) => text.replace(/\u200B/g, '').length === 0;
+
+        const resolveAdjacentEmptyInlineSdtEntry = () => {
+          if (!selection.empty) return null;
+
+          let targetPos = null;
+          state.doc.descendants((node, pos) => {
+            if (node.type.name !== 'structuredContent') return true;
+            if (node.content.size !== 0) return true;
+
+            if (event.key === 'ArrowLeft' && selection.from === pos + node.nodeSize) {
+              targetPos = pos + 1;
+              return false;
+            }
+
+            return true;
+          });
+
+          return targetPos;
+        };
 
         const resolveBoundaryExit = ($pos) => {
           for (let depth = $pos.depth; depth > 0; depth -= 1) {
@@ -61,6 +80,17 @@ export function createStructuredContentSelectPlugin(editor) {
           }
           return null;
         };
+
+        const adjacentEmptySdtEntry = resolveAdjacentEmptyInlineSdtEntry();
+        if (adjacentEmptySdtEntry != null) {
+          try {
+            view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, adjacentEmptySdtEntry)));
+            event.preventDefault();
+            return true;
+          } catch {
+            return false;
+          }
+        }
 
         const nextPos = resolveBoundaryExit(selection.$from);
         if (nextPos == null) return false;

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-select-plugin.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-select-plugin.test.js
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EditorState, NodeSelection, TextSelection } from 'prosemirror-state';
 import { initTestEditor } from '@tests/helpers/helpers.js';
 import { SELECT_INLINE_SDT_BEFORE_RUN_START_META } from '@core/commands/selectInlineSdtBeforeRunStart.js';
+import { createStructuredContentSelectPlugin } from './structured-content-select-plugin.js';
 
 function findNode(doc, nodeType) {
   let result = null;
@@ -310,6 +311,28 @@ describe('StructuredContentSelectPlugin', () => {
     expect(editor.state.selection.empty).toBe(true);
     expect(editor.state.selection.from).toBe(insideSdt);
     expect(editor.state.selection.to).toBe(insideSdt);
+  });
+
+  it('does not scan the document for empty inline SDT entry on ArrowRight', () => {
+    const inlineSdt = schema.nodes.structuredContent.create({ id: 'inline-1' });
+    const paragraph = schema.nodes.paragraph.create(null, [schema.text('Lead '), inlineSdt, schema.text(' trail')]);
+    applyDoc(schema.nodes.doc.create(null, [paragraph]));
+
+    const sdt = findNode(editor.state.doc, 'structuredContent');
+    expect(sdt).not.toBeNull();
+
+    const afterSdt = sdt.pos + sdt.node.nodeSize;
+    editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, afterSdt)));
+
+    const descendants = editor.state.doc.descendants.bind(editor.state.doc);
+    const descendantsSpy = vi.fn(descendants);
+    editor.state.doc.descendants = descendantsSpy;
+
+    const plugin = createStructuredContentSelectPlugin(editor);
+    const event = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true });
+
+    expect(plugin.props.handleKeyDown(editor.view, event)).toBe(false);
+    expect(descendantsSpy).not.toHaveBeenCalled();
   });
 
   it('does not intercept Shift+ArrowRight near inline SDT boundary', () => {

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-select-plugin.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-select-plugin.test.js
@@ -292,6 +292,26 @@ describe('StructuredContentSelectPlugin', () => {
     expect(editor.state.selection.from).toBeGreaterThanOrEqual(sdt.pos + 1);
   });
 
+  it('moves back inside an empty inline SDT with ArrowLeft from its trailing boundary', () => {
+    const inlineSdt = schema.nodes.structuredContent.create({ id: 'inline-1' });
+    const paragraph = schema.nodes.paragraph.create(null, [schema.text('Lead '), inlineSdt, schema.text(' trail')]);
+    applyDoc(schema.nodes.doc.create(null, [paragraph]));
+
+    const sdt = findNode(editor.state.doc, 'structuredContent');
+    expect(sdt).not.toBeNull();
+
+    const insideSdt = sdt.pos + 1;
+    const afterSdt = sdt.pos + sdt.node.nodeSize;
+    editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, afterSdt)));
+
+    const handled = pressArrow('ArrowLeft');
+
+    expect(handled).toBe(true);
+    expect(editor.state.selection.empty).toBe(true);
+    expect(editor.state.selection.from).toBe(insideSdt);
+    expect(editor.state.selection.to).toBe(insideSdt);
+  });
+
   it('does not intercept Shift+ArrowRight near inline SDT boundary', () => {
     const inlineSdt = schema.nodes.structuredContent.create({ id: 'inline-1' }, schema.text('Field'));
     const paragraph = schema.nodes.paragraph.create(null, [schema.text('A '), inlineSdt, schema.text(' Z')]);


### PR DESCRIPTION
## Summary

Stacks on top of `luccas/sdt-table-navigation`. Fixes hover/click cursor placement and keyboard interactions for empty inline and block structured-content controls (SDTs), and replaces the invisible 8px spacer with a real "Click or tap here to enter text" placeholder.

## Changes

### Placeholder rendering (visible "Click or tap here to enter text")
- `contracts`: introduce `EMPTY_SDT_PLACEHOLDER_TEXT` constant, broaden `visualPlaceholder` to `'emptyInlineSdt' | 'emptyBlockSdt'`, and add `isEmptySdtPlaceholderRun` helper (keeps `isEmptyInlineSdtPlaceholderRun` as a narrow alias).
- `pm-adapter/sdt/structured-content-block.ts`: emit a placeholder paragraph for empty block SDTs (including empty-paragraph and vanished-paragraph cases). Empty block paragraphs route through `paragraphToFlowBlocks` so the placeholder run inherits the paragraph's resolved font, size, and color.
- `painters/dom`: render placeholder via CSS pseudo-element (`::before` content from `data-placeholder-text`), not document text. New shared class `superdoc-empty-sdt-placeholder` plus per-variant `superdoc-empty-inline-sdt-placeholder` / `superdoc-empty-block-sdt-placeholder`. Selected-node highlight inherits system `Highlight` color. Placeholder is suppressed in viewing/print modes and when `appearance='hidden'`.
- `measuring/dom`: measure the actual placeholder text width (with letter-spacing) instead of a fixed 8px spacer; trust the measured value when non-zero, fall back to a length-based estimate otherwise.
- `layout-bridge/remeasure`: treat the placeholder as visible content during line breaking — return its text from `runText` (or empty string when `appearance='hidden'`) and include its measured width in the line-fit loop so it can wrap atomically.
- `contracts/pm-range`: keep the placeholder run's PM range atomic when computing line ranges (don't expand by character).
- `painters/dom/utils/sdt-helpers`: skip container chrome styling when `appearance='hidden'`.
- `painters/dom/styles`: size block SDT labels to `max-content` (capped at 130px) so short labels don't span the chrome width; inner span flexes with `min-width: 0` for ellipsis.
- `painters/dom/renderer`: include `appearance` in the SDT dataset and expose it on the DOM so CSS/JS can target hidden SDTs.

### Pointer / caret / keyboard interactions
- `DomPointerMapping`: clicks on the placeholder snap to its `pmStart` (inside the SDT) instead of the nearest wrapper edge.
- `DomSelectionGeometry`: caret geometry for the placeholder uses the surrounding line rect and only treats positions strictly past `pmEnd` as "at end".
- `EditorInputManager`: a click on an empty SDT placeholder no longer redirects to the wrapper's before/after boundary.
- `structured-content-select-plugin`: ArrowLeft from immediately after an empty inline SDT re-enters it.
- `structured-content-lock-plugin`:
  - Backspace/Delete inside an unlocked inline SDT (in a `run`) stays inside and deletes within the SDT instead of escaping into surrounding text.
  - Backspace/Delete targeting an `sdtContentLocked` inline SDT collapses the selection to the wrapper boundary rather than letting the keystroke fall through.
  - Allow `historyUndo`/`historyRedo` transactions through the lock guard so SDT content can be recovered after deletion.