### PR TITLE
test(behavior): real-Word parity for SDT keyboard behavior (SD-3237/SD-3218)

### DIFF
--- a/tests/behavior/tests/sdt/sdt-word-parity.spec.ts
+++ b/tests/behavior/tests/sdt/sdt-word-parity.spec.ts
@@ -1,0 +1,239 @@
+import { test, expect, type SuperDocFixture } from '../../fixtures/superdoc.js';
+
+/**
+ * SDT keyboard behavior — parity with real Microsoft Word.
+ *
+ * Expected values come from a real-keyboard Word oracle: each scenario was run
+ * on Windows Word 16 via the word-api `run_behavior_probe` tool (real
+ * WScript.Shell.SendKeys, not COM Selection methods), and the resulting state
+ * was captured as a golden. The goldens these tests derive from are committed
+ * alongside in `word-oracle-goldens/` (see its README); provenance is
+ * inputMode="win32-sendkeys-post-tscon".
+ *
+ * Word story-character offsets are NOT comparable to ProseMirror positions, so
+ * these tests assert the observable, ABI-independent facts the goldens
+ * establish (did the caret leave the SDT, was the SDT selected vs deleted, did
+ * select-all escape the SDT, is shift-selection character-granular) rather than
+ * raw offsets.
+ *
+ * SDTs are built with the insertStructuredContentInline command (same idiom as
+ * sdt-lock-modes.spec.ts); for lock-behavior purposes this produces the same PM
+ * node a .docx <w:lock> import would.
+ */
+
+test.use({ config: { toolbar: 'full', showSelection: true } });
+
+type LockMode = 'unlocked' | 'sdtLocked' | 'contentLocked' | 'sdtContentLocked';
+
+const SDT_ID = '9001';
+const SDT_TEXT = 'inline value';
+
+interface SdtRange {
+  pos: number;
+  start: number;
+  end: number;
+  nodeEnd: number;
+}
+
+/** Build "Before <inline SDT 'inline value'> After" in one paragraph; return the SDT range. */
+async function buildInlineSdt(superdoc: SuperDocFixture, lockMode: LockMode): Promise<SdtRange> {
+  await superdoc.page.evaluate(() => {
+    const editor = (window as any).editor;
+    editor.commands.selectAll();
+    editor.commands.deleteSelection();
+  });
+  await superdoc.waitForStable();
+
+  await superdoc.type('Before ');
+  await superdoc.waitForStable();
+
+  await superdoc.page.evaluate(
+    ({ id, text, lockMode }) => {
+      (window as any).editor.commands.insertStructuredContentInline({
+        attrs: { id, alias: 'Inline Field', tag: 'inline-parity', lockMode },
+        text,
+      });
+    },
+    { id: SDT_ID, text: SDT_TEXT, lockMode },
+  );
+  await superdoc.waitForStable();
+
+  await superdoc.press('End');
+  await superdoc.type(' After');
+  await superdoc.waitForStable();
+
+  return getSdtRange(superdoc, SDT_ID);
+}
+
+async function getSdtRange(superdoc: SuperDocFixture, sdtId: string): Promise<SdtRange> {
+  return superdoc.page.evaluate((sdtId) => {
+    const { state } = (window as any).editor;
+    let result: SdtRange | null = null;
+    state.doc.descendants((node: any, pos: number) => {
+      if (result) return false;
+      if (node.type.name === 'structuredContent' && String(node.attrs?.id ?? node.attrs?.sdtId) === sdtId) {
+        result = { pos, start: pos + 1, end: pos + node.nodeSize - 1, nodeEnd: pos + node.nodeSize };
+        return false;
+      }
+      return true;
+    });
+    if (!result) throw new Error(`inline SDT not found: ${sdtId}`);
+    return result;
+  }, sdtId);
+}
+
+/** Selection state + the text it covers + whether the SDT still exists. */
+async function getSel(superdoc: SuperDocFixture, sdtId: string) {
+  return superdoc.page.evaluate((sdtId) => {
+    const { state } = (window as any).editor;
+    const { selection } = state;
+    const $from = selection.$from;
+    const sdtIds: string[] = [];
+    for (let d = $from.depth; d > 0; d--) {
+      const n = $from.node(d);
+      if (n.type.name === 'structuredContent' || n.type.name === 'structuredContentBlock') {
+        const id = n.attrs?.id ?? n.attrs?.sdtId;
+        if (id != null) sdtIds.push(String(id));
+      }
+    }
+    let sdtExists = false;
+    let sdtText: string | null = null;
+    state.doc.descendants((node: any) => {
+      if (node.type.name === 'structuredContent' && String(node.attrs?.id ?? node.attrs?.sdtId) === sdtId) {
+        sdtExists = true;
+        sdtText = node.textContent;
+        return false;
+      }
+      return true;
+    });
+    return {
+      from: selection.from,
+      to: selection.to,
+      empty: selection.empty,
+      nodeType: selection.node?.type?.name ?? null,
+      selectedText: state.doc.textBetween(selection.from, selection.to, ' ', ' '),
+      caretSdtIds: sdtIds,
+      sdtExists,
+      sdtText,
+      docText: state.doc.textContent,
+    };
+  }, sdtId);
+}
+
+async function focus(superdoc: SuperDocFixture) {
+  await superdoc.page.evaluate(() => (window as any).editor.view.focus());
+}
+
+test.describe('SDT keyboard behavior parity with Word', () => {
+  // --- Right-arrow at trailing edge: one press exits the SDT ---
+  // Golden: sd3237-inline-unlocked.right-arrow-trailing.real-key.json
+  // Word: from the last position inside the content control, one Right-arrow
+  // flips wdInContentControl true -> false (caret leaves the SDT in one press).
+  test('Right-arrow at trailing edge exits the SDT in one press (unlocked)', async ({ superdoc }) => {
+    const sdt = await buildInlineSdt(superdoc, 'unlocked');
+
+    await superdoc.setTextSelection(sdt.end); // last position inside content
+    await focus(superdoc);
+    const before = await getSel(superdoc, SDT_ID);
+    expect(before.caretSdtIds).toContain(SDT_ID); // caret starts inside
+
+    await superdoc.press('ArrowRight');
+    await superdoc.waitForStable();
+
+    const after = await getSel(superdoc, SDT_ID);
+    expect(after.caretSdtIds).not.toContain(SDT_ID); // one press -> outside
+    expect(after.sdtExists).toBe(true); // navigation does not mutate
+  });
+
+  // --- Backspace from just outside the trailing edge: first press selects the
+  // SDT content, it does NOT immediately delete. Golden:
+  // *.backspace-from-outside.real-key.json (step1 selType=2, selText='inline value'). ---
+  for (const lockMode of ['unlocked', 'sdtLocked', 'contentLocked', 'sdtContentLocked'] as LockMode[]) {
+    test(`Backspace from outside trailing edge selects the SDT first (${lockMode})`, async ({ superdoc }) => {
+      const sdt = await buildInlineSdt(superdoc, lockMode);
+
+      await superdoc.setTextSelection(sdt.nodeEnd); // just outside, after the SDT
+      await focus(superdoc);
+
+      await superdoc.press('Backspace');
+      await superdoc.waitForStable();
+
+      const after = await getSel(superdoc, SDT_ID);
+      // Word's press 1 is non-destructive: the SDT still exists and its content
+      // is now selected (not collapsed).
+      expect(after.sdtExists).toBe(true);
+      expect(after.empty).toBe(false);
+      expect(after.selectedText).toContain(SDT_TEXT);
+    });
+  }
+
+  // --- Delete from just outside the leading edge: symmetric mirror of the
+  // Backspace case — first press selects the SDT content across all four lock
+  // modes. Goldens: *.delete-from-outside.real-key.json (step1 selType=2,
+  // selText is the SDT content in every mode). ---
+  for (const lockMode of ['unlocked', 'sdtLocked', 'contentLocked', 'sdtContentLocked'] as LockMode[]) {
+    test(`Delete from outside leading edge selects the SDT first (${lockMode})`, async ({ superdoc }) => {
+      const sdt = await buildInlineSdt(superdoc, lockMode);
+
+      await superdoc.setTextSelection(sdt.pos); // just before the SDT, end of "Before "
+      await focus(superdoc);
+
+      await superdoc.press('Delete');
+      await superdoc.waitForStable();
+
+      const after = await getSel(superdoc, SDT_ID);
+      expect(after.sdtExists).toBe(true);
+      expect(after.empty).toBe(false);
+      expect(after.selectedText).toContain(SDT_TEXT);
+    });
+  }
+
+  // --- Ctrl/Cmd+A with the caret inside the SDT selects the WHOLE document,
+  // not just the SDT content. Golden: sd3237-inline-unlocked.ctrl-a-inside-sdt.real-key.json
+  // (selText='Lead inline value trail.\r' — the entire body). ---
+  test('Select-all inside the SDT selects the whole document, not just the SDT', async ({ superdoc }) => {
+    const sdt = await buildInlineSdt(superdoc, 'unlocked');
+
+    await superdoc.setTextSelection(sdt.start + 1); // inside content
+    await focus(superdoc);
+
+    await superdoc.press('ControlOrMeta+a');
+    await superdoc.waitForStable();
+
+    const after = await getSel(superdoc, SDT_ID);
+    expect(after.empty).toBe(false);
+    // The selection escaped the SDT to the whole body: it spans the
+    // outside-the-SDT text on both sides plus the SDT content.
+    expect(after.selectedText).toContain('Before');
+    expect(after.selectedText).toContain('After');
+    expect(after.selectedText).toContain(SDT_TEXT);
+  });
+
+  // --- Shift+Arrow selecting into the SDT is character-granular: a single
+  // Shift+Right from just before the SDT does NOT atomically select the whole
+  // control. Golden: sd3237-inline-unlocked.shift-right-into-sdt.real-key.json
+  // (selEnd grows 6,7,8,... one position per press). ---
+  test('Shift+Right into the SDT extends selection character-by-character (not atomic)', async ({ superdoc }) => {
+    const sdt = await buildInlineSdt(superdoc, 'unlocked');
+
+    // Anchor in the text just before the SDT (Word's golden anchored at
+    // cc.Range.Start - 1, i.e. in the run before the control), not exactly on
+    // the node boundary — a collapsed caret placed precisely at sdt.pos steps
+    // into the node on the first Shift+Right instead of extending.
+    await superdoc.setTextSelection(sdt.pos - 2);
+    await focus(superdoc);
+
+    // Enough presses to cross the boundary and select a few characters of content.
+    for (let i = 0; i < 5; i++) {
+      await superdoc.press('Shift+ArrowRight');
+      await superdoc.waitForStable();
+    }
+
+    const after = await getSel(superdoc, SDT_ID);
+    expect(after.empty).toBe(false);
+    // Selection has entered the content a few characters deep ...
+    expect(after.selectedText).toContain('inl');
+    // ... but did NOT snap to the whole control — character-granular, like Word.
+    expect(after.selectedText).not.toContain(SDT_TEXT);
+  });
+});

