### PR TITLE
fix(superdoc): resolve @superdoc/font-system in the dev server

### DIFF
--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -342,13 +342,15 @@ export default defineConfig(({ mode, command }) => {
       },
     },
     resolve: {
-      // Under Vitest, alias @superdoc/font-system to its source so cdn-entry.test.js can
-      // resolve the import cdn-entry.js makes. The production CDN build aliases it in
-      // vite.config.cdn.js; the ES build never imports cdn-entry. Kept OUT of getAliases so
-      // the vite-plugin-dts build (which reads resolve.alias) is unaffected - an alias there
-      // makes it emit unresolvable source paths. The /bundled subpath precedes the bare one.
+      // Under Vitest and the dev server (command 'serve'), alias @superdoc/font-system to its
+      // source: cdn-entry.test.js needs it for the import cdn-entry.js makes, and the dev
+      // playground imports it transitively via layout-engine/super-editor source. font-system
+      // lives under shared/, so it is NOT covered by vite.sourceResolve's packages/** aliases.
+      // The production CDN build aliases it in vite.config.cdn.js; the ES build never imports
+      // cdn-entry. Kept OUT of getAliases so the vite-plugin-dts build (command 'build') is
+      // unaffected - an alias there makes it emit unresolvable source paths. /bundled precedes the bare one.
       alias: [
-        ...(process.env.VITEST
+        ...(process.env.VITEST || isDev
           ? [
               { find: '@superdoc/font-system/bundled', replacement: path.resolve(__dirname, '../../shared/font-system/src/bundled.ts') },
               { find: '@superdoc/font-system', replacement: path.resolve(__dirname, '../../shared/font-system/src/index.ts') },


### PR DESCRIPTION
`pnpm dev` couldn't boot the playground: Vite failed to resolve `@superdoc/font-system`, so the editor never mounted. That package lives under `shared/`, which the workspace alias helper (`vite.sourceResolve`) only maps for `packages/**`. The font-system imports were added recently and only the Vitest and CDN configs aliased it; the dev server (`command === 'serve'`) was missed.

- Extends the existing font-system source alias to also apply when `isDev`, so the dev server resolves it from `shared/font-system/src`.
- Left out of `getAliases` and gated on `isDev`, so the vite-plugin-dts build is unaffected (an alias there emits unresolvable source paths).

Verified: `pnpm dev` boots on :9094, the editor mounts, and the SD-3330 fixture renders. This was a hard Vite resolution failure before the alias.
