### PR TITLE
feat(footnote): reserve full footnote demand at body slice time (SD-2656)

### DIFF
--- a/packages/layout-engine/layout-engine/src/layout-paragraph.ts
+++ b/packages/layout-engine/layout-engine/src/layout-paragraph.ts
@@ -955,34 +955,23 @@ export function layoutParagraphBlock(ctx: ParagraphLayoutContext, anchors?: Para
     // commit-first-line rule keeps making progress and the band may end
     // up clipped — but that case is handled by the planner's continuation
     // split (separate fix path).
-    // SD-2656 Phase 1: body acceptance uses the ORDERED MINIMUM only.
-    //
-    //   ORDERED demand = sum(fullHeight of non-last) + firstLineHeight(last)
-    //                    + overhead.
-    //
-    // This is the rule's minimum: cluster's non-last anchors must fit fully,
-    // and the last anchor needs at least its first line. The body's
-    // acceptance rule is "the next line fits if ordered demand still fits".
-    //
-    // Why ORDERED only (not preferred): Phase 0 ledger diagnostics on
-    // IT-923 showed that 24 pages had `deadReserve > 30 px` — body
-    // reserved space for the PREFERRED (full of all) demand, but the
-    // planner only painted ORDERED-equivalent content. That dead reserve
-    // was the drift fuel. With ORDERED as the acceptance rule, body packs
-    // tighter; the planner uses any leftover capacity opportunistically
-    // (Phase 2) to extend the last anchor or drain continuations.
-    const computeOrderedDemandForRange = (pmStart: number, pmEnd: number): number => {
+    // Reserve the full footnote cluster height up front, so the body slicer
+    // backs off enough lines that every anchored footnote fits whole on its
+    // own page. This matches Word's pagination, which knows each footnote's
+    // full demand at every line decision rather than reserving a minimum
+    // and patching later. Cost: bodies that previously packed to the brink
+    // grow ≤ 1–4 pages per fixture; gain: footnote splits drop to ~0 on
+    // fixtures we measured (Carlsbad, IRA, SPA, IT-923 COI, MRL).
+    const computeFootnoteClusterDemand = (pmStart: number, pmEnd: number): number => {
       const candidate = ctx.getFootnoteAnchorsForBlockId
         ? ctx.getFootnoteAnchorsForBlockId(block.id, pmStart, pmEnd)
         : [];
       const committed = state.footnoteAnchorsThisPage ?? [];
       if (candidate.length === 0 && committed.length === 0) return 0;
-      const cluster = [...committed, ...candidate];
-      const lastIdx = cluster.length - 1;
-      let ordered = 0;
-      for (let i = 0; i < lastIdx; i += 1) ordered += cluster[i].fullHeight;
-      if (lastIdx >= 0) ordered += cluster[lastIdx].firstLineHeight;
-      return ordered;
+      let demand = 0;
+      for (const anchor of committed) demand += anchor.fullHeight;
+      for (const anchor of candidate) demand += anchor.fullHeight;
+      return demand;
     };
 
     const previewRange = computeFragmentPmRange(block, lines, fromLine, fromLine + 1);
@@ -992,7 +981,7 @@ export function layoutParagraphBlock(ctx: ParagraphLayoutContext, anchors?: Para
     // Re-evaluates against current state after advanceColumn (footnoteAnchorsThisPage
     // resets on a fresh page, so demand can shrink).
     const computePreviewBottom = () => {
-      const demand = computeOrderedDemandForRange(previewRange.pmStart ?? 0, previewRange.pmEnd ?? 0);
+      const demand = computeFootnoteClusterDemand(previewRange.pmStart ?? 0, previewRange.pmEnd ?? 0);
       return computeEffectiveBottom(demand, previewRefs);
     };
     let effectiveBottom = computePreviewBottom();
@@ -1046,7 +1035,7 @@ export function layoutParagraphBlock(ctx: ParagraphLayoutContext, anchors?: Para
       // line if ordered demand (full of non-last + firstLine of last)
       // still fits. The planner uses any leftover capacity opportunistically
       // (continuations, extending the last anchor).
-      const orderedDemand = computeOrderedDemandForRange(range.pmStart ?? 0, range.pmEnd ?? 0);
+      const orderedDemand = computeFootnoteClusterDemand(range.pmStart ?? 0, range.pmEnd ?? 0);
       const nextRefs = ctx.getFootnoteRefCountForBlockId
         ? ctx.getFootnoteRefCountForBlockId(block.id, range.pmStart, range.pmEnd)
         : 0;


### PR DESCRIPTION
## Summary

Architectural shift in how the body slicer handles footnote demand.
Instead of reserving the minimum (`firstLine` of last anchor) and
patching afterwards through four downstream layers, the body slicer
now reserves each anchored footnote's full height at slice time.

This matches Word's pagination model: every line decision is made
with knowledge of the full footnote demand, never with a deliberate
under-reservation.

## Why this PR is a draft (and points at the SD-2656 branch, not main)

This change replaces the design Phase 1 of SD-2656 deliberately
introduced (ordered-minimum acceptance). It supersedes the
post-hoc widow absorb committed earlier on the SD-2656 branch
(which becomes redundant — proactive demand catches every case
the post-hoc pass was designed to handle). Targeting the SD-2656
branch lets the architectural reset be reviewed independently
from the V1 + codex-fix + widow-absorb baseline already shipped
there.

If accepted, the next commits on the SD-2656 branch should remove
the now-redundant widow absorb and simplify the preferred-reserve
scorer trial loop. Those are follow-up cleanup commits, not part
of this PR.

## Fixture measurements

| Fixture | SD-2656 branch (baseline) | This PR |
|---|---|---|
| Carlsbad | 46p / 3 splits | **46p / 0 splits** |
| IRA | 48p / 9 splits | **46p / 0 splits** |
| SPA | 53p / 7 splits | **53p / 0 splits** |
| IT-923 COI | not measured | **54p / 1 split** (residual is genuine: fn 32 is too tall to fit on any single page) |
| MRL | 5p / 0 splits | 5p / 0 splits |

## Trade-off

Body content that previously packed tightly will grow by ≤ 1–4
pages on dense docs. Word grows under similar pressure, so this
trend is consistent with Word's own behavior. The corpus-wide
page-count delta should be checked via \`pnpm test:layout\` before
merge.

## Test plan

- [x] layout-engine 657 tests green
- [x] layout-bridge 1281 tests green
- [x] layout-tests 332 tests green
- [ ] \`pnpm test:layout\` corpus regression check (run before exit-draft)
- [ ] Visual sanity on 5+ corpus fixtures via \`compare-word-vs-superdoc\`
- [ ] Decide whether to delete the post-hoc widow absorb in a follow-up

## What this PR does NOT do

- Doesn't add body paragraph widow/orphan controls (Direction B). That's a separate ticket.
- Doesn't delete the post-hoc widow absorb. Leaving it in as a safety net for now; remove in cleanup pass once corpus validation confirms it's redundant.
- Doesn't tune any threshold. The previous threshold-based prototype (35 px) is replaced by an unconditional rule, which is the architecturally clean shape.