--- a/tests/behavior/tests/sdt/word-oracle-goldens/README.md
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/README.md
@@ -1,0 +1,43 @@
+# Word oracle goldens
+
+These JSON files record how **real Microsoft Word** behaves for specific SDT
+(content control) keyboard interactions. They are the expected-behavior source
+for `../sdt-word-parity.spec.ts`.
+
+## How they were captured
+
+Each golden was produced by running the scenario on Windows Word 16 through the
+`word-api` `run_behavior_probe` tool: it opens the fixture in visible Word,
+places the caret relative to `ContentControls(1)`, sends **real keystrokes**
+(`WScript.Shell.SendKeys`, not COM `Selection` methods — COM can bypass the
+lock-handler paths we care about), and captures selection + content-control
+state after each press. Provenance is in each file:
+
+```
+"inputMode": "win32-sendkeys-post-tscon"
+"source":    "Windows Word real keyboard via WScript.Shell.SendKeys post-tscon"
+"wordVersion": "16.0"
+```
+
+## How the spec uses them
+
+Word story-character offsets are **not** comparable to ProseMirror positions, so
+`sdt-word-parity.spec.ts` does not assert raw offsets. It asserts the
+observable, ABI-independent facts these goldens establish:
+
+| Golden | Word fact the spec asserts |
+|---|---|
+| `*.right-arrow-trailing.*` | one Right-arrow from the trailing edge exits the SDT |
+| `*.backspace-from-outside.*` (4 lock modes) | Backspace just outside the trailing edge selects the SDT content first (non-destructive press 1) |
+| `*.delete-from-outside.*` | Delete just outside the leading edge selects the SDT content first (symmetric mirror) |
+| `*.ctrl-a-inside-sdt.*` | select-all inside an SDT selects the whole document, not just the SDT |
+| `*.shift-right-into-sdt.*` | Shift+Right into an SDT is character-granular, not atomic |
+
+## Regenerating / extending
+
+Full methodology, the tscon-reattach discovery that made real keystroke routing
+possible, and the complete set of captured scenarios (including inside-edge
+Backspace/Delete and Enter-at-block-SDT) are documented out-of-tree in the
+review workspace under `.tmp/sd-3237-behavior-tests/word-oracle/`. New goldens
+are produced with `run_behavior_probe`; only the JSON (not the `.after.docx`
+artifacts) is committed here.

