### PR TITLE
fix(columns): equal-mode rendering and explicit count cap (SD-2324)

### DIFF
--- a/packages/layout-engine/contracts/src/column-layout.test.ts
+++ b/packages/layout-engine/contracts/src/column-layout.test.ts
@@ -95,6 +95,38 @@ describe('normalizeColumnLayout', () => {
     });
   });
 
+  it('ignores widths when equalWidth is omitted and divides evenly (SD-2324: omitted = equal mode)', () => {
+    // Omitted equalWidth is equal mode in Word; any widths present are not authoritative.
+    expect(normalizeColumnLayout({ count: 2, gap: 24, widths: [100, 200] }, 624)).toEqual({
+      count: 2,
+      gap: 24,
+      widths: [300, 300],
+      width: 300,
+    });
+  });
+
+  it('ignores widths when equalWidth is true and divides evenly (SD-2324)', () => {
+    expect(normalizeColumnLayout({ count: 2, gap: 24, widths: [100, 200], equalWidth: true }, 624)).toEqual({
+      count: 2,
+      gap: 24,
+      widths: [300, 300],
+      equalWidth: true,
+      width: 300,
+    });
+  });
+
+  it('clamps count to the explicit-widths length when w:num exceeds it (SD-2324 F8)', () => {
+    // w:num="4" with only two explicit widths: the surplus columns have no width and must not
+    // be synthesized as ~0px slivers (the F8 phantom-column bug). Clamp to the two real columns.
+    expect(normalizeColumnLayout({ count: 4, gap: 48, widths: [192, 384], equalWidth: false }, 624)).toEqual({
+      count: 2,
+      gap: 48,
+      widths: [192, 384],
+      equalWidth: false,
+      width: 384,
+    });
+  });
+
   it('falls back to a single column when there is no usable content width', () => {
     expect(normalizeColumnLayout({ count: 3, gap: 24 }, 0, 0.01)).toEqual({
       count: 1,

--- a/packages/layout-engine/contracts/src/column-layout.ts
+++ b/packages/layout-engine/contracts/src/column-layout.ts
@@ -30,14 +30,24 @@ export function normalizeColumnLayout(
   epsilon = 0.0001,
 ): NormalizedColumnLayout {
   const rawCount = input && Number.isFinite(input.count) ? Math.floor(input.count) : 1;
-  const count = Math.max(1, rawCount || 1);
+  let count = Math.max(1, rawCount || 1);
   const gap = Math.max(0, input?.gap ?? 0);
-  const totalGap = gap * (count - 1);
-  const availableWidth = contentWidth - totalGap;
+  // Honor per-column widths ONLY in explicit mode (`equalWidth === false`). In equal mode
+  // (true or omitted) Word ignores child widths and divides the content area evenly, so any
+  // widths that reach here are not authoritative and must not drive geometry. (SD-2324)
   const explicitWidths =
-    Array.isArray(input?.widths) && input.widths.length > 0
+    input?.equalWidth === false && Array.isArray(input?.widths) && input.widths.length > 0
       ? input.widths.filter((width) => typeof width === 'number' && Number.isFinite(width) && width > 0)
       : [];
+  // Explicit columns are defined by their <w:col> widths. When the section declares more
+  // columns than it supplies widths (e.g. w:num="4" with two <w:col>), the surplus columns
+  // have no width and previously padded to ~0px, rendering as 1px slivers of vertical text
+  // (SD-2324 F8). Clamp the count to the widths actually provided so every column renders.
+  if (explicitWidths.length > 0 && explicitWidths.length < count) {
+    count = explicitWidths.length;
+  }
+  const totalGap = gap * (count - 1);
+  const availableWidth = contentWidth - totalGap;
 
   let widths =
     explicitWidths.length > 0

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/sections/extraction.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/sections/extraction.test.ts
@@ -328,6 +328,218 @@ describe('extraction', () => {
       });
     });
 
+    it('drops child widths and uses the section gap when w:equalWidth="1" (equal mode, Word ignores children)', () => {
+      // SD-2324: Word treats w:equalWidth="1" as equal mode regardless of any <w:col w:w> children.
+      // It ignores child widths/spaces, derives equal columns from w:num, and the gap from w:cols/@w:space.
+      const para: PMNode = {
+        type: 'paragraph',
+        attrs: {
+          paragraphProperties: {
+            sectPr: {
+              type: 'element',
+              name: 'w:sectPr',
+              elements: [
+                {
+                  name: 'w:cols',
+                  attributes: { 'w:num': '2', 'w:equalWidth': '1', 'w:space': '720' },
+                  elements: [
+                    { name: 'w:col', attributes: { 'w:w': '2880' } },
+                    { name: 'w:col', attributes: { 'w:w': '5760' } },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = extractSectionData(para);
+
+      // No widths emitted; gap from the 720-twip section space (48px). Word equalizes such columns.
+      expect(result?.columnsPx).toEqual({
+        count: 2,
+        gap: 48,
+        withSeparator: false,
+        equalWidth: true,
+      });
+    });
+
+    it('drops child widths when w:equalWidth is omitted (omitted defaults to equal mode, like Word)', () => {
+      // SD-2324: an omitted w:equalWidth is equal mode in Word (verified: EvenlySpaced=true). Child
+      // <w:col w:w> values must NOT leak through as explicit widths.
+      const para: PMNode = {
+        type: 'paragraph',
+        attrs: {
+          paragraphProperties: {
+            sectPr: {
+              type: 'element',
+              name: 'w:sectPr',
+              elements: [
+                {
+                  name: 'w:cols',
+                  attributes: { 'w:num': '2', 'w:space': '720' },
+                  elements: [
+                    { name: 'w:col', attributes: { 'w:w': '2880', 'w:space': '720' } },
+                    { name: 'w:col', attributes: { 'w:w': '5760' } },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = extractSectionData(para);
+
+      // No widths, no equalWidth field; gap from the section space (48px).
+      expect(result?.columnsPx).toEqual({
+        count: 2,
+        gap: 48,
+        withSeparator: false,
+      });
+    });
+
+    it('ignores child w:space and defaults the gap to 720 twips in equal mode (SD-2324 gap-half)', () => {
+      // SD-2324: in equal mode the gap comes from w:cols/@w:space only. With the section space omitted,
+      // it defaults to 720 twips (48px) even though the children declare w:space="0". Consulting the
+      // child space here (the pre-fix behavior) would wrongly yield a 0px gap. Verified against Word.
+      const para: PMNode = {
+        type: 'paragraph',
+        attrs: {
+          paragraphProperties: {
+            sectPr: {
+              type: 'element',
+              name: 'w:sectPr',
+              elements: [
+                {
+                  name: 'w:cols',
+                  attributes: { 'w:num': '2' },
+                  elements: [
+                    { name: 'w:col', attributes: { 'w:w': '2880', 'w:space': '0' } },
+                    { name: 'w:col', attributes: { 'w:w': '2880', 'w:space': '0' } },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = extractSectionData(para);
+
+      expect(result?.columnsPx).toEqual({
+        count: 2,
+        gap: 48, // 720-twip default, NOT the child w:space of 0
+        withSeparator: false,
+      });
+    });
+
+    it('keeps explicit child widths with a 0 gap when w:equalWidth="0" and no child w:space (SD-2324 F5)', () => {
+      // Explicit mode is unchanged by the equal-mode fix: child widths are honored, and an absent child
+      // w:space yields a 0 gap (CT_Column/@space default 0), not the 720-twip section default.
+      const para: PMNode = {
+        type: 'paragraph',
+        attrs: {
+          paragraphProperties: {
+            sectPr: {
+              type: 'element',
+              name: 'w:sectPr',
+              elements: [
+                {
+                  name: 'w:cols',
+                  attributes: { 'w:num': '2', 'w:equalWidth': '0' },
+                  elements: [
+                    { name: 'w:col', attributes: { 'w:w': '4680' } },
+                    { name: 'w:col', attributes: { 'w:w': '4680' } },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = extractSectionData(para);
+
+      expect(result?.columnsPx).toEqual({
+        count: 2,
+        gap: 0,
+        withSeparator: false,
+        widths: [312, 312],
+        equalWidth: false,
+      });
+    });
+
+    it('resolves explicit-mode count as min(w:num default 1, valid child-width count); omitted num stays 1 (SD-2324, Word-verified)', () => {
+      // Word caps the explicit column count to the <w:col> children actually provided. With w:num
+      // omitted (default 1) and 3 children, Word renders 1 column (verified Count=1), not 3.
+      const para: PMNode = {
+        type: 'paragraph',
+        attrs: {
+          paragraphProperties: {
+            sectPr: {
+              type: 'element',
+              name: 'w:sectPr',
+              elements: [
+                {
+                  name: 'w:cols',
+                  attributes: { 'w:equalWidth': '0' },
+                  elements: [
+                    { name: 'w:col', attributes: { 'w:w': '2880' } },
+                    { name: 'w:col', attributes: { 'w:w': '2880' } },
+                    { name: 'w:col', attributes: { 'w:w': '2880' } },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = extractSectionData(para);
+
+      // min(1, 3) -> count is 1 (NOT 3 from the children).
+      expect(result?.columnsPx?.count).toBe(1);
+      expect(result?.columnsPx?.equalWidth).toBe(false);
+    });
+
+    it('caps explicit count to the valid child-width count when w:num exceeds it (SD-2324 F8)', () => {
+      // w:num="4" with only two <w:col> renders 2 columns in Word (verified), not 4. Capping the
+      // count at the source keeps the fill loop (which reads the raw count) from creating surplus
+      // 1px phantom columns. min(4, 2) -> 2.
+      const para: PMNode = {
+        type: 'paragraph',
+        attrs: {
+          paragraphProperties: {
+            sectPr: {
+              type: 'element',
+              name: 'w:sectPr',
+              elements: [
+                {
+                  name: 'w:cols',
+                  attributes: { 'w:num': '4', 'w:equalWidth': '0' },
+                  elements: [
+                    { name: 'w:col', attributes: { 'w:w': '2880', 'w:space': '720' } },
+                    { name: 'w:col', attributes: { 'w:w': '5760' } },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = extractSectionData(para);
+
+      expect(result?.columnsPx).toEqual({
+        count: 2,
+        gap: 48,
+        withSeparator: false,
+        widths: [192, 384],
+        equalWidth: false,
+      });
+    });
+
     it('should handle section with only normalized margins and no sectPr elements', () => {
       const para: PMNode = {
         type: 'paragraph',

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/sections/extraction.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/sections/extraction.ts
@@ -245,7 +245,7 @@ function extractColumns(elements: SectionElement[]): ColumnLayout | undefined {
   const cols = elements.find((el) => el?.name === 'w:cols');
   if (!cols?.attributes) return undefined;
 
-  const count = parseColumnCount(cols.attributes['w:num'] as string | number | undefined);
+  let count = parseColumnCount(cols.attributes['w:num'] as string | number | undefined);
   const withSeparator = parseColumnSeparator(cols.attributes['w:sep'] as string | number | undefined);
   const equalWidthRaw = cols.attributes['w:equalWidth'];
   const equalWidth =
@@ -255,26 +255,43 @@ function extractColumns(elements: SectionElement[]): ColumnLayout | undefined {
         ? true
         : undefined;
   const columnChildren = Array.isArray(cols.elements) ? cols.elements.filter((child) => child?.name === 'w:col') : [];
-  // Per ECMA-376 §17.6.4, when columns are NOT equal width (`w:equalWidth="0"`), the
-  // section-level `w:cols/@w:space` is IGNORED — inter-column spacing comes from each
-  // `<w:col>`'s own `w:space`. Only equal-width columns use the section space. Using the
-  // section space for explicit columns over-spaces them (forcing the widths to scale
-  // down to fit) and diverges from Word. (SD-2324; per-column-distinct spacing is SD-2629.)
+  // ECMA-376 §17.6.4 column mode, validated against Word (MS Word 16 oracle):
+  //   Explicit mode (`w:equalWidth="0"`): widths and inter-column spacing come from the child
+  //   `<w:col>` elements (`w:w` + `w:space`, default 0); the section `w:cols/@w:space` is
+  //   ignored. (Per-column distinct spacing is SD-2629; today the first child's space is
+  //   projected as the single gap.)
+  //   Equal mode (`w:equalWidth="1"` or omitted): Word ignores all child `<w:col>` data. The
+  //   gap comes from `w:cols/@w:space` (default 720); a child `w:space` is NOT consulted, and
+  //   child widths are dropped so the columns divide evenly. Count comes from `w:num`
+  //   (default 1) in equal mode, and is capped to the valid child-width count in explicit
+  //   mode (Word renders min(num, count of <w:col> with a usable w:w)). (SD-2324)
+  const isExplicit = equalWidth === false;
   const firstChildSpace = columnChildren.find((child) => child?.attributes?.['w:space'] != null)?.attributes?.[
     'w:space'
   ];
-  const gapTwips = equalWidth === false ? (firstChildSpace ?? 0) : (cols.attributes['w:space'] ?? firstChildSpace);
+  const gapTwips = isExplicit ? (firstChildSpace ?? 0) : cols.attributes['w:space'];
   const gapInches = parseColumnGap(gapTwips as string | number | undefined);
   const widths = columnChildren
     .map((child) => Number(child.attributes?.['w:w']))
     .filter((widthTwips) => Number.isFinite(widthTwips) && widthTwips > 0)
     .map((widthTwips) => (widthTwips / 1440) * PX_PER_INCH);
 
+  // Explicit mode: w:num is capped to the valid child-width count (widths.length), i.e. the
+  // number of <w:col> that supplied a usable w:w. Word renders min(num, that count) (e.g.
+  // w:num="4" with two <w:col> => 2 columns, verified vs Word). This is the authoritative
+  // count both the fill loop and width math read; the matching clamp in normalizeColumnLayout
+  // is a defensive net for any other producer. (SD-2324 F8)
+  if (isExplicit && widths.length > 0) {
+    count = Math.min(count, widths.length);
+  }
+
   const result: ColumnLayout = {
     count,
     gap: gapInches * PX_PER_INCH,
     withSeparator,
-    ...(widths.length > 0 ? { widths } : {}),
+    // Only explicit columns carry per-column widths; equal mode divides evenly (Word ignores
+    // child `w:w` when equalWidth is "1" or omitted).
+    ...(isExplicit && widths.length > 0 ? { widths } : {}),
     ...(equalWidth !== undefined ? { equalWidth } : {}),
   };
 


### PR DESCRIPTION
Multi-column sections with explicit `<w:col>` definitions didn't match Word in two ways, both fixed here.

Equal-width sections (`w:equalWidth="1"` or omitted) were carrying the child `<w:col>` widths and could take the gap from a child `w:space`. Word ignores both: equal columns come from `w:num` and the section `w:space` (default 720). Extraction now drops child widths in equal mode and reads the gap from the section only; `normalizeColumnLayout` honours per-column widths only when `w:equalWidth="0"`.

For explicit columns, `w:num` is capped to the number of `<w:col>` widths actually provided (Word renders `min(num, that count)`). Without it, a `w:num` larger than the children left the fill loop creating surplus 1px phantom columns.

Stacked on #3618 because it edits the same extraction lines; this PR will retarget to main once #3618 lands.

**Verified**: Word oracle (PageSetup.TextColumns + rendered paragraph geometry) across equalWidth 0/1/omitted, omitted w:num, and w:num=4 with two w:col; dev-app render parity on the affected fixtures.