### PR TITLE
fix(layout-engine): anchor inline SDT label to start of chrome

### DIFF
--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -120,7 +120,7 @@ describe('ensureSdtContainerStyles', () => {
     expect(sharedLabelDragHandleRule).toContain('center 3px / 2px 2px no-repeat,');
     expect(sharedLabelDragHandleRule).toContain('center 6px / 2px 2px no-repeat;');
     expect(inlineSelectedRule).toContain('display: inline-flex;');
-    expect(inlineLabelRule).toContain('left: 2px;');
+    expect(inlineLabelRule).toContain('inset-inline-start: 2px;');
     expect(inlineLabelRule).toContain('transform: none;');
     expect(inlineLabelRule).not.toContain('left: 50%;');
     expect(inlineLabelRule).not.toContain('translateX(-50%)');

--- a/packages/layout-engine/painters/dom/src/styles.test.ts
+++ b/packages/layout-engine/painters/dom/src/styles.test.ts
@@ -120,6 +120,10 @@ describe('ensureSdtContainerStyles', () => {
     expect(sharedLabelDragHandleRule).toContain('center 3px / 2px 2px no-repeat,');
     expect(sharedLabelDragHandleRule).toContain('center 6px / 2px 2px no-repeat;');
     expect(inlineSelectedRule).toContain('display: inline-flex;');
+    expect(inlineLabelRule).toContain('left: 2px;');
+    expect(inlineLabelRule).toContain('transform: none;');
+    expect(inlineLabelRule).not.toContain('left: 50%;');
+    expect(inlineLabelRule).not.toContain('translateX(-50%)');
     expect(inlineLabelRule).toContain('border-radius: 4px 4px 0 0;');
     expect(blockLabelRule).toContain('white-space: nowrap;');
     expect(blockLabelRule).toContain('top: -18px;');

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -740,7 +740,7 @@ const SDT_CONTAINER_STYLES = `
 .superdoc-structured-content-inline__label {
   position: absolute;
   bottom: calc(100% + 1px);
-  left: 2px;
+  inset-inline-start: 2px;
   transform: none;
   border-radius: 4px 4px 0 0;
   white-space: nowrap;

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -740,8 +740,8 @@ const SDT_CONTAINER_STYLES = `
 .superdoc-structured-content-inline__label {
   position: absolute;
   bottom: calc(100% + 1px);
-  left: 50%;
-  transform: translateX(-50%);
+  left: 2px;
+  transform: none;
   border-radius: 4px 4px 0 0;
   white-space: nowrap;
   z-index: 100;


### PR DESCRIPTION
Position the inline structured-content label at the leading edge of the container instead of centering it, so it stays anchored to a consistent spot regardless of label width.