--- a/tests/behavior/tests/sdt/word-oracle-goldens/sd3218-inline-sdtContentLocked.backspace-from-outside.real-key.json
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/sd3218-inline-sdtContentLocked.backspace-from-outside.real-key.json
@@ -1,0 +1,99 @@
+{
+  "fixture": "sd3218-inline-sdtContentLocked",
+  "foreground": {
+    "docHwnd": 1508126,
+    "title": "probe-bs19 - Word",
+    "setFgOk": true
+  },
+  "placement": "caret at cc.Range.End + 1 (just OUTSIDE the SDT trailing boundary)",
+  "recordedAt": "2026-05-28T20:40:57Z",
+  "source": "Windows Word real keyboard via WScript.Shell.SendKeys post-tscon",
+  "preflight": {
+    "mySessionId": 1,
+    "qwinstaBefore": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>console           Administrator             1  Active                      \r\n rdp-tcp                                 65536  Listen                      \r\n"
+  },
+  "steps": [
+    {
+      "docText": null,
+      "selStart": 19,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": false,
+      "label": "step0:placed-at-cc.Range.End-plus-1",
+      "selEnd": 19,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-sdtContentLocked",
+        "title": "sdtContentLocked Inline",
+        "lockContents": true
+      },
+      "selText": " "
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 1,
+      "selType": 2,
+      "inside": true,
+      "label": "step1:after-real-BACKSPACE-1",
+      "selEnd": 19,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-sdtContentLocked",
+        "title": "sdtContentLocked Inline",
+        "lockContents": true
+      },
+      "selText": "inline value"
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step2:after-real-BACKSPACE-2",
+      "selEnd": 5,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-sdtContentLocked",
+        "title": "sdtContentLocked Inline",
+        "lockContents": true
+      },
+      "selText": null
+    },
+    {
+      "docText": null,
+      "selStart": 4,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step3:after-real-BACKSPACE-3",
+      "selEnd": 4,
+      "cc": {
+        "rangeEnd": 17,
+        "lockContentControl": true,
+        "rangeStart": 5,
+        "rangeText": "inline value",
+        "tag": "inline-sdtContentLocked",
+        "title": "sdtContentLocked Inline",
+        "lockContents": true
+      },
+      "selText": null
+    }
+  ],
+  "sessionState": "Active",
+  "wordVersion": "16.0",
+  "test": "backspace-from-outside-trailing-x3",
+  "savedDocxBytes": 20461,
+  "trustedFor": ["real-keyboard-parity", "destructive-key-behavior"],
+  "inputMode": "win32-sendkeys-post-tscon"
+}

