### PR TITLE
test(behavior): SDT right-arrow + shift-right navigation parity (SD-3237/SD-3218)

### DIFF
--- a/tests/behavior/tests/sdt/sdt-right-arrow-trailing.spec.ts
+++ b/tests/behavior/tests/sdt/sdt-right-arrow-trailing.spec.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { test, expect, type SuperDocFixture } from '../../fixtures/superdoc.js';
+import { getInlineSdtRange, getInlineSdtSnapshot, caretLocation } from '../../helpers/sdt.js';
+
+/**
+ * Right-arrow at the inline SDT trailing edge. Word parity contract
+ *   sdt/inline-right-arrow-trailing, Word 16.0 (lock-invariant)
+ * One press moves the caret from inside the control to just after it
+ * (inside-cc -> after-cc); navigation does not depend on lock mode.
+ *
+ * First consumer of the parity axis helper caretLocation().
+ */
+
+test.use({ config: { toolbar: 'full', showSelection: true } });
+
+const DIR = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = {
+  unlocked: path.resolve(DIR, 'fixtures/sd3237-inline-unlocked.docx'),
+  contentLocked: path.resolve(DIR, 'fixtures/sd3237-inline-contentlocked.docx'),
+} as const;
+
+test.describe('SDT Right-arrow at the trailing edge - Word parity', () => {
+  for (const mode of ['unlocked', 'contentLocked'] as const) {
+    test(`${mode}: one Right-arrow moves the caret from inside the SDT to after it`, async ({ superdoc }) => {
+      await superdoc.loadDocument(FIXTURE[mode]);
+      await superdoc.waitForStable();
+      const sdt = await getInlineSdtRange(superdoc.page);
+      expect(sdt).not.toBeNull();
+
+      await superdoc.setTextSelection(sdt!.end); // last position inside the content
+      await superdoc.page.evaluate(() => (window as any).editor.view.focus());
+      await superdoc.waitForStable();
+      expect(caretLocation(await getInlineSdtSnapshot(superdoc.page, sdt!.id), sdt!)).toBe('inside-cc');
+
+      await superdoc.press('ArrowRight');
+      await superdoc.waitForStable();
+
+      const after = await getInlineSdtSnapshot(superdoc.page, sdt!.id);
+      expect(caretLocation(after, sdt!)).toBe('after-cc'); // exited in one press
+      expect(after.sdtExists).toBe(true); // navigation does not mutate
+    });
+  }
+});

--- a/tests/behavior/tests/sdt/sdt-shift-right-boundary.spec.ts
+++ b/tests/behavior/tests/sdt/sdt-shift-right-boundary.spec.ts
@@ -1,0 +1,55 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { test, expect, type SuperDocFixture } from '../../fixtures/superdoc.js';
+import { getInlineSdtRange, getInlineSdtSnapshot, selectionScope, type SelectionScope } from '../../helpers/sdt.js';
+
+/**
+ * Shift+Right extending a selection across the inline SDT leading boundary.
+ * Word parity contract sdt/inline-shift-right-boundary, Word 16.0 (lock-invariant).
+ *
+ * The parity fact: selection crosses into the control character-by-character
+ * (the scope progresses outside-cc -> cc-and-beyond), it never snaps to the
+ * whole control as a unit (whole-content-control). Lock-invariant.
+ *
+ * Consumes the parity axis helper selectionScope().
+ */
+
+test.use({ config: { toolbar: 'full', showSelection: true } });
+
+const DIR = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = {
+  unlocked: path.resolve(DIR, 'fixtures/sd3237-inline-unlocked.docx'),
+  contentLocked: path.resolve(DIR, 'fixtures/sd3237-inline-contentlocked.docx'),
+} as const;
+
+test.describe('SDT Shift+Right across the leading boundary - Word parity', () => {
+  for (const mode of ['unlocked', 'contentLocked'] as const) {
+    test(`${mode}: Shift+Right crosses into the SDT character-by-character, not atomically`, async ({ superdoc }) => {
+      await superdoc.loadDocument(FIXTURE[mode]);
+      await superdoc.waitForStable();
+      const sdt = await getInlineSdtRange(superdoc.page);
+      expect(sdt).not.toBeNull();
+
+      // Anchor in the text just before the SDT (mirrors the contract's
+      // outside-leading placement); a collapsed caret exactly on the node
+      // boundary steps into the node instead of extending.
+      await superdoc.setTextSelection(sdt!.pos - 2);
+      await superdoc.page.evaluate(() => (window as any).editor.view.focus());
+      await superdoc.waitForStable();
+
+      const scopes: SelectionScope[] = [];
+      for (let i = 0; i < 6; i++) {
+        await superdoc.press('Shift+ArrowRight');
+        await superdoc.waitForStable();
+        scopes.push(selectionScope(await getInlineSdtSnapshot(superdoc.page, sdt!.id), sdt!));
+      }
+
+      // Crossed into the content (overlaps + extends past the leading edge)...
+      expect(scopes).toContain('cc-and-beyond');
+      // ...but never selected the whole control as a unit - character-granular.
+      expect(scopes).not.toContain('whole-content-control');
+      // non-destructive
+      expect((await getInlineSdtSnapshot(superdoc.page, sdt!.id)).sdtExists).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
First consumer of the parity axis helpers merged in #3558. Two lock-invariant navigation contracts, asserted through the helpers rather than hand-rolled from/to math.

- **`sdt/inline-right-arrow-trailing`**: one Right-arrow moves the caret from inside the control to just after it - `caretLocation(snap, sdt)` goes `inside-cc` -> `after-cc` in a single press.
- **`sdt/inline-shift-right-boundary`**: Shift+Right crosses the leading boundary character-by-character - `selectionScope` reaches `cc-and-beyond` and never `whole-content-control`, i.e. it does not snap to the whole control as a unit.

Both lock-invariant (asserted for unlocked + contentLocked, matching the contracts). No divergence here - SuperDoc matches Word, so no `test.fail`. Narrow by design: no new contracts, no capture-script work, no broad refactor; the point is to show the helpers make the next consumer scenario a few readable lines.

**Verified**: `playwright test ...right-arrow-trailing ...shift-right-boundary` -> 12 passed across chromium, firefox, webkit.