--- a/tests/behavior/tests/sdt/word-oracle-goldens/sd3218-inline-sdtContentLocked.delete-from-outside.real-key.json
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/sd3218-inline-sdtContentLocked.delete-from-outside.real-key.json
@@ -1,0 +1,99 @@
+{
+  "fixture": "sd3218-inline-sdtContentLocked",
+  "foreground": {
+    "docHwnd": 2556778,
+    "title": "probe-del - Word",
+    "setFgOk": true
+  },
+  "placement": "outside-leading",
+  "recordedAt": "2026-05-28T21:13:28Z",
+  "source": "Windows Word real keyboard via WScript.Shell.SendKeys post-tscon",
+  "preflight": {
+    "mySessionId": 1,
+    "qwinstaBefore": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>console           Administrator             1  Active                      \r\n rdp-tcp                                 65536  Listen                      \r\n"
+  },
+  "steps": [
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step0:placed-at-cc.Range.Start-minus-1",
+      "selEnd": 5,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-sdtContentLocked",
+        "title": "sdtContentLocked Inline",
+        "lockContents": true
+      },
+      "selText": null
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 1,
+      "selType": 2,
+      "inside": true,
+      "label": "step1:after-real-DELETE-1",
+      "selEnd": 19,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-sdtContentLocked",
+        "title": "sdtContentLocked Inline",
+        "lockContents": true
+      },
+      "selText": "inline value"
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 1,
+      "selType": 2,
+      "inside": true,
+      "label": "step2:after-real-DELETE-2",
+      "selEnd": 19,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-sdtContentLocked",
+        "title": "sdtContentLocked Inline",
+        "lockContents": true
+      },
+      "selText": "inline value"
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 1,
+      "selType": 2,
+      "inside": true,
+      "label": "step3:after-real-DELETE-3",
+      "selEnd": 19,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-sdtContentLocked",
+        "title": "sdtContentLocked Inline",
+        "lockContents": true
+      },
+      "selText": "inline value"
+    }
+  ],
+  "sessionState": "Active",
+  "wordVersion": "16.0",
+  "test": "delete-from-outside-leading-x3",
+  "savedDocxBytes": 20468,
+  "trustedFor": ["real-keyboard-parity", "destructive-key-behavior"],
+  "inputMode": "win32-sendkeys-post-tscon"
+}

--- a/tests/behavior/tests/sdt/word-oracle-goldens/sd3218-inline-sdtLocked.backspace-from-outside.real-key.json
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/sd3218-inline-sdtLocked.backspace-from-outside.real-key.json
@@ -1,0 +1,99 @@
+{
+  "fixture": "sd3218-inline-sdtLocked",
+  "foreground": {
+    "docHwnd": 30146896,
+    "title": "probe-bs19 - Word",
+    "setFgOk": true
+  },
+  "placement": "caret at cc.Range.End + 1 (just OUTSIDE the SDT trailing boundary)",
+  "recordedAt": "2026-05-28T20:40:24Z",
+  "source": "Windows Word real keyboard via WScript.Shell.SendKeys post-tscon",
+  "preflight": {
+    "mySessionId": 1,
+    "qwinstaBefore": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>console           Administrator             1  Active                      \r\n rdp-tcp                                 65536  Listen                      \r\n"
+  },
+  "steps": [
+    {
+      "docText": null,
+      "selStart": 19,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": false,
+      "label": "step0:placed-at-cc.Range.End-plus-1",
+      "selEnd": 19,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-sdtLocked",
+        "title": "sdtLocked Inline",
+        "lockContents": false
+      },
+      "selText": " "
+    },
+    {
+      "docText": null,
+      "selStart": 6,
+      "ccCount": 1,
+      "selType": 2,
+      "inside": true,
+      "label": "step1:after-real-BACKSPACE-1",
+      "selEnd": 18,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-sdtLocked",
+        "title": "sdtLocked Inline",
+        "lockContents": false
+      },
+      "selText": "inline value"
+    },
+    {
+      "docText": null,
+      "selStart": 6,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step2:after-real-BACKSPACE-2",
+      "selEnd": 6,
+      "cc": {
+        "rangeEnd": 6,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": null,
+        "tag": "inline-sdtLocked",
+        "title": "sdtLocked Inline",
+        "lockContents": false
+      },
+      "selText": null
+    },
+    {
+      "docText": null,
+      "selStart": 6,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step3:after-real-BACKSPACE-3",
+      "selEnd": 6,
+      "cc": {
+        "rangeEnd": 6,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": null,
+        "tag": "inline-sdtLocked",
+        "title": "sdtLocked Inline",
+        "lockContents": false
+      },
+      "selText": null
+    }
+  ],
+  "sessionState": "Active",
+  "wordVersion": "16.0",
+  "test": "backspace-from-outside-trailing-x3",
+  "savedDocxBytes": 20449,
+  "trustedFor": ["real-keyboard-parity", "destructive-key-behavior"],
+  "inputMode": "win32-sendkeys-post-tscon"
+}

--- a/tests/behavior/tests/sdt/word-oracle-goldens/sd3218-inline-sdtLocked.delete-from-outside.real-key.json
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/sd3218-inline-sdtLocked.delete-from-outside.real-key.json
@@ -1,0 +1,99 @@
+{
+  "fixture": "sd3218-inline-sdtLocked",
+  "foreground": {
+    "docHwnd": 1573804,
+    "title": "probe-del - Word",
+    "setFgOk": true
+  },
+  "placement": "outside-leading",
+  "recordedAt": "2026-05-28T21:12:56Z",
+  "source": "Windows Word real keyboard via WScript.Shell.SendKeys post-tscon",
+  "preflight": {
+    "mySessionId": 1,
+    "qwinstaBefore": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>console           Administrator             1  Active                      \r\n rdp-tcp                                 65536  Listen                      \r\n"
+  },
+  "steps": [
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step0:placed-at-cc.Range.Start-minus-1",
+      "selEnd": 5,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-sdtLocked",
+        "title": "sdtLocked Inline",
+        "lockContents": false
+      },
+      "selText": null
+    },
+    {
+      "docText": null,
+      "selStart": 6,
+      "ccCount": 1,
+      "selType": 2,
+      "inside": true,
+      "label": "step1:after-real-DELETE-1",
+      "selEnd": 18,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-sdtLocked",
+        "title": "sdtLocked Inline",
+        "lockContents": false
+      },
+      "selText": "inline value"
+    },
+    {
+      "docText": null,
+      "selStart": 6,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step2:after-real-DELETE-2",
+      "selEnd": 6,
+      "cc": {
+        "rangeEnd": 6,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": null,
+        "tag": "inline-sdtLocked",
+        "title": "sdtLocked Inline",
+        "lockContents": false
+      },
+      "selText": null
+    },
+    {
+      "docText": null,
+      "selStart": 6,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step3:after-real-DELETE-3",
+      "selEnd": 6,
+      "cc": {
+        "rangeEnd": 6,
+        "lockContentControl": true,
+        "rangeStart": 6,
+        "rangeText": null,
+        "tag": "inline-sdtLocked",
+        "title": "sdtLocked Inline",
+        "lockContents": false
+      },
+      "selText": null
+    }
+  ],
+  "sessionState": "Active",
+  "wordVersion": "16.0",
+  "test": "delete-from-outside-leading-x3",
+  "savedDocxBytes": 20451,
+  "trustedFor": ["real-keyboard-parity", "destructive-key-behavior"],
+  "inputMode": "win32-sendkeys-post-tscon"
+}

--- a/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-contentLocked.backspace-from-outside.real-key.json
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-contentLocked.backspace-from-outside.real-key.json
@@ -1,0 +1,81 @@
+{
+  "fixture": "sd3237-inline-contentLocked",
+  "foreground": {
+    "docHwnd": 918016,
+    "title": "probe-bs19 - Word",
+    "setFgOk": true
+  },
+  "placement": "caret at cc.Range.End + 1 (just OUTSIDE the SDT trailing boundary)",
+  "recordedAt": "2026-05-28T20:40:42Z",
+  "source": "Windows Word real keyboard via WScript.Shell.SendKeys post-tscon",
+  "preflight": {
+    "mySessionId": 1,
+    "qwinstaBefore": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>console           Administrator             1  Active                      \r\n rdp-tcp                                 65536  Listen                      \r\n"
+  },
+  "steps": [
+    {
+      "docText": null,
+      "selStart": 20,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": false,
+      "label": "step0:placed-at-cc.Range.End-plus-1",
+      "selEnd": 20,
+      "cc": {
+        "rangeEnd": 19,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": "locked inline",
+        "tag": "inline-contentlocked",
+        "title": "Locked Inline",
+        "lockContents": true
+      },
+      "selText": " "
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 1,
+      "selType": 2,
+      "inside": true,
+      "label": "step1:after-real-BACKSPACE-1",
+      "selEnd": 20,
+      "cc": {
+        "rangeEnd": 19,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": "locked inline",
+        "tag": "inline-contentlocked",
+        "title": "Locked Inline",
+        "lockContents": true
+      },
+      "selText": "locked inline"
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 0,
+      "selType": 1,
+      "inside": false,
+      "label": "step2:after-real-BACKSPACE-2",
+      "selEnd": 5,
+      "selText": " "
+    },
+    {
+      "docText": null,
+      "selStart": 4,
+      "ccCount": 0,
+      "selType": 1,
+      "inside": false,
+      "label": "step3:after-real-BACKSPACE-3",
+      "selEnd": 4,
+      "selText": " "
+    }
+  ],
+  "sessionState": "Active",
+  "wordVersion": "16.0",
+  "test": "backspace-from-outside-trailing-x3",
+  "savedDocxBytes": 13395,
+  "trustedFor": ["real-keyboard-parity", "destructive-key-behavior"],
+  "inputMode": "win32-sendkeys-post-tscon"
+}

--- a/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-contentLocked.delete-from-outside.real-key.json
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-contentLocked.delete-from-outside.real-key.json
@@ -1,0 +1,81 @@
+{
+  "fixture": "sd3237-inline-contentLocked",
+  "foreground": {
+    "docHwnd": 2818490,
+    "title": "probe-del - Word",
+    "setFgOk": true
+  },
+  "placement": "outside-leading",
+  "recordedAt": "2026-05-28T21:13:12Z",
+  "source": "Windows Word real keyboard via WScript.Shell.SendKeys post-tscon",
+  "preflight": {
+    "mySessionId": 1,
+    "qwinstaBefore": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>console           Administrator             1  Active                      \r\n rdp-tcp                                 65536  Listen                      \r\n"
+  },
+  "steps": [
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step0:placed-at-cc.Range.Start-minus-1",
+      "selEnd": 5,
+      "cc": {
+        "rangeEnd": 19,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": "locked inline",
+        "tag": "inline-contentlocked",
+        "title": "Locked Inline",
+        "lockContents": true
+      },
+      "selText": null
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 1,
+      "selType": 2,
+      "inside": true,
+      "label": "step1:after-real-DELETE-1",
+      "selEnd": 20,
+      "cc": {
+        "rangeEnd": 19,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": "locked inline",
+        "tag": "inline-contentlocked",
+        "title": "Locked Inline",
+        "lockContents": true
+      },
+      "selText": "locked inline"
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 0,
+      "selType": 1,
+      "inside": false,
+      "label": "step2:after-real-DELETE-2",
+      "selEnd": 5,
+      "selText": " "
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 0,
+      "selType": 1,
+      "inside": false,
+      "label": "step3:after-real-DELETE-3",
+      "selEnd": 5,
+      "selText": "t"
+    }
+  ],
+  "sessionState": "Active",
+  "wordVersion": "16.0",
+  "test": "delete-from-outside-leading-x3",
+  "savedDocxBytes": 13396,
+  "trustedFor": ["real-keyboard-parity", "destructive-key-behavior"],
+  "inputMode": "win32-sendkeys-post-tscon"
+}

--- a/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-unlocked.backspace-from-outside.real-key.json
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-unlocked.backspace-from-outside.real-key.json
@@ -1,0 +1,90 @@
+{
+  "fixture": "sd3237-inline-unlocked",
+  "foreground": {
+    "docHwnd": 37290162,
+    "title": "probe-bs19 - Word",
+    "setFgOk": true
+  },
+  "placement": "caret at cc.Range.End + 1 (just OUTSIDE the SDT trailing boundary)",
+  "recordedAt": "2026-05-28T20:40:08Z",
+  "source": "Windows Word real keyboard via WScript.Shell.SendKeys post-tscon",
+  "preflight": {
+    "mySessionId": 1,
+    "qwinstaBefore": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>console           Administrator             1  Active                      \r\n rdp-tcp                                 65536  Listen                      \r\n"
+  },
+  "steps": [
+    {
+      "docText": null,
+      "selStart": 19,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": false,
+      "label": "step0:placed-at-cc.Range.End-plus-1",
+      "selEnd": 19,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-unlocked",
+        "title": "Inline Field",
+        "lockContents": false
+      },
+      "selText": " "
+    },
+    {
+      "docText": null,
+      "selStart": 6,
+      "ccCount": 1,
+      "selType": 2,
+      "inside": true,
+      "label": "step1:after-real-BACKSPACE-1",
+      "selEnd": 18,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-unlocked",
+        "title": "Inline Field",
+        "lockContents": false
+      },
+      "selText": "inline value"
+    },
+    {
+      "docText": null,
+      "selStart": 6,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step2:after-real-BACKSPACE-2",
+      "selEnd": 6,
+      "cc": {
+        "rangeEnd": 6,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": null,
+        "tag": "inline-unlocked",
+        "title": "Inline Field",
+        "lockContents": false
+      },
+      "selText": null
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 0,
+      "selType": 1,
+      "inside": false,
+      "label": "step3:after-real-BACKSPACE-3",
+      "selEnd": 5,
+      "selText": " "
+    }
+  ],
+  "sessionState": "Active",
+  "wordVersion": "16.0",
+  "test": "backspace-from-outside-trailing-x3",
+  "savedDocxBytes": 13428,
+  "trustedFor": ["real-keyboard-parity", "destructive-key-behavior"],
+  "inputMode": "win32-sendkeys-post-tscon"
+}

--- a/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-unlocked.ctrl-a-inside-sdt.real-key.json
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-unlocked.ctrl-a-inside-sdt.real-key.json
@@ -1,0 +1,91 @@
+{
+  "paragraphsInsideSdtContent": null,
+  "foreground": {
+    "setFgOk": true,
+    "docHwnd": 2556430,
+    "isWord": true,
+    "procName": "WINWORD",
+    "procId": 6360,
+    "title": "behavior-probe-scratch - Word",
+    "hwnd": 2556430
+  },
+  "placement": "cc-content-end",
+  "recordedAt": "2026-05-28T22:36:42Z",
+  "savedDocxBase64": "",
+  "preflight": {
+    "sessionStateInitial": "Active",
+    "qwinstaBefore": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>console           Administrator             1  Active                      \r\n rdp-tcp                                 65536  Listen                      \r\n",
+    "mySessionId": 1
+  },
+  "steps": [
+    {
+      "selType": 1,
+      "docText": null,
+      "label": "step0:placed",
+      "ccCount": 1,
+      "selStart": 18,
+      "paragraphCount": 1,
+      "inside": true,
+      "selEnd": 18,
+      "selText": null,
+      "cc": {
+        "lockContentControl": false,
+        "rangeText": "inline value",
+        "paragraphsInContent": 1,
+        "rangeEnd": 18,
+        "title": "Inline Field",
+        "rangeStart": 6,
+        "lockContents": false,
+        "tag": "inline-unlocked"
+      }
+    },
+    {
+      "selType": 2,
+      "docText": null,
+      "label": "step1:after-^a",
+      "ccCount": 1,
+      "selStart": 0,
+      "paragraphCount": 1,
+      "inside": true,
+      "selEnd": 27,
+      "selText": "Lead inline value trail.\r",
+      "cc": {
+        "lockContentControl": false,
+        "rangeText": "inline value",
+        "paragraphsInContent": 1,
+        "rangeEnd": 18,
+        "title": "Inline Field",
+        "rangeStart": 6,
+        "lockContents": false,
+        "tag": "inline-unlocked"
+      }
+    },
+    {
+      "selType": 2,
+      "docText": null,
+      "label": "step2:after-^a",
+      "ccCount": 1,
+      "selStart": 0,
+      "paragraphCount": 1,
+      "inside": true,
+      "selEnd": 27,
+      "selText": "Lead inline value trail.\r",
+      "cc": {
+        "lockContentControl": false,
+        "rangeText": "inline value",
+        "paragraphsInContent": 1,
+        "rangeEnd": 18,
+        "title": "Inline Field",
+        "rangeStart": 6,
+        "lockContents": false,
+        "tag": "inline-unlocked"
+      }
+    }
+  ],
+  "sessionState": "Active",
+  "wordVersion": "16.0",
+  "documentXmlSdtExcerpt": "",
+  "savedDocxBytes": 0,
+  "trustedFor": ["real-keyboard-parity", "destructive-key-behavior"],
+  "inputMode": "win32-sendkeys-post-tscon"
+}

--- a/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-unlocked.delete-from-outside.real-key.json
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-unlocked.delete-from-outside.real-key.json
@@ -1,0 +1,90 @@
+{
+  "fixture": "sd3237-inline-unlocked",
+  "foreground": {
+    "docHwnd": 2294428,
+    "title": "probe-del - Word",
+    "setFgOk": true
+  },
+  "placement": "outside-leading",
+  "recordedAt": "2026-05-28T21:12:36Z",
+  "source": "Windows Word real keyboard via WScript.Shell.SendKeys post-tscon",
+  "preflight": {
+    "mySessionId": 1,
+    "qwinstaBefore": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>console           Administrator             1  Active                      \r\n rdp-tcp                                 65536  Listen                      \r\n"
+  },
+  "steps": [
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step0:placed-at-cc.Range.Start-minus-1",
+      "selEnd": 5,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-unlocked",
+        "title": "Inline Field",
+        "lockContents": false
+      },
+      "selText": null
+    },
+    {
+      "docText": null,
+      "selStart": 6,
+      "ccCount": 1,
+      "selType": 2,
+      "inside": true,
+      "label": "step1:after-real-DELETE-1",
+      "selEnd": 18,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-unlocked",
+        "title": "Inline Field",
+        "lockContents": false
+      },
+      "selText": "inline value"
+    },
+    {
+      "docText": null,
+      "selStart": 6,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step2:after-real-DELETE-2",
+      "selEnd": 6,
+      "cc": {
+        "rangeEnd": 6,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": null,
+        "tag": "inline-unlocked",
+        "title": "Inline Field",
+        "lockContents": false
+      },
+      "selText": null
+    },
+    {
+      "docText": null,
+      "selStart": 5,
+      "ccCount": 0,
+      "selType": 1,
+      "inside": false,
+      "label": "step3:after-real-DELETE-3",
+      "selEnd": 5,
+      "selText": " "
+    }
+  ],
+  "sessionState": "Active",
+  "wordVersion": "16.0",
+  "test": "delete-from-outside-leading-x3",
+  "savedDocxBytes": 13429,
+  "trustedFor": ["real-keyboard-parity", "destructive-key-behavior"],
+  "inputMode": "win32-sendkeys-post-tscon"
+}

--- a/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-unlocked.right-arrow-trailing.real-key.json
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-unlocked.right-arrow-trailing.real-key.json
@@ -1,0 +1,83 @@
+{
+  "source": "Windows Word real keyboard via WScript.Shell.SendKeys post-tscon",
+  "recordedAt": "2026-05-28T20:31:05Z",
+  "trustedFor": ["navigation", "real-keyboard-parity"],
+  "fixture": "sd3237-inline-unlocked.docx",
+  "inputMode": "win32-sendkeys-post-tscon",
+  "preflight": {
+    "qwinstaAfter": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>console           Administrator             1  Active                      \r\n rdp-tcp                                 65536  Listen                      \r\n",
+    "tsconAttempt": "",
+    "qwinstaBefore": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>                  Administrator             1  Disc                        \r\n console                                     2  Conn                        \r\n rdp-tcp                                 65536  Listen                      \r\n",
+    "mySessionId": 1,
+    "tsconExit": 0
+  },
+  "foreground": {
+    "title": "probe-scratch - Word",
+    "hwnd": 786914,
+    "setFgOk": true,
+    "wordHwnd": 786914
+  },
+  "test": "right-arrow-trailing",
+  "wordVersion": "16.0",
+  "sessionState": "Active",
+  "steps": [
+    {
+      "docText": null,
+      "selStart": 18,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": true,
+      "label": "step0:placed-at-trailing-edge",
+      "selEnd": 18,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-unlocked",
+        "title": "Inline Field",
+        "lockContents": false
+      },
+      "selText": null
+    },
+    {
+      "docText": null,
+      "selStart": 19,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": false,
+      "label": "step1:after-real-key-RIGHT",
+      "selEnd": 19,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-unlocked",
+        "title": "Inline Field",
+        "lockContents": false
+      },
+      "selText": " "
+    },
+    {
+      "docText": null,
+      "selStart": 20,
+      "ccCount": 1,
+      "selType": 1,
+      "inside": false,
+      "label": "step2:after-real-key-RIGHT",
+      "selEnd": 20,
+      "cc": {
+        "rangeEnd": 18,
+        "lockContentControl": false,
+        "rangeStart": 6,
+        "rangeText": "inline value",
+        "tag": "inline-unlocked",
+        "title": "Inline Field",
+        "lockContents": false
+      },
+      "selText": "t"
+    }
+  ],
+  "notTrustedFor": []
+}

--- a/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-unlocked.shift-right-into-sdt.real-key.json
+++ b/tests/behavior/tests/sdt/word-oracle-goldens/sd3237-inline-unlocked.shift-right-into-sdt.real-key.json
@@ -1,0 +1,175 @@
+{
+  "paragraphsInsideSdtContent": null,
+  "foreground": {
+    "setFgOk": true,
+    "docHwnd": 4653712,
+    "isWord": true,
+    "procName": "WINWORD",
+    "procId": 4548,
+    "title": "behavior-probe-scratch - Word",
+    "hwnd": 4653712
+  },
+  "placement": "cc-content-start-minus-1",
+  "recordedAt": "2026-05-28T22:35:46Z",
+  "savedDocxBase64": "",
+  "preflight": {
+    "sessionStateInitial": "Active",
+    "qwinstaBefore": " SESSIONNAME       USERNAME                 ID  STATE   TYPE        DEVICE \r\n services                                    0  Disc                        \r\n>console           Administrator             1  Active                      \r\n rdp-tcp                                 65536  Listen                      \r\n",
+    "mySessionId": 1
+  },
+  "steps": [
+    {
+      "selType": 1,
+      "docText": null,
+      "label": "step0:placed",
+      "ccCount": 1,
+      "selStart": 5,
+      "paragraphCount": 1,
+      "inside": true,
+      "selEnd": 5,
+      "selText": null,
+      "cc": {
+        "lockContentControl": false,
+        "rangeText": "inline value",
+        "paragraphsInContent": 1,
+        "rangeEnd": 18,
+        "title": "Inline Field",
+        "rangeStart": 6,
+        "lockContents": false,
+        "tag": "inline-unlocked"
+      }
+    },
+    {
+      "selType": 2,
+      "docText": null,
+      "label": "step1:after-+{RIGHT}",
+      "ccCount": 1,
+      "selStart": 5,
+      "paragraphCount": 1,
+      "inside": true,
+      "selEnd": 6,
+      "selText": null,
+      "cc": {
+        "lockContentControl": false,
+        "rangeText": "inline value",
+        "paragraphsInContent": 1,
+        "rangeEnd": 18,
+        "title": "Inline Field",
+        "rangeStart": 6,
+        "lockContents": false,
+        "tag": "inline-unlocked"
+      }
+    },
+    {
+      "selType": 2,
+      "docText": null,
+      "label": "step2:after-+{RIGHT}",
+      "ccCount": 1,
+      "selStart": 5,
+      "paragraphCount": 1,
+      "inside": true,
+      "selEnd": 7,
+      "selText": "i",
+      "cc": {
+        "lockContentControl": false,
+        "rangeText": "inline value",
+        "paragraphsInContent": 1,
+        "rangeEnd": 18,
+        "title": "Inline Field",
+        "rangeStart": 6,
+        "lockContents": false,
+        "tag": "inline-unlocked"
+      }
+    },
+    {
+      "selType": 2,
+      "docText": null,
+      "label": "step3:after-+{RIGHT}",
+      "ccCount": 1,
+      "selStart": 5,
+      "paragraphCount": 1,
+      "inside": true,
+      "selEnd": 8,
+      "selText": "in",
+      "cc": {
+        "lockContentControl": false,
+        "rangeText": "inline value",
+        "paragraphsInContent": 1,
+        "rangeEnd": 18,
+        "title": "Inline Field",
+        "rangeStart": 6,
+        "lockContents": false,
+        "tag": "inline-unlocked"
+      }
+    },
+    {
+      "selType": 2,
+      "docText": null,
+      "label": "step4:after-+{RIGHT}",
+      "ccCount": 1,
+      "selStart": 5,
+      "paragraphCount": 1,
+      "inside": true,
+      "selEnd": 9,
+      "selText": "inl",
+      "cc": {
+        "lockContentControl": false,
+        "rangeText": "inline value",
+        "paragraphsInContent": 1,
+        "rangeEnd": 18,
+        "title": "Inline Field",
+        "rangeStart": 6,
+        "lockContents": false,
+        "tag": "inline-unlocked"
+      }
+    },
+    {
+      "selType": 2,
+      "docText": null,
+      "label": "step5:after-+{RIGHT}",
+      "ccCount": 1,
+      "selStart": 5,
+      "paragraphCount": 1,
+      "inside": true,
+      "selEnd": 10,
+      "selText": "inli",
+      "cc": {
+        "lockContentControl": false,
+        "rangeText": "inline value",
+        "paragraphsInContent": 1,
+        "rangeEnd": 18,
+        "title": "Inline Field",
+        "rangeStart": 6,
+        "lockContents": false,
+        "tag": "inline-unlocked"
+      }
+    },
+    {
+      "selType": 2,
+      "docText": null,
+      "label": "step6:after-+{RIGHT}",
+      "ccCount": 1,
+      "selStart": 5,
+      "paragraphCount": 1,
+      "inside": true,
+      "selEnd": 11,
+      "selText": "inlin",
+      "cc": {
+        "lockContentControl": false,
+        "rangeText": "inline value",
+        "paragraphsInContent": 1,
+        "rangeEnd": 18,
+        "title": "Inline Field",
+        "rangeStart": 6,
+        "lockContents": false,
+        "tag": "inline-unlocked"
+      }
+    }
+  ],
+  "sessionState": "Active",
+  "wordVersion": "16.0",
+  "documentXmlSdtExcerpt": "",
+  "savedDocxBytes": 0,
+  "trustedFor": ["real-keyboard-parity", "destructive-key-behavior"],
+  "inputMode": "win32-sendkeys-post-tscon"
+}


### PR DESCRIPTION
Locks in regression coverage for how SuperDoc handles the keyboard around structured content (SDTs), with the expected behavior taken from real Microsoft Word rather than guessed. Each scenario was run on Windows Word 16 through the word-api `run_behavior_probe` tool (real `WScript.Shell.SendKeys`, not COM Selection methods, since COM can bypass the lock-handler paths that matter), captured as a golden, and committed alongside the spec in `word-oracle-goldens/`.

Word story-character offsets are not comparable to ProseMirror positions, so the tests assert the observable, ABI-independent facts the goldens establish, not raw offsets.

- Right-arrow at the trailing edge exits the SDT in one press.
- Backspace just outside the trailing edge and Delete just outside the leading edge both select the content first (non-destructive press 1) across all four lock modes.
- Select-all with the caret inside an SDT selects the whole document, not just the control.
- Shift+Right into an SDT extends the selection character-by-character, not atomically.

**Verified**: `playwright test tests/sdt/sdt-word-parity.spec.ts` → 33 passed across chromium, firefox, webkit.

Placeholder/showingPlcHdr and group SDT behavior are a separate fixture/oracle batch and will follow in their own PR.