### PR TITLE
feat(page-reference): resolve PAGEREF fields to live target page numbers (SD-3007)

### DIFF
--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -146,6 +146,7 @@ export {
 } from './header-footer-inheritance.js';
 export {
   formatChapterPageNumberText,
+  formatIntegerWithNumericPicture,
   formatPageNumber,
   formatPageNumberFieldValue,
   formatSectionPageNumberText,
@@ -153,6 +154,8 @@ export {
   type PageNumberChapterSeparator,
   type PageNumberFormat,
 } from './page-number-formatting.js';
+
+export { buildPageRefAnchorMap } from './page-ref-anchor.js';
 /** Inline field annotation metadata extracted from w:sdt nodes. */
 export type FieldAnnotationMetadata = {
   type: 'fieldAnnotation';
@@ -405,6 +408,26 @@ export type RunMarks = {
   baselineShift?: number;
 };
 
+export type PageReferenceRelativePositionText = 'above' | 'below';
+
+export type FieldResultFormat = 'charformat' | 'mergeformat';
+
+export type NumericPictureFormat = {
+  /** Raw argument after the \# switch, without surrounding quotes. */
+  picture: string;
+};
+
+export interface PageRefLocation {
+  physicalPage: number;
+  displayNumber: number;
+  displayText: string;
+  pageFormat?: PageNumberFormat;
+  chapterNumberText?: string;
+  chapterSeparator?: PageNumberChapterSeparator;
+  sectionIndex?: number;
+  pmPosition?: number;
+}
+
 export type TextRun = RunMarks & {
   kind?: 'text';
   text: string;
@@ -427,7 +450,7 @@ export type TextRun = RunMarks & {
   link?: FlowRunLink;
   /** Token annotations for dynamic content (page numbers, etc.). */
   token?: 'pageNumber' | 'totalPageCount' | 'pageReference' | 'sectionPageCount';
-  /** Explicit formatting requested by PAGE/NUMPAGES field switches. */
+  /** Explicit formatting requested by PAGE/NUMPAGES/SECTIONPAGES field switches. */
   pageNumberFieldFormat?: PageNumberFieldFormat;
   /** Absolute ProseMirror position (inclusive) of first character in this run. */
   pmStart?: number;
@@ -437,6 +460,14 @@ export type TextRun = RunMarks & {
   pageRefMetadata?: {
     bookmarkId: string;
     instruction: string;
+    /** True when the instruction has \p. */
+    relativePosition?: boolean;
+    /** General numeric formatting switch for the PAGEREF page value. */
+    pageNumberFieldFormat?: PageNumberFieldFormat;
+    /** Raw numeric picture from \#. */
+    numericPictureFormat?: NumericPictureFormat;
+    /** CHARFORMAT / MERGEFORMAT, if present. */
+    fieldResultFormat?: FieldResultFormat;
   };
   /** Tracked-change metadata from ProseMirror marks. */
   trackedChange?: TrackedChangeMeta;

--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -449,7 +449,7 @@ export type TextRun = RunMarks & {
   visualPlaceholder?: SdtVisualPlaceholder;
   link?: FlowRunLink;
   /** Token annotations for dynamic content (page numbers, etc.). */
-  token?: 'pageNumber' | 'totalPageCount' | 'pageReference' | 'sectionPageCount';
+  token?: 'pageNumber' | 'totalPageCount' | 'pageReference' | 'sectionPageCount' | 'seq';
   /** Explicit formatting requested by PAGE/NUMPAGES/SECTIONPAGES field switches. */
   pageNumberFieldFormat?: PageNumberFieldFormat;
   /** Absolute ProseMirror position (inclusive) of first character in this run. */
@@ -468,6 +468,21 @@ export type TextRun = RunMarks & {
     numericPictureFormat?: NumericPictureFormat;
     /** CHARFORMAT / MERGEFORMAT, if present. */
     fieldResultFormat?: FieldResultFormat;
+  };
+  /** Metadata for SEQ tokens (resolved by super-editor before layout measurement). */
+  seqMetadata?: {
+    identifier: string;
+    instruction?: string;
+    fieldArgument?: string;
+    sequenceMode?: 'next' | 'current';
+    hideResult?: boolean;
+    restartNumber?: number | null;
+    restartLevel?: number | null;
+    format?: string;
+    hasGeneralFormat?: boolean;
+    pageNumberFieldFormat?: PageNumberFieldFormat | null;
+    numericPictureFormat?: NumericPictureFormat | null;
+    cachedText?: string;
   };
   /** Tracked-change metadata from ProseMirror marks. */
   trackedChange?: TrackedChangeMeta;

--- a/packages/layout-engine/contracts/src/page-number-formatting.test.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { formatPageNumber, formatPageNumberFieldValue } from './page-number-formatting.js';
+import {
+  formatIntegerWithNumericPicture,
+  formatPageNumber,
+  formatPageNumberFieldValue,
+} from './page-number-formatting.js';
 
 describe('page number formatting', () => {
   it('formats the supported Word page number formats', () => {
@@ -29,5 +33,20 @@ describe('page number formatting', () => {
   it('applies decimal zero padding for field values', () => {
     expect(formatPageNumberFieldValue(7, { format: 'decimal', zeroPadding: 3 })).toBe('007');
     expect(formatPageNumberFieldValue(7, { format: 'lowerRoman', zeroPadding: 3 })).toBe('vii');
+  });
+
+  it('formats integer values with numeric pictures', () => {
+    expect(formatIntegerWithNumericPicture(5, '00')).toBe('05');
+    expect(formatIntegerWithNumericPicture(1234, '#,##0')).toBe('1,234');
+    expect(formatIntegerWithNumericPicture(5, '##%')).toBe('5%');
+    expect(formatIntegerWithNumericPicture(5, "00 'pages'")).toBe('05 pages');
+    expect(formatIntegerWithNumericPicture(1234, 'x##')).toBe('34');
+    expect(formatIntegerWithNumericPicture(5, '0.00')).toBe('5.00');
+  });
+
+  it('selects numeric picture sections for positive, negative, and zero values', () => {
+    expect(formatIntegerWithNumericPicture(5, '0;minus 0;zero')).toBe('5');
+    expect(formatIntegerWithNumericPicture(-5, '0;minus 0;zero')).toBe('minus 5');
+    expect(formatIntegerWithNumericPicture(0, '0;minus 0;zero')).toBe('zero');
   });
 });

--- a/packages/layout-engine/contracts/src/page-number-formatting.test.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.test.ts
@@ -14,6 +14,19 @@ describe('page number formatting', () => {
     expect(formatPageNumber(28, 'upperLetter')).toBe('BB');
     expect(formatPageNumber(703, 'lowerLetter')).toBe('a'.repeat(28));
     expect(formatPageNumber(12, 'numberInDash')).toBe('- 12 -');
+    expect(formatPageNumber(1, 'ordinal')).toBe('1st');
+    expect(formatPageNumber(2, 'ordinal')).toBe('2nd');
+    expect(formatPageNumber(3, 'ordinal')).toBe('3rd');
+    expect(formatPageNumber(4, 'ordinal')).toBe('4th');
+    expect(formatPageNumber(11, 'ordinal')).toBe('11th');
+    expect(formatPageNumber(12, 'ordinal')).toBe('12th');
+    expect(formatPageNumber(13, 'ordinal')).toBe('13th');
+    expect(formatPageNumber(21, 'ordinal')).toBe('21st');
+    expect(formatPageNumber(22, 'ordinal')).toBe('22nd');
+    expect(formatPageNumber(23, 'ordinal')).toBe('23rd');
+    expect(formatPageNumber(111, 'ordinal')).toBe('111th');
+    expect(formatPageNumber(112, 'ordinal')).toBe('112th');
+    expect(formatPageNumber(113, 'ordinal')).toBe('113th');
   });
 
   it('normalizes page numbers before formatting', () => {
@@ -33,6 +46,16 @@ describe('page number formatting', () => {
   it('applies decimal zero padding for field values', () => {
     expect(formatPageNumberFieldValue(7, { format: 'decimal', zeroPadding: 3 })).toBe('007');
     expect(formatPageNumberFieldValue(7, { format: 'lowerRoman', zeroPadding: 3 })).toBe('vii');
+  });
+
+  it('formats ordinal field values', () => {
+    expect(formatPageNumberFieldValue(32, { format: 'ordinal' })).toBe('32nd');
+  });
+
+  it('uses numeric pictures before enum format and zero padding', () => {
+    expect(formatPageNumberFieldValue(1234, { numericPicture: '#,##0' })).toBe('1,234');
+    expect(formatPageNumberFieldValue(7, { format: 'ordinal', zeroPadding: 3, numericPicture: '00' })).toBe('07');
+    expect(formatPageNumberFieldValue(0, { numericPicture: '00' })).toBe('01');
   });
 
   it('formats integer values with numeric pictures', () => {

--- a/packages/layout-engine/contracts/src/page-number-formatting.test.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.test.ts
@@ -49,4 +49,13 @@ describe('page number formatting', () => {
     expect(formatIntegerWithNumericPicture(-5, '0;minus 0;zero')).toBe('minus 5');
     expect(formatIntegerWithNumericPicture(0, '0;minus 0;zero')).toBe('zero');
   });
+
+  it('documents unsupported numeric picture features for PAGEREF page values', () => {
+    // PAGEREF only formats integer page numbers here. Backtick numbered-item
+    // references, localized separators, and fractional rounding are out of
+    // scope for this numeric-picture subset.
+    expect(formatIntegerWithNumericPicture(5, '`1`')).toBe('`1`');
+    expect(formatIntegerWithNumericPicture(1234, '#.##0')).toBe('1234.0');
+    expect(formatIntegerWithNumericPicture(5, '0.9')).toBe('5.9');
+  });
 });

--- a/packages/layout-engine/contracts/src/page-number-formatting.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.ts
@@ -99,3 +99,180 @@ export function formatSectionPageNumberText(args: {
     chapterSeparator: args.chapterSeparator,
   });
 }
+
+/**
+ * Formats integer field values with a Word numeric picture subset used by PAGEREF.
+ * Unsupported ECMA features are intentionally out of scope here: backtick
+ * numbered-item references, localized separators, and fractional rounding.
+ */
+export function formatIntegerWithNumericPicture(value: number, picture: string): string {
+  const integerValue = Math.trunc(Number.isFinite(value) ? value : 0);
+  const sections = splitPictureSections(typeof picture === 'string' && picture.length > 0 ? picture : '0');
+  const hasExplicitNegativeSection = integerValue < 0 && sections[1] != null;
+  const section =
+    integerValue > 0 ? sections[0] : integerValue < 0 ? (sections[1] ?? sections[0]) : (sections[2] ?? sections[0]);
+  return formatNumericPictureSection(
+    Math.abs(integerValue),
+    integerValue < 0,
+    section ?? '0',
+    hasExplicitNegativeSection,
+  );
+}
+
+function splitPictureSections(picture: string): string[] {
+  const sections: string[] = [];
+  let current = '';
+  let inQuote = false;
+
+  for (let index = 0; index < picture.length; index += 1) {
+    const char = picture[index]!;
+    if (char === "'") {
+      inQuote = !inQuote;
+      current += char;
+      continue;
+    }
+    if (char === ';' && !inQuote) {
+      sections.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+
+  sections.push(current);
+  return sections;
+}
+
+type PictureToken =
+  | { kind: 'placeholder'; value: '0' | '#' | 'x' | ',' | '.' | '+' | '-' }
+  | { kind: 'literal'; value: string };
+
+function tokenizePicture(section: string): PictureToken[] {
+  const tokens: PictureToken[] = [];
+  for (let index = 0; index < section.length; index += 1) {
+    const char = section[index]!;
+    if (char === "'") {
+      let literal = '';
+      index += 1;
+      while (index < section.length && section[index] !== "'") {
+        literal += section[index]!;
+        index += 1;
+      }
+      tokens.push({ kind: 'literal', value: literal });
+      continue;
+    }
+    if (char === '0' || char === '#' || char === 'x' || char === ',' || char === '.' || char === '+' || char === '-') {
+      tokens.push({ kind: 'placeholder', value: char });
+    } else {
+      tokens.push({ kind: 'literal', value: char });
+    }
+  }
+  return tokens;
+}
+
+function formatNumericPictureSection(
+  value: number,
+  isNegative: boolean,
+  section: string,
+  suppressDefaultNegative = false,
+): string {
+  const tokens = tokenizePicture(section);
+  const decimalIndex = tokens.findIndex((token) => token.kind === 'placeholder' && token.value === '.');
+  const integerTokens = decimalIndex >= 0 ? tokens.slice(0, decimalIndex) : tokens;
+  const fractionalTokens = decimalIndex >= 0 ? tokens.slice(decimalIndex + 1) : [];
+  const integerPart = formatIntegerPictureTokens(value, isNegative, integerTokens, suppressDefaultNegative);
+  const fractionalPart = formatFractionalPictureTokens(fractionalTokens);
+  return fractionalTokens.length > 0 ? `${integerPart}.${fractionalPart}` : integerPart;
+}
+
+function formatIntegerPictureTokens(
+  value: number,
+  isNegative: boolean,
+  tokens: PictureToken[],
+  suppressDefaultNegative: boolean,
+): string {
+  let xIndex = -1;
+  for (let index = tokens.length - 1; index >= 0; index -= 1) {
+    const token = tokens[index]!;
+    if (token.kind === 'placeholder' && token.value === 'x') {
+      xIndex = index;
+      break;
+    }
+  }
+  const activeTokens = xIndex >= 0 ? tokens.slice(xIndex + 1) : tokens;
+  const placeholderCount = activeTokens.filter(
+    (token) => token.kind === 'placeholder' && (token.value === '0' || token.value === '#'),
+  ).length;
+  const rawDigits = String(value);
+  const digits = xIndex >= 0 && placeholderCount > 0 ? rawDigits.slice(-placeholderCount) : rawDigits;
+  let digitIndex = digits.length - 1;
+  let output = '';
+  let signSlot: '+' | '-' | null = null;
+  const hasGrouping = activeTokens.some((token) => token.kind === 'placeholder' && token.value === ',');
+
+  for (let index = activeTokens.length - 1; index >= 0; index -= 1) {
+    const token = activeTokens[index]!;
+    if (token.kind === 'literal') {
+      output = token.value + output;
+      continue;
+    }
+
+    switch (token.value) {
+      case '0':
+        output = (digitIndex >= 0 ? digits[digitIndex] : '0') + output;
+        digitIndex -= 1;
+        break;
+      case '#':
+        if (digitIndex >= 0) {
+          output = digits[digitIndex]! + output;
+          digitIndex -= 1;
+        }
+        break;
+      case '+':
+      case '-':
+        signSlot = token.value;
+        break;
+      case ',':
+      case 'x':
+      case '.':
+        break;
+    }
+  }
+
+  if (placeholderCount > 0 && xIndex < 0 && digitIndex >= 0) {
+    output = digits.slice(0, digitIndex + 1) + output;
+  }
+  if (hasGrouping) {
+    output = applyGrouping(output);
+  }
+  if (signSlot === '+') {
+    output = `${isNegative ? '-' : '+'}${output}`;
+  } else if (signSlot === '-') {
+    output = `${isNegative ? '-' : ' '}${output}`;
+  } else if (isNegative && !suppressDefaultNegative) {
+    output = `-${output}`;
+  }
+  return output;
+}
+
+function formatFractionalPictureTokens(tokens: PictureToken[]): string {
+  let output = '';
+  for (const token of tokens) {
+    if (token.kind === 'literal') {
+      output += token.value;
+      continue;
+    }
+    if (token.value === '0') {
+      output += '0';
+    } else if (token.value !== '#') {
+      output += token.value;
+    }
+  }
+  return output;
+}
+
+function applyGrouping(value: string): string {
+  const match = value.match(/^([^0-9]*)([0-9]+)(.*)$/);
+  if (!match) return value;
+  return `${match[1]}${match[2].replace(/\B(?=(\d{3})+(?!\d))/g, ',')}${match[3]}`;
+}

--- a/packages/layout-engine/contracts/src/page-number-formatting.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.ts
@@ -1,6 +1,7 @@
 export type PageNumberFieldFormat = {
-  format?: 'decimal' | 'upperRoman' | 'lowerRoman' | 'upperLetter' | 'lowerLetter' | 'numberInDash';
+  format?: 'decimal' | 'upperRoman' | 'lowerRoman' | 'upperLetter' | 'lowerLetter' | 'numberInDash' | 'ordinal';
   zeroPadding?: number;
+  numericPicture?: string;
 };
 
 export type PageNumberFormat = NonNullable<PageNumberFieldFormat['format']>;
@@ -31,6 +32,22 @@ function toUpperLetter(value: number): string {
   return String.fromCharCode(65 + index).repeat(repeatCount);
 }
 
+function toOrdinal(value: number): string {
+  const remainder = value % 100;
+  if (remainder >= 11 && remainder <= 13) return `${value}th`;
+
+  switch (value % 10) {
+    case 1:
+      return `${value}st`;
+    case 2:
+      return `${value}nd`;
+    case 3:
+      return `${value}rd`;
+    default:
+      return `${value}th`;
+  }
+}
+
 export function formatPageNumber(pageNumber: number, format: PageNumberFormat): string {
   const value = Math.max(1, Math.trunc(Number.isFinite(pageNumber) ? pageNumber : 1));
 
@@ -45,6 +62,8 @@ export function formatPageNumber(pageNumber: number, format: PageNumberFormat): 
       return toUpperLetter(value).toLowerCase();
     case 'numberInDash':
       return `- ${value} -`;
+    case 'ordinal':
+      return toOrdinal(value);
     case 'decimal':
     default:
       return String(value);
@@ -52,6 +71,11 @@ export function formatPageNumber(pageNumber: number, format: PageNumberFormat): 
 }
 
 export function formatPageNumberFieldValue(pageNumber: number, fieldFormat?: PageNumberFieldFormat): string {
+  if (fieldFormat?.numericPicture) {
+    const value = Math.max(1, Math.trunc(Number.isFinite(pageNumber) ? pageNumber : 1));
+    return formatIntegerWithNumericPicture(value, fieldFormat.numericPicture);
+  }
+
   const format = fieldFormat?.format ?? 'decimal';
   const formatted = formatPageNumber(pageNumber, format);
   return fieldFormat?.zeroPadding && format === 'decimal'
@@ -101,7 +125,7 @@ export function formatSectionPageNumberText(args: {
 }
 
 /**
- * Formats integer field values with a Word numeric picture subset used by PAGEREF.
+ * Formats integer page field values with a Word numeric picture subset.
  * Unsupported ECMA features are intentionally out of scope here: backtick
  * numbered-item references, localized separators, and fractional rounding.
  */

--- a/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
@@ -115,6 +115,28 @@ describe('buildPageRefAnchorMap', () => {
     });
   });
 
+  it('omits bookmarks in gaps between visible fragments', () => {
+    const layout: Layout = {
+      pageSize: { w: 800, h: 1000 },
+      pages: [
+        {
+          number: 1,
+          fragments: [
+            { kind: 'para', blockId: 'before', fromLine: 0, toLine: 1, x: 0, y: 0, width: 100, pmStart: 10, pmEnd: 20 },
+          ],
+        },
+        {
+          number: 2,
+          fragments: [
+            { kind: 'para', blockId: 'after', fromLine: 0, toLine: 1, x: 0, y: 0, width: 100, pmStart: 30, pmEnd: 40 },
+          ],
+        },
+      ],
+    };
+
+    expect(buildPageRefAnchorMap(new Map([['gap', 25]]), layout).has('gap')).toBe(false);
+  });
+
   it('falls back to visible paragraph ranges inside table blocks', () => {
     const table: TableBlock = {
       kind: 'table',

--- a/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
@@ -137,6 +137,28 @@ describe('buildPageRefAnchorMap', () => {
     expect(buildPageRefAnchorMap(new Map([['gap', 25]]), layout).has('gap')).toBe(false);
   });
 
+  it('maps bookmark markers immediately before a later visible fragment', () => {
+    const layout: Layout = {
+      pageSize: { w: 800, h: 1000 },
+      pages: [
+        {
+          number: 1,
+          fragments: [
+            { kind: 'para', blockId: 'before', fromLine: 0, toLine: 1, x: 0, y: 0, width: 100, pmStart: 10, pmEnd: 20 },
+          ],
+        },
+        {
+          number: 2,
+          fragments: [
+            { kind: 'para', blockId: 'target', fromLine: 0, toLine: 1, x: 0, y: 0, width: 100, pmStart: 32, pmEnd: 40 },
+          ],
+        },
+      ],
+    };
+
+    expect(buildPageRefAnchorMap(new Map([['target', 30]]), layout).get('target')?.physicalPage).toBe(2);
+  });
+
   it('falls back to visible paragraph ranges inside table blocks', () => {
     const table: TableBlock = {
       kind: 'table',

--- a/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
@@ -150,6 +150,58 @@ describe('buildPageRefAnchorMap', () => {
     );
   });
 
+  it('limits table fallback ranges to the rows covered by each table fragment', () => {
+    const table: TableBlock = {
+      kind: 'table',
+      id: 't1',
+      rows: [
+        {
+          id: 'r1',
+          cells: [
+            {
+              id: 'c1',
+              paragraph: {
+                kind: 'paragraph',
+                id: 'p1',
+                runs: [{ text: 'First row', fontFamily: 'Arial', fontSize: 12, pmStart: 100, pmEnd: 109 }],
+              },
+            },
+          ],
+        },
+        {
+          id: 'r2',
+          cells: [
+            {
+              id: 'c2',
+              paragraph: {
+                kind: 'paragraph',
+                id: 'p2',
+                runs: [{ text: 'Second row', fontFamily: 'Arial', fontSize: 12, pmStart: 200, pmEnd: 210 }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const layout: Layout = {
+      pageSize: { w: 800, h: 1000 },
+      pages: [
+        {
+          number: 1,
+          fragments: [{ kind: 'table', blockId: 't1', fromRow: 0, toRow: 1, x: 0, y: 0, width: 100, height: 20 }],
+        },
+        {
+          number: 2,
+          fragments: [{ kind: 'table', blockId: 't1', fromRow: 1, toRow: 2, x: 0, y: 0, width: 100, height: 20 }],
+        },
+      ],
+    };
+
+    expect(buildPageRefAnchorMap(new Map([['secondRow', 205]]), layout, [table]).get('secondRow')?.physicalPage).toBe(
+      2,
+    );
+  });
+
   it('falls back to list item paragraph ranges when fragment PM data is missing', () => {
     const list: ListBlock = {
       kind: 'list',

--- a/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Layout, ParagraphBlock, TableBlock } from './index.js';
+import type { Layout, ListBlock, ParagraphBlock, TableBlock } from './index.js';
 import { buildPageRefAnchorMap } from './page-ref-anchor.js';
 
 describe('buildPageRefAnchorMap', () => {
@@ -147,6 +147,50 @@ describe('buildPageRefAnchorMap', () => {
 
     expect(buildPageRefAnchorMap(new Map([['cellTarget', 202]]), layout, [table]).get('cellTarget')?.physicalPage).toBe(
       5,
+    );
+  });
+
+  it('falls back to list item paragraph ranges when fragment PM data is missing', () => {
+    const list: ListBlock = {
+      kind: 'list',
+      id: 'list1',
+      listType: 'number',
+      items: [
+        {
+          id: 'li1',
+          marker: { kind: 'number', text: '1.', level: 0 },
+          paragraph: {
+            kind: 'paragraph',
+            id: 'p1',
+            runs: [{ text: 'Heading', fontFamily: 'Arial', fontSize: 12, pmStart: 300, pmEnd: 307 }],
+          },
+        },
+      ],
+    };
+    const layout: Layout = {
+      pageSize: { w: 800, h: 1000 },
+      pages: [
+        {
+          number: 6,
+          fragments: [
+            {
+              kind: 'list-item',
+              blockId: 'list1',
+              itemId: 'li1',
+              fromLine: 0,
+              toLine: 1,
+              x: 0,
+              y: 0,
+              width: 100,
+              markerWidth: 20,
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(buildPageRefAnchorMap(new Map([['listTarget', 303]]), layout, [list]).get('listTarget')?.physicalPage).toBe(
+      6,
     );
   });
 

--- a/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Layout, ListBlock, ParagraphBlock, TableBlock } from './index.js';
+import type { Layout, ListBlock, ParagraphBlock, TableBlock, TableMeasure } from './index.js';
 import { buildPageRefAnchorMap } from './page-ref-anchor.js';
 
 describe('buildPageRefAnchorMap', () => {
@@ -200,6 +200,110 @@ describe('buildPageRefAnchorMap', () => {
     expect(buildPageRefAnchorMap(new Map([['secondRow', 205]]), layout, [table]).get('secondRow')?.physicalPage).toBe(
       2,
     );
+  });
+
+  it('limits split-row table fallback ranges to visible partial row lines', () => {
+    const table: TableBlock = {
+      kind: 'table',
+      id: 't1',
+      rows: [
+        {
+          id: 'r1',
+          cells: [
+            {
+              id: 'c1',
+              paragraph: {
+                kind: 'paragraph',
+                id: 'p1',
+                runs: [
+                  { text: 'First line', fontFamily: 'Arial', fontSize: 12, pmStart: 100, pmEnd: 110 },
+                  { text: 'Second line', fontFamily: 'Arial', fontSize: 12, pmStart: 111, pmEnd: 122 },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const measure: TableMeasure = {
+      kind: 'table',
+      rows: [
+        {
+          height: 40,
+          cells: [
+            {
+              width: 100,
+              height: 40,
+              paragraph: {
+                kind: 'paragraph',
+                totalHeight: 40,
+                lines: [
+                  { fromRun: 0, fromChar: 0, toRun: 0, toChar: 10, width: 60, ascent: 8, descent: 2, lineHeight: 20 },
+                  { fromRun: 1, fromChar: 0, toRun: 1, toChar: 11, width: 70, ascent: 8, descent: 2, lineHeight: 20 },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      totalHeight: 40,
+      columnWidths: [100],
+    };
+    const layout: Layout = {
+      pageSize: { w: 800, h: 1000 },
+      pages: [
+        {
+          number: 1,
+          fragments: [
+            {
+              kind: 'table',
+              blockId: 't1',
+              fromRow: 0,
+              toRow: 1,
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 20,
+              partialRow: {
+                rowIndex: 0,
+                fromLineByCell: [0],
+                toLineByCell: [1],
+                isFirstPart: true,
+                isLastPart: false,
+                partialHeight: 20,
+              },
+            },
+          ],
+        },
+        {
+          number: 2,
+          fragments: [
+            {
+              kind: 'table',
+              blockId: 't1',
+              fromRow: 0,
+              toRow: 1,
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 20,
+              partialRow: {
+                rowIndex: 0,
+                fromLineByCell: [1],
+                toLineByCell: [2],
+                isFirstPart: false,
+                isLastPart: true,
+                partialHeight: 20,
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      buildPageRefAnchorMap(new Map([['secondLine', 115]]), layout, [table], [measure]).get('secondLine')?.physicalPage,
+    ).toBe(2);
   });
 
   it('falls back to list item paragraph ranges when fragment PM data is missing', () => {

--- a/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import type { Layout, ParagraphBlock, TableBlock } from './index.js';
+import { buildPageRefAnchorMap } from './page-ref-anchor.js';
+
+describe('buildPageRefAnchorMap', () => {
+  it('returns display page information for fragment PM ranges', () => {
+    const layout: Layout = {
+      pageSize: { w: 800, h: 1000 },
+      pages: [
+        {
+          number: 4,
+          displayNumber: 2,
+          numberText: 'ii',
+          pageNumberFormat: 'lowerRoman',
+          pageNumberChapterText: 'A',
+          pageNumberChapterSeparator: 'colon',
+          sectionIndex: 1,
+          fragments: [
+            { kind: 'para', blockId: 'p1', fromLine: 0, toLine: 1, x: 0, y: 0, width: 100, pmStart: 10, pmEnd: 20 },
+          ],
+        },
+      ],
+    };
+
+    const result = buildPageRefAnchorMap(new Map([['target', 12]]), layout);
+
+    expect(result.get('target')).toMatchObject({
+      physicalPage: 4,
+      displayNumber: 2,
+      displayText: 'ii',
+      pageFormat: 'lowerRoman',
+      chapterNumberText: 'A',
+      chapterSeparator: 'colon',
+      sectionIndex: 1,
+      pmPosition: 12,
+    });
+  });
+
+  it('resolves targets inside table fragments with PM ranges', () => {
+    const layout: Layout = {
+      pageSize: { w: 800, h: 1000 },
+      pages: [
+        {
+          number: 2,
+          fragments: [
+            {
+              kind: 'table',
+              blockId: 't1',
+              fromRow: 0,
+              toRow: 1,
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 20,
+              pmStart: 30,
+              pmEnd: 60,
+            } as any,
+          ],
+        },
+      ],
+    };
+
+    expect(buildPageRefAnchorMap(new Map([['inTable', 45]]), layout).get('inTable')?.physicalPage).toBe(2);
+  });
+
+  it('falls back to paragraph block run ranges when fragment PM data is missing', () => {
+    const block: ParagraphBlock = {
+      kind: 'paragraph',
+      id: 'p1',
+      runs: [{ text: 'Target', fontFamily: 'Arial', fontSize: 12, pmStart: 100, pmEnd: 106 }],
+    };
+    const layout: Layout = {
+      pageSize: { w: 800, h: 1000 },
+      pages: [
+        {
+          number: 3,
+          fragments: [{ kind: 'para', blockId: 'p1', fromLine: 0, toLine: 1, x: 0, y: 0, width: 100 }],
+        },
+      ],
+    };
+
+    expect(buildPageRefAnchorMap(new Map([['target', 103]]), layout, [block]).get('target')?.physicalPage).toBe(3);
+  });
+
+  it('maps leading bookmark markers to the next visible fragment', () => {
+    const layout: Layout = {
+      pageSize: { w: 800, h: 1000 },
+      pages: [
+        {
+          number: 2,
+          displayNumber: 2,
+          numberText: '2',
+          fragments: [
+            {
+              kind: 'para',
+              blockId: 'target',
+              fromLine: 0,
+              toLine: 1,
+              x: 0,
+              y: 0,
+              width: 100,
+              pmStart: 1377,
+              pmEnd: 1400,
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(buildPageRefAnchorMap(new Map([['target', 1374]]), layout).get('target')).toMatchObject({
+      physicalPage: 2,
+      displayNumber: 2,
+      displayText: '2',
+      pmPosition: 1374,
+    });
+  });
+
+  it('falls back to visible paragraph ranges inside table blocks', () => {
+    const table: TableBlock = {
+      kind: 'table',
+      id: 't1',
+      rows: [
+        {
+          id: 'r1',
+          cells: [
+            {
+              id: 'c1',
+              paragraph: {
+                kind: 'paragraph',
+                id: 'p1',
+                runs: [{ text: 'Cell', fontFamily: 'Arial', fontSize: 12, pmStart: 200, pmEnd: 204 }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const layout: Layout = {
+      pageSize: { w: 800, h: 1000 },
+      pages: [
+        {
+          number: 5,
+          fragments: [{ kind: 'table', blockId: 't1', fromRow: 0, toRow: 1, x: 0, y: 0, width: 100, height: 20 }],
+        },
+      ],
+    };
+
+    expect(buildPageRefAnchorMap(new Map([['cellTarget', 202]]), layout, [table]).get('cellTarget')?.physicalPage).toBe(
+      5,
+    );
+  });
+
+  it('omits bookmarks not found in any fragment', () => {
+    const layout: Layout = {
+      pageSize: { w: 800, h: 1000 },
+      pages: [{ number: 1, fragments: [] }],
+    };
+
+    expect(buildPageRefAnchorMap(new Map([['missing', 1]]), layout).has('missing')).toBe(false);
+  });
+});

--- a/packages/layout-engine/contracts/src/page-ref-anchor.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.ts
@@ -1,4 +1,14 @@
-import type { FlowBlock, Fragment, Layout, Page, PageRefLocation, ParagraphBlock, Run, TableBlock } from './index.js';
+import type {
+  FlowBlock,
+  Fragment,
+  Layout,
+  ListBlock,
+  Page,
+  PageRefLocation,
+  ParagraphBlock,
+  Run,
+  TableBlock,
+} from './index.js';
 
 export function buildPageRefAnchorMap(
   bookmarks: Map<string, number>,
@@ -42,6 +52,13 @@ function findPageRefLocation(
         return pageRefLocationFromPage(page, pmPosition);
       }
       if (fragment.kind === 'table' && block?.kind === 'table' && tableContainsPosition(block, pmPosition)) {
+        return pageRefLocationFromPage(page, pmPosition);
+      }
+      if (
+        fragment.kind === 'list-item' &&
+        block?.kind === 'list' &&
+        listItemContainsPosition(block, fragment.itemId, pmPosition)
+      ) {
         return pageRefLocationFromPage(page, pmPosition);
       }
 
@@ -101,7 +118,20 @@ function fragmentStartPosition(fragment: Fragment, block: FlowBlock | undefined)
   if (range.pmStart != null) return range.pmStart;
   if (block?.kind === 'paragraph') return runRange(block.runs)?.start ?? null;
   if (block?.kind === 'table') return tableRunRange(block)?.start ?? null;
+  if (fragment.kind === 'list-item' && block?.kind === 'list') {
+    return listItemRunRange(block, fragment.itemId)?.start ?? null;
+  }
   return null;
+}
+
+function listItemContainsPosition(block: ListBlock, itemId: string, pmPosition: number): boolean {
+  const range = listItemRunRange(block, itemId);
+  return range != null && pmPosition >= range.start && pmPosition < range.end;
+}
+
+function listItemRunRange(block: ListBlock, itemId: string): { start: number; end: number } | null {
+  const item = block.items.find((candidate) => candidate.id === itemId);
+  return item ? runRange(item.paragraph.runs) : null;
 }
 
 function tableRunRange(block: TableBlock): { start: number; end: number } | null {

--- a/packages/layout-engine/contracts/src/page-ref-anchor.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.ts
@@ -17,6 +17,8 @@ import type {
 } from './index.js';
 import { computeFragmentPmRange } from './pm-range.js';
 
+const MAX_BOOKMARK_MARKER_LEAD_DISTANCE = 3;
+
 export function buildPageRefAnchorMap(
   bookmarks: Map<string, number>,
   layout: Layout,
@@ -91,7 +93,7 @@ function findPageRefLocation(
       const fragmentStart = fragmentRange?.start ?? null;
       if (fragmentStart != null && fragmentStart > pmPosition) {
         const distance = fragmentStart - pmPosition;
-        if (!hasPriorVisibleRange && distance < nextDistance) {
+        if ((!hasPriorVisibleRange || distance <= MAX_BOOKMARK_MARKER_LEAD_DISTANCE) && distance < nextDistance) {
           nextDistance = distance;
           nextLocation = pageRefLocationFromPage(page, pmPosition);
         }

--- a/packages/layout-engine/contracts/src/page-ref-anchor.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.ts
@@ -57,6 +57,7 @@ function findPageRefLocation(
 ): PageRefLocation | null {
   let nextLocation: PageRefLocation | null = null;
   let nextDistance = Number.POSITIVE_INFINITY;
+  let hasPriorVisibleRange = false;
 
   for (const page of layout.pages) {
     for (const fragment of page.fragments) {
@@ -83,10 +84,14 @@ function findPageRefLocation(
         return pageRefLocationFromPage(page, pmPosition);
       }
 
-      const fragmentStart = fragmentStartPosition(fragment, block);
+      const fragmentRange = fragmentPositionRange(fragment, block);
+      if (fragmentRange?.end != null && fragmentRange.end <= pmPosition) {
+        hasPriorVisibleRange = true;
+      }
+      const fragmentStart = fragmentRange?.start ?? null;
       if (fragmentStart != null && fragmentStart > pmPosition) {
         const distance = fragmentStart - pmPosition;
-        if (distance < nextDistance) {
+        if (!hasPriorVisibleRange && distance < nextDistance) {
           nextDistance = distance;
           nextLocation = pageRefLocationFromPage(page, pmPosition);
         }
@@ -238,13 +243,16 @@ function tableBlockContainsPosition(block: TableBlock, pmPosition: number): bool
   return false;
 }
 
-function fragmentStartPosition(fragment: Fragment, block: FlowBlock | undefined): number | null {
-  const range = fragment as { pmStart?: number };
-  if (range.pmStart != null) return range.pmStart;
-  if (block?.kind === 'paragraph') return runRange(block.runs)?.start ?? null;
-  if (block?.kind === 'table') return tableRunRange(block)?.start ?? null;
+function fragmentPositionRange(
+  fragment: Fragment,
+  block: FlowBlock | undefined,
+): { start: number; end: number } | null {
+  const fullRange = fragment as { pmStart?: number; pmEnd?: number };
+  if (fullRange.pmStart != null && fullRange.pmEnd != null) return { start: fullRange.pmStart, end: fullRange.pmEnd };
+  if (block?.kind === 'paragraph') return runRange(block.runs);
+  if (block?.kind === 'table') return tableRunRange(block);
   if (fragment.kind === 'list-item' && block?.kind === 'list') {
-    return listItemRunRange(block, fragment.itemId)?.start ?? null;
+    return listItemRunRange(block, fragment.itemId);
   }
   return null;
 }

--- a/packages/layout-engine/contracts/src/page-ref-anchor.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.ts
@@ -8,6 +8,7 @@ import type {
   ParagraphBlock,
   Run,
   TableBlock,
+  TableFragment,
 } from './index.js';
 
 export function buildPageRefAnchorMap(
@@ -51,7 +52,7 @@ function findPageRefLocation(
       if (fragment.kind === 'para' && block?.kind === 'paragraph' && blockContainsPosition(block, pmPosition)) {
         return pageRefLocationFromPage(page, pmPosition);
       }
-      if (fragment.kind === 'table' && block?.kind === 'table' && tableContainsPosition(block, pmPosition)) {
+      if (fragment.kind === 'table' && block?.kind === 'table' && tableContainsPosition(block, fragment, pmPosition)) {
         return pageRefLocationFromPage(page, pmPosition);
       }
       if (
@@ -100,13 +101,30 @@ function blockContainsPosition(block: ParagraphBlock, pmPosition: number): boole
   return range != null && pmPosition >= range.start && pmPosition < range.end;
 }
 
-function tableContainsPosition(block: TableBlock, pmPosition: number): boolean {
+function tableContainsPosition(block: TableBlock, fragment: TableFragment, pmPosition: number): boolean {
+  const fromRow = Math.max(0, fragment.fromRow);
+  const toRow = Math.min(block.rows.length, fragment.toRow);
+  for (let rowIndex = fromRow; rowIndex < toRow; rowIndex += 1) {
+    const row = block.rows[rowIndex];
+    if (!row) continue;
+    for (const cell of row.cells) {
+      const blocks = cell.blocks ?? (cell.paragraph ? [cell.paragraph] : []);
+      for (const childBlock of blocks) {
+        if (childBlock.kind === 'paragraph' && blockContainsPosition(childBlock, pmPosition)) return true;
+        if (childBlock.kind === 'table' && tableBlockContainsPosition(childBlock, pmPosition)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+function tableBlockContainsPosition(block: TableBlock, pmPosition: number): boolean {
   for (const row of block.rows) {
     for (const cell of row.cells) {
       const blocks = cell.blocks ?? (cell.paragraph ? [cell.paragraph] : []);
       for (const childBlock of blocks) {
         if (childBlock.kind === 'paragraph' && blockContainsPosition(childBlock, pmPosition)) return true;
-        if (childBlock.kind === 'table' && tableContainsPosition(childBlock, pmPosition)) return true;
+        if (childBlock.kind === 'table' && tableBlockContainsPosition(childBlock, pmPosition)) return true;
       }
     }
   }

--- a/packages/layout-engine/contracts/src/page-ref-anchor.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.ts
@@ -1,0 +1,138 @@
+import type { FlowBlock, Fragment, Layout, Page, PageRefLocation, ParagraphBlock, Run, TableBlock } from './index.js';
+
+export function buildPageRefAnchorMap(
+  bookmarks: Map<string, number>,
+  layout: Layout,
+  blocks: FlowBlock[] = [],
+): Map<string, PageRefLocation> {
+  const anchors = new Map<string, PageRefLocation>();
+  if (bookmarks.size === 0) return anchors;
+
+  const blockById = new Map<string, FlowBlock>();
+  for (const block of blocks) {
+    blockById.set(block.id, block);
+  }
+
+  for (const [bookmarkName, pmPosition] of bookmarks) {
+    const location = findPageRefLocation(pmPosition, layout, blockById);
+    if (location) {
+      anchors.set(bookmarkName, { ...location, pmPosition });
+    }
+  }
+
+  return anchors;
+}
+
+function findPageRefLocation(
+  pmPosition: number,
+  layout: Layout,
+  blockById: Map<string, FlowBlock>,
+): PageRefLocation | null {
+  let nextLocation: PageRefLocation | null = null;
+  let nextDistance = Number.POSITIVE_INFINITY;
+
+  for (const page of layout.pages) {
+    for (const fragment of page.fragments) {
+      if (fragmentContainsPosition(fragment, pmPosition)) {
+        return pageRefLocationFromPage(page, pmPosition);
+      }
+
+      const block = blockById.get(fragment.blockId);
+      if (fragment.kind === 'para' && block?.kind === 'paragraph' && blockContainsPosition(block, pmPosition)) {
+        return pageRefLocationFromPage(page, pmPosition);
+      }
+      if (fragment.kind === 'table' && block?.kind === 'table' && tableContainsPosition(block, pmPosition)) {
+        return pageRefLocationFromPage(page, pmPosition);
+      }
+
+      const fragmentStart = fragmentStartPosition(fragment, block);
+      if (fragmentStart != null && fragmentStart > pmPosition) {
+        const distance = fragmentStart - pmPosition;
+        if (distance < nextDistance) {
+          nextDistance = distance;
+          nextLocation = pageRefLocationFromPage(page, pmPosition);
+        }
+      }
+    }
+  }
+
+  return nextLocation;
+}
+
+function pageRefLocationFromPage(page: Page, pmPosition: number): PageRefLocation {
+  const displayNumber = Math.max(1, page.displayNumber ?? page.effectivePageNumber ?? page.number);
+  return {
+    physicalPage: page.number,
+    displayNumber,
+    displayText: page.numberText ?? String(displayNumber),
+    pageFormat: page.pageNumberFormat,
+    chapterNumberText: page.pageNumberChapterText,
+    chapterSeparator: page.pageNumberChapterSeparator,
+    sectionIndex: page.sectionIndex,
+    pmPosition,
+  };
+}
+
+function fragmentContainsPosition(fragment: Fragment, pmPosition: number): boolean {
+  const range = fragment as { pmStart?: number; pmEnd?: number };
+  return range.pmStart != null && range.pmEnd != null && pmPosition >= range.pmStart && pmPosition < range.pmEnd;
+}
+
+function blockContainsPosition(block: ParagraphBlock, pmPosition: number): boolean {
+  const range = runRange(block.runs);
+  return range != null && pmPosition >= range.start && pmPosition < range.end;
+}
+
+function tableContainsPosition(block: TableBlock, pmPosition: number): boolean {
+  for (const row of block.rows) {
+    for (const cell of row.cells) {
+      const blocks = cell.blocks ?? (cell.paragraph ? [cell.paragraph] : []);
+      for (const childBlock of blocks) {
+        if (childBlock.kind === 'paragraph' && blockContainsPosition(childBlock, pmPosition)) return true;
+        if (childBlock.kind === 'table' && tableContainsPosition(childBlock, pmPosition)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+function fragmentStartPosition(fragment: Fragment, block: FlowBlock | undefined): number | null {
+  const range = fragment as { pmStart?: number };
+  if (range.pmStart != null) return range.pmStart;
+  if (block?.kind === 'paragraph') return runRange(block.runs)?.start ?? null;
+  if (block?.kind === 'table') return tableRunRange(block)?.start ?? null;
+  return null;
+}
+
+function tableRunRange(block: TableBlock): { start: number; end: number } | null {
+  let start = Number.POSITIVE_INFINITY;
+  let end = Number.NEGATIVE_INFINITY;
+  for (const row of block.rows) {
+    for (const cell of row.cells) {
+      const blocks = cell.blocks ?? (cell.paragraph ? [cell.paragraph] : []);
+      for (const childBlock of blocks) {
+        const range =
+          childBlock.kind === 'paragraph'
+            ? runRange(childBlock.runs)
+            : childBlock.kind === 'table'
+              ? tableRunRange(childBlock)
+              : null;
+        if (!range) continue;
+        start = Math.min(start, range.start);
+        end = Math.max(end, range.end);
+      }
+    }
+  }
+  return Number.isFinite(start) && Number.isFinite(end) && start < end ? { start, end } : null;
+}
+
+function runRange(runs: Run[]): { start: number; end: number } | null {
+  let start = Number.POSITIVE_INFINITY;
+  let end = Number.NEGATIVE_INFINITY;
+  for (const run of runs) {
+    const range = run as { pmStart?: number; pmEnd?: number };
+    if (range.pmStart != null) start = Math.min(start, range.pmStart);
+    if (range.pmEnd != null) end = Math.max(end, range.pmEnd);
+  }
+  return Number.isFinite(start) && Number.isFinite(end) && start < end ? { start, end } : null;
+}

--- a/packages/layout-engine/contracts/src/page-ref-anchor.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.ts
@@ -3,29 +3,44 @@ import type {
   Fragment,
   Layout,
   ListBlock,
+  Measure,
   Page,
   PageRefLocation,
   ParagraphBlock,
+  ParagraphMeasure,
   Run,
   TableBlock,
+  TableCell,
+  TableCellMeasure,
   TableFragment,
+  TableMeasure,
 } from './index.js';
+import { computeFragmentPmRange } from './pm-range.js';
 
 export function buildPageRefAnchorMap(
   bookmarks: Map<string, number>,
   layout: Layout,
   blocks: FlowBlock[] = [],
+  measures: Measure[] = [],
 ): Map<string, PageRefLocation> {
   const anchors = new Map<string, PageRefLocation>();
   if (bookmarks.size === 0) return anchors;
 
   const blockById = new Map<string, FlowBlock>();
+  const measureById = new Map<string, Measure>();
   for (const block of blocks) {
     blockById.set(block.id, block);
   }
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index];
+    const measure = measures[index];
+    if (block && measure) {
+      measureById.set(block.id, measure);
+    }
+  }
 
   for (const [bookmarkName, pmPosition] of bookmarks) {
-    const location = findPageRefLocation(pmPosition, layout, blockById);
+    const location = findPageRefLocation(pmPosition, layout, blockById, measureById);
     if (location) {
       anchors.set(bookmarkName, { ...location, pmPosition });
     }
@@ -38,6 +53,7 @@ function findPageRefLocation(
   pmPosition: number,
   layout: Layout,
   blockById: Map<string, FlowBlock>,
+  measureById: Map<string, Measure>,
 ): PageRefLocation | null {
   let nextLocation: PageRefLocation | null = null;
   let nextDistance = Number.POSITIVE_INFINITY;
@@ -52,7 +68,11 @@ function findPageRefLocation(
       if (fragment.kind === 'para' && block?.kind === 'paragraph' && blockContainsPosition(block, pmPosition)) {
         return pageRefLocationFromPage(page, pmPosition);
       }
-      if (fragment.kind === 'table' && block?.kind === 'table' && tableContainsPosition(block, fragment, pmPosition)) {
+      if (
+        fragment.kind === 'table' &&
+        block?.kind === 'table' &&
+        tableContainsPosition(block, fragment, pmPosition, measureById.get(fragment.blockId))
+      ) {
         return pageRefLocationFromPage(page, pmPosition);
       }
       if (
@@ -101,13 +121,29 @@ function blockContainsPosition(block: ParagraphBlock, pmPosition: number): boole
   return range != null && pmPosition >= range.start && pmPosition < range.end;
 }
 
-function tableContainsPosition(block: TableBlock, fragment: TableFragment, pmPosition: number): boolean {
+function tableContainsPosition(
+  block: TableBlock,
+  fragment: TableFragment,
+  pmPosition: number,
+  measure?: Measure,
+): boolean {
   const fromRow = Math.max(0, fragment.fromRow);
   const toRow = Math.min(block.rows.length, fragment.toRow);
+  const tableMeasure = measure?.kind === 'table' ? (measure as TableMeasure) : undefined;
   for (let rowIndex = fromRow; rowIndex < toRow; rowIndex += 1) {
     const row = block.rows[rowIndex];
     if (!row) continue;
-    for (const cell of row.cells) {
+    const isPartialRow = fragment.partialRow?.rowIndex === rowIndex;
+    for (let cellIndex = 0; cellIndex < row.cells.length; cellIndex += 1) {
+      const cell = row.cells[cellIndex];
+      if (!cell) continue;
+      if (isPartialRow && tableMeasure) {
+        const cellMeasure = tableMeasure.rows[rowIndex]?.cells[cellIndex];
+        if (cellContainsPositionInLineRange(cell, cellMeasure, fragment.partialRow!, cellIndex, pmPosition)) {
+          return true;
+        }
+        continue;
+      }
       const blocks = cell.blocks ?? (cell.paragraph ? [cell.paragraph] : []);
       for (const childBlock of blocks) {
         if (childBlock.kind === 'paragraph' && blockContainsPosition(childBlock, pmPosition)) return true;
@@ -116,6 +152,77 @@ function tableContainsPosition(block: TableBlock, fragment: TableFragment, pmPos
     }
   }
   return false;
+}
+
+function cellContainsPositionInLineRange(
+  cell: TableCell,
+  cellMeasure: TableCellMeasure | undefined,
+  partialRow: NonNullable<TableFragment['partialRow']>,
+  cellIndex: number,
+  pmPosition: number,
+): boolean {
+  if (!cellMeasure) return false;
+
+  const totalLines = getCellTotalLines(cellMeasure);
+  const rawFromLine = partialRow.fromLineByCell[cellIndex];
+  const rawToLine = partialRow.toLineByCell[cellIndex];
+  const fromLine = typeof rawFromLine === 'number' && rawFromLine >= 0 ? Math.min(rawFromLine, totalLines) : 0;
+  const toLine =
+    typeof rawToLine === 'number'
+      ? Math.max(0, Math.min(rawToLine === -1 ? totalLines : rawToLine, totalLines))
+      : totalLines;
+
+  const range = computeCellLineRange(cell, cellMeasure, fromLine, Math.max(fromLine, toLine));
+  return range != null && pmPosition >= range.start && pmPosition < range.end;
+}
+
+function computeCellLineRange(
+  cell: TableCell,
+  cellMeasure: TableCellMeasure,
+  fromLine: number,
+  toLine: number,
+): { start: number; end: number } | null {
+  let start = Number.POSITIVE_INFINITY;
+  let end = Number.NEGATIVE_INFINITY;
+  const blocks = cell.blocks ?? (cell.paragraph ? [cell.paragraph] : []);
+  const measures = cellMeasure.blocks ?? (cellMeasure.paragraph ? [cellMeasure.paragraph] : []);
+  const blockCount = Math.min(blocks.length, measures.length);
+
+  let lineOffset = 0;
+  for (let blockIndex = 0; blockIndex < blockCount; blockIndex += 1) {
+    const childBlock = blocks[blockIndex];
+    const childMeasure = measures[blockIndex];
+    const lineCount = getBlockLineCount(childMeasure);
+    const blockFromLine = Math.max(fromLine, lineOffset) - lineOffset;
+    const blockToLine = Math.min(toLine, lineOffset + lineCount) - lineOffset;
+
+    if (childBlock?.kind === 'paragraph' && childMeasure?.kind === 'paragraph' && blockFromLine < blockToLine) {
+      const range = computeFragmentPmRange(
+        childBlock,
+        (childMeasure as ParagraphMeasure).lines,
+        blockFromLine,
+        blockToLine,
+      );
+      if (range.pmStart != null) start = Math.min(start, range.pmStart);
+      if (range.pmEnd != null) end = Math.max(end, range.pmEnd);
+    }
+
+    lineOffset += lineCount;
+  }
+
+  return Number.isFinite(start) && Number.isFinite(end) && start < end ? { start, end } : null;
+}
+
+function getCellTotalLines(cellMeasure: TableCellMeasure): number {
+  const measures = cellMeasure.blocks ?? (cellMeasure.paragraph ? [cellMeasure.paragraph] : []);
+  return measures.reduce((total, measure) => total + getBlockLineCount(measure), 0);
+}
+
+function getBlockLineCount(measure: Measure | undefined): number {
+  if (!measure) return 0;
+  if (measure.kind === 'paragraph') return (measure as ParagraphMeasure).lines.length;
+  if (measure.kind === 'table') return (measure as TableMeasure).rows.length;
+  return 1;
 }
 
 function tableBlockContainsPosition(block: TableBlock, pmPosition: number): boolean {

--- a/packages/layout-engine/contracts/src/page-ref-anchor.ts
+++ b/packages/layout-engine/contracts/src/page-ref-anchor.ts
@@ -17,6 +17,9 @@ import type {
 } from './index.js';
 import { computeFragmentPmRange } from './pm-range.js';
 
+// Bookmark start/end markers are inline PM leaf nodes. A bookmark can legally sit
+// immediately before visible text, and with start+end plus one wrapper/offset
+// boundary the visible fragment may begin up to three PM positions later.
 const MAX_BOOKMARK_MARKER_LEAD_DISTANCE = 3;
 
 export function buildPageRefAnchorMap(

--- a/packages/layout-engine/layout-engine/src/index.ts
+++ b/packages/layout-engine/layout-engine/src/index.ts
@@ -30,6 +30,7 @@ import type {
   NormalizedColumnLayout,
   DocumentBackground,
   HeaderFooterResolutionSection,
+  PageNumberFormat,
 } from '@superdoc/contracts';
 import {
   buildLayoutSourceIdentityForFragment,
@@ -1427,8 +1428,7 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
   // Paginator encapsulation for page/column helpers
   let pageCount = 0;
   // Page numbering state
-  let activeNumberFormat: 'decimal' | 'lowerLetter' | 'upperLetter' | 'lowerRoman' | 'upperRoman' | 'numberInDash' =
-    'decimal';
+  let activeNumberFormat: PageNumberFormat = 'decimal';
   let activePageCounter = 1;
   let activeSectionPageCounterStart = activePageCounter;
   let pendingNumbering: SectionNumbering | null = null;

--- a/packages/layout-engine/layout-engine/src/resolvePageRefs.ts
+++ b/packages/layout-engine/layout-engine/src/resolvePageRefs.ts
@@ -4,6 +4,10 @@
  * Handles two-pass layout for dynamic cross-reference resolution:
  * - Pass 1: Build anchor map (bookmark → page number)
  * - Pass 2: Resolve pageReference tokens and re-measure affected paragraphs
+ *
+ * Superseded by resolve-stage PAGEREF handling in @superdoc/layout-resolved.
+ * SD-3007 follow-up: remove this legacy scan once step 12 consolidates the
+ * interim anchor-map implementations.
  */
 
 import type { Layout, FlowBlock, ParagraphBlock } from '@superdoc/contracts';

--- a/packages/layout-engine/layout-engine/src/resolvePageTokens.test.ts
+++ b/packages/layout-engine/layout-engine/src/resolvePageTokens.test.ts
@@ -299,4 +299,70 @@ describe('resolveTokensInBlock', () => {
     expect((block.runs[0] as TextRun).token).toBeUndefined();
     expect((block.runs[0] as TextRun).pageNumberFieldFormat).toBeUndefined();
   });
+
+  it('should apply run-local total page count zero padding', () => {
+    const block: ParagraphBlock = {
+      kind: 'paragraph',
+      id: 'test-total-count-zero-padding-format',
+      runs: [
+        {
+          text: '0',
+          token: 'totalPageCount',
+          pageNumberFieldFormat: { format: 'decimal', zeroPadding: 3 },
+          fontFamily: 'Arial',
+          fontSize: 12,
+        } as TextRun,
+      ],
+    };
+
+    const wasModified = resolveTokensInBlock(block, 1, 7);
+
+    expect(wasModified).toBe(true);
+    expect((block.runs[0] as TextRun).text).toBe('007');
+    expect((block.runs[0] as TextRun).token).toBeUndefined();
+  });
+
+  it('should apply run-local total page count grouping picture', () => {
+    const block: ParagraphBlock = {
+      kind: 'paragraph',
+      id: 'test-total-count-picture-format',
+      runs: [
+        {
+          text: '0',
+          token: 'totalPageCount',
+          pageNumberFieldFormat: { numericPicture: '#,##0' },
+          fontFamily: 'Arial',
+          fontSize: 12,
+        } as TextRun,
+      ],
+    };
+
+    const wasModified = resolveTokensInBlock(block, 1, 1234);
+
+    expect(wasModified).toBe(true);
+    expect((block.runs[0] as TextRun).text).toBe('1,234');
+    expect((block.runs[0] as TextRun).token).toBeUndefined();
+  });
+
+  it('should apply run-local total page count ordinal format', () => {
+    const block: ParagraphBlock = {
+      kind: 'paragraph',
+      id: 'test-total-count-ordinal-format',
+      runs: [
+        {
+          text: '0',
+          token: 'totalPageCount',
+          pageNumberFieldFormat: { format: 'ordinal' },
+          fontFamily: 'Arial',
+          fontSize: 12,
+        } as TextRun,
+      ],
+    };
+
+    const wasModified = resolveTokensInBlock(block, 1, 22);
+
+    expect(wasModified).toBe(true);
+    expect((block.runs[0] as TextRun).text).toBe('22nd');
+    expect((block.runs[0] as TextRun).token).toBeUndefined();
+  });
 });

--- a/packages/layout-engine/layout-engine/src/resolvePageTokens.ts
+++ b/packages/layout-engine/layout-engine/src/resolvePageTokens.ts
@@ -335,9 +335,12 @@ export function resolveTokensInBlock(block: ParagraphBlock, pageNumber: number, 
         blockModified = true;
       } else if (run.token === 'totalPageCount') {
         // Replace placeholder text with total page count
-        run.text = totalPagesStr;
+        run.text = run.pageNumberFieldFormat
+          ? formatPageNumberFieldValue(totalPages, run.pageNumberFieldFormat)
+          : totalPagesStr;
         // Clear token metadata to treat as normal text after resolution
         delete run.token;
+        delete run.pageNumberFieldFormat;
         blockModified = true;
       }
       // Note: pageReference tokens are handled by resolvePageRefs.ts

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
@@ -297,6 +297,90 @@ describe('resolveLayout', () => {
 
       expect((input.blocks[0] as any).runs[0].text).toBe('5');
     });
+
+    it('resolves PAGEREF text inside table cells', () => {
+      const tableBlock: FlowBlock = {
+        kind: 'table',
+        id: 'source-table',
+        rows: [
+          {
+            id: 'row1',
+            cells: [
+              {
+                id: 'cell1',
+                paragraph: {
+                  kind: 'paragraph',
+                  id: 'cell-para',
+                  runs: [pageRefRun()],
+                },
+              },
+            ],
+          },
+        ],
+      } as any;
+      const targetBlock: FlowBlock = {
+        kind: 'paragraph',
+        id: 'target-block',
+        runs: [{ text: 'Target', fontFamily: 'Arial', fontSize: 12, pmStart: 100, pmEnd: 106 }],
+      } as any;
+      const measures: Measure[] = [
+        { kind: 'table', rows: [{ height: 20, cells: [{ width: 100 }] }], columnWidths: [100] } as any,
+        {
+          kind: 'paragraph',
+          lines: [{ fromRun: 0, fromChar: 0, toRun: 0, toChar: 6, width: 40, ascent: 8, descent: 2, lineHeight: 12 }],
+        } as any,
+      ];
+      const layout: Layout = {
+        pageSize: { w: 800, h: 1000 },
+        pages: [
+          {
+            number: 1,
+            fragments: [
+              {
+                kind: 'table',
+                blockId: 'source-table',
+                fromRow: 0,
+                toRow: 1,
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 20,
+              },
+            ],
+          },
+          {
+            number: 2,
+            displayNumber: 12,
+            numberText: '12',
+            fragments: [
+              {
+                kind: 'para',
+                blockId: 'target-block',
+                fromLine: 0,
+                toLine: 1,
+                x: 0,
+                y: 0,
+                width: 100,
+                pmStart: 100,
+                pmEnd: 106,
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = resolveLayout({
+        layout,
+        flowMode: 'paginated',
+        blocks: [tableBlock, targetBlock],
+        measures,
+        bookmarks: new Map([['target', 100]]),
+      });
+      const item = result.pages[0].items[0] as import('@superdoc/contracts').ResolvedTableItem;
+
+      expect(item.block.rows[0].cells[0].paragraph?.runs[0].text).toBe('12');
+      expect((tableBlock as any).rows[0].cells[0].paragraph.runs[0].text).toBe('5');
+    });
   });
 
   it('derives neutral layout identity for resolved fragments even when input fragments do not precompute it', () => {

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
@@ -324,7 +324,26 @@ describe('resolveLayout', () => {
         runs: [{ text: 'Target', fontFamily: 'Arial', fontSize: 12, pmStart: 100, pmEnd: 106 }],
       } as any;
       const measures: Measure[] = [
-        { kind: 'table', rows: [{ height: 20, cells: [{ width: 100 }] }], columnWidths: [100] } as any,
+        {
+          kind: 'table',
+          rows: [
+            {
+              height: 20,
+              cells: [
+                {
+                  width: 100,
+                  paragraph: {
+                    lines: [
+                      { fromRun: 0, fromChar: 0, toRun: 0, toChar: 1, width: 8, ascent: 8, descent: 2, lineHeight: 12 },
+                    ],
+                    totalHeight: 12,
+                  },
+                },
+              ],
+            },
+          ],
+          columnWidths: [100],
+        } as any,
         {
           kind: 'paragraph',
           lines: [{ fromRun: 0, fromChar: 0, toRun: 0, toChar: 6, width: 40, ascent: 8, descent: 2, lineHeight: 12 }],
@@ -379,6 +398,7 @@ describe('resolveLayout', () => {
       const item = result.pages[0].items[0] as import('@superdoc/contracts').ResolvedTableItem;
 
       expect(item.block.rows[0].cells[0].paragraph?.runs[0].text).toBe('12');
+      expect(item.measure.rows[0].cells[0].paragraph?.lines[0].toChar).toBe(2);
       expect((tableBlock as any).rows[0].cells[0].paragraph.runs[0].text).toBe('5');
     });
 
@@ -478,6 +498,7 @@ describe('resolveLayout', () => {
       const item = result.pages[0].items[0] as any;
 
       expect(item.block.items[0].paragraph.runs[0].text).toBe('12');
+      expect(item.measure.items[0].paragraph.lines[0].toChar).toBe(2);
       expect((listBlock as any).items[0].paragraph.runs[0].text).toBe('5');
     });
   });

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
@@ -335,6 +335,68 @@ describe('resolveLayout', () => {
       expect((result.pages[0].items[0] as any).block.runs[0].text).toBe('above');
     });
 
+    it('resolves same-page relative PAGEREF text to below when the source precedes the target', () => {
+      const input = makePageRefInput(
+        pageRefRun({
+          pmStart: 50,
+          pageRefMetadata: { bookmarkId: 'target', instruction: 'PAGEREF target \\p', relativePosition: true },
+        }),
+      );
+      input.layout.pages = [
+        {
+          number: 1,
+          displayNumber: 1,
+          numberText: '1',
+          fragments: [
+            {
+              kind: 'para',
+              blockId: 'source',
+              fromLine: 0,
+              toLine: 1,
+              x: 0,
+              y: 0,
+              width: 100,
+              pmStart: 40,
+              pmEnd: 60,
+            },
+            {
+              kind: 'para',
+              blockId: 'target-block',
+              fromLine: 0,
+              toLine: 1,
+              x: 0,
+              y: 20,
+              width: 100,
+              pmStart: 100,
+              pmEnd: 106,
+            },
+          ],
+        },
+      ];
+      const result = resolveLayout({ ...input, flowMode: 'paginated', bookmarks: new Map([['target', 100]]) });
+
+      expect((result.pages[0].items[0] as any).block.runs[0].text).toBe('below');
+    });
+
+    it('applies Roman PAGEREF formatting while preserving the target chapter prefix', () => {
+      const input = makePageRefInput(
+        pageRefRun({
+          pageRefMetadata: {
+            bookmarkId: 'target',
+            instruction: 'PAGEREF target \\* Roman',
+            pageNumberFieldFormat: { format: 'upperRoman' },
+          },
+        }),
+      );
+      input.layout.pages[1].displayNumber = 4;
+      input.layout.pages[1].numberText = 'A:4';
+      input.layout.pages[1].pageNumberChapterText = 'A';
+      input.layout.pages[1].pageNumberChapterSeparator = 'colon';
+      const result = resolveLayout({ ...input, flowMode: 'paginated', bookmarks: new Map([['target', 100]]) });
+
+      expect((result.pages[0].items[0] as any).block.runs[0].text).toBe('A:IV');
+    });
+
     it('applies PAGEREF numeric formatting against the target display number', () => {
       const input = makePageRefInput(
         pageRefRun({
@@ -350,6 +412,79 @@ describe('resolveLayout', () => {
       const result = resolveLayout({ ...input, flowMode: 'paginated', bookmarks: new Map([['target', 100]]) });
 
       expect((result.pages[0].items[0] as any).block.runs[0].text).toBe('03');
+    });
+
+    it('resolves multiple PAGEREF tokens in one paragraph independently', () => {
+      const input = makePageRefInput();
+      input.blocks[0] = {
+        kind: 'paragraph',
+        id: 'source',
+        runs: [
+          pageRefRun({ text: '5', pmStart: 5, pmEnd: 6 }),
+          { text: ' and ', fontFamily: 'Arial', fontSize: 12, pmStart: 6, pmEnd: 11 },
+          pageRefRun({
+            text: '6',
+            pmStart: 11,
+            pmEnd: 12,
+            pageRefMetadata: { bookmarkId: 'other', instruction: 'PAGEREF other' },
+          }),
+        ],
+      } as any;
+      input.blocks.push({
+        kind: 'paragraph',
+        id: 'other-block',
+        runs: [{ text: 'Other', fontFamily: 'Arial', fontSize: 12, pmStart: 200, pmEnd: 205 }],
+      } as any);
+      input.measures[0] = {
+        kind: 'paragraph',
+        lines: [
+          {
+            fromRun: 0,
+            fromChar: 0,
+            toRun: 2,
+            toChar: 1,
+            width: 60,
+            ascent: 8,
+            descent: 2,
+            lineHeight: 12,
+          },
+        ],
+      } as any;
+      input.measures.push({
+        kind: 'paragraph',
+        lines: [{ fromRun: 0, fromChar: 0, toRun: 0, toChar: 5, width: 40, ascent: 8, descent: 2, lineHeight: 12 }],
+      } as any);
+      input.layout.pages.push({
+        number: 3,
+        displayNumber: 23,
+        numberText: '23',
+        fragments: [
+          {
+            kind: 'para',
+            blockId: 'other-block',
+            fromLine: 0,
+            toLine: 1,
+            x: 0,
+            y: 0,
+            width: 100,
+            pmStart: 200,
+            pmEnd: 205,
+          },
+        ],
+      });
+
+      const result = resolveLayout({
+        ...input,
+        flowMode: 'paginated',
+        bookmarks: new Map([
+          ['target', 100],
+          ['other', 200],
+        ]),
+      });
+      const item = result.pages[0].items[0] as any;
+
+      expect(item.block.runs.map((run: any) => run.text).join('')).toBe('12 and 23');
+      expect(item.content.lines[0].line.toChar).toBe(2);
     });
 
     it('does not mutate input blocks', () => {

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
@@ -107,6 +107,198 @@ describe('resolveLayout', () => {
     expect(a).toEqual(b);
   });
 
+  describe('PAGEREF resolution', () => {
+    const pageRefRun = (overrides: Partial<Extract<FlowBlock, { kind: 'paragraph' }>['runs'][number]> = {}) =>
+      ({
+        text: '5',
+        fontFamily: 'Arial',
+        fontSize: 12,
+        token: 'pageReference',
+        pmStart: 5,
+        pmEnd: 6,
+        pageRefMetadata: { bookmarkId: 'target', instruction: 'PAGEREF target' },
+        ...overrides,
+      }) as any;
+
+    const makePageRefInput = (run = pageRefRun()) => {
+      const sourceBlock: FlowBlock = { kind: 'paragraph', id: 'source', runs: [run] } as any;
+      const targetBlock: FlowBlock = {
+        kind: 'paragraph',
+        id: 'target-block',
+        runs: [{ text: 'Target', fontFamily: 'Arial', fontSize: 12, pmStart: 100, pmEnd: 106 }],
+      } as any;
+      const measures: Measure[] = [
+        {
+          kind: 'paragraph',
+          lines: [{ fromRun: 0, fromChar: 0, toRun: 0, toChar: 1, width: 8, ascent: 8, descent: 2, lineHeight: 12 }],
+        } as any,
+        {
+          kind: 'paragraph',
+          lines: [{ fromRun: 0, fromChar: 0, toRun: 0, toChar: 6, width: 40, ascent: 8, descent: 2, lineHeight: 12 }],
+        } as any,
+      ];
+      const layout: Layout = {
+        pageSize: { w: 800, h: 1000 },
+        pages: [
+          {
+            number: 1,
+            displayNumber: 1,
+            numberText: '1',
+            fragments: [
+              {
+                kind: 'para',
+                blockId: 'source',
+                fromLine: 0,
+                toLine: 1,
+                x: 0,
+                y: 0,
+                width: 100,
+                pmStart: 1,
+                pmEnd: 10,
+              },
+            ],
+          },
+          {
+            number: 2,
+            displayNumber: 12,
+            numberText: '12',
+            fragments: [
+              {
+                kind: 'para',
+                blockId: 'target-block',
+                fromLine: 0,
+                toLine: 1,
+                x: 0,
+                y: 0,
+                width: 100,
+                pmStart: 100,
+                pmEnd: 106,
+              },
+            ],
+          },
+        ],
+      };
+      return { layout, blocks: [sourceBlock, targetBlock], measures };
+    };
+
+    it('resolves PAGEREF text to the target display page text', () => {
+      const input = makePageRefInput();
+      const result = resolveLayout({ ...input, flowMode: 'paginated', bookmarks: new Map([['target', 100]]) });
+      const item = result.pages[0].items[0] as any;
+
+      expect(item.block.runs[0].text).toBe('12');
+      expect(item.content.lines[0].line.toChar).toBe(2);
+    });
+
+    it('changes the paint cache version when the target display page changes', () => {
+      const input1 = makePageRefInput();
+      const input2 = makePageRefInput();
+      input2.layout.pages[1].displayNumber = 13;
+      input2.layout.pages[1].numberText = '13';
+
+      const result1 = resolveLayout({ ...input1, flowMode: 'paginated', bookmarks: new Map([['target', 100]]) });
+      const result2 = resolveLayout({ ...input2, flowMode: 'paginated', bookmarks: new Map([['target', 100]]) });
+      const item1 = result1.pages[0].items[0] as any;
+      const item2 = result2.pages[0].items[0] as any;
+
+      expect(item1.block.runs[0].text).toBe('12');
+      expect(item2.block.runs[0].text).toBe('13');
+      expect(item1.paintCacheVersion).not.toBe(item2.paintCacheVersion);
+    });
+
+    it('keeps fallback text when bookmarks are not passed', () => {
+      const input = makePageRefInput();
+      const result = resolveLayout({ ...input, flowMode: 'paginated' });
+
+      expect((result.pages[0].items[0] as any).block.runs[0].text).toBe('5');
+    });
+
+    it('keeps fallback text when the target bookmark is missing', () => {
+      const input = makePageRefInput();
+      const result = resolveLayout({ ...input, flowMode: 'paginated', bookmarks: new Map([['other', 100]]) });
+
+      expect((result.pages[0].items[0] as any).block.runs[0].text).toBe('5');
+    });
+
+    it('resolves relative PAGEREF text across pages', () => {
+      const input = makePageRefInput(
+        pageRefRun({
+          pageRefMetadata: { bookmarkId: 'target', instruction: 'PAGEREF target \\p', relativePosition: true },
+        }),
+      );
+      const result = resolveLayout({ ...input, flowMode: 'paginated', bookmarks: new Map([['target', 100]]) });
+
+      expect((result.pages[0].items[0] as any).block.runs[0].text).toBe('on page 12');
+    });
+
+    it('resolves same-page relative PAGEREF text using PM order', () => {
+      const input = makePageRefInput(
+        pageRefRun({
+          pmStart: 150,
+          pageRefMetadata: { bookmarkId: 'target', instruction: 'PAGEREF target \\p', relativePosition: true },
+        }),
+      );
+      input.layout.pages = [
+        {
+          number: 1,
+          displayNumber: 1,
+          numberText: '1',
+          fragments: [
+            {
+              kind: 'para',
+              blockId: 'source',
+              fromLine: 0,
+              toLine: 1,
+              x: 0,
+              y: 0,
+              width: 100,
+              pmStart: 140,
+              pmEnd: 160,
+            },
+            {
+              kind: 'para',
+              blockId: 'target-block',
+              fromLine: 0,
+              toLine: 1,
+              x: 0,
+              y: 20,
+              width: 100,
+              pmStart: 100,
+              pmEnd: 106,
+            },
+          ],
+        },
+      ];
+      const result = resolveLayout({ ...input, flowMode: 'paginated', bookmarks: new Map([['target', 100]]) });
+
+      expect((result.pages[0].items[0] as any).block.runs[0].text).toBe('above');
+    });
+
+    it('applies PAGEREF numeric formatting against the target display number', () => {
+      const input = makePageRefInput(
+        pageRefRun({
+          pageRefMetadata: {
+            bookmarkId: 'target',
+            instruction: 'PAGEREF target \\# "00"',
+            numericPictureFormat: { picture: '00' },
+          },
+        }),
+      );
+      input.layout.pages[1].displayNumber = 3;
+      input.layout.pages[1].numberText = '3';
+      const result = resolveLayout({ ...input, flowMode: 'paginated', bookmarks: new Map([['target', 100]]) });
+
+      expect((result.pages[0].items[0] as any).block.runs[0].text).toBe('03');
+    });
+
+    it('does not mutate input blocks', () => {
+      const input = makePageRefInput();
+      resolveLayout({ ...input, flowMode: 'paginated', bookmarks: new Map([['target', 100]]) });
+
+      expect((input.blocks[0] as any).runs[0].text).toBe('5');
+    });
+  });
+
   it('derives neutral layout identity for resolved fragments even when input fragments do not precompute it', () => {
     const layout: Layout = {
       pageSize: { w: 800, h: 1000 },

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
@@ -12,6 +12,7 @@ import type {
   DrawingFragment,
   SourceAnchor,
 } from '@superdoc/contracts';
+import { sliceRunsForLine } from '@superdoc/contracts';
 
 describe('resolveLayout', () => {
   const baseLayout: Layout = {
@@ -188,6 +189,66 @@ describe('resolveLayout', () => {
 
       expect(item.block.runs[0].text).toBe('12');
       expect(item.content.lines[0].line.toChar).toBe(2);
+    });
+
+    it('does not duplicate resolved PAGEREF text across cached split lines', () => {
+      const input = makePageRefInput(pageRefRun({ text: '123456', pmStart: 5, pmEnd: 11 }));
+      input.measures[0] = {
+        kind: 'paragraph',
+        lines: [
+          {
+            fromRun: 0,
+            fromChar: 0,
+            toRun: 0,
+            toChar: 3,
+            width: 24,
+            ascent: 8,
+            descent: 2,
+            lineHeight: 12,
+            segments: [{ runIndex: 0, fromChar: 0, toChar: 3, width: 24, x: 0 }],
+          },
+          {
+            fromRun: 0,
+            fromChar: 3,
+            toRun: 0,
+            toChar: 6,
+            width: 24,
+            ascent: 8,
+            descent: 2,
+            lineHeight: 12,
+            segments: [{ runIndex: 0, fromChar: 3, toChar: 6, width: 24, x: 0 }],
+          },
+        ],
+        totalHeight: 24,
+      } as any;
+      input.layout.pages[0].fragments = [
+        {
+          kind: 'para',
+          blockId: 'source',
+          fromLine: 0,
+          toLine: 2,
+          x: 0,
+          y: 0,
+          width: 100,
+          pmStart: 1,
+          pmEnd: 12,
+        },
+      ];
+
+      const result = resolveLayout({ ...input, flowMode: 'paginated', bookmarks: new Map([['target', 100]]) });
+      const item = result.pages[0].items[0] as any;
+      const paintedText = item.content.lines
+        .flatMap((lineItem: any) => sliceRunsForLine(item.block, lineItem.line))
+        .map((run: any) => run.text ?? '')
+        .join('');
+      const segmentText = item.content.lines
+        .flatMap((lineItem: any) => lineItem.line.segments ?? [])
+        .map((segment: any) => item.block.runs[segment.runIndex].text.slice(segment.fromChar, segment.toChar))
+        .join('');
+
+      expect(item.block.runs[0].text).toBe('12');
+      expect(paintedText).toBe('12');
+      expect(segmentText).toBe('12');
     });
 
     it('changes the paint cache version when the target display page changes', () => {

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.test.ts
@@ -381,6 +381,105 @@ describe('resolveLayout', () => {
       expect(item.block.rows[0].cells[0].paragraph?.runs[0].text).toBe('12');
       expect((tableBlock as any).rows[0].cells[0].paragraph.runs[0].text).toBe('5');
     });
+
+    it('resolves PAGEREF text inside list items', () => {
+      const listBlock: FlowBlock = {
+        kind: 'list',
+        id: 'source-list',
+        listType: 'number',
+        items: [
+          {
+            id: 'li1',
+            marker: { kind: 'number', text: '1.', level: 0 },
+            paragraph: {
+              kind: 'paragraph',
+              id: 'list-para',
+              runs: [pageRefRun()],
+            },
+          },
+        ],
+      } as any;
+      const targetBlock: FlowBlock = {
+        kind: 'paragraph',
+        id: 'target-block',
+        runs: [{ text: 'Target', fontFamily: 'Arial', fontSize: 12, pmStart: 100, pmEnd: 106 }],
+      } as any;
+      const measures: Measure[] = [
+        {
+          kind: 'list',
+          items: [
+            {
+              itemId: 'li1',
+              markerWidth: 20,
+              markerTextWidth: 8,
+              indentLeft: 0,
+              paragraph: {
+                lines: [
+                  { fromRun: 0, fromChar: 0, toRun: 0, toChar: 1, width: 8, ascent: 8, descent: 2, lineHeight: 12 },
+                ],
+                totalHeight: 12,
+              },
+            },
+          ],
+          totalHeight: 12,
+        } as any,
+        {
+          kind: 'paragraph',
+          lines: [{ fromRun: 0, fromChar: 0, toRun: 0, toChar: 6, width: 40, ascent: 8, descent: 2, lineHeight: 12 }],
+        } as any,
+      ];
+      const layout: Layout = {
+        pageSize: { w: 800, h: 1000 },
+        pages: [
+          {
+            number: 1,
+            fragments: [
+              {
+                kind: 'list-item',
+                blockId: 'source-list',
+                itemId: 'li1',
+                fromLine: 0,
+                toLine: 1,
+                x: 0,
+                y: 0,
+                width: 100,
+                markerWidth: 20,
+              },
+            ],
+          },
+          {
+            number: 2,
+            displayNumber: 12,
+            numberText: '12',
+            fragments: [
+              {
+                kind: 'para',
+                blockId: 'target-block',
+                fromLine: 0,
+                toLine: 1,
+                x: 0,
+                y: 0,
+                width: 100,
+                pmStart: 100,
+                pmEnd: 106,
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = resolveLayout({
+        layout,
+        flowMode: 'paginated',
+        blocks: [listBlock, targetBlock],
+        measures,
+        bookmarks: new Map([['target', 100]]),
+      });
+      const item = result.pages[0].items[0] as any;
+
+      expect(item.block.items[0].paragraph.runs[0].text).toBe('12');
+      expect((listBlock as any).items[0].paragraph.runs[0].text).toBe('5');
+    });
   });
 
   it('derives neutral layout identity for resolved fragments even when input fragments do not precompute it', () => {

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.ts
@@ -76,6 +76,11 @@ type ParagraphPageRefResolution = {
   changed: boolean;
 };
 
+type ResolvedPageRefRunText = {
+  text: string;
+  originalLength: number;
+};
+
 function resolveParagraphPageRefs(
   fragment: ParaFragment,
   block: ParagraphBlock,
@@ -118,8 +123,8 @@ function resolveParagraphPageRefBlock(
 function collectResolvedPageRefRunTexts(
   block: ParagraphBlock,
   context?: PageRefResolutionContext,
-): Map<number, string> {
-  const runTexts = new Map<number, string>();
+): Map<number, ResolvedPageRefRunText> {
+  const runTexts = new Map<number, ResolvedPageRefRunText>();
   if (!context?.anchorMap?.size) return runTexts;
 
   block.runs.forEach((run, index) => {
@@ -133,16 +138,19 @@ function collectResolvedPageRefRunTexts(
       metadata: run.pageRefMetadata,
     });
     if (resolvedText !== run.text) {
-      runTexts.set(index, resolvedText);
+      runTexts.set(index, { text: resolvedText, originalLength: run.text.length });
     }
   });
 
   return runTexts;
 }
 
-function resolvePageRefRuns(block: ParagraphBlock, runTexts: Map<number, string>): ParagraphBlock['runs'] {
+function resolvePageRefRuns(
+  block: ParagraphBlock,
+  runTexts: Map<number, ResolvedPageRefRunText>,
+): ParagraphBlock['runs'] {
   return block.runs.map((run, index) =>
-    runTexts.has(index) && isTextRun(run) ? { ...run, text: runTexts.get(index)! } : run,
+    runTexts.has(index) && isTextRun(run) ? { ...run, text: runTexts.get(index)!.text } : run,
   );
 }
 
@@ -285,28 +293,37 @@ function isPageReferenceTextRun(
   return isTextRun(run) && run.token === 'pageReference' && run.pageRefMetadata != null;
 }
 
-function adjustLineForResolvedPageRefs(line: Line, runTexts: Map<number, string>): Line {
+function adjustLineForResolvedPageRefs(line: Line, runTexts: Map<number, ResolvedPageRefRunText>): Line {
   let changed = false;
   const nextLine: Line = { ...line };
 
-  for (const [runIndex, text] of runTexts) {
+  for (const [runIndex, resolved] of runTexts) {
     if (runIndex < line.fromRun || runIndex > line.toRun) continue;
     changed = true;
-    if (line.fromRun === runIndex) nextLine.fromChar = 0;
-    if (line.toRun === runIndex) nextLine.toChar = text.length;
+    if (line.fromRun === runIndex) nextLine.fromChar = clampResolvedRunBoundary(line.fromChar, resolved);
+    if (line.toRun === runIndex) nextLine.toChar = clampResolvedRunBoundary(line.toChar, resolved);
   }
 
   if (line.segments?.length) {
     const segments = line.segments.map((segment) => {
-      const text = runTexts.get(segment.runIndex);
-      if (text == null) return segment;
+      const resolved = runTexts.get(segment.runIndex);
+      if (resolved == null) return segment;
       changed = true;
-      return { ...segment, fromChar: 0, toChar: text.length } satisfies LineSegment;
+      return {
+        ...segment,
+        fromChar: clampResolvedRunBoundary(segment.fromChar, resolved),
+        toChar: clampResolvedRunBoundary(segment.toChar, resolved),
+      } satisfies LineSegment;
     });
     nextLine.segments = segments;
   }
 
   return changed ? nextLine : line;
+}
+
+function clampResolvedRunBoundary(offset: number, resolved: ResolvedPageRefRunText): number {
+  if (offset === resolved.originalLength) return resolved.text.length;
+  return Math.min(offset, resolved.text.length);
 }
 
 function sumLineHeights(lines: Line[], from: number, to: number): number {

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.ts
@@ -20,6 +20,7 @@ import type {
   ListBlock,
   ParagraphBlock,
   ParagraphMeasure,
+  TableMeasure,
   LayoutStoryLocator,
   LineSegment,
   PageRefLocation,
@@ -100,11 +101,18 @@ function resolveParagraphPageRefs(
 
 function resolveParagraphPageRefBlock(
   block: ParagraphBlock,
+  measure?: ParagraphMeasure,
   context?: PageRefResolutionContext,
-): { block: ParagraphBlock; changed: boolean } {
+): { block: ParagraphBlock; measure?: ParagraphMeasure; changed: boolean } {
   const runTexts = collectResolvedPageRefRunTexts(block, context);
   if (runTexts.size === 0) return { block, changed: false };
-  return { block: { ...block, runs: resolvePageRefRuns(block, runTexts) }, changed: true };
+  return {
+    block: { ...block, runs: resolvePageRefRuns(block, runTexts) },
+    measure: measure
+      ? { ...measure, lines: measure.lines.map((line) => adjustLineForResolvedPageRefs(line, runTexts)) }
+      : undefined,
+    changed: true,
+  };
 }
 
 function collectResolvedPageRefRunTexts(
@@ -140,32 +148,59 @@ function resolvePageRefRuns(block: ParagraphBlock, runTexts: Map<number, string>
 
 function resolveTablePageRefs(
   block: TableBlock,
+  measure?: TableMeasure,
   context?: PageRefResolutionContext,
-): { block: TableBlock; changed: boolean } {
+): { block: TableBlock; measure?: TableMeasure; changed: boolean } {
   if (!context?.anchorMap?.size) return { block, changed: false };
 
   let changed = false;
-  const rows = block.rows.map((row) => {
+  let measureChanged = false;
+  const measureRows = measure?.rows.slice();
+  const rows = block.rows.map((row, rowIndex) => {
     let rowChanged = false;
-    const cells = row.cells.map((cell) => {
+    const measureRow = measureRows?.[rowIndex];
+    const measureCells = measureRow?.cells.slice();
+    const cells = row.cells.map((cell, cellIndex) => {
       let cellChanged = false;
       let nextParagraph = cell.paragraph;
+      let nextCellMeasure = measureCells?.[cellIndex];
       if (cell.paragraph) {
-        const resolved = resolveParagraphPageRefBlock(cell.paragraph, context);
+        const resolved = resolveParagraphPageRefBlock(cell.paragraph, nextCellMeasure?.paragraph, context);
         nextParagraph = resolved.block;
+        if (resolved.measure && nextCellMeasure) {
+          nextCellMeasure = { ...nextCellMeasure, paragraph: resolved.measure };
+        }
         cellChanged ||= resolved.changed;
       }
 
       let nextBlocks = cell.blocks;
+      let nextBlockMeasures = nextCellMeasure?.blocks;
       if (cell.blocks) {
-        nextBlocks = cell.blocks.map((childBlock) => {
+        nextBlocks = cell.blocks.map((childBlock, childIndex) => {
+          const childMeasure = nextBlockMeasures?.[childIndex];
           if (childBlock.kind === 'paragraph') {
-            const resolved = resolveParagraphPageRefBlock(childBlock, context);
+            const resolved = resolveParagraphPageRefBlock(
+              childBlock,
+              childMeasure?.kind === 'paragraph' ? (childMeasure as ParagraphMeasure) : undefined,
+              context,
+            );
+            if (resolved.measure && nextBlockMeasures) {
+              nextBlockMeasures = nextBlockMeasures.slice();
+              nextBlockMeasures[childIndex] = resolved.measure;
+            }
             cellChanged ||= resolved.changed;
             return resolved.block;
           }
           if (childBlock.kind === 'table') {
-            const resolved = resolveTablePageRefs(childBlock, context);
+            const resolved = resolveTablePageRefs(
+              childBlock,
+              childMeasure?.kind === 'table' ? (childMeasure as TableMeasure) : undefined,
+              context,
+            );
+            if (resolved.measure && nextBlockMeasures) {
+              nextBlockMeasures = nextBlockMeasures.slice();
+              nextBlockMeasures[childIndex] = resolved.measure;
+            }
             cellChanged ||= resolved.changed;
             return resolved.block;
           }
@@ -175,6 +210,13 @@ function resolveTablePageRefs(
 
       if (!cellChanged) return cell;
       rowChanged = true;
+      if (nextCellMeasure && measureCells) {
+        if (nextBlockMeasures && nextBlockMeasures !== nextCellMeasure.blocks) {
+          nextCellMeasure = { ...nextCellMeasure, blocks: nextBlockMeasures };
+        }
+        measureCells[cellIndex] = nextCellMeasure;
+        measureChanged = true;
+      }
       return {
         ...cell,
         ...(nextParagraph ? { paragraph: nextParagraph } : {}),
@@ -184,29 +226,53 @@ function resolveTablePageRefs(
 
     if (!rowChanged) return row;
     changed = true;
+    if (measureRow && measureCells && measureCells !== measureRow.cells) {
+      measureRows![rowIndex] = { ...measureRow, cells: measureCells };
+    }
     return { ...row, cells };
   });
 
-  return changed ? { block: { ...block, rows }, changed: true } : { block, changed: false };
+  return changed
+    ? {
+        block: { ...block, rows },
+        measure: measure && measureChanged && measureRows ? { ...measure, rows: measureRows } : measure,
+        changed: true,
+      }
+    : { block, changed: false };
 }
 
 function resolveListItemPageRefs(
   block: ListBlock,
   itemId: string,
+  measure?: ListMeasure,
   context?: PageRefResolutionContext,
-): { block: ListBlock; changed: boolean } {
+): { block: ListBlock; measure?: ListMeasure; changed: boolean } {
   if (!context?.anchorMap?.size) return { block, changed: false };
 
   let changed = false;
+  let measureChanged = false;
+  const measureItems = measure?.items.slice();
   const items = block.items.map((item) => {
     if (item.id !== itemId) return item;
-    const resolved = resolveParagraphPageRefBlock(item.paragraph, context);
+    const itemMeasureIndex = measureItems?.findIndex((candidate) => candidate.itemId === itemId) ?? -1;
+    const itemMeasure = itemMeasureIndex >= 0 ? measureItems?.[itemMeasureIndex] : undefined;
+    const resolved = resolveParagraphPageRefBlock(item.paragraph, itemMeasure?.paragraph, context);
     if (!resolved.changed) return item;
+    if (resolved.measure && itemMeasure && measureItems) {
+      measureItems[itemMeasureIndex] = { ...itemMeasure, paragraph: resolved.measure };
+      measureChanged = true;
+    }
     changed = true;
     return { ...item, paragraph: resolved.block };
   });
 
-  return changed ? { block: { ...block, items }, changed: true } : { block, changed: false };
+  return changed
+    ? {
+        block: { ...block, items },
+        measure: measure && measureChanged && measureItems ? { ...measure, items: measureItems } : measure,
+        changed: true,
+      }
+    : { block, changed: false };
 }
 
 function isTextRun(run: Run): run is TextRun {
@@ -437,9 +503,10 @@ export function resolveFragmentItem(
   switch (fragment.kind) {
     case 'table': {
       const item = resolveTableItem(fragment as TableFragment, fragmentIndex, pageIndex, blockMap);
-      const tablePageRefs = resolveTablePageRefs(item.block, pageRefContext);
+      const tablePageRefs = resolveTablePageRefs(item.block, item.measure, pageRefContext);
       if (tablePageRefs.changed) {
         item.block = tablePageRefs.block;
+        if (tablePageRefs.measure) item.measure = tablePageRefs.measure;
       }
       if (sdtContainerKey != null) item.sdtContainerKey = sdtContainerKey;
       if (fragment.sourceAnchor != null) item.sourceAnchor = fragment.sourceAnchor;
@@ -481,7 +548,12 @@ export function resolveFragmentItem(
           : null;
       const listPageRefs =
         fragment.kind === 'list-item' && entry?.block.kind === 'list'
-          ? resolveListItemPageRefs(entry.block as ListBlock, (fragment as ListItemFragment).itemId, pageRefContext)
+          ? resolveListItemPageRefs(
+              entry.block as ListBlock,
+              (fragment as ListItemFragment).itemId,
+              entry.measure.kind === 'list' ? (entry.measure as ListMeasure) : undefined,
+              pageRefContext,
+            )
           : null;
       const itemVersion = paragraphPageRefs?.changed
         ? fragmentSignature(paragraphPageRefs.fragment, deriveFontAwareBlockVersion(paragraphPageRefs.block, fontSignature))
@@ -525,7 +597,7 @@ export function resolveFragmentItem(
           const listBlock = listPageRefs?.block ?? (entry.block as ListBlock);
           const listItem = listBlock.items.find((candidate) => candidate.id === (fragment as ListItemFragment).itemId);
           item.block = listBlock;
-          item.measure = entry.measure as ListMeasure;
+          item.measure = listPageRefs?.measure ?? (entry.measure as ListMeasure);
           if (item.sourceAnchor == null) {
             item.sourceAnchor = listItem?.sourceAnchor ?? listItem?.paragraph.sourceAnchor ?? listBlock.sourceAnchor;
           }

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.ts
@@ -190,6 +190,25 @@ function resolveTablePageRefs(
   return changed ? { block: { ...block, rows }, changed: true } : { block, changed: false };
 }
 
+function resolveListItemPageRefs(
+  block: ListBlock,
+  itemId: string,
+  context?: PageRefResolutionContext,
+): { block: ListBlock; changed: boolean } {
+  if (!context?.anchorMap?.size) return { block, changed: false };
+
+  let changed = false;
+  const items = block.items.map((item) => {
+    if (item.id !== itemId) return item;
+    const resolved = resolveParagraphPageRefBlock(item.paragraph, context);
+    if (!resolved.changed) return item;
+    changed = true;
+    return { ...item, paragraph: resolved.block };
+  });
+
+  return changed ? { block: { ...block, items }, changed: true } : { block, changed: false };
+}
+
 function isTextRun(run: Run): run is TextRun {
   return (run.kind === 'text' || run.kind === undefined) && 'text' in run;
 }
@@ -378,10 +397,14 @@ function computeBlockVersion(
   // Prepend the document's font-mapping signature so a `fonts.map` change busts paint reuse the
   // same way a font load (getFontConfigVersion, folded inside deriveBlockVersion) does. The cache
   // is per resolveLayout pass, so the signature is constant here; '' leaves the version unchanged.
-  const version = deriveBlockVersion(entry.block);
-  const versioned = fontSignature ? `${fontSignature}|${version}` : version;
+  const versioned = deriveFontAwareBlockVersion(entry.block, fontSignature);
   cache.set(blockId, versioned);
   return versioned;
+}
+
+function deriveFontAwareBlockVersion(block: FlowBlock, fontSignature = ''): string {
+  const version = deriveBlockVersion(block);
+  return fontSignature ? `${fontSignature}|${version}` : version;
 }
 
 function applyPaintVersions(item: Extract<ResolvedPaintItem, { kind: 'fragment' }>, visualVersion: string): void {
@@ -423,7 +446,9 @@ export function resolveFragmentItem(
       item.layoutSourceIdentity = layoutSourceIdentity;
       applyPaintVersions(
         item,
-        tablePageRefs.changed ? fragmentSignature(fragment, deriveBlockVersion(tablePageRefs.block)) : version,
+        tablePageRefs.changed
+          ? fragmentSignature(fragment, deriveFontAwareBlockVersion(tablePageRefs.block, fontSignature))
+          : version,
       );
       return item;
     }
@@ -454,15 +479,15 @@ export function resolveFragmentItem(
               pageRefContext,
             )
           : null;
-      const pageRefBlockVer =
-        paragraphPageRefs?.changed && fontSignature
-          ? `${fontSignature}|${deriveBlockVersion(paragraphPageRefs.block)}`
-          : paragraphPageRefs?.changed
-            ? deriveBlockVersion(paragraphPageRefs.block)
-            : '';
+      const listPageRefs =
+        fragment.kind === 'list-item' && entry?.block.kind === 'list'
+          ? resolveListItemPageRefs(entry.block as ListBlock, (fragment as ListItemFragment).itemId, pageRefContext)
+          : null;
       const itemVersion = paragraphPageRefs?.changed
-        ? fragmentSignature(paragraphPageRefs.fragment, pageRefBlockVer)
-        : version;
+        ? fragmentSignature(paragraphPageRefs.fragment, deriveFontAwareBlockVersion(paragraphPageRefs.block, fontSignature))
+        : listPageRefs?.changed
+          ? fragmentSignature(fragment, deriveFontAwareBlockVersion(listPageRefs.block, fontSignature))
+          : version;
       // para, list-item — existing generic resolution
       const item: ResolvedFragmentItem = {
         kind: 'fragment',
@@ -497,7 +522,7 @@ export function resolveFragmentItem(
           item.measure = entry.measure as ParagraphMeasure;
           if (item.sourceAnchor == null) item.sourceAnchor = (entry.block as ParagraphBlock).sourceAnchor;
         } else if (fragment.kind === 'list-item' && entry.block.kind === 'list' && entry.measure.kind === 'list') {
-          const listBlock = entry.block as ListBlock;
+          const listBlock = listPageRefs?.block ?? (entry.block as ListBlock);
           const listItem = listBlock.items.find((candidate) => candidate.id === (fragment as ListItemFragment).itemId);
           item.block = listBlock;
           item.measure = entry.measure as ListMeasure;

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.ts
@@ -563,7 +563,7 @@ export function resolveLayout(input: ResolveLayoutInput): ResolvedLayout {
   const fontSignature = input.fontSignature ?? '';
   const blockMap = buildBlockMap(blocks, measures);
   const blockVersionCache = new Map<string, string>();
-  const pageRefAnchorMap = bookmarks?.size ? buildPageRefAnchorMap(bookmarks, layout, blocks) : undefined;
+  const pageRefAnchorMap = bookmarks?.size ? buildPageRefAnchorMap(bookmarks, layout, blocks, measures) : undefined;
 
   const pages: ResolvedPage[] = layout.pages.map((page, pageIndex) => ({
     id: `page-${pageIndex}`,

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.ts
@@ -24,6 +24,7 @@ import type {
   LineSegment,
   PageRefLocation,
   Run,
+  TableBlock,
   TextRun,
 } from '@superdoc/contracts';
 import { buildPageRefAnchorMap, getSdtContainerKey } from '@superdoc/contracts';
@@ -80,11 +81,39 @@ function resolveParagraphPageRefs(
   measure: ParagraphMeasure,
   context?: PageRefResolutionContext,
 ): ParagraphPageRefResolution {
-  if (!context?.anchorMap?.size) {
+  const runTexts = collectResolvedPageRefRunTexts(block, context);
+
+  if (runTexts.size === 0) {
     return { block, fragment, changed: false };
   }
 
+  const nextRuns = resolvePageRefRuns(block, runTexts);
+  const sourceLines = fragment.lines ?? measure.lines.slice(fragment.fromLine, fragment.toLine);
+  const nextLines = sourceLines.map((line) => adjustLineForResolvedPageRefs(line, runTexts));
+
+  return {
+    block: { ...block, runs: nextRuns },
+    fragment: { ...fragment, lines: nextLines },
+    changed: true,
+  };
+}
+
+function resolveParagraphPageRefBlock(
+  block: ParagraphBlock,
+  context?: PageRefResolutionContext,
+): { block: ParagraphBlock; changed: boolean } {
+  const runTexts = collectResolvedPageRefRunTexts(block, context);
+  if (runTexts.size === 0) return { block, changed: false };
+  return { block: { ...block, runs: resolvePageRefRuns(block, runTexts) }, changed: true };
+}
+
+function collectResolvedPageRefRunTexts(
+  block: ParagraphBlock,
+  context?: PageRefResolutionContext,
+): Map<number, string> {
   const runTexts = new Map<number, string>();
+  if (!context?.anchorMap?.size) return runTexts;
+
   block.runs.forEach((run, index) => {
     if (!isPageReferenceTextRun(run)) return;
     const target = context.anchorMap?.get(run.pageRefMetadata.bookmarkId);
@@ -100,21 +129,65 @@ function resolveParagraphPageRefs(
     }
   });
 
-  if (runTexts.size === 0) {
-    return { block, fragment, changed: false };
-  }
+  return runTexts;
+}
 
-  const nextRuns = block.runs.map((run, index) =>
+function resolvePageRefRuns(block: ParagraphBlock, runTexts: Map<number, string>): ParagraphBlock['runs'] {
+  return block.runs.map((run, index) =>
     runTexts.has(index) && isTextRun(run) ? { ...run, text: runTexts.get(index)! } : run,
   );
-  const sourceLines = fragment.lines ?? measure.lines.slice(fragment.fromLine, fragment.toLine);
-  const nextLines = sourceLines.map((line) => adjustLineForResolvedPageRefs(line, runTexts));
+}
 
-  return {
-    block: { ...block, runs: nextRuns },
-    fragment: { ...fragment, lines: nextLines },
-    changed: true,
-  };
+function resolveTablePageRefs(
+  block: TableBlock,
+  context?: PageRefResolutionContext,
+): { block: TableBlock; changed: boolean } {
+  if (!context?.anchorMap?.size) return { block, changed: false };
+
+  let changed = false;
+  const rows = block.rows.map((row) => {
+    let rowChanged = false;
+    const cells = row.cells.map((cell) => {
+      let cellChanged = false;
+      let nextParagraph = cell.paragraph;
+      if (cell.paragraph) {
+        const resolved = resolveParagraphPageRefBlock(cell.paragraph, context);
+        nextParagraph = resolved.block;
+        cellChanged ||= resolved.changed;
+      }
+
+      let nextBlocks = cell.blocks;
+      if (cell.blocks) {
+        nextBlocks = cell.blocks.map((childBlock) => {
+          if (childBlock.kind === 'paragraph') {
+            const resolved = resolveParagraphPageRefBlock(childBlock, context);
+            cellChanged ||= resolved.changed;
+            return resolved.block;
+          }
+          if (childBlock.kind === 'table') {
+            const resolved = resolveTablePageRefs(childBlock, context);
+            cellChanged ||= resolved.changed;
+            return resolved.block;
+          }
+          return childBlock;
+        });
+      }
+
+      if (!cellChanged) return cell;
+      rowChanged = true;
+      return {
+        ...cell,
+        ...(nextParagraph ? { paragraph: nextParagraph } : {}),
+        ...(nextBlocks ? { blocks: nextBlocks } : {}),
+      };
+    });
+
+    if (!rowChanged) return row;
+    changed = true;
+    return { ...row, cells };
+  });
+
+  return changed ? { block: { ...block, rows }, changed: true } : { block, changed: false };
 }
 
 function isTextRun(run: Run): run is TextRun {
@@ -341,10 +414,17 @@ export function resolveFragmentItem(
   switch (fragment.kind) {
     case 'table': {
       const item = resolveTableItem(fragment as TableFragment, fragmentIndex, pageIndex, blockMap);
+      const tablePageRefs = resolveTablePageRefs(item.block, pageRefContext);
+      if (tablePageRefs.changed) {
+        item.block = tablePageRefs.block;
+      }
       if (sdtContainerKey != null) item.sdtContainerKey = sdtContainerKey;
       if (fragment.sourceAnchor != null) item.sourceAnchor = fragment.sourceAnchor;
       item.layoutSourceIdentity = layoutSourceIdentity;
-      applyPaintVersions(item, version);
+      applyPaintVersions(
+        item,
+        tablePageRefs.changed ? fragmentSignature(fragment, deriveBlockVersion(tablePageRefs.block)) : version,
+      );
       return item;
     }
     case 'image': {

--- a/packages/layout-engine/layout-resolved/src/resolveLayout.ts
+++ b/packages/layout-engine/layout-resolved/src/resolveLayout.ts
@@ -21,8 +21,12 @@ import type {
   ParagraphBlock,
   ParagraphMeasure,
   LayoutStoryLocator,
+  LineSegment,
+  PageRefLocation,
+  Run,
+  TextRun,
 } from '@superdoc/contracts';
-import { getSdtContainerKey } from '@superdoc/contracts';
+import { buildPageRefAnchorMap, getSdtContainerKey } from '@superdoc/contracts';
 import { resolveParagraphContent } from './resolveParagraph.js';
 import { resolveTableItem } from './resolveTable.js';
 import { resolveImageItem } from './resolveImage.js';
@@ -35,6 +39,7 @@ import {
   resolveFragmentLayoutIdentity,
   sourceAnchorSignature,
 } from './versionSignature.js';
+import { resolvePageRefText } from './resolvePageRefText.js';
 
 export type ResolveLayoutInput = {
   layout: Layout;
@@ -47,6 +52,7 @@ export type ResolveLayoutInput = {
    * epoch). Omitted/'' for default documents, leaving the version unchanged from before.
    */
   fontSignature?: string;
+  bookmarks?: Map<string, number>;
 };
 
 export function buildBlockMap(blocks: FlowBlock[], measures: Measure[]): Map<string, BlockMapEntry> {
@@ -55,6 +61,94 @@ export function buildBlockMap(blocks: FlowBlock[], measures: Measure[]): Map<str
     map.set(blocks[i].id, { block: blocks[i], measure: measures[i] });
   }
   return map;
+}
+
+type PageRefResolutionContext = {
+  sourcePage: number;
+  anchorMap?: Map<string, PageRefLocation>;
+};
+
+type ParagraphPageRefResolution = {
+  block: ParagraphBlock;
+  fragment: ParaFragment;
+  changed: boolean;
+};
+
+function resolveParagraphPageRefs(
+  fragment: ParaFragment,
+  block: ParagraphBlock,
+  measure: ParagraphMeasure,
+  context?: PageRefResolutionContext,
+): ParagraphPageRefResolution {
+  if (!context?.anchorMap?.size) {
+    return { block, fragment, changed: false };
+  }
+
+  const runTexts = new Map<number, string>();
+  block.runs.forEach((run, index) => {
+    if (!isPageReferenceTextRun(run)) return;
+    const target = context.anchorMap?.get(run.pageRefMetadata.bookmarkId);
+    if (!target) return;
+    const resolvedText = resolvePageRefText({
+      sourcePage: context.sourcePage,
+      sourcePmPosition: run.pmStart,
+      target,
+      metadata: run.pageRefMetadata,
+    });
+    if (resolvedText !== run.text) {
+      runTexts.set(index, resolvedText);
+    }
+  });
+
+  if (runTexts.size === 0) {
+    return { block, fragment, changed: false };
+  }
+
+  const nextRuns = block.runs.map((run, index) =>
+    runTexts.has(index) && isTextRun(run) ? { ...run, text: runTexts.get(index)! } : run,
+  );
+  const sourceLines = fragment.lines ?? measure.lines.slice(fragment.fromLine, fragment.toLine);
+  const nextLines = sourceLines.map((line) => adjustLineForResolvedPageRefs(line, runTexts));
+
+  return {
+    block: { ...block, runs: nextRuns },
+    fragment: { ...fragment, lines: nextLines },
+    changed: true,
+  };
+}
+
+function isTextRun(run: Run): run is TextRun {
+  return (run.kind === 'text' || run.kind === undefined) && 'text' in run;
+}
+
+function isPageReferenceTextRun(
+  run: Run,
+): run is TextRun & { pageRefMetadata: NonNullable<TextRun['pageRefMetadata']> } {
+  return isTextRun(run) && run.token === 'pageReference' && run.pageRefMetadata != null;
+}
+
+function adjustLineForResolvedPageRefs(line: Line, runTexts: Map<number, string>): Line {
+  let changed = false;
+  const nextLine: Line = { ...line };
+
+  for (const [runIndex, text] of runTexts) {
+    if (runIndex < line.fromRun || runIndex > line.toRun) continue;
+    changed = true;
+    if (line.fromRun === runIndex) nextLine.fromChar = 0;
+    if (line.toRun === runIndex) nextLine.toChar = text.length;
+  }
+
+  if (line.segments?.length) {
+    const segments = line.segments.map((segment) => {
+      const text = runTexts.get(segment.runIndex);
+      if (text == null) return segment;
+      changed = true;
+      return { ...segment, fromChar: 0, toChar: text.length } satisfies LineSegment;
+    });
+    nextLine.segments = segments;
+  }
+
+  return changed ? nextLine : line;
 }
 
 function sumLineHeights(lines: Line[], from: number, to: number): number {
@@ -133,13 +227,23 @@ function resolveFragmentId(fragment: Fragment): string {
 function resolveParagraphContentIfApplicable(
   fragment: Fragment,
   blockMap: Map<string, BlockMapEntry>,
+  pageRefContext?: PageRefResolutionContext,
 ): ResolvedParagraphContent | undefined {
   if (fragment.kind !== 'para') return undefined;
 
   const entry = blockMap.get(fragment.blockId);
   if (!entry || entry.block.kind !== 'paragraph' || entry.measure.kind !== 'paragraph') return undefined;
 
-  return resolveParagraphContent(fragment, entry.block as ParagraphBlock, entry.measure as ParagraphMeasure);
+  const paragraphBlock = entry.block as ParagraphBlock;
+  const paragraphMeasure = entry.measure as ParagraphMeasure;
+  const resolvedPageRefs = resolveParagraphPageRefs(
+    fragment as ParaFragment,
+    paragraphBlock,
+    paragraphMeasure,
+    pageRefContext,
+  );
+
+  return resolveParagraphContent(resolvedPageRefs.fragment, resolvedPageRefs.block, paragraphMeasure);
 }
 
 function resolveFragmentParagraphBorders(
@@ -226,6 +330,7 @@ export function resolveFragmentItem(
   blockVersionCache: Map<string, string>,
   story?: LayoutStoryLocator,
   fontSignature = '',
+  pageRefContext?: PageRefResolutionContext,
 ): ResolvedPaintItem {
   const sdtContainerKey = resolveFragmentSdtContainerKey(fragment, blockMap);
   const blockVer = computeBlockVersion(fragment.blockId, blockMap, blockVersionCache, fontSignature);
@@ -259,6 +364,25 @@ export function resolveFragmentItem(
       return item;
     }
     default: {
+      const entry = blockMap.get(fragment.blockId);
+      const paragraphPageRefs =
+        fragment.kind === 'para' && entry?.block.kind === 'paragraph' && entry.measure.kind === 'paragraph'
+          ? resolveParagraphPageRefs(
+              fragment as ParaFragment,
+              entry.block as ParagraphBlock,
+              entry.measure as ParagraphMeasure,
+              pageRefContext,
+            )
+          : null;
+      const pageRefBlockVer =
+        paragraphPageRefs?.changed && fontSignature
+          ? `${fontSignature}|${deriveBlockVersion(paragraphPageRefs.block)}`
+          : paragraphPageRefs?.changed
+            ? deriveBlockVersion(paragraphPageRefs.block)
+            : '';
+      const itemVersion = paragraphPageRefs?.changed
+        ? fragmentSignature(paragraphPageRefs.fragment, pageRefBlockVer)
+        : version;
       // para, list-item — existing generic resolution
       const item: ResolvedFragmentItem = {
         kind: 'fragment',
@@ -273,7 +397,13 @@ export function resolveFragmentItem(
         fragment,
         blockId: fragment.blockId,
         fragmentIndex,
-        content: resolveParagraphContentIfApplicable(fragment, blockMap),
+        content: paragraphPageRefs
+          ? resolveParagraphContent(
+              paragraphPageRefs.fragment,
+              paragraphPageRefs.block,
+              (entry as BlockMapEntry).measure as ParagraphMeasure,
+            )
+          : resolveParagraphContentIfApplicable(fragment, blockMap, pageRefContext),
         layoutSourceIdentity,
       };
       if (sdtContainerKey != null) item.sdtContainerKey = sdtContainerKey;
@@ -281,10 +411,9 @@ export function resolveFragmentItem(
 
       // Pre-extract block/measure for para and list-item fragments so the painter
       // can prefer resolved data over a blockLookup read.
-      const entry = blockMap.get(fragment.blockId);
       if (entry) {
         if (fragment.kind === 'para' && entry.block.kind === 'paragraph' && entry.measure.kind === 'paragraph') {
-          item.block = entry.block as ParagraphBlock;
+          item.block = paragraphPageRefs?.block ?? (entry.block as ParagraphBlock);
           item.measure = entry.measure as ParagraphMeasure;
           if (item.sourceAnchor == null) item.sourceAnchor = (entry.block as ParagraphBlock).sourceAnchor;
         } else if (fragment.kind === 'list-item' && entry.block.kind === 'list' && entry.measure.kind === 'list') {
@@ -318,17 +447,18 @@ export function resolveFragmentItem(
         if (listItem.continuesOnNext != null) item.continuesOnNext = listItem.continuesOnNext;
         if (listItem.markerWidth != null) item.markerWidth = listItem.markerWidth;
       }
-      applyPaintVersions(item, version);
+      applyPaintVersions(item, itemVersion);
       return item;
     }
   }
 }
 
 export function resolveLayout(input: ResolveLayoutInput): ResolvedLayout {
-  const { layout, flowMode, blocks, measures } = input;
+  const { layout, flowMode, blocks, measures, bookmarks } = input;
   const fontSignature = input.fontSignature ?? '';
   const blockMap = buildBlockMap(blocks, measures);
   const blockVersionCache = new Map<string, string>();
+  const pageRefAnchorMap = bookmarks?.size ? buildPageRefAnchorMap(bookmarks, layout, blocks) : undefined;
 
   const pages: ResolvedPage[] = layout.pages.map((page, pageIndex) => ({
     id: `page-${pageIndex}`,
@@ -339,7 +469,16 @@ export function resolveLayout(input: ResolveLayoutInput): ResolvedLayout {
     width: page.size?.w ?? layout.pageSize.w,
     height: page.size?.h ?? layout.pageSize.h,
     items: page.fragments.map((fragment, fragmentIndex) =>
-      resolveFragmentItem(fragment, fragmentIndex, pageIndex, blockMap, blockVersionCache, undefined, fontSignature),
+      resolveFragmentItem(
+        fragment,
+        fragmentIndex,
+        pageIndex,
+        blockMap,
+        blockVersionCache,
+        undefined,
+        fontSignature,
+        pageRefAnchorMap ? { sourcePage: page.number, anchorMap: pageRefAnchorMap } : undefined,
+      ),
     ),
     margins: page.margins,
     footnoteReserved: page.footnoteReserved,

--- a/packages/layout-engine/layout-resolved/src/resolvePageRefText.ts
+++ b/packages/layout-engine/layout-resolved/src/resolvePageRefText.ts
@@ -1,0 +1,51 @@
+import type { PageRefLocation, TextRun } from '@superdoc/contracts';
+import {
+  formatChapterPageNumberText,
+  formatIntegerWithNumericPicture,
+  formatPageNumberFieldValue,
+} from '@superdoc/contracts';
+
+export function resolvePageRefText(args: {
+  sourcePage: number;
+  sourcePmPosition?: number;
+  target: PageRefLocation;
+  metadata: NonNullable<TextRun['pageRefMetadata']>;
+}): string {
+  const formattedTargetPageText = formatTargetPageText(args.target, args.metadata);
+
+  if (!args.metadata.relativePosition) {
+    return formattedTargetPageText;
+  }
+
+  if (args.sourcePage !== args.target.physicalPage) {
+    return `on page ${formattedTargetPageText}`;
+  }
+
+  return args.target.pmPosition != null &&
+    args.sourcePmPosition != null &&
+    args.target.pmPosition < args.sourcePmPosition
+    ? 'above'
+    : 'below';
+}
+
+function formatTargetPageText(target: PageRefLocation, metadata: NonNullable<TextRun['pageRefMetadata']>): string {
+  const displayNumber = Math.max(1, Math.trunc(Number.isFinite(target.displayNumber) ? target.displayNumber : 1));
+
+  if (metadata.numericPictureFormat) {
+    return formatChapterPageNumberText({
+      pageComponent: formatIntegerWithNumericPicture(displayNumber, metadata.numericPictureFormat.picture),
+      chapterNumberText: target.chapterNumberText,
+      chapterSeparator: target.chapterSeparator,
+    });
+  }
+
+  if (metadata.pageNumberFieldFormat) {
+    return formatChapterPageNumberText({
+      pageComponent: formatPageNumberFieldValue(displayNumber, metadata.pageNumberFieldFormat),
+      chapterNumberText: target.chapterNumberText,
+      chapterSeparator: target.chapterSeparator,
+    });
+  }
+
+  return target.displayText;
+}

--- a/packages/layout-engine/measuring/dom/src/index.test.ts
+++ b/packages/layout-engine/measuring/dom/src/index.test.ts
@@ -8,8 +8,10 @@ import type {
   DrawingMeasure,
   DrawingBlock,
   TableMeasure,
+  TextRun,
 } from '@superdoc/contracts';
 import { EMPTY_SDT_PLACEHOLDER_TEXT } from '@superdoc/contracts';
+import { resolvePhysicalFamily } from '@superdoc/font-system';
 
 const expectParagraphMeasure = (measure: Measure): ParagraphMeasure => {
   expect(measure.kind).toBe('paragraph');
@@ -81,6 +83,91 @@ describe('measureBlock', () => {
       // lineHeight should be at least ascent + descent (+ safety margin)
       expect(measure.lines[0].lineHeight).toBeGreaterThanOrEqual(measure.lines[0].ascent + measure.lines[0].descent);
       expect(measure.totalHeight).toBe(measure.lines[0].lineHeight);
+    });
+
+    it('does not count empty text runs as justification spaces', async () => {
+      const visibleRuns = [
+        {
+          text: '1. Confidential Information. In connection with ',
+          fontFamily: 'Arial',
+          fontSize: 16,
+        },
+      ];
+      const withoutEmptyRuns: FlowBlock = {
+        kind: 'paragraph',
+        id: 'without-empty-runs',
+        runs: visibleRuns,
+        attrs: { alignment: 'justify' },
+      };
+      const withEmptyRuns: FlowBlock = {
+        kind: 'paragraph',
+        id: 'with-empty-runs',
+        runs: [
+          { text: '', fontFamily: 'Arial', fontSize: 16 },
+          { text: '', fontFamily: 'Arial', fontSize: 16 },
+          { text: '', fontFamily: 'Arial', fontSize: 16 },
+          ...visibleRuns,
+        ],
+        attrs: { alignment: 'justify' },
+      };
+
+      const baseMeasure = expectParagraphMeasure(await measureBlock(withoutEmptyRuns, 1000));
+      const emptyPrefixMeasure = expectParagraphMeasure(await measureBlock(withEmptyRuns, 1000));
+
+      expect(emptyPrefixMeasure.lines).toHaveLength(1);
+      expect(emptyPrefixMeasure.lines[0].width).toBeCloseTo(baseMeasure.lines[0].width, 3);
+      expect(emptyPrefixMeasure.lines[0].spaceCount).toBe(baseMeasure.lines[0].spaceCount);
+      expect(emptyPrefixMeasure.lines[0].segments).toEqual([
+        {
+          runIndex: 3,
+          fromChar: 0,
+          toChar: visibleRuns[0].text.length,
+          width: expect.any(Number),
+        },
+      ]);
+    });
+
+    it('keeps empty-only paragraphs measurable without phantom spaces', async () => {
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'empty-only-runs',
+        runs: [
+          { text: '', fontFamily: 'Arial', fontSize: 16 },
+          { text: '', fontFamily: 'Arial', fontSize: 16 },
+        ],
+        attrs: {},
+      };
+
+      const measure = expectParagraphMeasure(await measureBlock(block, 1000));
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.lines[0].width).toBe(0);
+      expect(measure.lines[0].spaceCount).toBeUndefined();
+      expect(measure.lines[0].segments).toEqual([]);
+      expect(measure.totalHeight).toBeGreaterThan(0);
+    });
+
+    it('does not let skipped empty runs inflate visible line height', async () => {
+      const visibleBlock: FlowBlock = {
+        kind: 'paragraph',
+        id: 'visible-small-run',
+        runs: [{ text: 'visible', fontFamily: 'Arial', fontSize: 12 }],
+        attrs: {},
+      };
+      const emptyPrefixBlock: FlowBlock = {
+        kind: 'paragraph',
+        id: 'empty-large-prefix-run',
+        runs: [
+          { text: '', fontFamily: 'Arial', fontSize: 48 },
+          { text: 'visible', fontFamily: 'Arial', fontSize: 12 },
+        ],
+        attrs: {},
+      };
+
+      const visibleMeasure = expectParagraphMeasure(await measureBlock(visibleBlock, 1000));
+      const emptyPrefixMeasure = expectParagraphMeasure(await measureBlock(emptyPrefixBlock, 1000));
+
+      expect(emptyPrefixMeasure.lines[0].lineHeight).toBeCloseTo(visibleMeasure.lines[0].lineHeight, 3);
     });
 
     // SD-3330: a line containing only tabs must be measured at the run's font size,
@@ -744,7 +831,7 @@ describe('measureBlock', () => {
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
       expect(ctx).not.toBeNull();
-      ctx!.font = '16px Arial';
+      ctx!.font = `16px ${resolvePhysicalFamily('Arial')}`;
       const transformedPlaceholderText = EMPTY_SDT_PLACEHOLDER_TEXT.toUpperCase();
       const transformedWidth = ctx!.measureText(transformedPlaceholderText).width;
       const untransformedWidth = ctx!.measureText(EMPTY_SDT_PLACEHOLDER_TEXT).width;

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -2198,6 +2198,10 @@ async function measureParagraphBlock(
     // Handle text runs
     lastFontSize = run.fontSize;
     hasSeenTextRun = true;
+    if (run.text === '') {
+      pendingRunSpacing = 0;
+      continue;
+    }
     const { font } = buildFontString(run, fontContext);
     const tabSegments = run.text.split('\t');
 

--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -6946,6 +6946,31 @@ describe('DomPainter', () => {
       resolvePartText({ text: '3', fieldType: 'SECTIONPAGES' }, { pageNumber: 1, totalPages: 9, section: 'body' }),
     ).toBe('3');
   });
+
+  it('formats NUMPAGES drawing text with supported pageNumberFormat', () => {
+    const painter = new DomPainter();
+    const resolvePartText = (
+      painter as unknown as {
+        resolveShapeTextPartText: (
+          part: { text: string; fieldType: string; pageNumberFormat?: string },
+          context: { pageNumber: number; totalPages: number; section: 'body' },
+        ) => string;
+      }
+    ).resolveShapeTextPartText.bind(painter);
+
+    expect(
+      resolvePartText(
+        { text: '9', fieldType: 'NUMPAGES', pageNumberFormat: 'upperRoman' },
+        { pageNumber: 1, totalPages: 9, section: 'body' },
+      ),
+    ).toBe('IX');
+    expect(
+      resolvePartText(
+        { text: '9', fieldType: 'NUMPAGES', pageNumberFormat: 'ordinal' },
+        { pageNumber: 1, totalPages: 12, section: 'body' },
+      ),
+    ).toBe('12th');
+  });
   describe('resolved paragraph rendering', () => {
     it('renders resolved paragraph lines with precomputed indent styles', () => {
       const paragraphBlock: FlowBlock = {

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -3158,7 +3158,8 @@ export class DomPainter {
       return context?.pageNumberText ?? String(context?.pageNumber ?? 1);
     }
     if (part.fieldType === 'NUMPAGES') {
-      return String(context?.totalPages ?? 1);
+      const totalPages = context?.totalPages ?? 1;
+      return part.pageNumberFormat ? formatPageNumber(totalPages, part.pageNumberFormat) : String(totalPages);
     }
     if (part.fieldType === 'SECTIONPAGES') {
       if (context?.sectionPageCount == null) return part.text ?? '1';

--- a/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.test.ts
+++ b/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.test.ts
@@ -311,6 +311,28 @@ describe('HeaderFooterEditorManager', () => {
     expect(sectionPages.textContent).toBe('IV');
   });
 
+  it('refreshes total page count DOM text with node numeric picture format', () => {
+    const editor = createMockEditor();
+    const manager = new HeaderFooterEditorManager(editor);
+    const descriptor = { id: 'rId-header-default', kind: 'header' } as const;
+    const host = document.createElement('div');
+
+    const sectionEditor = manager.ensureEditorSync(descriptor, { editorHost: host });
+    expect(sectionEditor).toBeDefined();
+    const totalPages = document.createElement('span');
+    totalPages.dataset.id = 'auto-total-pages';
+    totalPages.textContent = '1';
+    sectionEditor!.view.dom.appendChild(totalPages);
+    (sectionEditor!.view as unknown as { posAtDOM: ReturnType<typeof vi.fn> }).posAtDOM = vi.fn(() => 0);
+    (sectionEditor as unknown as { state: { doc: { nodeAt: ReturnType<typeof vi.fn> } } }).state = {
+      doc: { nodeAt: vi.fn(() => ({ attrs: { pageNumberNumericPicture: '000' } })) },
+    };
+
+    manager.ensureEditorSync(descriptor, { editorHost: host, totalPageCount: 12 });
+
+    expect(totalPages.textContent).toBe('012');
+  });
+
   it('refreshes chapter-prefixed page number DOM text with node pageNumberFormat', () => {
     const editor = createMockEditor();
     const manager = new HeaderFooterEditorManager(editor);

--- a/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.ts
+++ b/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.ts
@@ -2,6 +2,7 @@ import { toFlowBlocks } from '@core/layout-adapter';
 import { getAtomNodeTypes as getAtomNodeTypesFromSchema } from '../presentation-editor/utils/SchemaNodeTypes.js';
 import {
   formatPageNumber,
+  formatPageNumberFieldValue,
   formatSectionPageNumberText,
   type FlowBlock,
   type PageNumberChapterSeparator,
@@ -14,6 +15,7 @@ import { EventEmitter } from '@core/EventEmitter.js';
 import { createHeaderFooterEditor, onHeaderFooterDataUpdate } from '@extensions/pagination/pagination-helpers.js';
 import type { ConverterContext } from '@core/layout-adapter/converter-context.js';
 import { buildStoryKey } from '../../document-api-adapters/story-runtime/story-key.js';
+import { getPageNumberFieldFormat } from '../layout-adapter/converters/inline-converters/page-number-field-format.js';
 
 const HEADER_FOOTER_VARIANTS = ['default', 'first', 'even', 'odd'] as const;
 const DEFAULT_HEADER_FOOTER_HEIGHT = 100;
@@ -504,7 +506,7 @@ export class HeaderFooterEditorManager extends EventEmitter {
       typeof opts.currentPageChapterSeparator === 'string'
         ? (opts.currentPageChapterSeparator as PageNumberChapterSeparator)
         : undefined;
-    const totalPages = String(opts.totalPageCount || parentEditor?.currentTotalPages || '1');
+    const totalPages = Number(opts.totalPageCount || parentEditor?.currentTotalPages || 1) || 1;
     const sectionPages = opts.sectionPageCount;
 
     const pageNumberEls = container.querySelectorAll('[data-id="auto-page-number"]');
@@ -524,7 +526,9 @@ export class HeaderFooterEditorManager extends EventEmitter {
       if (el.textContent !== text) el.textContent = text;
     });
     totalPagesEls.forEach((el) => {
-      if (el.textContent !== totalPages) el.textContent = totalPages;
+      const pageNumberFieldFormat = this.#getPageNumberFieldFormatForDomNode(editor, el);
+      const text = formatPageNumberFieldValue(totalPages, pageNumberFieldFormat);
+      if (el.textContent !== text) el.textContent = text;
     });
     sectionPagesEls.forEach((el) => {
       if (sectionPages == null) return;
@@ -545,6 +549,18 @@ export class HeaderFooterEditorManager extends EventEmitter {
       return typeof format === 'string' ? (format as PageNumberFormat) : null;
     } catch {
       return null;
+    }
+  }
+
+  #getPageNumberFieldFormatForDomNode(editor: Editor, el: Element): ReturnType<typeof getPageNumberFieldFormat> {
+    try {
+      const view = editor.view;
+      if (!view) return undefined;
+      const pos = view.posAtDOM(el, 0);
+      const node = editor.state.doc.nodeAt(pos);
+      return getPageNumberFieldFormat(node?.attrs);
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/attributes/paragraph.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/attributes/paragraph.ts
@@ -203,6 +203,18 @@ const resolveHeadingLevel = (
   return undefined;
 };
 
+export const resolveParagraphHeadingLevel = (
+  paragraphProperties: ParagraphProperties | undefined,
+  converterContext?: ConverterContext,
+): number | undefined => {
+  const properties = paragraphProperties ?? {};
+  const resolvedParagraphProperties = converterContext
+    ? resolveParagraphProperties(converterContext, properties, converterContext.tableInfo)
+    : properties;
+
+  return resolveHeadingLevel(resolvedParagraphProperties.styleId, resolvedParagraphProperties, converterContext);
+};
+
 const TRACKED_CHANGE_KEYS = new Set(['trackInsert', 'trackDelete']);
 
 export const hasExplicitParagraphRunProperties = (

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.test.ts
@@ -11,6 +11,15 @@ describe('getPageNumberFieldFormat', () => {
     ).toEqual({ format: 'decimal', zeroPadding: 2 });
   });
 
+  it('threads ordinal and numeric-picture attributes for layout runs', () => {
+    expect(
+      getPageNumberFieldFormat({
+        pageNumberFormat: 'ordinal',
+        pageNumberNumericPicture: '#,##0',
+      }),
+    ).toEqual({ format: 'ordinal', numericPicture: '#,##0' });
+  });
+
   it('ignores invalid format attributes', () => {
     expect(getPageNumberFieldFormat(undefined)).toBeUndefined();
     expect(getPageNumberFieldFormat({ pageNumberFormat: 1, pageNumberZeroPadding: Number.NaN })).toBeUndefined();

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.ts
@@ -9,9 +9,14 @@ export function getPageNumberFieldFormat(
     typeof attrs.pageNumberZeroPadding === 'number' && Number.isFinite(attrs.pageNumberZeroPadding)
       ? attrs.pageNumberZeroPadding
       : undefined;
-  if (!format && !zeroPadding) return undefined;
+  const numericPicture =
+    typeof attrs.pageNumberNumericPicture === 'string' && attrs.pageNumberNumericPicture.length > 0
+      ? attrs.pageNumberNumericPicture
+      : undefined;
+  if (!format && !zeroPadding && !numericPicture) return undefined;
   return {
     ...(format ? { format: format as NonNullable<TextRun['pageNumberFieldFormat']>['format'] } : {}),
-    ...(zeroPadding ? { zeroPadding } : {}),
+    ...(zeroPadding != null ? { zeroPadding } : {}),
+    ...(numericPicture ? { numericPicture } : {}),
   };
 }

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-reference.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-reference.test.ts
@@ -142,4 +142,34 @@ describe('pageReferenceNodeToBlock', () => {
 
     expect(vi.mocked(resolveRunProperties).mock.calls.at(-1)?.[1]).toBe(fieldRunProperties);
   });
+
+  it('preserves PM source positions from the pageReference node', () => {
+    const node: PMNode = {
+      type: 'pageReference',
+      attrs: { instruction: 'PAGEREF _Toc123' },
+      content: [{ type: 'text', text: '15' } as PMNode],
+    };
+    const positions = new WeakMap<PMNode, { start: number; end: number }>();
+    positions.set(node, { start: 42, end: 48 });
+
+    const run = pageReferenceNodeToBlock(makeParams({}, { node, positions })) as TextRun | undefined;
+
+    expect(run?.pmStart).toBe(42);
+    expect(run?.pmEnd).toBe(48);
+  });
+
+  it('sets PAGEREF formatting metadata from typed attrs', () => {
+    const pageNumberFieldFormat = { format: 'upperRoman' as const };
+    const numericPictureFormat = { picture: '00' };
+    const run = pageReferenceNodeToBlock(
+      makeParams({
+        instruction: 'PAGEREF _Toc123',
+        pageNumberFieldFormat,
+        numericPictureFormat,
+      }),
+    ) as TextRun | undefined;
+
+    expect(run?.pageRefMetadata?.pageNumberFieldFormat).toBe(pageNumberFieldFormat);
+    expect(run?.pageRefMetadata?.numericPictureFormat).toBe(numericPictureFormat);
+  });
 });

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-reference.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-reference.test.ts
@@ -25,6 +25,7 @@ vi.mock('@superdoc/style-engine/ooxml', () => ({
 }));
 
 import { pageReferenceNodeToBlock } from './page-reference.js';
+import { resolveRunProperties } from '@superdoc/style-engine/ooxml';
 
 function makeParams(
   attrs: Record<string, unknown>,
@@ -107,5 +108,38 @@ describe('pageReferenceNodeToBlock', () => {
 
     expect(run!.link?.anchor).toBe('_Toc123');
     expect(run!.pageRefMetadata?.relativePosition).toBe(true);
+  });
+
+  it('uses captured instruction run properties for CHARFORMAT fields', () => {
+    const fieldRunProperties = { bold: true, color: 'FF0000' };
+    vi.mocked(resolveRunProperties).mockClear();
+    pageReferenceNodeToBlock(
+      makeParams(
+        {
+          instruction: 'PAGEREF _Toc123 \\* CHARFORMAT',
+          fieldResultFormat: 'charformat',
+          fieldRunProperties,
+        },
+        {
+          node: {
+            type: 'pageReference',
+            attrs: {
+              instruction: 'PAGEREF _Toc123 \\* CHARFORMAT',
+              fieldResultFormat: 'charformat',
+              fieldRunProperties,
+            },
+            content: [
+              {
+                type: 'run',
+                attrs: { runProperties: { italic: true } },
+                content: [{ type: 'text', text: '15' } as PMNode],
+              } as PMNode,
+            ],
+          },
+        },
+      ),
+    );
+
+    expect(vi.mocked(resolveRunProperties).mock.calls.at(-1)?.[1]).toBe(fieldRunProperties);
   });
 });

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-reference.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-reference.test.ts
@@ -95,4 +95,17 @@ describe('pageReferenceNodeToBlock', () => {
     const run = pageReferenceNodeToBlock(makeParams({ instruction: 'PAGEREF _Toc123 \\H' })) as TextRun | undefined;
     expect(run!.link?.anchor).toBe('_Toc123');
   });
+
+  it('falls back to parsing legacy instructions when boolean attrs contain schema defaults', () => {
+    const run = pageReferenceNodeToBlock(
+      makeParams({
+        instruction: 'PAGEREF _Toc123 \\h \\p',
+        hasHyperlinkSwitch: false,
+        hasRelativePositionSwitch: false,
+      }),
+    ) as TextRun | undefined;
+
+    expect(run!.link?.anchor).toBe('_Toc123');
+    expect(run!.pageRefMetadata?.relativePosition).toBe(true);
+  });
 });

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-reference.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-reference.ts
@@ -61,7 +61,9 @@ export function pageReferenceNodeToBlock(params: InlineConverterParams): TextRun
       };
       fallbackText = node.content.map(extractText).join('').trim() || '??';
     }
-    if (Object.keys(runProperties).length === 0 && fieldRunProperties) {
+    if (fieldResultFormat === 'charformat' && fieldRunProperties) {
+      runProperties = fieldRunProperties;
+    } else if (Object.keys(runProperties).length === 0 && fieldRunProperties) {
       runProperties = fieldRunProperties;
     }
 

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-reference.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-reference.ts
@@ -1,10 +1,11 @@
-import type { TextRun } from '@superdoc/contracts';
+import type { FieldResultFormat, NumericPictureFormat, PageNumberFieldFormat, TextRun } from '@superdoc/contracts';
 import { type InlineConverterParams } from './common';
 import { getNodeInstruction } from '../../sdt/index.js';
 import type { PMNode, PMMark } from '../../types.js';
 import { textNodeToRun } from './text-run.js';
 import { buildFlowRunLink } from '../../marks/links.js';
 import { type RunProperties, resolveRunProperties } from '@superdoc/style-engine/ooxml';
+import { parsePageRefInstruction } from '../../../super-converter/field-references/shared/pageref-instruction.js';
 
 export function pageReferenceNodeToBlock(params: InlineConverterParams): TextRun | void {
   const {
@@ -24,14 +25,26 @@ export function pageReferenceNodeToBlock(params: InlineConverterParams): TextRun
   const refMarks = Array.isArray(nodeAttrs.marksAsAttrs) ? (nodeAttrs.marksAsAttrs as PMMark[]) : [];
   const mergedMarks = [...refMarks, ...(inheritedMarks ?? [])];
 
-  // Extract bookmark ID from instruction, handling optional quotes
-  // Examples: "PAGEREF _Toc123 \h" or "PAGEREF "_Toc123" \h"
-  const bookmarkMatch = instruction.match(/PAGEREF\s+"?([^"\s\\]+)"?/i);
-  const bookmarkId = bookmarkMatch ? bookmarkMatch[1] : '';
+  const parsed = parsePageRefInstruction(instruction);
+  const bookmarkId = readStringAttr(nodeAttrs.bookmarkId) || parsed.bookmarkId;
+  const hasHyperlinkSwitch = readBooleanAttr(nodeAttrs.hasHyperlinkSwitch) || parsed.hasHyperlinkSwitch;
+  const hasRelativePositionSwitch =
+    readBooleanAttr(nodeAttrs.hasRelativePositionSwitch) || parsed.hasRelativePositionSwitch;
+  const pageNumberFieldFormat =
+    readObjectAttr<PageNumberFieldFormat>(nodeAttrs.pageNumberFieldFormat) ??
+    (parsed.pageNumberFieldFormat as PageNumberFieldFormat | undefined);
+  const numericPictureFormat =
+    readObjectAttr<NumericPictureFormat>(nodeAttrs.numericPictureFormat) ?? parsed.numericPictureFormat;
+  const attrFieldResultFormat = readStringAttr(nodeAttrs.fieldResultFormat);
+  const fieldResultFormat: FieldResultFormat | undefined =
+    attrFieldResultFormat === 'charformat' || attrFieldResultFormat === 'mergeformat'
+      ? attrFieldResultFormat
+      : parsed.fieldResultFormat;
 
   // If we have a bookmark ID, create a token run for dynamic resolution
   let runProperties: RunProperties = {};
   if (bookmarkId) {
+    const fieldRunProperties = readObjectAttr<RunProperties>(nodeAttrs.fieldRunProperties);
     // Check if there's materialized content (pre-baked page number from Word)
     let fallbackText = '??'; // Default placeholder if resolution fails
     if (Array.isArray(node.content) && node.content.length > 0) {
@@ -47,6 +60,9 @@ export function pageReferenceNodeToBlock(params: InlineConverterParams): TextRun
         return '';
       };
       fallbackText = node.content.map(extractText).join('').trim() || '??';
+    }
+    if (Object.keys(runProperties).length === 0 && fieldRunProperties) {
+      runProperties = fieldRunProperties;
     }
 
     // Create token run with pageReference metadata
@@ -81,10 +97,14 @@ export function pageReferenceNodeToBlock(params: InlineConverterParams): TextRun
     tokenRun.pageRefMetadata = {
       bookmarkId,
       instruction,
+      ...(hasRelativePositionSwitch ? { relativePosition: true } : {}),
+      ...(pageNumberFieldFormat ? { pageNumberFieldFormat } : {}),
+      ...(numericPictureFormat ? { numericPictureFormat } : {}),
+      ...(fieldResultFormat ? { fieldResultFormat } : {}),
     };
 
     // \h switch - case-insensitive per ECMA-376 §17.16.1.
-    if (/\\h\b/i.test(instruction)) {
+    if (hasHyperlinkSwitch) {
       const synthesized = buildFlowRunLink({ anchor: bookmarkId });
       if (synthesized) {
         tokenRun.link = tokenRun.link ? { ...tokenRun.link, ...synthesized, anchor: bookmarkId } : synthesized;
@@ -104,4 +124,16 @@ export function pageReferenceNodeToBlock(params: InlineConverterParams): TextRun
       visitNode(child, mergedMarks, sdtMetadata, runProperties, false, parentInlineRunProperties),
     );
   }
+}
+
+function readStringAttr(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function readBooleanAttr(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function readObjectAttr<T extends object>(value: unknown): T | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as T) : undefined;
 }

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/sequence-field.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/sequence-field.ts
@@ -4,18 +4,33 @@ import { textNodeToRun } from './text-run.js';
 import type { InlineConverterParams } from './common.js';
 
 /**
- * Converts a sequenceField PM node to a TextRun with the resolved sequence number.
+ * Converts a sequenceField PM node to a TextRun token for post-assembly resolution.
  */
 export function sequenceFieldNodeToRun(params: InlineConverterParams): TextRun | null {
   const { node, positions, sdtMetadata } = params;
 
   const attrs = (node.attrs ?? {}) as Record<string, unknown>;
-  const resolvedNumber = (attrs.resolvedNumber as string) || '0';
+  const cachedText = typeof attrs.resolvedNumber === 'string' ? attrs.resolvedNumber : '';
 
   const run = textNodeToRun({
     ...params,
-    node: { type: 'text', text: resolvedNumber, marks: [...(node.marks ?? [])] } as PMNode,
+    node: { type: 'text', text: cachedText || '1', marks: [...(node.marks ?? [])] } as PMNode,
   });
+  run.token = 'seq';
+  run.seqMetadata = {
+    identifier: String(attrs.identifier ?? ''),
+    instruction: String(attrs.instruction ?? ''),
+    fieldArgument: String(attrs.fieldArgument ?? ''),
+    sequenceMode: attrs.sequenceMode === 'current' ? 'current' : 'next',
+    hideResult: attrs.hideResult === true,
+    restartNumber: typeof attrs.restartNumber === 'number' ? attrs.restartNumber : null,
+    restartLevel: typeof attrs.restartLevel === 'number' ? attrs.restartLevel : null,
+    format: typeof attrs.format === 'string' ? attrs.format : undefined,
+    hasGeneralFormat: attrs.hasGeneralFormat === true,
+    pageNumberFieldFormat: readObjectAttr(attrs.pageNumberFieldFormat),
+    numericPictureFormat: readObjectAttr(attrs.numericPictureFormat),
+    cachedText,
+  };
 
   const pos = positions.get(node);
   if (pos) {
@@ -28,4 +43,8 @@ export function sequenceFieldNodeToRun(params: InlineConverterParams): TextRun |
   }
 
   return run;
+}
+
+function readObjectAttr<T extends object>(value: unknown): T | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as T) : null;
 }

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/index.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/index.test.ts
@@ -2588,6 +2588,47 @@ describe('toFlowBlocks', () => {
       });
     });
 
+    it('uses typed pageReference attrs before reparsing raw instruction', () => {
+      const pmDoc = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'pageReference',
+                attrs: {
+                  instruction: 'PAGEREF legacy',
+                  bookmarkId: '_TypedTarget',
+                  hasHyperlinkSwitch: true,
+                  hasRelativePositionSwitch: true,
+                  pageNumberFieldFormat: { format: 'upperRoman' },
+                  numericPictureFormat: { picture: '00' },
+                  fieldResultFormat: 'mergeformat',
+                },
+                content: [{ type: 'text', text: '7' }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const { blocks } = toFlowBlocks(pmDoc);
+
+      expect(blocks[0].runs[0]).toMatchObject({
+        token: 'pageReference',
+        link: { anchor: '_TypedTarget' },
+        pageRefMetadata: {
+          bookmarkId: '_TypedTarget',
+          instruction: 'PAGEREF legacy',
+          relativePosition: true,
+          pageNumberFieldFormat: { format: 'upperRoman' },
+          numericPictureFormat: { picture: '00' },
+          fieldResultFormat: 'mergeformat',
+        },
+      });
+    });
+
     it('handles pageReference without bookmark (transparent container fallback)', () => {
       const pmDoc = {
         type: 'doc',

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/internal.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/internal.ts
@@ -21,6 +21,7 @@ import {
 } from './sections/index.js';
 import { normalizePrefix, buildPositionMap, createBlockIdGenerator } from './utilities.js';
 import { stampTrackedChangeColors } from '@superdoc/contracts';
+import { resolveSequenceFieldTokens } from './resolve-sequence-fields.js';
 import {
   paragraphToFlowBlocks,
   contentBlockNodeToDrawingBlock,
@@ -295,6 +296,7 @@ export function toFlowBlocks(pmDoc: PMNode | object, options?: AdapterOptions): 
   // read it directly without invoking app callbacks. Passing `undefined`
   // clears stale colors from cached blocks when the host disables the feature.
   stampTrackedChangeColors(mergedBlocks, options?.resolveTrackedChangeColor);
+  resolveSequenceFieldTokens(mergedBlocks);
 
   // Commit cache cycle - swaps next to previous, retaining only blocks seen this render
   flowBlockCache?.commit();

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/resolve-sequence-fields.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/resolve-sequence-fields.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest';
+import type { FlowBlock, ParagraphBlock, TableBlock, TextRun } from '@superdoc/contracts';
+import { toFlowBlocks as baseToFlowBlocks, FlowBlockCache } from './index.js';
+import { resolveSequenceFieldTokens } from './resolve-sequence-fields.js';
+import type { AdapterOptions, PMNode } from './index.js';
+
+const createDefaultConverterContext = () => ({
+  docx: {},
+  translatedLinkedStyles: {
+    docDefaults: {},
+    latentStyles: {},
+    styles: {},
+  },
+  translatedNumbering: {
+    abstracts: {},
+    definitions: {},
+  },
+});
+
+const toFlowBlocks = (pmDoc: PMNode | object, options: AdapterOptions = {}) =>
+  baseToFlowBlocks(pmDoc, { converterContext: createDefaultConverterContext(), ...options });
+
+const seq = (attrs: Record<string, unknown> = {}) => ({
+  type: 'sequenceField',
+  attrs: {
+    instruction: 'SEQ Figure',
+    identifier: 'Figure',
+    sequenceMode: 'next',
+    hideResult: false,
+    restartNumber: null,
+    restartLevel: null,
+    format: 'Arabic',
+    hasGeneralFormat: false,
+    pageNumberFieldFormat: null,
+    numericPictureFormat: null,
+    resolvedNumber: '',
+    ...attrs,
+  },
+});
+
+const paragraph = (content: PMNode['content'] = [], attrs: Record<string, unknown> = {}) => ({
+  type: 'paragraph',
+  attrs,
+  content,
+});
+
+const stableParagraph = (id: string, content: PMNode['content'] = []) =>
+  paragraph(content, { sdBlockId: id, sdBlockRev: 1 });
+
+const tableWithCellContent = (content: PMNode['content']) => ({
+  type: 'table',
+  content: [
+    {
+      type: 'tableRow',
+      content: [
+        {
+          type: 'tableCell',
+          content,
+        },
+      ],
+    },
+  ],
+});
+
+const textRuns = (blocks: FlowBlock[]): TextRun[] => {
+  const runs: TextRun[] = [];
+  const visit = (block: FlowBlock) => {
+    if (block.kind === 'paragraph') {
+      for (const run of (block as ParagraphBlock).runs) {
+        if ('text' in run) runs.push(run as TextRun);
+      }
+      return;
+    }
+    if (block.kind === 'table') {
+      for (const row of (block as TableBlock).rows) {
+        for (const cell of row.cells) {
+          for (const childBlock of cell.blocks ?? (cell.paragraph ? [cell.paragraph] : [])) {
+            visit(childBlock);
+          }
+        }
+      }
+      return;
+    }
+    if (block.kind === 'list') {
+      for (const item of block.items) {
+        visit(item.paragraph);
+      }
+    }
+  };
+  blocks.forEach(visit);
+  return runs;
+};
+
+const runTexts = (blocks: FlowBlock[]) => textRuns(blocks).map((run) => run.text);
+
+describe('resolveSequenceFieldTokens', () => {
+  it('renders two cached-empty sequence fields as 1 and 2', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [paragraph([seq()]), paragraph([seq()])],
+    });
+
+    expect(runTexts(blocks)).toEqual(['1', '2']);
+    expect(textRuns(blocks).map((run) => run.token)).toEqual(['seq', 'seq']);
+  });
+
+  it('keeps interleaved identifiers independent', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([seq({ identifier: 'Figure' })]),
+        paragraph([seq({ identifier: 'Table', instruction: 'SEQ Table' })]),
+        paragraph([seq({ identifier: 'Figure' })]),
+      ],
+    });
+
+    expect(runTexts(blocks)).toEqual(['1', '1', '2']);
+  });
+
+  it('repeats the prior display for current mode', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [paragraph([seq()]), paragraph([seq({ sequenceMode: 'current', instruction: 'SEQ Figure \\c' })])],
+    });
+
+    expect(runTexts(blocks)).toEqual(['1', '1']);
+  });
+
+  it('honors restartNumber and continues from it', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [paragraph([seq({ restartNumber: 10, instruction: 'SEQ Figure \\r 10' })]), paragraph([seq()])],
+    });
+
+    expect(runTexts(blocks)).toEqual(['10', '11']);
+  });
+
+  it('hides hidden results while still advancing the counter', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([seq()]),
+        paragraph([seq({ hideResult: true, instruction: 'SEQ Figure \\h' })]),
+        paragraph([seq()]),
+      ],
+    });
+
+    expect(runTexts(blocks)).toEqual(['1', '', '3']);
+  });
+
+  it('lets hidden restart-zero fields seed the next visible value at one', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([
+          seq({
+            instruction: 'seq level2 \\h \\r0',
+            identifier: 'level2',
+            hideResult: true,
+            restartNumber: 0,
+          }),
+        ]),
+        paragraph([seq({ instruction: 'seq level2 \\*arabic', identifier: 'level2', hasGeneralFormat: true })]),
+      ],
+    });
+
+    expect(runTexts(blocks)).toEqual(['', '1']);
+  });
+
+  it('restarts after resolved heading-level paragraphs', () => {
+    const headingAttrs = { paragraphProperties: { outlineLvl: 0 } };
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([{ type: 'text', text: 'Chapter 1' }], headingAttrs),
+        paragraph([seq({ restartLevel: 1, instruction: 'SEQ Figure \\s 1' })]),
+        paragraph([seq({ restartLevel: 1, instruction: 'SEQ Figure \\s 1' })]),
+        paragraph([{ type: 'text', text: 'Chapter 2' }], headingAttrs),
+        paragraph([seq({ restartLevel: 1, instruction: 'SEQ Figure \\s 1' })]),
+      ],
+    });
+
+    expect(runTexts(blocks)).toEqual(['Chapter 1', '1', '2', 'Chapter 2', '1']);
+  });
+
+  it('applies page-number and numeric-picture formats', () => {
+    const roman = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([seq({ pageNumberFieldFormat: { format: 'lowerRoman' }, hasGeneralFormat: true })]),
+        paragraph([seq({ pageNumberFieldFormat: { format: 'lowerRoman' }, hasGeneralFormat: true })]),
+      ],
+    });
+    const picture = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([seq({ numericPictureFormat: { picture: '00' } })]),
+        paragraph([seq({ numericPictureFormat: { picture: '00' } })]),
+      ],
+    });
+
+    expect(runTexts(roman.blocks)).toEqual(['i', 'ii']);
+    expect(runTexts(picture.blocks)).toEqual(['01', '02']);
+  });
+
+  it('isolates counters across separate toFlowBlocks calls', () => {
+    const doc = { type: 'doc', content: [paragraph([seq()])] };
+
+    expect(runTexts(toFlowBlocks(doc).blocks)).toEqual(['1']);
+    expect(runTexts(toFlowBlocks(doc).blocks)).toEqual(['1']);
+  });
+
+  it('counts sequence fields inside table cells in document order', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [paragraph([seq()]), tableWithCellContent([paragraph([seq()])]), paragraph([seq()])],
+    });
+
+    expect(runTexts(blocks)).toEqual(['1', '2', '3']);
+  });
+
+  it('renumbers cache-hit paragraphs after a sequence field is inserted above them', () => {
+    const cache = new FlowBlockCache();
+    const firstDoc = {
+      type: 'doc',
+      content: [stableParagraph('p1', [seq()]), stableParagraph('p2', [seq()]), stableParagraph('p3', [seq()])],
+    };
+    expect(runTexts(toFlowBlocks(firstDoc, { flowBlockCache: cache }).blocks)).toEqual(['1', '2', '3']);
+
+    const secondDoc = {
+      type: 'doc',
+      content: [
+        stableParagraph('p1', [seq()]),
+        stableParagraph('inserted', [seq()]),
+        stableParagraph('p2', [seq()]),
+        stableParagraph('p3', [seq()]),
+      ],
+    };
+    const { blocks } = toFlowBlocks(secondDoc, { flowBlockCache: cache });
+
+    expect(cache.stats.hits).toBeGreaterThanOrEqual(3);
+    expect(runTexts(blocks)).toEqual(['1', '2', '3', '4']);
+  });
+
+  it('walks list item paragraphs when list blocks are present', () => {
+    const seqRun = (identifier = 'Figure'): TextRun => ({
+      text: '1',
+      token: 'seq',
+      seqMetadata: { identifier, cachedText: '' },
+      fontFamily: 'Times New Roman, serif',
+      fontSize: 12,
+    });
+    const blocks: FlowBlock[] = [
+      {
+        kind: 'list',
+        id: 'list-1',
+        listType: 'number',
+        items: [
+          {
+            id: 'item-1',
+            marker: { text: '1.', width: 10 },
+            paragraph: { kind: 'paragraph', id: 'p1', runs: [seqRun()] },
+          },
+          {
+            id: 'item-2',
+            marker: { text: '2.', width: 10 },
+            paragraph: { kind: 'paragraph', id: 'p2', runs: [seqRun()] },
+          },
+        ],
+      },
+    ];
+
+    resolveSequenceFieldTokens(blocks);
+
+    expect(runTexts(blocks)).toEqual(['1', '2']);
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/resolve-sequence-fields.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/resolve-sequence-fields.ts
@@ -1,0 +1,60 @@
+import type { FlowBlock, ListBlock, ParagraphBlock, Run, TableBlock } from '@superdoc/contracts';
+import { SequenceFieldEvaluator } from '../super-converter/field-references/shared/seq-evaluator.js';
+
+/**
+ * Resolve SEQ token runs after all blocks have been assembled in document order.
+ * This keeps numbering cache-safe because cached paragraphs still contribute
+ * their preserved token metadata to the linear pass.
+ */
+export function resolveSequenceFieldTokens(blocks: FlowBlock[]): void {
+  const evaluator = new SequenceFieldEvaluator();
+  for (const block of blocks) {
+    resolveBlock(block, evaluator);
+  }
+}
+
+function resolveBlock(block: FlowBlock, evaluator: SequenceFieldEvaluator): void {
+  if (block.kind === 'paragraph') {
+    resolveParagraph(block as ParagraphBlock, evaluator);
+    return;
+  }
+
+  if (block.kind === 'table') {
+    resolveTable(block as TableBlock, evaluator);
+    return;
+  }
+
+  if (block.kind === 'list') {
+    resolveList(block as ListBlock, evaluator);
+  }
+}
+
+function resolveParagraph(block: ParagraphBlock, evaluator: SequenceFieldEvaluator): void {
+  evaluator.enterParagraph({ paragraphHeadingLevel: block.attrs?.headingLevel });
+  for (const run of block.runs) {
+    resolveRun(run, evaluator);
+  }
+}
+
+function resolveTable(block: TableBlock, evaluator: SequenceFieldEvaluator): void {
+  for (const row of block.rows) {
+    for (const cell of row.cells) {
+      const childBlocks = cell.blocks ?? (cell.paragraph ? [cell.paragraph] : []);
+      for (const childBlock of childBlocks) {
+        resolveBlock(childBlock, evaluator);
+      }
+    }
+  }
+}
+
+function resolveList(block: ListBlock, evaluator: SequenceFieldEvaluator): void {
+  for (const item of block.items) {
+    resolveParagraph(item.paragraph, evaluator);
+  }
+}
+
+function resolveRun(run: Run, evaluator: SequenceFieldEvaluator): void {
+  if ('token' in run && run.token === 'seq' && run.seqMetadata) {
+    run.text = evaluator.evaluateField(run.seqMetadata).text;
+  }
+}

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -3442,6 +3442,7 @@ export class PresentationEditor extends EventEmitter {
       blocks,
       measures,
       fontSignature: this.#layoutFontSignature,
+      bookmarks: isBodyPageTokensEnabled() ? this.#layoutState.bookmarks : undefined,
     });
 
     const isSemanticFlow = this.#layoutOptions.flowMode === 'semantic';

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -84,16 +84,6 @@ function serializePerIdNumbering(
   return parts.join(';');
 }
 
-function isBodyPageTokensEnabled(): boolean {
-  if (typeof process === 'undefined' || typeof process.env === 'undefined') {
-    return true;
-  }
-  const value = process.env.SD_BODY_PAGE_TOKENS;
-  if (value === 'false' || value === '0') return false;
-  if (value === 'true' || value === '1') return true;
-  return true;
-}
-
 import { safeCleanup } from './utils/SafeCleanup.js';
 import { createHiddenHost } from './dom/HiddenHost.js';
 import {
@@ -3442,7 +3432,7 @@ export class PresentationEditor extends EventEmitter {
       blocks,
       measures,
       fontSignature: this.#layoutFontSignature,
-      bookmarks: isBodyPageTokensEnabled() ? this.#layoutState.bookmarks : undefined,
+      bookmarks: this.#layoutState.bookmarks,
     });
 
     const isSemanticFlow = this.#layoutOptions.flowMode === 'semantic';
@@ -7063,7 +7053,7 @@ export class PresentationEditor extends EventEmitter {
           blocks: bodyBlocksForPaint,
           measures: bodyMeasuresForPaint,
           fontSignature,
-          bookmarks: isBodyPageTokensEnabled() ? bookmarks : undefined,
+          bookmarks,
         });
 
         headerLayouts = result.headers;

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -83,6 +83,17 @@ function serializePerIdNumbering(
   }
   return parts.join(';');
 }
+
+function isBodyPageTokensEnabled(): boolean {
+  if (typeof process === 'undefined' || typeof process.env === 'undefined') {
+    return true;
+  }
+  const value = process.env.SD_BODY_PAGE_TOKENS;
+  if (value === 'false' || value === '0') return false;
+  if (value === 'true' || value === '1') return true;
+  return true;
+}
+
 import { safeCleanup } from './utils/SafeCleanup.js';
 import { createHiddenHost } from './dom/HiddenHost.js';
 import {
@@ -7051,6 +7062,7 @@ export class PresentationEditor extends EventEmitter {
           blocks: bodyBlocksForPaint,
           measures: bodyMeasuresForPaint,
           fontSignature,
+          bookmarks: isBodyPageTokensEnabled() ? bookmarks : undefined,
         });
 
         headerLayouts = result.headers;

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.test.ts
@@ -332,6 +332,8 @@ vi.mock('@superdoc/layout-bridge', () => ({
     extractFooterId: vi.fn(() => 'rId-footer-default'),
   })),
   buildMultiSectionIdentifier: vi.fn(() => ({ sections: [] })),
+  buildEffectiveHeaderFooterRefsBySection: vi.fn(() => new Map()),
+  collectReferencedHeaderFooterRIds: vi.fn(() => new Set()),
   getHeaderFooterTypeForSection: vi.fn(() => 'default'),
   getHeaderFooterType: vi.fn((_pageNumber, _identifier, _options) => {
     // Returns the type of header/footer for a given page
@@ -443,6 +445,8 @@ describe('PresentationEditor', () => {
 
     // Clear all mocks
     vi.clearAllMocks();
+    mockToFlowBlocks.mockReset();
+    mockToFlowBlocks.mockReturnValue({ blocks: [], bookmarks: new Map() });
     // Reset mockIncrementalLayout to default implementation (clearAllMocks doesn't reset mockResolvedValue)
     mockIncrementalLayout.mockReset();
     mockIncrementalLayout.mockResolvedValue({ layout: { pages: [] }, measures: [] });
@@ -574,6 +578,48 @@ describe('PresentationEditor', () => {
         if (originalFontFace) Object.defineProperty(window, 'FontFace', originalFontFace);
         else Reflect.deleteProperty(window, 'FontFace');
       }
+    });
+  });
+
+  describe('formatting marks repaint', () => {
+    it('preserves body bookmarks when repainting the current layout', async () => {
+      const bookmarks = new Map([['target', 100]]);
+      const blocks = [
+        {
+          kind: 'paragraph',
+          id: 'source',
+          runs: [{ text: '5', fontFamily: 'Arial', fontSize: 12 }],
+        },
+      ];
+      const measures = [
+        {
+          kind: 'paragraph',
+          lines: [{ fromRun: 0, fromChar: 0, toRun: 0, toChar: 1, width: 8, ascent: 8, descent: 2, lineHeight: 12 }],
+        },
+      ];
+      mockToFlowBlocks.mockReturnValue({ blocks, bookmarks });
+      mockIncrementalLayout.mockResolvedValueOnce({
+        layout: {
+          pageSize: { w: 800, h: 1000 },
+          pages: [{ number: 1, fragments: [{ kind: 'para', blockId: 'source', fromLine: 0, toLine: 1 }] }],
+        },
+        measures,
+      });
+
+      editor = new PresentationEditor({
+        element: container,
+        documentId: 'formatting-marks-pageref-doc',
+        content: { type: 'doc', content: [{ type: 'paragraph' }] },
+        mode: 'docx',
+      });
+
+      await vi.waitFor(() => expect(mockIncrementalLayout).toHaveBeenCalled());
+      mockResolveLayout.mockClear();
+
+      editor.setShowFormattingMarks(true);
+
+      expect(mockResolveLayout).toHaveBeenCalledTimes(1);
+      expect(mockResolveLayout.mock.calls[0]?.[0]).toMatchObject({ bookmarks });
     });
   });
 

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.test.ts
@@ -407,6 +407,7 @@ vi.mock('../../header-footer/EditorOverlayManager', () => ({
 describe('PresentationEditor', () => {
   let container: HTMLElement;
   let editor: PresentationEditor;
+  let originalBodyPageTokens: string | undefined;
 
   const makeNodeSelection = (from: number, to: number, node: Record<string, unknown>) => {
     const selection = Object.create(NodeSelection.prototype);
@@ -439,6 +440,8 @@ describe('PresentationEditor', () => {
   };
 
   beforeEach(() => {
+    originalBodyPageTokens = process.env.SD_BODY_PAGE_TOKENS;
+
     // Create a container element for the presentation editor
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -469,6 +472,12 @@ describe('PresentationEditor', () => {
   });
 
   afterEach(() => {
+    if (originalBodyPageTokens === undefined) {
+      delete process.env.SD_BODY_PAGE_TOKENS;
+    } else {
+      process.env.SD_BODY_PAGE_TOKENS = originalBodyPageTokens;
+    }
+
     if (editor) {
       editor.destroy();
     }
@@ -582,7 +591,49 @@ describe('PresentationEditor', () => {
   });
 
   describe('formatting marks repaint', () => {
+    it('passes body bookmarks to initial layout resolution when body page tokens are disabled', async () => {
+      // Disabling PAGE/NUMPAGES convergence must not suppress PAGEREF bookmark resolution.
+      process.env.SD_BODY_PAGE_TOKENS = 'false';
+
+      const bookmarks = new Map([['target', 100]]);
+      const blocks = [
+        {
+          kind: 'paragraph',
+          id: 'source',
+          runs: [{ text: '5', fontFamily: 'Arial', fontSize: 12 }],
+        },
+      ];
+      const measures = [
+        {
+          kind: 'paragraph',
+          lines: [{ fromRun: 0, fromChar: 0, toRun: 0, toChar: 1, width: 8, ascent: 8, descent: 2, lineHeight: 12 }],
+        },
+      ];
+      mockToFlowBlocks.mockReturnValue({ blocks, bookmarks });
+      mockIncrementalLayout.mockResolvedValueOnce({
+        layout: {
+          pageSize: { w: 800, h: 1000 },
+          pages: [{ number: 1, fragments: [{ kind: 'para', blockId: 'source', fromLine: 0, toLine: 1 }] }],
+        },
+        measures,
+      });
+
+      editor = new PresentationEditor({
+        element: container,
+        documentId: 'body-page-tokens-disabled-pageref-doc',
+        content: { type: 'doc', content: [{ type: 'paragraph' }] },
+        mode: 'docx',
+      });
+
+      await vi.waitFor(() => expect(mockResolveLayout).toHaveBeenCalled());
+
+      expect(mockResolveLayout.mock.calls[0]?.[0]).toMatchObject({ bookmarks });
+    });
+
     it('preserves body bookmarks when repainting the current layout', async () => {
+      // Disabling PAGE/NUMPAGES convergence must not suppress PAGEREF bookmark resolution.
+      process.env.SD_BODY_PAGE_TOKENS = 'false';
+
       const bookmarks = new Map([['target', 100]]);
       const blocks = [
         {

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/index.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/index.js
@@ -39,9 +39,6 @@ import { extractFieldKeyword } from '../field-keyword.js';
  * @returns {InstructionPreProcessor | null} The pre-processor function or null if not found.
  */
 export const getInstructionPreProcessor = (instruction) => {
-  const rawInstructionType = String(instruction ?? '')
-    .trim()
-    .split(/\s+/)[0];
   const instructionType = extractFieldKeyword(instruction);
   switch (instructionType) {
     case 'PAGE':
@@ -72,7 +69,6 @@ export const getInstructionPreProcessor = (instruction) => {
     case 'STYLEREF':
       return preProcessStylerefInstruction;
     case 'SEQ':
-      if (rawInstructionType !== 'SEQ') return null;
       return preProcessSeqInstruction;
     case 'CITATION':
       return preProcessCitationInstruction;

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/index.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/index.test.js
@@ -87,10 +87,13 @@ describe('getInstructionPreProcessor', () => {
     expect(processor).toBe(preProcessSeqInstruction);
   });
 
-  it('should leave lowercase seq fields unprocessed to preserve cached numbering results', () => {
-    const processor = getInstructionPreProcessor('seq level2 \\*arabic');
-    expect(processor).toBeNull();
-  });
+  it.each(['seq level2 \\*arabic', 'Seq Figure \\* Arabic'])(
+    'should dispatch SEQ fields case-insensitively: %s',
+    (instruction) => {
+      const processor = getInstructionPreProcessor(instruction);
+      expect(processor).toBe(preProcessSeqInstruction);
+    },
+  );
 
   it('should return preProcessTocInstruction for TOC instruction', () => {
     const instruction = 'TOC \\o "1-3" \\h \\z \\u';

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/page-ref-preprocessor.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/page-ref-preprocessor.js
@@ -6,13 +6,30 @@
  * @returns {import('../../v2/types/index.js').OpenXmlNode[]}
  * @see {@link https://ecma-international.org/publications-and-standards/standards/ecma-376/} "Fundamentals And Markup Language Reference", page 1234
  */
+import { translator as wRPrTranslator } from '../../v3/handlers/w/rpr/index.js';
+import { parsePageRefInstruction } from '../shared/pageref-instruction.js';
+
 export function preProcessPageRefInstruction(nodesToCombine, instrText, options = {}) {
-  void options;
+  const parsed = parsePageRefInstruction(instrText);
+  const instructionTokens = options.instructionTokens ?? null;
+  const firstInstrTextRunRPr = options.firstInstrTextRunRPr ?? null;
+  const fieldRunProperties =
+    parsed.fieldResultFormat === 'charformat' && firstInstrTextRunRPr
+      ? wRPrTranslator.encode({ ...(options.docx ? { docx: options.docx } : {}), nodes: [firstInstrTextRunRPr] })
+      : null;
   const pageRefNode = {
     name: 'sd:pageReference',
     type: 'element',
     attributes: {
-      instruction: instrText,
+      instruction: parsed.instruction,
+      ...(instructionTokens?.length ? { instructionTokens } : {}),
+      ...(parsed.bookmarkId ? { bookmarkId: parsed.bookmarkId } : {}),
+      ...(parsed.hasHyperlinkSwitch ? { hasHyperlinkSwitch: true } : {}),
+      ...(parsed.hasRelativePositionSwitch ? { hasRelativePositionSwitch: true } : {}),
+      ...(parsed.pageNumberFieldFormat ? { pageNumberFieldFormat: parsed.pageNumberFieldFormat } : {}),
+      ...(parsed.numericPictureFormat ? { numericPictureFormat: parsed.numericPictureFormat } : {}),
+      ...(parsed.fieldResultFormat ? { fieldResultFormat: parsed.fieldResultFormat } : {}),
+      ...(fieldRunProperties ? { fieldRunProperties } : {}),
     },
     elements: nodesToCombine,
   };

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/page-ref-preprocessor.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/page-ref-preprocessor.test.js
@@ -54,4 +54,27 @@ describe('preProcessPageRefInstruction', () => {
     });
     expect(result[0].elements).toBe(mockNodesToCombine);
   });
+
+  it('stores converted CHARFORMAT run properties from the first instruction run', () => {
+    const firstInstrTextRunRPr = {
+      name: 'w:rPr',
+      elements: [
+        { name: 'w:b', attributes: { 'w:val': '1' } },
+        { name: 'w:color', attributes: { 'w:val': 'FF0000' } },
+      ],
+    };
+    const result = preProcessPageRefInstruction(mockNodesToCombine, 'PAGEREF _Toc123 \\* CHARFORMAT', {
+      firstInstrTextRunRPr,
+    });
+
+    expect(result[0].attributes).toMatchObject({
+      fieldResultFormat: 'charformat',
+      fieldRunProperties: {
+        bold: true,
+        color: { val: 'FF0000' },
+      },
+    });
+    expect(result[0].attributes.fieldRunProperties).not.toHaveProperty('name');
+    expect(result[0].attributes.fieldRunProperties).not.toHaveProperty('elements');
+  });
 });

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/page-ref-preprocessor.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/page-ref-preprocessor.test.js
@@ -6,14 +6,16 @@ describe('preProcessPageRefInstruction', () => {
   const mockNodesToCombine = [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1' }] }] }];
 
   it('should process a page reference instruction', () => {
-    const instruction = 'PAGEREF _Toc123456789 h';
+    const instruction = 'PAGEREF _Toc123456789 \\h';
     const result = preProcessPageRefInstruction(mockNodesToCombine, instruction, {});
     expect(result).toEqual([
       {
         name: 'sd:pageReference',
         type: 'element',
         attributes: {
-          instruction: 'PAGEREF _Toc123456789 h',
+          instruction: 'PAGEREF _Toc123456789 \\h',
+          bookmarkId: '_Toc123456789',
+          hasHyperlinkSwitch: true,
         },
         elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1' }] }] }],
       },
@@ -30,9 +32,26 @@ describe('preProcessPageRefInstruction', () => {
         type: 'element',
         attributes: {
           instruction: 'PAGEREF _Toc123456789 h',
+          bookmarkId: '_Toc123456789',
         },
         elements: [],
       },
     ]);
+  });
+
+  it('stores parsed PAGEREF switches and instruction tokens', () => {
+    const result = preProcessPageRefInstruction(mockNodesToCombine, ' PAGEREF "_Toc1" \\p \\* Roman \\# "00" ', {
+      instructionTokens: [{ type: 'text', text: ' PAGEREF "_Toc1" \\p \\* Roman \\# "00" ' }],
+    });
+
+    expect(result[0].attributes).toMatchObject({
+      instruction: 'PAGEREF "_Toc1" \\p \\* Roman \\# "00"',
+      instructionTokens: [{ type: 'text', text: ' PAGEREF "_Toc1" \\p \\* Roman \\# "00" ' }],
+      bookmarkId: '_Toc1',
+      hasRelativePositionSwitch: true,
+      pageNumberFieldFormat: { format: 'upperRoman', zeroPadding: 2 },
+      numericPictureFormat: { picture: '00' },
+    });
+    expect(result[0].elements).toBe(mockNodesToCombine);
   });
 });

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.js
@@ -37,6 +37,8 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
   let collectedNodesStack = [];
   let rawCollectedNodesStack = [];
   let fieldRunRPrStack = [];
+  let firstInstrTextRunRPrStack = [];
+  let firstInstrTextRunSeenStack = [];
   let currentFieldStack = [];
   let unpairedEnd = null;
   let unpairedEndPreserveRaw = null;
@@ -52,6 +54,8 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
       const collectedNodes = collectedNodesStack.pop().filter((n) => n !== null);
       const rawCollectedNodes = rawCollectedNodesStack.pop().filter((n) => n !== null);
       const fieldRunRPr = fieldRunRPrStack.pop() ?? null;
+      const firstInstrTextRunRPr = firstInstrTextRunRPrStack.pop() ?? null;
+      firstInstrTextRunSeenStack.pop();
       const currentField = currentFieldStack.pop();
       let outputNodes = rawCollectedNodes;
       if (!currentField.preserveRaw) {
@@ -61,6 +65,7 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
           docx,
           currentField.instructionTokens,
           fieldRunRPr,
+          firstInstrTextRunRPr,
         );
         outputNodes = combinedResult.handled ? combinedResult.nodes : rawCollectedNodes;
       } else if (currentField.preserveRawConstructive) {
@@ -160,6 +165,8 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
       rawNodeSourceTokens.set(rawNode, rawSourceToken);
       capturedRawNodes.add(rawNode);
       fieldRunRPrStack.push(extractFieldRunRPr(node));
+      firstInstrTextRunRPrStack.push(null);
+      firstInstrTextRunSeenStack.push(false);
       currentFieldStack.push({ instrText: '', instructionTokens: [], afterSeparate: false });
       return;
     }
@@ -174,6 +181,10 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
           const fieldRunRPr = extractFieldRunRPr(node);
           if (fieldRunRPr) {
             fieldRunRPrStack[fieldRunRPrStack.length - 1] = fieldRunRPr;
+          }
+          if (instrTextEl && !firstInstrTextRunSeenStack[firstInstrTextRunSeenStack.length - 1]) {
+            firstInstrTextRunSeenStack[firstInstrTextRunSeenStack.length - 1] = true;
+            firstInstrTextRunRPrStack[firstInstrTextRunRPrStack.length - 1] = fieldRunRPr;
           }
           currentField.instructionTokens.push(...instructionTokens);
           const instrTextValue = instrTextEl?.elements?.[0]?.text;
@@ -321,13 +332,26 @@ export const preProcessNodesForFldChar = (nodes = [], docx) => {
  * @param {import('../v2/docxHelper').ParsedDocx} [docx] - The docx object.
  * @param {Array<{type: string, text?: string}>} [instructionTokens] - Raw instruction tokens.
  * @param {OpenXmlNode | null} [fieldRunRPr] - The w:rPr captured from field sequence runs.
+ * @param {OpenXmlNode | null} [firstInstrTextRunRPr] - The w:rPr captured from the first instrText run.
  * @returns {{ nodes: OpenXmlNode[], handled: boolean }} The processed nodes and whether a preprocessor handled them.
  */
-const _processCombinedNodesForFldChar = (nodesToCombine = [], instrText, docx, instructionTokens, fieldRunRPr) => {
+const _processCombinedNodesForFldChar = (
+  nodesToCombine = [],
+  instrText,
+  docx,
+  instructionTokens,
+  fieldRunRPr,
+  firstInstrTextRunRPr,
+) => {
   const instructionPreProcessor = getInstructionPreProcessor(instrText);
   if (instructionPreProcessor) {
     return {
-      nodes: instructionPreProcessor(nodesToCombine, instrText, { docx, instructionTokens, fieldRunRPr }),
+      nodes: instructionPreProcessor(nodesToCombine, instrText, {
+        docx,
+        instructionTokens,
+        fieldRunRPr,
+        firstInstrTextRunRPr,
+      }),
       handled: true,
     };
   }

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -183,7 +183,11 @@ describe('preProcessNodesForFldChar', () => {
           {
             name: 'sd:pageReference',
             type: 'element',
-            attributes: { instruction: 'PAGEREF bookmark' },
+            attributes: {
+              bookmarkId: 'bookmark',
+              instruction: 'PAGEREF bookmark',
+              instructionTokens: [{ type: 'text', text: 'PAGEREF bookmark' }],
+            },
             elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '5' }] }] }],
           },
         ],

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -86,6 +86,44 @@ describe('preProcessNodesForFldChar', () => {
     },
   );
 
+  it('preserves complex NUMPAGES numeric picture switches', () => {
+    const { processedNodes } = preProcessNodesForFldChar(complexFieldNodes('NUMPAGES \\# "#,##0"', '1,234'), mockDocx);
+
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0]).toMatchObject({
+      name: 'sd:totalPageNumber',
+      attributes: {
+        instruction: 'NUMPAGES \\# "#,##0"',
+        pageNumberNumericPicture: '#,##0',
+        importedCachedText: '1,234',
+      },
+    });
+  });
+
+  it('preserves fldSimple NUMPAGES zero-padding switches', () => {
+    const { processedNodes } = preProcessNodesForFldChar(
+      [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': 'NUMPAGES \\# "000"' },
+          elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '007' }] }] }],
+        },
+      ],
+      mockDocx,
+    );
+
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0]).toMatchObject({
+      name: 'sd:totalPageNumber',
+      attributes: {
+        instruction: 'NUMPAGES \\# "000"',
+        pageNumberFormat: 'decimal',
+        pageNumberZeroPadding: 3,
+        importedCachedText: '007',
+      },
+    });
+  });
+
   it('preserves SECTIONPAGES field run properties when cached result has no run properties', () => {
     const fieldRunRPr = { name: 'w:rPr', elements: [{ name: 'w:i' }] };
     const { processedNodes } = preProcessNodesForFldChar(
@@ -143,15 +181,47 @@ describe('preProcessNodesForFldChar', () => {
     ]);
   });
 
-  it('should preserve cached visible result runs for lowercase seq fields', () => {
-    const { processedNodes } = preProcessNodesForFldChar(complexFieldNodes('seq level2 \\*arabic', '1'), mockDocx);
+  it.each([
+    ['uppercase complex', complexFieldNodes('SEQ Figure \\* ARABIC', '7'), 'SEQ Figure \\* ARABIC', true],
+    ['lowercase complex', complexFieldNodes('seq Figure \\* arabic', '8'), 'seq Figure \\* arabic', true],
+    [
+      'uppercase fldSimple',
+      [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': 'SEQ Figure \\* ARABIC' },
+          elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '9' }] }] }],
+        },
+      ],
+      'SEQ Figure \\* ARABIC',
+      false,
+    ],
+    [
+      'lowercase fldSimple',
+      [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': 'seq Figure \\* arabic' },
+          elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '10' }] }] }],
+        },
+      ],
+      'seq Figure \\* arabic',
+      false,
+    ],
+  ])('processes %s SEQ fields and preserves cached result runs', (_name, nodes, instruction, hasInstructionTokens) => {
+    const { processedNodes } = preProcessNodesForFldChar(nodes, mockDocx);
 
-    expect(processedNodes).toHaveLength(5);
-    expect(processedNodes.some((node) => node.name === 'sd:sequenceField')).toBe(false);
-    expect(processedNodes[3]).toEqual({
-      name: 'w:r',
-      elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1' }] }],
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0]).toMatchObject({
+      name: 'sd:sequenceField',
+      attributes: { instruction },
     });
+    expect(processedNodes[0].elements).toHaveLength(1);
+    expect(processedNodes[0].elements[0].name).toBe('w:r');
+    expect(processedNodes[0].elements[0].elements?.[0]?.name).toBe('w:t');
+    expect(processedNodes[0].attributes.instructionTokens).toEqual(
+      hasInstructionTokens ? [{ type: 'text', text: instruction }] : undefined,
+    );
   });
 
   it('should handle nested fields (PAGEREF within HYPERLINK)', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.js
@@ -182,7 +182,8 @@ function scanFieldSequence(nodes, beginIndex) {
     const instrTextEl = node.elements?.find((el) => el.name === 'w:instrText');
 
     if (instrTextEl) {
-      instrText += (instrTextEl.elements?.[0]?.text || '') + ' ';
+      const fragment = instrTextEl.elements?.[0]?.text || '';
+      instrText += shouldInsertSwitchBoundarySpace(instrText, fragment) ? ` ${fragment}` : fragment;
     }
 
     // Capture rPr from field sequence nodes (before separate) if we don't have one yet
@@ -218,6 +219,13 @@ function scanFieldSequence(nodes, beginIndex) {
     fieldRunRPr,
     endIndex,
   };
+}
+
+function shouldInsertSwitchBoundarySpace(existingInstruction, nextFragment) {
+  return (
+    (/\w$/.test(existingInstruction) && /^\\/.test(nextFragment)) ||
+    (/(^|\s)\\[#*]$/.test(existingInstruction) && /^\S/.test(nextFragment))
+  );
 }
 
 /**

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
@@ -28,6 +28,31 @@ describe('preProcessPageFieldsOnly', () => {
     ];
   }
 
+  function complexFieldNodesFromInstructionFragments(instructionFragments, cachedText = '1') {
+    return [
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }],
+      },
+      ...instructionFragments.map((text) => ({
+        name: 'w:r',
+        elements: [{ name: 'w:instrText', elements: [{ type: 'text', text }] }],
+      })),
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }],
+      },
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:t', elements: [{ type: 'text', text: cachedText }] }],
+      },
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }],
+      },
+    ];
+  }
+
   describe('complex field syntax (w:fldChar)', () => {
     it('should process PAGE field with fldChar syntax', () => {
       const nodes = [
@@ -133,6 +158,119 @@ describe('preProcessPageFieldsOnly', () => {
           pageNumberFormat: 'decimal',
           pageNumberZeroPadding: 2,
           importedCachedText: '05',
+        },
+      });
+    });
+
+    it('should preserve NUMPAGES quoted numeric picture whitespace across split instrText runs', () => {
+      const nodes = [
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'NUMPAGES \\# "#' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: '   pages"' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1   pages' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:totalPageNumber',
+        attributes: {
+          instruction: 'NUMPAGES \\# "#   pages"',
+          pageNumberNumericPicture: '#   pages',
+          importedCachedText: '1   pages',
+        },
+      });
+    });
+
+    it('should process NUMPAGES switches split at a run boundary without whitespace', () => {
+      const nodes = [
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'NUMPAGES' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: '\\# "000"' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:t', elements: [{ type: 'text', text: '007' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:totalPageNumber',
+        attributes: {
+          instruction: 'NUMPAGES \\# "000"',
+          pageNumberFormat: 'decimal',
+          pageNumberZeroPadding: 3,
+          importedCachedText: '007',
+        },
+      });
+    });
+
+    it('should process NUMPAGES numeric switches split between operator and argument', () => {
+      const result = preProcessPageFieldsOnly(
+        complexFieldNodesFromInstructionFragments(['NUMPAGES', '\\#', '"000"'], '007'),
+      );
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:totalPageNumber',
+        attributes: {
+          instruction: 'NUMPAGES \\# "000"',
+          pageNumberFormat: 'decimal',
+          pageNumberZeroPadding: 3,
+          importedCachedText: '007',
+        },
+      });
+    });
+
+    it('should process PAGE general-format switches split between operator and argument', () => {
+      const result = preProcessPageFieldsOnly(complexFieldNodesFromInstructionFragments(['PAGE', '\\*', 'Roman']));
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:autoPageNumber',
+        attributes: {
+          instruction: 'PAGE \\* Roman',
+          pageNumberFormat: 'upperRoman',
         },
       });
     });

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
@@ -8,6 +8,7 @@ export const GENERAL_FORMATS = new Map([
   ['alphabetic', 'lowerLetter'],
   ['ALPHABETIC', 'upperLetter'],
   ['ArabicDash', 'numberInDash'],
+  ['Ordinal', 'ordinal'],
 ]);
 
 export const CASE_INSENSITIVE_GENERAL_FORMATS = new Map([
@@ -18,17 +19,18 @@ export const CASE_INSENSITIVE_GENERAL_FORMATS = new Map([
 /**
  * @param {string} instruction
  * @param {'PAGE' | 'NUMPAGES' | 'SECTIONPAGES'} fieldType
- * @returns {{ instruction?: string, pageNumberFormat?: string, pageNumberZeroPadding?: number }}
+ * @returns {{ instruction?: string, pageNumberFormat?: string, pageNumberZeroPadding?: number, pageNumberNumericPicture?: string }}
  */
 export function parsePageNumberFieldSwitches(instruction, fieldType) {
-  const normalizedInstruction = typeof instruction === 'string' ? instruction.trim().replace(/\s+/g, ' ') : fieldType;
+  const switchInstruction = typeof instruction === 'string' ? instruction.trim() : fieldType;
+  const normalizedInstruction = normalizeInstructionWhitespace(switchInstruction);
   const result = {};
 
   if (normalizedInstruction && normalizedInstruction !== fieldType) {
     result.instruction = normalizedInstruction;
   }
 
-  for (const match of normalizedInstruction.matchAll(/\\\*\s+("[^"]+"|\S+)/g)) {
+  for (const match of switchInstruction.matchAll(/\\\*\s+("[^"]+"|\S+)/g)) {
     const rawValue = unquote(match[1]);
     const mapped = GENERAL_FORMATS.get(rawValue) ?? CASE_INSENSITIVE_GENERAL_FORMATS.get(rawValue.toLowerCase());
     if (mapped) {
@@ -37,13 +39,18 @@ export function parsePageNumberFieldSwitches(instruction, fieldType) {
     }
   }
 
-  for (const match of normalizedInstruction.matchAll(/\\#\s+("[^"]+"|\S+)/g)) {
+  for (const match of switchInstruction.matchAll(/\\#\s+("[^"]+"|\S+)/g)) {
     const picture = unquote(match[1]);
+    if (!picture) continue;
+
     if (/^0+$/.test(picture)) {
       result.pageNumberFormat ??= 'decimal';
       result.pageNumberZeroPadding = picture.length;
-      break;
+    } else {
+      result.pageNumberNumericPicture = picture;
     }
+
+    break;
   }
 
   return result;
@@ -51,12 +58,13 @@ export function parsePageNumberFieldSwitches(instruction, fieldType) {
 
 /**
  * @param {number} pageNumber
- * @param {{ pageNumberFormat?: string | null, pageNumberZeroPadding?: number | null }} attrs
+ * @param {{ pageNumberFormat?: string | null, pageNumberZeroPadding?: number | null, pageNumberNumericPicture?: string | null }} attrs
  */
 export function formatPageNumberFieldValue(pageNumber, attrs = {}) {
   return formatSharedPageNumberFieldValue(pageNumber, {
     format: attrs.pageNumberFormat || 'decimal',
     zeroPadding: attrs.pageNumberZeroPadding ?? undefined,
+    numericPicture: attrs.pageNumberNumericPicture ?? undefined,
   });
 }
 
@@ -65,4 +73,41 @@ export function formatPageNumberFieldValue(pageNumber, attrs = {}) {
  */
 function unquote(value) {
   return value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value;
+}
+
+/**
+ * Collapse field-code whitespace outside quoted switch arguments while
+ * preserving significant whitespace inside numeric-picture literals.
+ *
+ * @param {string} instruction
+ */
+function normalizeInstructionWhitespace(instruction) {
+  let normalized = '';
+  let inQuote = false;
+  let pendingSpace = false;
+
+  for (const char of instruction) {
+    if (char === '"') {
+      if (pendingSpace && normalized.length > 0) {
+        normalized += ' ';
+        pendingSpace = false;
+      }
+      normalized += char;
+      inQuote = !inQuote;
+      continue;
+    }
+
+    if (!inQuote && /\s/.test(char)) {
+      pendingSpace = true;
+      continue;
+    }
+
+    if (pendingSpace && normalized.length > 0) {
+      normalized += ' ';
+      pendingSpace = false;
+    }
+    normalized += char;
+  }
+
+  return normalized;
 }

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
@@ -1,6 +1,6 @@
 import { formatPageNumberFieldValue as formatSharedPageNumberFieldValue } from '@superdoc/contracts';
 
-const GENERAL_FORMATS = new Map([
+export const GENERAL_FORMATS = new Map([
   ['Arabic', 'decimal'],
   ['roman', 'lowerRoman'],
   ['Roman', 'upperRoman'],
@@ -10,7 +10,7 @@ const GENERAL_FORMATS = new Map([
   ['ArabicDash', 'numberInDash'],
 ]);
 
-const CASE_INSENSITIVE_GENERAL_FORMATS = new Map([
+export const CASE_INSENSITIVE_GENERAL_FORMATS = new Map([
   ['arabic', 'decimal'],
   ['arabicdash', 'numberInDash'],
 ]);

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.test.js
@@ -14,8 +14,16 @@ describe('parsePageNumberFieldSwitches', () => {
     ['PAGE \\* ArabicDash', { instruction: 'PAGE \\* ArabicDash', pageNumberFormat: 'numberInDash' }],
     ['PAGE \\* arabicdash', { instruction: 'PAGE \\* arabicdash', pageNumberFormat: 'numberInDash' }],
     ['PAGE \\* ARABICDASH', { instruction: 'PAGE \\* ARABICDASH', pageNumberFormat: 'numberInDash' }],
+    ['PAGE \\* Ordinal', { instruction: 'PAGE \\* Ordinal', pageNumberFormat: 'ordinal' }],
   ])('parses general format switch %s', (instruction, expected) => {
     expect(parsePageNumberFieldSwitches(instruction, 'PAGE')).toEqual(expected);
+  });
+
+  it('parses NUMPAGES Ordinal format switches', () => {
+    expect(parsePageNumberFieldSwitches('NUMPAGES \\* Ordinal', 'NUMPAGES')).toEqual({
+      instruction: 'NUMPAGES \\* Ordinal',
+      pageNumberFormat: 'ordinal',
+    });
   });
 
   it.each([['PAGE \\* rOman'], ['PAGE \\* Alphabetic'], ['PAGE \\* aLpHaBeTiC']])(
@@ -29,6 +37,15 @@ describe('parsePageNumberFieldSwitches', () => {
     ['NUMPAGES \\# "00"', { instruction: 'NUMPAGES \\# "00"', pageNumberFormat: 'decimal', pageNumberZeroPadding: 2 }],
     ['NUMPAGES \\# 000', { instruction: 'NUMPAGES \\# 000', pageNumberFormat: 'decimal', pageNumberZeroPadding: 3 }],
   ])('parses zero-padding picture switch %s', (instruction, expected) => {
+    expect(parsePageNumberFieldSwitches(instruction, 'NUMPAGES')).toEqual(expected);
+  });
+
+  it.each([
+    ['NUMPAGES \\# "#,##0"', { instruction: 'NUMPAGES \\# "#,##0"', pageNumberNumericPicture: '#,##0' }],
+    ['NUMPAGES \\# #,##0', { instruction: 'NUMPAGES \\# #,##0', pageNumberNumericPicture: '#,##0' }],
+    ['NUMPAGES \\# "# pages"', { instruction: 'NUMPAGES \\# "# pages"', pageNumberNumericPicture: '# pages' }],
+    ['NUMPAGES \\# "#   pages"', { instruction: 'NUMPAGES \\# "#   pages"', pageNumberNumericPicture: '#   pages' }],
+  ])('preserves non-zero numeric picture switch %s', (instruction, expected) => {
     expect(parsePageNumberFieldSwitches(instruction, 'NUMPAGES')).toEqual(expected);
   });
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/pageref-instruction.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/pageref-instruction.js
@@ -1,0 +1,127 @@
+import { CASE_INSENSITIVE_GENERAL_FORMATS, GENERAL_FORMATS } from './page-number-field-switches.js';
+
+const TOKEN_PATTERN = /"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|\\[#*]|\\[^\s]+|[^\s]+/g;
+
+/**
+ * @param {string} instruction
+ * @returns {{
+ *   instruction: string,
+ *   bookmarkId: string,
+ *   hasHyperlinkSwitch: boolean,
+ *   hasRelativePositionSwitch: boolean,
+ *   pageNumberFieldFormat?: { format?: string, zeroPadding?: number },
+ *   numericPictureFormat?: { picture: string },
+ *   fieldResultFormat?: 'charformat' | 'mergeformat',
+ *   unsupportedGeneralFormat?: string,
+ *   rawSwitches: Array<{ switch: string, value?: string }>,
+ * }}
+ */
+export function parsePageRefInstruction(instruction) {
+  const rawInstruction = typeof instruction === 'string' ? instruction.trim() : '';
+  const tokens = tokenizeInstruction(rawInstruction);
+  const result = {
+    instruction: rawInstruction,
+    bookmarkId: '',
+    hasHyperlinkSwitch: false,
+    hasRelativePositionSwitch: false,
+    rawSwitches: [],
+  };
+
+  if (!tokens.length || !/^PAGEREF$/i.test(tokens[0].value)) {
+    return result;
+  }
+
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index].value;
+    if (!token) continue;
+
+    if (token.startsWith('\\')) {
+      const normalized = token.toLowerCase();
+      if (normalized === '\\h') {
+        result.hasHyperlinkSwitch = true;
+        result.rawSwitches.push({ switch: token });
+        continue;
+      }
+      if (normalized === '\\p') {
+        result.hasRelativePositionSwitch = true;
+        result.rawSwitches.push({ switch: token });
+        continue;
+      }
+      if (token === '\\*') {
+        const value = tokens[index + 1]?.value;
+        if (value != null) {
+          result.rawSwitches.push({ switch: token, value });
+          applyGeneralFormat(result, value);
+          index += 1;
+        } else {
+          result.rawSwitches.push({ switch: token });
+        }
+        continue;
+      }
+      if (token === '\\#') {
+        const value = tokens[index + 1]?.value;
+        if (value != null) {
+          result.rawSwitches.push({ switch: token, value });
+          result.numericPictureFormat = { picture: value };
+          if (/^0+$/.test(value)) {
+            result.pageNumberFieldFormat = { ...(result.pageNumberFieldFormat ?? {}), zeroPadding: value.length };
+          }
+          index += 1;
+        } else {
+          result.rawSwitches.push({ switch: token });
+        }
+        continue;
+      }
+
+      result.rawSwitches.push({ switch: token });
+      continue;
+    }
+
+    if (!result.bookmarkId) {
+      result.bookmarkId = token;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * @param {string} instruction
+ */
+function tokenizeInstruction(instruction) {
+  const tokens = [];
+  for (const match of instruction.matchAll(TOKEN_PATTERN)) {
+    tokens.push({ value: unescapeQuotedToken(match[1] ?? match[2] ?? match[0]) });
+  }
+  return tokens;
+}
+
+/**
+ * @param {string} value
+ */
+function unescapeQuotedToken(value) {
+  return value.replace(/\\(["'\\])/g, '$1');
+}
+
+/**
+ * @param {ReturnType<typeof parsePageRefInstruction>} result
+ * @param {string} value
+ */
+function applyGeneralFormat(result, value) {
+  const normalized = value.toLowerCase();
+  if (normalized === 'charformat') {
+    result.fieldResultFormat = 'charformat';
+    return;
+  }
+  if (normalized === 'mergeformat') {
+    result.fieldResultFormat = 'mergeformat';
+    return;
+  }
+
+  const mapped = GENERAL_FORMATS.get(value) ?? CASE_INSENSITIVE_GENERAL_FORMATS.get(normalized);
+  if (mapped) {
+    result.pageNumberFieldFormat = { ...(result.pageNumberFieldFormat ?? {}), format: mapped };
+  } else {
+    result.unsupportedGeneralFormat = value;
+  }
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/pageref-instruction.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/pageref-instruction.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { parsePageRefInstruction } from './pageref-instruction.js';
+
+describe('parsePageRefInstruction', () => {
+  it('parses unquoted and case-insensitive PAGEREF targets', () => {
+    expect(parsePageRefInstruction('PAGEREF _Toc123')).toMatchObject({
+      instruction: 'PAGEREF _Toc123',
+      bookmarkId: '_Toc123',
+    });
+    expect(parsePageRefInstruction('pageref _Toc123')).toMatchObject({
+      bookmarkId: '_Toc123',
+    });
+  });
+
+  it('parses quoted bookmark targets and hyperlink switches', () => {
+    expect(parsePageRefInstruction('PAGEREF "_Toc123" \\h')).toMatchObject({
+      bookmarkId: '_Toc123',
+      hasHyperlinkSwitch: true,
+    });
+    expect(parsePageRefInstruction('PAGEREF _Toc123 \\H')).toMatchObject({
+      bookmarkId: '_Toc123',
+      hasHyperlinkSwitch: true,
+    });
+  });
+
+  it('parses relative-position switches', () => {
+    expect(parsePageRefInstruction('PAGEREF _Toc123 \\p')).toMatchObject({
+      bookmarkId: '_Toc123',
+      hasRelativePositionSwitch: true,
+    });
+    expect(parsePageRefInstruction('PAGEREF _Toc123 \\P')).toMatchObject({
+      bookmarkId: '_Toc123',
+      hasRelativePositionSwitch: true,
+    });
+    expect(parsePageRefInstruction('PAGEREF _Toc123 \\h \\p')).toMatchObject({
+      hasHyperlinkSwitch: true,
+      hasRelativePositionSwitch: true,
+    });
+  });
+
+  it('maps supported general numeric formats', () => {
+    expect(parsePageRefInstruction('PAGEREF _Toc123 \\* Roman').pageNumberFieldFormat).toEqual({
+      format: 'upperRoman',
+    });
+    expect(parsePageRefInstruction('PAGEREF _Toc123 \\* roman').pageNumberFieldFormat).toEqual({
+      format: 'lowerRoman',
+    });
+    expect(parsePageRefInstruction('PAGEREF _Toc123 \\* ArabicDash').pageNumberFieldFormat).toEqual({
+      format: 'numberInDash',
+    });
+  });
+
+  it('parses numeric picture switches', () => {
+    expect(parsePageRefInstruction('PAGEREF _Toc123 \\# "00"')).toMatchObject({
+      numericPictureFormat: { picture: '00' },
+      pageNumberFieldFormat: { zeroPadding: 2 },
+    });
+    expect(parsePageRefInstruction('PAGEREF _Toc123 \\# #,##0')).toMatchObject({
+      numericPictureFormat: { picture: '#,##0' },
+    });
+  });
+
+  it('does not treat bare h as the hyperlink switch', () => {
+    expect(parsePageRefInstruction('PAGEREF bh-target')).toMatchObject({
+      bookmarkId: 'bh-target',
+      hasHyperlinkSwitch: false,
+    });
+  });
+
+  it('preserves unknown switches in rawSwitches', () => {
+    expect(parsePageRefInstruction('PAGEREF _Toc123 \\z value').rawSwitches).toEqual([{ switch: '\\z' }]);
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-evaluator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-evaluator.js
@@ -1,0 +1,163 @@
+import { formatIntegerWithNumericPicture, formatPageNumberFieldValue } from '@superdoc/contracts';
+import { normalizeSeqIdentifier } from './seq-instruction.js';
+
+/**
+ * @typedef {{
+ *   initialCounters?: Map<string, number>,
+ * }} SeqEvaluatorOptions
+ *
+ * Note: no `storyKey` is needed. One evaluator instance is created per linear
+ * pass over one story's ordered content, so per-story isolation is structural.
+ *
+ * @typedef {{
+ *   identifier: string,
+ *   instruction?: string,
+ *   fieldArgument?: string,
+ *   sequenceMode?: 'next' | 'current',
+ *   hideResult?: boolean,
+ *   restartNumber?: number | null,
+ *   restartLevel?: number | null,
+ *   format?: string,
+ *   hasGeneralFormat?: boolean,
+ *   pageNumberFieldFormat?: import('@superdoc/contracts').PageNumberFieldFormat | null,
+ *   numericPictureFormat?: { picture: string } | null,
+ *   cachedText?: string,
+ * }} SeqFieldInput
+ *
+ * @typedef {{
+ *   paragraphHeadingLevel?: number | null,
+ * }} SeqFieldContext
+ *
+ * @typedef {{
+ *   value: number | null,
+ *   text: string,
+ *   hidden: boolean,
+ * }} SeqFieldEvaluation
+ */
+
+export class SequenceFieldEvaluator {
+  /**
+   * @param {SeqEvaluatorOptions} options
+   */
+  constructor(options = {}) {
+    this.counters = new Map(options.initialCounters ?? []);
+    this.headingSerialsByLevel = new Map();
+    this.lastResetSerialByIdentifierLevel = new Map();
+  }
+
+  /**
+   * @param {SeqFieldContext} context
+   */
+  enterParagraph(context = {}) {
+    const level = context.paragraphHeadingLevel;
+    if (!isValidHeadingLevel(level)) return;
+
+    this.headingSerialsByLevel.set(level, (this.headingSerialsByLevel.get(level) ?? 0) + 1);
+    for (let deeperLevel = level + 1; deeperLevel <= 9; deeperLevel += 1) {
+      this.headingSerialsByLevel.delete(deeperLevel);
+    }
+  }
+
+  /**
+   * @param {SeqFieldInput} field
+   * @returns {SeqFieldEvaluation}
+   */
+  evaluateField(field) {
+    const identifier = normalizeSeqIdentifier(field?.identifier);
+    const cachedText = typeof field?.cachedText === 'string' ? field.cachedText : '';
+
+    if (!identifier) {
+      return { value: null, text: cachedText, hidden: false };
+    }
+
+    if (hasFieldArgument(field)) {
+      // A SEQ field argument references a bookmarked item elsewhere. Correct
+      // behavior needs bookmark position resolution; until Phase 7 wires that
+      // in, preserve cached text or conservatively repeat the current counter.
+      // This short-circuit intentionally bypasses \h suppression for now.
+      if (cachedText) return { value: null, text: cachedText, hidden: false };
+      if (!this.counters.has(identifier)) return { value: null, text: '', hidden: false };
+
+      const value = this.counters.get(identifier);
+      return { value, text: formatSeqValue(value, field), hidden: false };
+    }
+
+    const restartLevel = normalizeRestartLevel(field?.restartLevel);
+    if (restartLevel != null) {
+      const key = `${identifier}|${restartLevel}`;
+      const serial = this.headingSerialsByLevel.get(restartLevel) ?? 0;
+      const previousSerial = this.lastResetSerialByIdentifierLevel.get(key);
+      if (previousSerial === undefined || serial !== previousSerial) {
+        // ECMA says \s "resets to the heading level"; Word interprets this as
+        // restarting sequence numbering within each heading-N section.
+        this.counters.set(identifier, 0);
+        this.lastResetSerialByIdentifierLevel.set(key, serial);
+      }
+    }
+
+    const restartNumber = normalizeRestartNumber(field?.restartNumber);
+    let value;
+    if (restartNumber != null) {
+      this.counters.set(identifier, restartNumber);
+      value = restartNumber;
+    } else if (field?.sequenceMode === 'current') {
+      if (!this.counters.has(identifier)) {
+        return { value: 0, text: cachedText, hidden: false };
+      }
+      value = this.counters.get(identifier);
+    } else {
+      value = (this.counters.get(identifier) ?? 0) + 1;
+      this.counters.set(identifier, value);
+    }
+
+    const hidden = Boolean(field?.hideResult && !field.hasGeneralFormat && !field.numericPictureFormat);
+    return {
+      value,
+      text: hidden ? '' : formatSeqValue(value, field),
+      hidden,
+    };
+  }
+}
+
+/**
+ * @param {unknown} value
+ */
+function isValidHeadingLevel(value) {
+  return Number.isInteger(value) && value >= 1 && value <= 9;
+}
+
+/**
+ * @param {unknown} value
+ */
+function normalizeRestartLevel(value) {
+  return isValidHeadingLevel(value) ? value : null;
+}
+
+/**
+ * @param {unknown} value
+ */
+function normalizeRestartNumber(value) {
+  return Number.isFinite(value) && Number.isInteger(value) ? Math.trunc(value) : null;
+}
+
+/**
+ * @param {SeqFieldInput | undefined} field
+ */
+function hasFieldArgument(field) {
+  return typeof field?.fieldArgument === 'string' && field.fieldArgument.trim().length > 0;
+}
+
+/**
+ * @param {number} value
+ * @param {SeqFieldInput | undefined} field
+ */
+function formatSeqValue(value, field) {
+  const picture = field?.numericPictureFormat?.picture;
+  if (picture) {
+    return formatIntegerWithNumericPicture(value, picture);
+  }
+  if (field?.pageNumberFieldFormat) {
+    return formatPageNumberFieldValue(value, field.pageNumberFieldFormat);
+  }
+  return String(value);
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-evaluator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-evaluator.test.js
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+import { SequenceFieldEvaluator } from './seq-evaluator.js';
+
+describe('SequenceFieldEvaluator', () => {
+  it('numbers each identifier independently in document order', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 1, text: '1' });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 2, text: '2' });
+    expect(evaluator.evaluateField({ identifier: 'Table' })).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('treats explicit next mode as the default', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure', sequenceMode: 'next' })).toMatchObject({
+      value: 1,
+      text: '1',
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 2, text: '2' });
+  });
+
+  it('repeats the current value without incrementing', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.evaluateField({ identifier: 'Figure' });
+    expect(evaluator.evaluateField({ identifier: 'Figure', sequenceMode: 'current' })).toMatchObject({
+      value: 1,
+      text: '1',
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 2, text: '2' });
+  });
+
+  it('uses cached text or empty text for current mode before any prior value', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure', sequenceMode: 'current', cachedText: 'cached' })).toEqual({
+      value: 0,
+      text: 'cached',
+      hidden: false,
+    });
+    expect(evaluator.evaluateField({ identifier: 'Table', sequenceMode: 'current' })).toEqual({
+      value: 0,
+      text: '',
+      hidden: false,
+    });
+  });
+
+  it('applies explicit restart and continues from that value', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartNumber: 10 })).toMatchObject({
+      value: 10,
+      text: '10',
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 11, text: '11' });
+  });
+
+  it('hides text while still updating the counter', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 1, text: '1' });
+    expect(evaluator.evaluateField({ identifier: 'Figure', hideResult: true })).toEqual({
+      value: 2,
+      text: '',
+      hidden: true,
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 3, text: '3' });
+  });
+
+  it('does not hide text when a general format is present', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(
+      evaluator.evaluateField({
+        identifier: 'Figure',
+        hideResult: true,
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'decimal' },
+      }),
+    ).toEqual({ value: 1, text: '1', hidden: false });
+  });
+
+  it('restarts on the first heading-level reset field and when that heading level changes', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 1 })).toMatchObject({ value: 1, text: '1' });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 1 })).toMatchObject({ value: 2, text: '2' });
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 1 })).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('restarts for level 2 only when the level 2 serial changes', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 2 })).toMatchObject({ value: 1, text: '1' });
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 2 })).toMatchObject({ value: 2, text: '2' });
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 2 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 2 })).toMatchObject({ value: 1, text: '1' });
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 2 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 2 })).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('treats a deleted deeper heading serial as 0 for heading-level resets', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    evaluator.enterParagraph({ paragraphHeadingLevel: 3 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 3 })).toMatchObject({ value: 1, text: '1' });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 2, text: '2' });
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 3 })).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('lets explicit restart win over heading-level reset', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 1, restartNumber: 7 })).toMatchObject({
+      value: 7,
+      text: '7',
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 8, text: '8' });
+  });
+
+  it('repeats the current counter after explicit restart', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.evaluateField({ identifier: 'Figure', restartNumber: 7 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', sequenceMode: 'current' })).toMatchObject({
+      value: 7,
+      text: '7',
+    });
+  });
+
+  it('formats values with general and numeric-picture formats', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(
+      evaluator.evaluateField({ identifier: 'Roman', pageNumberFieldFormat: { format: 'lowerRoman' } }),
+    ).toMatchObject({ value: 1, text: 'i' });
+    expect(
+      evaluator.evaluateField({ identifier: 'Alpha', pageNumberFieldFormat: { format: 'upperLetter' } }),
+    ).toMatchObject({ value: 1, text: 'A' });
+    expect(
+      evaluator.evaluateField({ identifier: 'Dash', pageNumberFieldFormat: { format: 'numberInDash' } }),
+    ).toMatchObject({ value: 1, text: '- 1 -' });
+    expect(evaluator.evaluateField({ identifier: 'Picture', numericPictureFormat: { picture: '00' } })).toMatchObject({
+      value: 1,
+      text: '01',
+    });
+  });
+
+  it('gives numeric-picture formatting priority over general formatting', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(
+      evaluator.evaluateField({
+        identifier: 'Figure',
+        pageNumberFieldFormat: { format: 'lowerRoman' },
+        numericPictureFormat: { picture: '00' },
+      }),
+    ).toMatchObject({ value: 1, text: '01' });
+  });
+
+  it('defaults unknown formats to decimal display instead of cached text', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(
+      evaluator.evaluateField({
+        identifier: 'Figure',
+        format: 'OrdText',
+        hasGeneralFormat: true,
+        cachedText: 'cached',
+      }),
+    ).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('returns cached fallback for empty identifiers without mutating counters', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: '', cachedText: 'cached' })).toEqual({
+      value: null,
+      text: 'cached',
+      hidden: false,
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('handles field arguments conservatively without mutating counters', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure', fieldArgument: 'bookmark', cachedText: 'cached' })).toEqual({
+      value: null,
+      text: 'cached',
+      hidden: false,
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 1, text: '1' });
+    expect(evaluator.evaluateField({ identifier: 'Figure', fieldArgument: 'bookmark' })).toEqual({
+      value: 1,
+      text: '1',
+      hidden: false,
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 2, text: '2' });
+  });
+
+  it('can start from caller-provided initial counters', () => {
+    const evaluator = new SequenceFieldEvaluator({ initialCounters: new Map([['Figure', 4]]) });
+
+    expect(evaluator.evaluateField({ identifier: 'Figure', sequenceMode: 'current' })).toMatchObject({
+      value: 4,
+      text: '4',
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 5, text: '5' });
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.js
@@ -1,0 +1,293 @@
+import { extractFieldKeyword } from '../field-keyword.js';
+import { CASE_INSENSITIVE_GENERAL_FORMATS, GENERAL_FORMATS } from './page-number-field-switches.js';
+
+const TOKEN_PATTERN = /"((?:[^"\\]|\\.)*)"|\\[#*](?=\s|$)|\\[^\s]+|[^\s]+/g;
+
+/**
+ * @typedef {'next' | 'current'} SeqMode
+ * @typedef {{ picture: string }} SeqNumericPictureFormat
+ * @typedef {{
+ *   instruction: string,
+ *   keyword: string,
+ *   identifier: string,
+ *   fieldArgument: string,
+ *   sequenceMode: SeqMode,
+ *   hideResult: boolean,
+ *   restartNumber: number | null,
+ *   restartLevel: number | null,
+ *   format: string,
+ *   pageNumberFieldFormat?: import('@superdoc/contracts').PageNumberFieldFormat,
+ *   numericPictureFormat: SeqNumericPictureFormat | null,
+ *   hasGeneralFormat: boolean,
+ *   unknownSwitches: string[],
+ * }} ParsedSeqInstruction
+ *
+ * @typedef {{
+ *   identifier: string,
+ *   fieldArgument: string,
+ *   sequenceMode: SeqMode,
+ *   hideResult: boolean,
+ *   restartNumber: number | null,
+ *   restartLevel: number | null,
+ *   format: string,
+ *   hasGeneralFormat: boolean,
+ *   pageNumberFieldFormat: import('@superdoc/contracts').PageNumberFieldFormat | null,
+ *   numericPictureFormat: SeqNumericPictureFormat | null,
+ * }} SequenceFieldParsedAttrs
+ */
+
+/**
+ * @param {string} instruction
+ * @returns {ParsedSeqInstruction}
+ */
+export function parseSeqInstruction(instruction) {
+  const rawInstruction = typeof instruction === 'string' ? instruction : '';
+  const tokens = tokenizeInstruction(rawInstruction);
+  const keyword = tokens[0]?.value ?? '';
+  const result = createEmptyParse(rawInstruction, keyword);
+
+  if (extractFieldKeyword(rawInstruction) !== 'SEQ') {
+    return result;
+  }
+
+  let sawSwitch = false;
+
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index].value;
+    if (!token) continue;
+
+    if (token.startsWith('\\')) {
+      sawSwitch = true;
+      const attachedValueSwitch = parseAttachedNumericSwitch(token);
+      const normalized = (attachedValueSwitch?.switchToken ?? token).toLowerCase();
+
+      if (normalized === '\\n') {
+        result.sequenceMode = 'next';
+        continue;
+      }
+
+      if (normalized === '\\c') {
+        result.sequenceMode = 'current';
+        continue;
+      }
+
+      if (normalized === '\\h') {
+        result.hideResult = true;
+        continue;
+      }
+
+      if (normalized === '\\r') {
+        const value = attachedValueSwitch?.value ?? tokens[index + 1]?.value;
+        if (value != null && (attachedValueSwitch || !value.startsWith('\\'))) {
+          const parsed = parseInteger(value);
+          if (parsed != null) result.restartNumber = parsed;
+          if (!attachedValueSwitch) index += 1;
+        }
+        continue;
+      }
+
+      if (normalized === '\\s') {
+        const value = attachedValueSwitch?.value ?? tokens[index + 1]?.value;
+        if (value != null && (attachedValueSwitch || !value.startsWith('\\'))) {
+          const parsed = parseInteger(value);
+          if (parsed != null && parsed >= 1 && parsed <= 9) result.restartLevel = parsed;
+          if (!attachedValueSwitch) index += 1;
+        }
+        continue;
+      }
+
+      const attachedGeneralFormat = parseAttachedGeneralFormatSwitch(token);
+      if (normalized === '\\*' || attachedGeneralFormat != null) {
+        const value = attachedGeneralFormat ?? tokens[index + 1]?.value;
+        if (value != null && (attachedGeneralFormat != null || !value.startsWith('\\'))) {
+          result.format = value;
+          result.hasGeneralFormat = true;
+          applyGeneralFormat(result, value);
+          if (attachedGeneralFormat == null) index += 1;
+        } else {
+          result.unknownSwitches.push(token);
+        }
+        continue;
+      }
+
+      const attachedNumericPicture = parseAttachedNumericPictureSwitch(token);
+      if (normalized === '\\#' || attachedNumericPicture != null) {
+        const value = attachedNumericPicture ?? tokens[index + 1]?.value;
+        if (value != null && (attachedNumericPicture != null || !value.startsWith('\\'))) {
+          if (result.numericPictureFormat == null) {
+            result.numericPictureFormat = { picture: value };
+          } else {
+            result.unknownSwitches.push(token, value);
+          }
+          if (attachedNumericPicture == null) index += 1;
+        } else {
+          result.unknownSwitches.push(token);
+        }
+        continue;
+      }
+
+      result.unknownSwitches.push(token);
+      // Unknown switch arity is ambiguous; preserve the adjacent value token
+      // when present so later phases do not silently drop raw instruction data.
+      const value = tokens[index + 1]?.value;
+      if (value != null && !value.startsWith('\\')) {
+        result.unknownSwitches.push(value);
+        index += 1;
+      }
+      continue;
+    }
+
+    if (!result.identifier) {
+      result.identifier = normalizeSeqIdentifier(token);
+      continue;
+    }
+
+    if (!sawSwitch && !result.fieldArgument) {
+      result.fieldArgument = token;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * @param {string} instruction
+ */
+export function isSeqInstruction(instruction) {
+  return extractFieldKeyword(instruction) === 'SEQ';
+}
+
+/**
+ * @param {unknown} identifier
+ */
+export function normalizeSeqIdentifier(identifier) {
+  return typeof identifier === 'string' ? identifier.trim() : '';
+}
+
+/**
+ * Project parsed SEQ instruction metadata into sequenceField PM attrs.
+ *
+ * @param {ParsedSeqInstruction} parsed
+ * @returns {SequenceFieldParsedAttrs}
+ */
+export function sequenceFieldAttrsFromParsed(parsed) {
+  return {
+    identifier: parsed.identifier,
+    fieldArgument: parsed.fieldArgument,
+    sequenceMode: parsed.sequenceMode,
+    hideResult: parsed.hideResult,
+    restartNumber: parsed.restartNumber,
+    restartLevel: parsed.restartLevel,
+    format: parsed.hasGeneralFormat ? parsed.format : 'ARABIC',
+    hasGeneralFormat: parsed.hasGeneralFormat,
+    pageNumberFieldFormat: parsed.pageNumberFieldFormat ?? null,
+    numericPictureFormat: parsed.numericPictureFormat,
+  };
+}
+
+/**
+ * @param {string} instruction
+ */
+function tokenizeInstruction(instruction) {
+  const tokens = [];
+  for (const match of instruction.matchAll(TOKEN_PATTERN)) {
+    tokens.push({ value: match[1] !== undefined ? unescapeQuotedToken(match[1]) : match[0] });
+  }
+  return tokens;
+}
+
+/**
+ * @param {string} instruction
+ * @param {string} keyword
+ * @returns {ParsedSeqInstruction}
+ */
+function createEmptyParse(instruction, keyword) {
+  return {
+    instruction,
+    keyword,
+    identifier: '',
+    fieldArgument: '',
+    sequenceMode: 'next',
+    hideResult: false,
+    restartNumber: null,
+    restartLevel: null,
+    format: 'Arabic',
+    numericPictureFormat: null,
+    hasGeneralFormat: false,
+    unknownSwitches: [],
+  };
+}
+
+/**
+ * @param {string} value
+ */
+function parseInteger(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || !Number.isInteger(number)) return null;
+  return Math.trunc(number);
+}
+
+/**
+ * Word often serializes numeric SEQ switches without a separating space
+ * (`\r0`, `\s1`). Normalize those into the same path as `\r 0` / `\s 1`.
+ *
+ * @param {string} token
+ */
+function parseAttachedNumericSwitch(token) {
+  const match = /^\\([rRsS])([+-]?\d+(?:\.\d+)?)$/.exec(token);
+  if (!match) return null;
+  return {
+    switchToken: `\\${match[1]}`,
+    value: match[2],
+  };
+}
+
+/**
+ * Word can serialize general-format switches without a separating space
+ * (`\*roman`). Normalize those into the same path as `\* roman`.
+ *
+ * @param {string} token
+ */
+function parseAttachedGeneralFormatSwitch(token) {
+  const match = /^\\\*(\S+)$/.exec(token);
+  return normalizeAttachedSwitchValue(match?.[1]);
+}
+
+/**
+ * Keep attached numeric picture switches (`\#00`) equivalent to `\# 00`.
+ *
+ * @param {string} token
+ */
+function parseAttachedNumericPictureSwitch(token) {
+  const match = /^\\#(\S+)$/.exec(token);
+  return normalizeAttachedSwitchValue(match?.[1]);
+}
+
+/**
+ * @param {string | undefined} value
+ */
+function normalizeAttachedSwitchValue(value) {
+  if (value == null) return null;
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return unescapeQuotedToken(value.slice(1, -1));
+  }
+  return value;
+}
+
+/**
+ * @param {ParsedSeqInstruction} result
+ * @param {string} value
+ */
+function applyGeneralFormat(result, value) {
+  const mapped = GENERAL_FORMATS.get(value) ?? CASE_INSENSITIVE_GENERAL_FORMATS.get(value.toLowerCase());
+  if (mapped) {
+    result.pageNumberFieldFormat = { format: mapped };
+  }
+}
+
+/**
+ * @param {string} value
+ */
+function unescapeQuotedToken(value) {
+  return value.replace(/\\(["\\])/g, '$1');
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.test.js
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSeqInstruction,
+  normalizeSeqIdentifier,
+  parseSeqInstruction,
+  sequenceFieldAttrsFromParsed,
+} from './seq-instruction.js';
+
+describe('parseSeqInstruction', () => {
+  it.each([
+    ['SEQ Figure', { keyword: 'SEQ', identifier: 'Figure', sequenceMode: 'next', format: 'Arabic' }],
+    ['seq Figure', { keyword: 'seq', identifier: 'Figure', sequenceMode: 'next', format: 'Arabic' }],
+    ['Seq Figure \\n', { keyword: 'Seq', identifier: 'Figure', sequenceMode: 'next' }],
+    ['SEQ Figure \\c', { identifier: 'Figure', sequenceMode: 'current' }],
+    ['SEQ Figure \\h', { identifier: 'Figure', hideResult: true }],
+    ['SEQ Figure \\r 10', { identifier: 'Figure', restartNumber: 10 }],
+    ['SEQ Figure \\r0', { identifier: 'Figure', restartNumber: 0 }],
+    ['SEQ Figure \\R0', { identifier: 'Figure', restartNumber: 0 }],
+    ['SEQ Figure \\s 1', { identifier: 'Figure', restartLevel: 1 }],
+    ['SEQ Figure \\s1', { identifier: 'Figure', restartLevel: 1 }],
+    ['SEQ Figure \\S1', { identifier: 'Figure', restartLevel: 1 }],
+    ['seq level2 \\h \\r0', { keyword: 'seq', identifier: 'level2', hideResult: true, restartNumber: 0 }],
+    ['SEQ Figure bookmarkName', { identifier: 'Figure', fieldArgument: 'bookmarkName' }],
+    ['SEQ Figure "bookmark name"', { identifier: 'Figure', fieldArgument: 'bookmark name' }],
+    [
+      'SEQ Figure \\* roman',
+      {
+        identifier: 'Figure',
+        format: 'roman',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'lowerRoman' },
+      },
+    ],
+    [
+      'SEQ Figure \\*roman',
+      {
+        identifier: 'Figure',
+        format: 'roman',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'lowerRoman' },
+      },
+    ],
+    [
+      'seq level2 \\*arabic',
+      {
+        keyword: 'seq',
+        identifier: 'level2',
+        format: 'arabic',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'decimal' },
+      },
+    ],
+    [
+      'SEQ Figure \\*"Roman"',
+      {
+        identifier: 'Figure',
+        format: 'Roman',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'upperRoman' },
+      },
+    ],
+    [
+      'SEQ Figure \\* ALPHABETIC',
+      {
+        identifier: 'Figure',
+        format: 'ALPHABETIC',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'upperLetter' },
+      },
+    ],
+    [
+      'SEQ Figure \\* ArabicDash',
+      {
+        identifier: 'Figure',
+        format: 'ArabicDash',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'numberInDash' },
+      },
+    ],
+    ['SEQ Figure \\# "00"', { identifier: 'Figure', numericPictureFormat: { picture: '00' } }],
+    ['SEQ Figure \\#00', { identifier: 'Figure', numericPictureFormat: { picture: '00' } }],
+    ['SEQ Figure \\#"00"', { identifier: 'Figure', numericPictureFormat: { picture: '00' } }],
+    ['SEQ Figure \\# "#,##0"', { identifier: 'Figure', numericPictureFormat: { picture: '#,##0' } }],
+    [
+      'SEQ Figure \\r 10 \\* roman \\h',
+      {
+        identifier: 'Figure',
+        restartNumber: 10,
+        format: 'roman',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'lowerRoman' },
+        hideResult: true,
+      },
+    ],
+    ['SEQ Figure \\c \\n', { identifier: 'Figure', sequenceMode: 'next' }],
+    ['SEQ Figure \\r nope \\s 99', { identifier: 'Figure', restartNumber: null, restartLevel: null }],
+  ])('parses %s', (instruction, expected) => {
+    expect(parseSeqInstruction(instruction)).toMatchObject({
+      instruction,
+      fieldArgument: '',
+      hideResult: false,
+      restartNumber: null,
+      restartLevel: null,
+      numericPictureFormat: null,
+      hasGeneralFormat: false,
+      unknownSwitches: [],
+      ...expected,
+    });
+  });
+
+  it('returns a safe empty parse for non-SEQ instructions', () => {
+    expect(parseSeqInstruction('PAGEREF bookmark')).toEqual({
+      instruction: 'PAGEREF bookmark',
+      keyword: 'PAGEREF',
+      identifier: '',
+      fieldArgument: '',
+      sequenceMode: 'next',
+      hideResult: false,
+      restartNumber: null,
+      restartLevel: null,
+      format: 'Arabic',
+      numericPictureFormat: null,
+      hasGeneralFormat: false,
+      unknownSwitches: [],
+    });
+  });
+
+  it('uses the shared keyword extractor for SEQ dispatch', () => {
+    expect(parseSeqInstruction('"SEQ" Figure')).toMatchObject({
+      keyword: 'SEQ',
+      identifier: '',
+      sequenceMode: 'next',
+      format: 'Arabic',
+    });
+  });
+
+  it('preserves the original instruction string without trimming', () => {
+    expect(parseSeqInstruction('  SEQ Figure  \\n  ')).toMatchObject({
+      instruction: '  SEQ Figure  \\n  ',
+      keyword: 'SEQ',
+      identifier: 'Figure',
+    });
+  });
+
+  it('keeps unknown general formats without page-number mapping', () => {
+    const parsed = parseSeqInstruction('SEQ Figure \\* OrdText');
+    expect(parsed).toMatchObject({
+      format: 'OrdText',
+      hasGeneralFormat: true,
+    });
+    expect(parsed).not.toHaveProperty('pageNumberFieldFormat');
+  });
+
+  it('preserves unknown switches as raw tokens', () => {
+    expect(parseSeqInstruction('SEQ Figure \\z value \\q').unknownSwitches).toEqual(['\\z', 'value', '\\q']);
+  });
+
+  it('preserves only the first numeric picture and records later numeric switches as unknown', () => {
+    expect(parseSeqInstruction('SEQ Figure \\# "00" \\# "000"')).toMatchObject({
+      numericPictureFormat: { picture: '00' },
+      unknownSwitches: ['\\#', '000'],
+    });
+  });
+
+  it('parses quoted identifiers and switch values', () => {
+    expect(parseSeqInstruction('SEQ "Figure Set" \\* "Roman" \\# "00"')).toMatchObject({
+      identifier: 'Figure Set',
+      format: 'Roman',
+      pageNumberFieldFormat: { format: 'upperRoman' },
+      numericPictureFormat: { picture: '00' },
+    });
+  });
+
+  it('unescapes quoted tokens without rewriting unquoted tokens', () => {
+    expect(parseSeqInstruction('SEQ "Figure \\"Set\\""').identifier).toBe('Figure "Set"');
+    expect(parseSeqInstruction('SEQ Figure\\\\Set').identifier).toBe('Figure\\\\Set');
+  });
+});
+
+describe('isSeqInstruction', () => {
+  it('matches SEQ instructions case-insensitively', () => {
+    expect(isSeqInstruction('SEQ Figure')).toBe(true);
+    expect(isSeqInstruction('seq Figure')).toBe(true);
+    expect(isSeqInstruction('PAGEREF target')).toBe(false);
+  });
+});
+
+describe('normalizeSeqIdentifier', () => {
+  it('trims string identifiers and ignores non-strings', () => {
+    expect(normalizeSeqIdentifier(' Figure ')).toBe('Figure');
+    expect(normalizeSeqIdentifier(null)).toBe('');
+  });
+});
+
+describe('sequenceFieldAttrsFromParsed', () => {
+  it('projects parsed SEQ metadata into normalized sequenceField attrs', () => {
+    const attrs = sequenceFieldAttrsFromParsed(parseSeqInstruction('SEQ Figure \\r 3 \\* roman'));
+
+    expect(attrs).toEqual({
+      identifier: 'Figure',
+      fieldArgument: '',
+      sequenceMode: 'next',
+      hideResult: false,
+      restartNumber: 3,
+      restartLevel: null,
+      format: 'roman',
+      hasGeneralFormat: true,
+      pageNumberFieldFormat: { format: 'lowerRoman' },
+      numericPictureFormat: null,
+    });
+  });
+
+  it('keeps the parser default separate from the legacy PM attr default', () => {
+    const parsed = parseSeqInstruction('SEQ Figure');
+
+    expect(parsed.format).toBe('Arabic');
+    expect(sequenceFieldAttrsFromParsed(parsed)).toMatchObject({
+      format: 'ARABIC',
+      pageNumberFieldFormat: null,
+      numericPictureFormat: null,
+    });
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
@@ -18,6 +18,7 @@ import { autoPageHandlerEntity, autoTotalPageCountEntity, sectionPageCountEntity
 import { documentStatFieldHandlerEntity } from './documentStatFieldImporter.js';
 import { pageReferenceEntity } from './pageReferenceImporter.js';
 import { crossReferenceEntity } from './crossReferenceImporter.js';
+import { sequenceFieldEntity } from './sequenceFieldImporter.js';
 import { pictNodeHandlerEntity } from './pictNodeImporter.js';
 import { importCommentData } from './documentCommentsImporter.js';
 import { buildTrackedChangeIdMap, buildTrackedChangeIdMapsByPart } from './trackedChangeIdMapper.js';
@@ -376,6 +377,7 @@ export const defaultNodeListHandler = () => {
     documentStatFieldHandlerEntity,
     pageReferenceEntity,
     crossReferenceEntity,
+    sequenceFieldEntity,
     permStartHandlerEntity,
     permEndHandlerEntity,
     mathNodeHandlerEntity,

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.integration.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.integration.test.js
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { defaultNodeListHandler } from './docxImporter.js';
+import { sequenceFieldEntity } from './sequenceFieldImporter.js';
+import { preProcessNodesForFldChar } from '../../field-references/index.js';
+
+const createEditorStub = () => ({
+  schema: {
+    nodes: {
+      run: { isInline: true, spec: { group: 'inline' } },
+      sequenceField: { isInline: true, spec: { group: 'inline', atom: true } },
+    },
+  },
+});
+
+describe('sequenceField v2 importer wiring', () => {
+  it('registers sequenceFieldEntity before passthrough in defaultNodeListHandler', () => {
+    const entities = defaultNodeListHandler().handlerEntities;
+    expect(entities).toContain(sequenceFieldEntity);
+    expect(entities.indexOf(sequenceFieldEntity)).toBeLessThan(
+      entities.findIndex((entity) => entity.handlerName === 'passthroughNodeHandler'),
+    );
+  });
+
+  it.each([
+    ['uppercase complex', 'SEQ Figure \\n \\r 10 \\s 2 \\h \\* roman', '10', 'next', 'roman'],
+    ['lowercase complex', 'seq Figure \\c \\r 10 \\s 2 \\h \\* arabic', '11', 'current', 'arabic'],
+    ['uppercase fldSimple', 'SEQ Figure \\n \\r 10 \\s 2 \\h \\* roman', '12', 'next', 'roman'],
+    ['lowercase fldSimple', 'seq Figure \\c \\r 10 \\s 2 \\h \\* arabic', '13', 'current', 'arabic'],
+  ])(
+    'imports %s SEQ fields through the real preprocessor and v2 route',
+    (_name, instruction, cachedText, sequenceMode, format) => {
+      const paragraph = _name.includes('fldSimple')
+        ? buildFldSimpleSeqParagraph(instruction, cachedText)
+        : buildComplexSeqParagraph(instruction, cachedText);
+
+      const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+      const nodeListHandler = defaultNodeListHandler();
+      const pmNodes = nodeListHandler.handler({
+        nodes: processedNodes,
+        docx: {},
+        editor: createEditorStub(),
+        path: [],
+      });
+
+      const sequenceField = collectNodesOfType(pmNodes[0], 'sequenceField')[0];
+      expect(sequenceField).toBeTruthy();
+      expect(sequenceField.attrs).toMatchObject({
+        instruction,
+        identifier: 'Figure',
+        format,
+        sequenceMode,
+        restartLevel: 2,
+        restartNumber: 10,
+        hideResult: true,
+        resolvedNumber: cachedText,
+        resolvedNumberIsCurrent: false,
+      });
+    },
+  );
+
+  it('imports sequence field arguments and numeric formats onto PM attrs', () => {
+    const instruction = 'SEQ Figure bookmark \\# "00"';
+    const paragraph = buildComplexSeqParagraph(instruction, '07');
+
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const pmNodes = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      editor: createEditorStub(),
+      path: [],
+    });
+
+    const sequenceField = collectNodesOfType(pmNodes[0], 'sequenceField')[0];
+    expect(sequenceField.attrs).toMatchObject({
+      instruction,
+      identifier: 'Figure',
+      fieldArgument: 'bookmark',
+      numericPictureFormat: { picture: '00' },
+      hasGeneralFormat: false,
+      pageNumberFieldFormat: null,
+      resolvedNumber: '07',
+      resolvedNumberIsCurrent: false,
+    });
+  });
+});
+
+function buildComplexSeqParagraph(instruction, cachedText) {
+  const run = (inner) => ({ name: 'w:r', elements: inner });
+  return {
+    name: 'w:p',
+    elements: [
+      run([{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }]),
+      run([{ name: 'w:instrText', elements: [{ type: 'text', text: instruction }] }]),
+      run([{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }]),
+      run([{ name: 'w:t', elements: [{ type: 'text', text: cachedText }] }]),
+      run([{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }]),
+    ],
+  };
+}
+
+function buildFldSimpleSeqParagraph(instruction, cachedText) {
+  return {
+    name: 'w:p',
+    elements: [
+      {
+        name: 'w:fldSimple',
+        attributes: { 'w:instr': instruction },
+        elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: cachedText }] }] }],
+      },
+    ],
+  };
+}
+
+function collectNodesOfType(root, type) {
+  const out = [];
+  const visit = (node) => {
+    if (!node) return;
+    if (node.type === type) out.push(node);
+    if (Array.isArray(node.content)) node.content.forEach(visit);
+  };
+  visit(root);
+  return out;
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.js
@@ -1,0 +1,7 @@
+import { generateV2HandlerEntity } from '@core/super-converter/v3/handlers/utils';
+import { translator } from '../../v3/handlers/sd/sequenceField/sequenceField-translator.js';
+
+/**
+ * @type {import("./docxImporter").NodeHandlerEntry}
+ */
+export const sequenceFieldEntity = generateV2HandlerEntity('sequenceFieldNodeHandler', translator);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/pageReference/pageReference-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/pageReference/pageReference-translator.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { NodeTranslator } from '@translator';
 import { exportSchemaToJson, processOutputMarks } from '../../../../exporter.js';
+import { buildInstructionElements } from '../shared/index.js';
 
 /** @type {import('@translator').XmlNodeName} */
 const XML_NODE_NAME = 'sd:pageReference';
@@ -28,6 +29,16 @@ const encode = (params) => {
     attrs: {
       instruction: node.attributes?.instruction || '',
       marksAsAttrs: node.marks || [],
+      ...(node.attributes?.instructionTokens ? { instructionTokens: node.attributes.instructionTokens } : {}),
+      ...(node.attributes?.bookmarkId ? { bookmarkId: node.attributes.bookmarkId } : {}),
+      ...(node.attributes?.hasHyperlinkSwitch ? { hasHyperlinkSwitch: true } : {}),
+      ...(node.attributes?.hasRelativePositionSwitch ? { hasRelativePositionSwitch: true } : {}),
+      ...(node.attributes?.pageNumberFieldFormat
+        ? { pageNumberFieldFormat: node.attributes.pageNumberFieldFormat }
+        : {}),
+      ...(node.attributes?.numericPictureFormat ? { numericPictureFormat: node.attributes.numericPictureFormat } : {}),
+      ...(node.attributes?.fieldResultFormat ? { fieldResultFormat: node.attributes.fieldResultFormat } : {}),
+      ...(node.attributes?.fieldRunProperties ? { fieldRunProperties: node.attributes.fieldRunProperties } : {}),
     },
     content: processedText,
   };
@@ -45,6 +56,7 @@ const decode = (params) => {
 
   const outputMarks = processOutputMarks(node.attrs?.marksAsAttrs || []);
   const contentNodes = (node.content ?? []).flatMap((n) => exportSchemaToJson({ ...params, node: n }));
+  const instructionElements = buildInstructionElements(node.attrs?.instruction, node.attrs?.instructionTokens);
   const translated = [
     {
       name: 'w:r',
@@ -63,22 +75,7 @@ const decode = (params) => {
     },
     {
       name: 'w:r',
-      elements: [
-        {
-          name: 'w:rPr',
-          elements: outputMarks,
-        },
-        {
-          name: 'w:instrText',
-          attributes: { 'xml:space': 'preserve' },
-          elements: [
-            {
-              type: 'text',
-              text: `${node.attrs.instruction}`,
-            },
-          ],
-        },
-      ],
+      elements: [{ name: 'w:rPr', elements: outputMarks }, ...instructionElements],
     },
     {
       name: 'w:r',

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/pageReference/pageReference-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/pageReference/pageReference-translator.js
@@ -2,6 +2,7 @@
 import { NodeTranslator } from '@translator';
 import { exportSchemaToJson, processOutputMarks } from '../../../../exporter.js';
 import { buildInstructionElements } from '../shared/index.js';
+import { translator as wRPrTranslator } from '../../w/rpr/index.js';
 
 /** @type {import('@translator').XmlNodeName} */
 const XML_NODE_NAME = 'sd:pageReference';
@@ -57,6 +58,7 @@ const decode = (params) => {
   const outputMarks = processOutputMarks(node.attrs?.marksAsAttrs || []);
   const contentNodes = (node.content ?? []).flatMap((n) => exportSchemaToJson({ ...params, node: n }));
   const instructionElements = buildInstructionElements(node.attrs?.instruction, node.attrs?.instructionTokens);
+  const instructionRunProperties = resolveInstructionRunProperties(params, outputMarks);
   const translated = [
     {
       name: 'w:r',
@@ -75,7 +77,7 @@ const decode = (params) => {
     },
     {
       name: 'w:r',
-      elements: [{ name: 'w:rPr', elements: outputMarks }, ...instructionElements],
+      elements: [{ name: 'w:rPr', elements: instructionRunProperties }, ...instructionElements],
     },
     {
       name: 'w:r',
@@ -111,6 +113,27 @@ const decode = (params) => {
   ];
 
   return translated;
+};
+
+const resolveInstructionRunProperties = (params, outputMarks) => {
+  const { node } = params;
+  const fieldRunProperties = node.attrs?.fieldRunProperties;
+  const shouldUseFieldRunProperties =
+    node.attrs?.fieldResultFormat === 'charformat' &&
+    fieldRunProperties &&
+    typeof fieldRunProperties === 'object' &&
+    !Array.isArray(fieldRunProperties) &&
+    Object.keys(fieldRunProperties).length > 0;
+
+  if (!shouldUseFieldRunProperties) {
+    return outputMarks;
+  }
+
+  const fieldRunPropertiesNode = wRPrTranslator.decode({
+    ...params,
+    node: { attrs: { runProperties: fieldRunProperties } },
+  });
+  return Array.isArray(fieldRunPropertiesNode?.elements) ? fieldRunPropertiesNode.elements : outputMarks;
 };
 
 /** @type {import('@translator').NodeTranslatorConfig} */

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/pageReference/pageReference-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/pageReference/pageReference-translator.test.js
@@ -61,4 +61,31 @@ describe('pageReference translator', () => {
     expect(JSON.stringify(exported)).not.toContain('bookmarkId');
     expect(JSON.stringify(exported)).not.toContain('pageNumberFieldFormat');
   });
+
+  it('serializes CHARFORMAT fieldRunProperties on the instruction run', () => {
+    const exported = exportSchemaToJson({
+      node: {
+        type: 'pageReference',
+        attrs: {
+          instruction: 'PAGEREF target \\* CHARFORMAT',
+          fieldResultFormat: 'charformat',
+          fieldRunProperties: { bold: true, color: { val: '00FF00' } },
+          marksAsAttrs: [{ type: 'italic', attrs: {} }],
+        },
+        content: [{ type: 'text', text: '7' }],
+      },
+    });
+
+    const instructionRun = exported.find((node) => node?.elements?.some((element) => element?.name === 'w:instrText'));
+    const instructionRunProperties = instructionRun?.elements?.find((element) => element?.name === 'w:rPr');
+    expect(instructionRunProperties?.elements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'w:b' }),
+        expect.objectContaining({ name: 'w:color', attributes: { 'w:val': '00FF00' } }),
+      ]),
+    );
+    expect(instructionRunProperties?.elements).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'w:i' })]),
+    );
+  });
 });

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/pageReference/pageReference-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/pageReference/pageReference-translator.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { exportSchemaToJson } from '../../../../exporter.js';
+import { translator as pageReferenceTranslator } from './pageReference-translator.js';
+
+describe('pageReference translator', () => {
+  it('encodes runtime attrs from sd:pageReference attributes', () => {
+    const encoded = pageReferenceTranslator.encode({
+      nodes: [
+        {
+          name: 'sd:pageReference',
+          attributes: {
+            instruction: 'PAGEREF target \\h',
+            bookmarkId: 'target',
+            hasHyperlinkSwitch: true,
+            hasRelativePositionSwitch: true,
+            pageNumberFieldFormat: { format: 'upperRoman' },
+            numericPictureFormat: { picture: '00' },
+            fieldResultFormat: 'mergeformat',
+          },
+          elements: [],
+        },
+      ],
+      nodeListHandler: { handler: () => [] },
+    });
+
+    expect(encoded.attrs).toMatchObject({
+      instruction: 'PAGEREF target \\h',
+      bookmarkId: 'target',
+      hasHyperlinkSwitch: true,
+      hasRelativePositionSwitch: true,
+      pageNumberFieldFormat: { format: 'upperRoman' },
+      numericPictureFormat: { picture: '00' },
+      fieldResultFormat: 'mergeformat',
+    });
+  });
+
+  it('decodes instruction tokens and does not serialize runtime-only attrs', () => {
+    const exported = exportSchemaToJson({
+      node: {
+        type: 'pageReference',
+        attrs: {
+          instruction: 'PAGEREF target \\h',
+          instructionTokens: [
+            { type: 'text', text: 'PAGEREF target ' },
+            { type: 'tab' },
+            { type: 'text', text: '\\h' },
+          ],
+          bookmarkId: 'target',
+          hasHyperlinkSwitch: true,
+          pageNumberFieldFormat: { format: 'upperRoman' },
+          numericPictureFormat: { picture: '00' },
+        },
+        content: [{ type: 'text', text: '7' }],
+      },
+    });
+
+    const instructionRun = exported.find((node) =>
+      node?.elements?.some((element) => element?.name === 'w:instrText' || element?.name === 'w:tab'),
+    );
+    expect(instructionRun?.elements?.some((element) => element?.name === 'w:tab')).toBe(true);
+    expect(JSON.stringify(exported)).not.toContain('bookmarkId');
+    expect(JSON.stringify(exported)).not.toContain('pageNumberFieldFormat');
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequence-field-export-routing.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequence-field-export-routing.test.js
@@ -30,6 +30,16 @@ function hasFieldCharType(node, fieldType) {
   );
 }
 
+function resultTexts(exported) {
+  const separateIndex = exported.findIndex((node) => hasFieldCharType(node, 'separate'));
+  const endIndex = exported.findIndex((node) => hasFieldCharType(node, 'end'));
+  return exported
+    .slice(separateIndex + 1, endIndex)
+    .flatMap((node) => node?.elements ?? [])
+    .filter((element) => element?.name === 'w:t')
+    .map((element) => element?.elements?.[0]?.text);
+}
+
 describe('sequenceField export routing', () => {
   it('extracts cached result text from run-wrapped field content', () => {
     const encoded = sequenceFieldTranslator.encode({
@@ -51,6 +61,83 @@ describe('sequenceField export routing', () => {
     });
 
     expect(encoded.attrs.resolvedNumber).toBe('1');
+    expect(encoded.attrs.resolvedNumberIsCurrent).toBe(false);
+    expect(encoded.attrs.identifier).toBe('level2');
+    expect(encoded.attrs.format).toBe('arabic');
+  });
+
+  it('round-trips lowercase SEQ cached result text before recompute', () => {
+    const encoded = sequenceFieldTranslator.encode({
+      nodes: [
+        {
+          name: 'sd:sequenceField',
+          attributes: { instruction: 'seq Figure \\* arabic' },
+          elements: [
+            {
+              type: 'run',
+              content: [{ type: 'text', text: '42', marks: [] }],
+            },
+          ],
+        },
+      ],
+      nodeListHandler: {
+        handler: () => [{ type: 'run', content: [{ type: 'text', text: '42', marks: [] }] }],
+      },
+    });
+
+    const exported = exportSchemaToJson({ node: encoded });
+    const resultRun = exported.find(
+      (node) =>
+        node?.name === 'w:r' &&
+        node?.elements?.some((element) => element?.name === 'w:t' && element?.elements?.[0]?.text === '42'),
+    );
+
+    expect(encoded.attrs.resolvedNumberIsCurrent).toBe(false);
+    expect(resultRun).toBeTruthy();
+  });
+
+  it('exports current resolvedNumber instead of stale cached child content', () => {
+    const exported = exportSchemaToJson({
+      node: buildSequenceFieldNode({
+        attrs: { resolvedNumber: '12', resolvedNumberIsCurrent: true },
+        content: [{ type: 'run', attrs: {}, content: [{ type: 'text', text: '3' }] }],
+      }),
+    });
+
+    expect(resultTexts(exported)).toEqual(['12']);
+  });
+
+  it('exports no result runs for current hidden or empty output', () => {
+    const exported = exportSchemaToJson({
+      node: buildSequenceFieldNode({
+        attrs: { resolvedNumber: '', resolvedNumberIsCurrent: true },
+        content: [{ type: 'run', attrs: {}, content: [{ type: 'text', text: '3' }] }],
+      }),
+    });
+
+    expect(resultTexts(exported)).toEqual([]);
+  });
+
+  it('preserves imported cached child content when resolvedNumber is not current', () => {
+    const exported = exportSchemaToJson({
+      node: buildSequenceFieldNode({
+        attrs: { resolvedNumber: '12', resolvedNumberIsCurrent: false },
+        content: [{ type: 'run', attrs: {}, content: [{ type: 'text', text: '3' }] }],
+      }),
+    });
+
+    expect(resultTexts(exported)).toEqual(['3']);
+  });
+
+  it('falls back to non-current resolvedNumber when no cached child content exists', () => {
+    const exported = exportSchemaToJson({
+      node: buildSequenceFieldNode({
+        attrs: { resolvedNumber: '12', resolvedNumberIsCurrent: false },
+        content: [],
+      }),
+    });
+
+    expect(resultTexts(exported)).toEqual(['12']);
   });
 
   it('exports sequenceField nodes as fldChar + instrText runs', () => {
@@ -69,6 +156,32 @@ describe('sequenceField export routing', () => {
     const instructionElement = instructionRun?.elements?.find((element) => element?.name === 'w:instrText');
 
     expect(instructionElement?.elements?.[0]?.text).toBe(SEQUENCE_FIELD_INSTRUCTION);
+  });
+
+  it('preserves raw split instructionTokens during export', () => {
+    const instructionTokens = [
+      { type: 'text', text: 'SEQ Figure ' },
+      { type: 'text', text: '\\* roman' },
+    ];
+    const exported = exportSchemaToJson({
+      node: buildSequenceFieldNode({
+        attrs: {
+          instruction: 'SEQ Figure \\* roman',
+          instructionTokens,
+          resolvedNumber: '1',
+          resolvedNumberIsCurrent: true,
+        },
+      }),
+    });
+
+    const instructionRun = exported.find(
+      (node) => node?.name === 'w:r' && node?.elements?.some((element) => element?.name === 'w:instrText'),
+    );
+    const instructionTexts = instructionRun?.elements
+      ?.filter((element) => element?.name === 'w:instrText')
+      .map((element) => element?.elements?.[0]?.text);
+
+    expect(instructionTexts).toEqual(['SEQ Figure ', '\\* roman']);
   });
 
   it('expands run-wrapped sequenceField nodes into field-code runs', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequenceField-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequenceField-translator.js
@@ -1,6 +1,10 @@
 // @ts-check
 import { NodeTranslator } from '@translator';
 import { exportSchemaToJson, processOutputMarks } from '../../../../exporter.js';
+import {
+  parseSeqInstruction,
+  sequenceFieldAttrsFromParsed,
+} from '../../../../field-references/shared/seq-instruction.js';
 import { buildInstructionElements } from '../shared/index.js';
 
 /** @type {import('@translator').XmlNodeName} */
@@ -24,17 +28,18 @@ const encode = (params) => {
   });
 
   const instruction = node.attributes?.instruction || '';
-  const { identifier, format, restartLevel } = parseSeqInstruction(instruction);
+  const parsed = parseSeqInstruction(instruction);
+  const parsedAttrs = sequenceFieldAttrsFromParsed(parsed);
 
   return {
     type: SD_NODE_NAME,
     attrs: {
       instruction,
       instructionTokens: node.attributes?.instructionTokens || null,
-      identifier,
-      format,
-      restartLevel,
+      // Raw instruction remains the export source of truth; these parsed attrs support import-time routing and later evaluation.
+      ...parsedAttrs,
       resolvedNumber: extractResolvedText(processedText),
+      resolvedNumberIsCurrent: false,
       marksAsAttrs: node.marks || [],
     },
     content: processedText,
@@ -49,7 +54,7 @@ const encode = (params) => {
 const decode = (params) => {
   const { node } = params;
   const outputMarks = processOutputMarks(node.attrs?.marksAsAttrs || []);
-  const contentNodes = (node.content ?? []).flatMap((n) => exportSchemaToJson({ ...params, node: n }));
+  const contentNodes = buildResultContentNodes(params, outputMarks);
   const instructionElements = buildInstructionElements(node.attrs?.instruction, node.attrs?.instructionTokens);
 
   return [
@@ -83,27 +88,43 @@ const decode = (params) => {
 };
 
 /**
- * Parses a SEQ instruction into its components.
- * @param {string} instruction
- * @returns {{ identifier: string; format: string; restartLevel: number | null }}
+ * @param {import('@translator').SCDecoderConfig} params
+ * @param {Array<any>} outputMarks
+ * @returns {Array<any>}
  */
-function parseSeqInstruction(instruction) {
-  const parts = instruction.trim().split(/\s+/);
-  const identifier = parts[1] || '';
-  let format = 'ARABIC';
-  let restartLevel = null;
+function buildResultContentNodes(params, outputMarks) {
+  const { node } = params;
+  const resolvedNumber = node.attrs?.resolvedNumber;
+  const hasCurrentResult = node.attrs?.resolvedNumberIsCurrent === true;
 
-  for (let i = 2; i < parts.length; i++) {
-    if (parts[i] === '\\*' && parts[i + 1]) {
-      format = parts[i + 1];
-      i++;
-    } else if (parts[i] === '\\s' && parts[i + 1]) {
-      restartLevel = parseInt(parts[i + 1], 10) || null;
-      i++;
-    }
+  if (hasCurrentResult) {
+    return typeof resolvedNumber === 'string' && resolvedNumber.length > 0
+      ? [buildResolvedNumberRun(resolvedNumber, outputMarks)]
+      : [];
   }
 
-  return { identifier, format, restartLevel };
+  if (Array.isArray(node.content) && node.content.length > 0) {
+    return node.content.flatMap((n) => exportSchemaToJson({ ...params, node: n }));
+  }
+
+  return typeof resolvedNumber === 'string' && resolvedNumber.length > 0
+    ? [buildResolvedNumberRun(resolvedNumber, outputMarks)]
+    : [];
+}
+
+/**
+ * @param {string} text
+ * @param {Array<any>} outputMarks
+ * @returns {any}
+ */
+function buildResolvedNumberRun(text, outputMarks) {
+  return {
+    name: 'w:r',
+    elements: [
+      { name: 'w:rPr', elements: outputMarks },
+      { name: 'w:t', elements: [{ type: 'text', text }] },
+    ],
+  };
 }
 
 /**

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.js
@@ -66,6 +66,9 @@ function getPageNumberFieldAttrs(node) {
   if (node.attributes?.pageNumberZeroPadding != null) {
     attrs.pageNumberZeroPadding = Number(node.attributes.pageNumberZeroPadding);
   }
+  if (node.attributes?.pageNumberNumericPicture) {
+    attrs.pageNumberNumericPicture = node.attributes.pageNumberNumericPicture;
+  }
   return attrs;
 }
 
@@ -82,7 +85,7 @@ function resolveCachedPageCount(params, node) {
   const cacheMap = params.statFieldCacheMap;
   if (cacheMap?.has?.('NUMPAGES')) {
     const pageCount = Number(cacheMap.get('NUMPAGES'));
-    if (node.attrs?.pageNumberFormat || node.attrs?.pageNumberZeroPadding) {
+    if (node.attrs?.pageNumberFormat || node.attrs?.pageNumberZeroPadding || node.attrs?.pageNumberNumericPicture) {
       return formatPageNumberFieldValue(pageCount, node.attrs);
     }
     return String(cacheMap.get('NUMPAGES'));

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.test.js
@@ -89,6 +89,30 @@ describe('sd:totalPageNumber translator', () => {
           {
             name: 'sd:totalPageNumber',
             attributes: {
+              instruction: 'NUMPAGES \\# "#,##0"',
+              pageNumberNumericPicture: '#,##0',
+            },
+            elements: [],
+          },
+        ],
+      });
+
+      expect(result.attrs).toEqual({
+        marksAsAttrs: [],
+        importedCachedText: null,
+        instruction: 'NUMPAGES \\# "#,##0"',
+        pageNumberNumericPicture: '#,##0',
+      });
+    });
+
+    it('preserves imported zero-padding field attributes', () => {
+      vi.mocked(parseMarks).mockReturnValue([]);
+
+      const result = config.encode({
+        nodes: [
+          {
+            name: 'sd:totalPageNumber',
+            attributes: {
               instruction: 'NUMPAGES \\# "00"',
               pageNumberFormat: 'decimal',
               pageNumberZeroPadding: 2,
@@ -186,6 +210,39 @@ describe('sd:totalPageNumber translator', () => {
       expect(result[3].elements[1].elements[0].text).toBe('07');
     });
 
+    it('round-trips an imported numeric-picture attr through PM attrs and exported cached text', () => {
+      vi.mocked(parseMarks).mockReturnValue([]);
+      vi.mocked(processOutputMarks).mockReturnValue([]);
+
+      const imported = config.encode({
+        nodes: [
+          {
+            name: 'sd:totalPageNumber',
+            attributes: {
+              instruction: 'NUMPAGES \\# "#,##0"',
+              pageNumberNumericPicture: '#,##0',
+              importedCachedText: '1,000',
+            },
+            elements: [],
+          },
+        ],
+      });
+
+      expect(imported.attrs).toMatchObject({
+        instruction: 'NUMPAGES \\# "#,##0"',
+        pageNumberNumericPicture: '#,##0',
+        importedCachedText: '1,000',
+      });
+
+      const exported = config.decode({
+        node: imported,
+        statFieldCacheMap: new Map([['NUMPAGES', 1234]]),
+      });
+
+      expect(exported[1].elements[1].elements[0].text).toBe(' NUMPAGES \\# "#,##0"');
+      expect(exported[3].elements[1].elements[0].text).toBe('1,234');
+    });
+
     it('falls back to resolvedText when cache map is absent', () => {
       vi.mocked(processOutputMarks).mockReturnValue([]);
 
@@ -236,11 +293,11 @@ describe('sd:totalPageNumber translator', () => {
       const result = config.decode({
         node: {
           type: 'total-page-number',
-          attrs: { instruction: 'NUMPAGES \\# "00"', importedCachedText: '07' },
+          attrs: { instruction: 'NUMPAGES \\# "#   pages"', importedCachedText: '7   pages' },
         },
       });
 
-      expect(result[1].elements[1].elements[0].text).toBe(' NUMPAGES \\# "00"');
+      expect(result[1].elements[1].elements[0].text).toBe(' NUMPAGES \\# "#   pages"');
     });
   });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/caption-resolver.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/caption-resolver.test.ts
@@ -81,4 +81,39 @@ describe('caption resolver', () => {
     expect(seqCaption?.instruction).toBe('SEQ Figure \\* ARABIC');
     expect(seqCaption?.label).toBe('Figure');
   });
+
+  it('detects lowercase seq fields by SEQ field fallback', () => {
+    ({ editor } = initTestEditor({
+      content: docData.docx,
+      media: docData.media,
+      mediaFiles: docData.mediaFiles,
+      fonts: docData.fonts,
+      useImmediateSetTimeout: false,
+    }));
+
+    const sequenceField = editor.schema.nodes.sequenceField.create({
+      instruction: 'seq Figure \\* arabic',
+      identifier: 'Figure',
+      format: 'arabic',
+      resolvedNumber: '1',
+      marksAsAttrs: [],
+      sdBlockId: 'seq-caption-node-lowercase',
+    });
+
+    const captionParagraph = editor.schema.nodes.paragraph.create(
+      {
+        sdBlockId: 'caption-seq-only-lowercase',
+      },
+      [sequenceField, editor.schema.text(': Caption with lowercase seq')],
+    );
+
+    editor.dispatch(editor.state.tr.insert(editor.state.doc.content.size, captionParagraph));
+
+    const captions = findAllCaptions(editor.state.doc);
+    const seqCaption = captions.find((caption) => caption.nodeId === 'caption-seq-only-lowercase');
+
+    expect(seqCaption).toBeTruthy();
+    expect(seqCaption?.instruction).toBe('seq Figure \\* arabic');
+    expect(seqCaption?.label).toBe('Figure');
+  });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/caption-resolver.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/caption-resolver.ts
@@ -11,6 +11,7 @@ import type { Editor } from '../../core/Editor.js';
 import type { CaptionAddress, CaptionDomain, CaptionInfo, DiscoveryItem } from '@superdoc/document-api';
 import { buildDiscoveryItem, buildResolvedHandle } from '@superdoc/document-api';
 import { DocumentApiAdapterError } from '../errors.js';
+import { isSeqInstruction } from '../../core/super-converter/field-references/shared/seq-instruction.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -54,7 +55,7 @@ function isCaptionParagraph(node: ProseMirrorNode): boolean {
   const seqField = findSeqField(node);
   if (!seqField) return false;
   const instruction = (seqField.attrs?.instruction as string) ?? '';
-  return instruction.trim().startsWith('SEQ ');
+  return isSeqInstruction(instruction);
 }
 
 function findSeqField(node: ProseMirrorNode): ProseMirrorNode | null {

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.test.ts
@@ -22,12 +22,40 @@ const schema = new Schema({
         resolvedText: { default: null },
       },
     },
+    'total-page-number': {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      content: 'text*',
+      attrs: {
+        instruction: { default: null },
+        importedCachedText: { default: null },
+        resolvedText: { default: null },
+      },
+    },
+    sequenceField: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        instruction: { default: '' },
+        identifier: { default: '' },
+        resolvedNumber: { default: '' },
+      },
+    },
   },
 });
 
 function createDocWithSectionPageCount(attrs: Record<string, unknown>, text?: string): ProseMirrorNode {
   const content = text ? schema.text(text) : undefined;
   const field = schema.nodes['section-page-count'].create(attrs, content);
+  const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, field);
+  return schema.nodes.doc.create(null, paragraph);
+}
+
+function createDocWithTotalPageNumber(attrs: Record<string, unknown>, text?: string): ProseMirrorNode {
+  const content = text ? schema.text(text) : undefined;
+  const field = schema.nodes['total-page-number'].create(attrs, content);
   const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, field);
   return schema.nodes.doc.create(null, paragraph);
 }
@@ -63,5 +91,45 @@ describe('field-resolver synthetic section page count fields', () => {
         resolvedText: '4',
       },
     ]);
+  });
+});
+
+describe('field-resolver synthetic total page number fields', () => {
+  it('discovers total-page-number with imported switched instruction', () => {
+    const doc = createDocWithTotalPageNumber({ instruction: 'NUMPAGES \\# "#,##0"', resolvedText: '1,234' });
+
+    expect(findAllFields(doc)).toEqual([
+      {
+        pos: 1,
+        blockId: 'block-1',
+        occurrenceIndex: 0,
+        nestingDepth: 0,
+        instruction: 'NUMPAGES \\# "#,##0"',
+        fieldType: 'NUMPAGES',
+        resolvedText: '1,234',
+      },
+    ]);
+  });
+});
+
+describe('field-resolver sequence fields', () => {
+  it('uses sequenceField.resolvedNumber as resolvedText', () => {
+    const field = schema.nodes.sequenceField.create({
+      instruction: 'SEQ Figure \\* ARABIC',
+      identifier: 'Figure',
+      resolvedNumber: '2',
+    });
+    const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-seq' }, field);
+    const doc = schema.nodes.doc.create(null, paragraph);
+
+    expect(findAllFields(doc)).toContainEqual({
+      pos: 1,
+      blockId: 'block-seq',
+      occurrenceIndex: 0,
+      nestingDepth: 0,
+      instruction: 'SEQ Figure \\* ARABIC',
+      fieldType: 'SEQ',
+      resolvedText: '2',
+    });
   });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.ts
@@ -56,7 +56,14 @@ const SYNTHETIC_FIELD_NODE_TYPES: Record<
   string,
   { fieldType: string; instruction: string; resolveInstruction?: (node: ProseMirrorNode) => string }
 > = {
-  'total-page-number': { fieldType: 'NUMPAGES', instruction: 'NUMPAGES' },
+  'total-page-number': {
+    fieldType: 'NUMPAGES',
+    instruction: 'NUMPAGES',
+    resolveInstruction: (node) =>
+      typeof node.attrs?.instruction === 'string' && node.attrs.instruction.trim()
+        ? node.attrs.instruction
+        : 'NUMPAGES',
+  },
   'section-page-count': {
     fieldType: 'SECTIONPAGES',
     instruction: 'SECTIONPAGES',
@@ -112,7 +119,10 @@ export function findAllFields(doc: ProseMirrorNode): ResolvedField[] {
     blockOccurrenceCounters.set(blockId, counter + 1);
 
     const fieldType = extractFieldType(instruction);
-    const resolvedText = (node.attrs?.resolvedText as string) ?? '';
+    const resolvedText =
+      node.type.name === 'sequenceField'
+        ? ((node.attrs?.resolvedNumber as string) ?? '')
+        : ((node.attrs?.resolvedText as string) ?? '');
 
     results.push({
       pos,

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sections-resolver.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sections-resolver.ts
@@ -4,6 +4,8 @@ import type {
   SectionDomain,
   SectionInfo,
   SectionPageMargins,
+  SectionPageNumbering,
+  SectionPageNumberingFormat,
   SectionsListQuery,
   SectionsListResult,
 } from '@superdoc/document-api';
@@ -65,10 +67,43 @@ interface ConverterWithSections {
 }
 
 const PIXELS_PER_INCH = 96;
+const SECTION_PAGE_NUMBER_FORMATS: readonly SectionPageNumberingFormat[] = [
+  'decimal',
+  'lowerLetter',
+  'upperLetter',
+  'lowerRoman',
+  'upperRoman',
+  'numberInDash',
+] as const;
 
 function pxToInches(value: number | null | undefined): number | undefined {
   if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
   return value / PIXELS_PER_INCH;
+}
+
+function toSectionPageNumbering(numbering: SectionRange['numbering']): SectionPageNumbering | undefined {
+  if (!numbering) return undefined;
+
+  const format = SECTION_PAGE_NUMBER_FORMATS.includes(numbering.format as SectionPageNumberingFormat)
+    ? (numbering.format as SectionPageNumberingFormat)
+    : undefined;
+  const result: SectionPageNumbering = {
+    start: numbering.start,
+    format,
+    chapterStyle: numbering.chapterStyle,
+    chapterSeparator: numbering.chapterSeparator,
+  };
+
+  if (
+    result.start === undefined &&
+    result.format === undefined &&
+    result.chapterStyle === undefined &&
+    result.chapterSeparator === undefined
+  ) {
+    return undefined;
+  }
+
+  return result;
 }
 
 function buildSectionId(index: number): string {
@@ -301,7 +336,7 @@ function sectionRangeToSectionDomain(
     headerFooterMargins: hasHeaderFooterMargins ? headerFooterMargins : undefined,
     columns: hasColumns ? columns : undefined,
     lineNumbering: parsedLineNumbering,
-    pageNumbering: range.numbering ?? parsedPageNumbering,
+    pageNumbering: toSectionPageNumbering(range.numbering) ?? parsedPageNumbering,
     titlePage: range.titlePg,
     oddEvenHeadersFooters,
     verticalAlign: range.vAlign ?? parsedVerticalAlign,

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.test.ts
@@ -1,0 +1,193 @@
+import { Schema, type Node as ProseMirrorNode } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
+import { describe, expect, it } from 'vitest';
+import { updateSequenceFieldsInTransaction } from './sequence-field-updater.js';
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      attrs: {
+        sdBlockId: { default: null },
+        paragraphProperties: { default: null },
+        styleName: { default: null },
+      },
+    },
+    text: { group: 'inline' },
+    sequenceField: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        instruction: { default: '' },
+        identifier: { default: '' },
+        fieldArgument: { default: '' },
+        sequenceMode: { default: 'next' },
+        hideResult: { default: false },
+        restartNumber: { default: null },
+        restartLevel: { default: null },
+        format: { default: 'Arabic' },
+        hasGeneralFormat: { default: false },
+        pageNumberFieldFormat: { default: null },
+        numericPictureFormat: { default: null },
+        resolvedNumber: { default: '' },
+        resolvedNumberIsCurrent: { default: false },
+        sdBlockId: { default: null },
+      },
+    },
+  },
+});
+
+function seq(instruction: string, attrs: Record<string, unknown> = {}) {
+  return schema.nodes.sequenceField.create({
+    instruction,
+    ...attrs,
+  });
+}
+
+function p(...content: ProseMirrorNode[]) {
+  return schema.nodes.paragraph.create({}, content);
+}
+
+function resolvedNumbers(doc: ProseMirrorNode): string[] {
+  const values: string[] = [];
+  doc.descendants((node) => {
+    if (node.type.name === 'sequenceField') values.push(node.attrs.resolvedNumber as string);
+    return true;
+  });
+  return values;
+}
+
+function updateDoc(doc: ProseMirrorNode, options: Parameters<typeof updateSequenceFieldsInTransaction>[0] = {} as any) {
+  const state = EditorState.create({ schema, doc });
+  const tr = state.tr;
+  const result = updateSequenceFieldsInTransaction({
+    tr,
+    schema,
+    ...options,
+  });
+  return { result, doc: tr.doc };
+}
+
+describe('updateSequenceFieldsInTransaction', () => {
+  it('recomputes all SEQ fields in document order and marks them current', () => {
+    const doc = schema.nodes.doc.create(null, [
+      p(seq('SEQ Figure \\* ARABIC', { resolvedNumber: '9' })),
+      p(seq('SEQ Figure \\* ARABIC', { resolvedNumber: '9' })),
+      p(seq('SEQ Table \\* ARABIC', { resolvedNumber: '9' })),
+    ]);
+
+    const updated = updateDoc(doc);
+
+    expect(updated.result).toEqual({ changed: true, updated: 3 });
+    expect(resolvedNumbers(updated.doc)).toEqual(['1', '2', '1']);
+    updated.doc.descendants((node) => {
+      if (node.type.name === 'sequenceField') expect(node.attrs.resolvedNumberIsCurrent).toBe(true);
+      return true;
+    });
+  });
+
+  it('evaluates fields before a range but only writes overlapping nodes', () => {
+    const first = p(seq('SEQ Figure'));
+    const second = p(seq('SEQ Figure'));
+    const doc = schema.nodes.doc.create(null, [first, second]);
+    const secondPos = first.nodeSize + 1;
+
+    const updated = updateDoc(doc, { scope: { kind: 'range', from: secondPos, to: secondPos + second.nodeSize } });
+
+    expect(updated.result).toEqual({ changed: true, updated: 1 });
+    expect(resolvedNumbers(updated.doc)).toEqual(['', '2']);
+  });
+
+  it('updates only the requested identifier while preserving shared counter evaluation', () => {
+    const doc = schema.nodes.doc.create(null, [
+      p(seq('SEQ Figure')),
+      p(seq('SEQ Table')),
+      p(seq('SEQ Figure')),
+      p(seq('SEQ Table')),
+    ]);
+
+    const updated = updateDoc(doc, { scope: { kind: 'identifier', identifier: 'Table' } });
+
+    expect(updated.result).toEqual({ changed: true, updated: 2 });
+    expect(resolvedNumbers(updated.doc)).toEqual(['', '1', '', '2']);
+  });
+
+  it('uses shared style-aware heading resolution for restart-level fields when converter context is available', () => {
+    const heading = schema.nodes.paragraph.create({
+      paragraphProperties: { styleId: 'HeadingOne' },
+    });
+    const caption1 = p(seq('SEQ Figure \\s 1'));
+    const heading2 = schema.nodes.paragraph.create({
+      paragraphProperties: { styleId: 'HeadingOne' },
+    });
+    const caption2 = p(seq('SEQ Figure \\s 1'));
+    const doc = schema.nodes.doc.create(null, [heading, caption1, heading2, caption2]);
+
+    const updated = updateDoc(doc, {
+      converterContext: {
+        translatedLinkedStyles: {
+          docDefaults: {},
+          styles: {
+            HeadingOne: { name: 'Custom Heading', paragraphProperties: { outlineLvl: 0 } },
+          },
+        },
+        translatedNumbering: {},
+      } as any,
+    });
+
+    expect(resolvedNumbers(updated.doc)).toEqual(['1', '1']);
+  });
+
+  it('skips restart-level heading resets when converter context is unavailable', () => {
+    const heading = schema.nodes.paragraph.create({
+      paragraphProperties: { outlineLvl: 0 },
+    });
+    const caption1 = p(seq('SEQ Figure \\s 1'));
+    const heading2 = schema.nodes.paragraph.create({
+      paragraphProperties: { outlineLvl: 0 },
+    });
+    const caption2 = p(seq('SEQ Figure \\s 1'));
+    const doc = schema.nodes.doc.create(null, [heading, caption1, heading2, caption2]);
+
+    const updated = updateDoc(doc);
+
+    expect(resolvedNumbers(updated.doc)).toEqual(['1', '2']);
+  });
+
+  it('parses stale attrs from the raw instruction before writing current results', () => {
+    const doc = schema.nodes.doc.create(null, [
+      p(
+        seq('SEQ Figure \\r 7 \\* roman', {
+          identifier: 'Stale',
+          restartNumber: null,
+          format: 'Arabic',
+        }),
+      ),
+    ]);
+
+    const updated = updateDoc(doc);
+    const field = updated.doc.nodeAt(1);
+
+    expect(field?.attrs.identifier).toBe('Figure');
+    expect(field?.attrs.restartNumber).toBe(7);
+    expect(field?.attrs.format).toBe('roman');
+    expect(field?.attrs.pageNumberFieldFormat).toEqual({ format: 'lowerRoman' });
+    expect(field?.attrs.resolvedNumber).toBe('vii');
+  });
+
+  it('handles field arguments conservatively without advancing counters', () => {
+    const doc = schema.nodes.doc.create(null, [
+      p(seq('SEQ Figure')),
+      p(seq('SEQ Figure bookmark', { resolvedNumber: 'cached' })),
+      p(seq('SEQ Figure bookmark')),
+      p(seq('SEQ Figure')),
+    ]);
+
+    const updated = updateDoc(doc);
+
+    expect(resolvedNumbers(updated.doc)).toEqual(['1', 'cached', '1', '2']);
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.ts
@@ -1,0 +1,181 @@
+import type { Schema, Node as ProseMirrorNode } from 'prosemirror-model';
+import type { Transaction } from 'prosemirror-state';
+import type { PageNumberFieldFormat } from '@superdoc/contracts';
+import type { ParagraphProperties } from '@superdoc/style-engine/ooxml';
+import type { ConverterContext } from '../../core/layout-adapter/converter-context.js';
+import { resolveParagraphHeadingLevel } from '../../core/layout-adapter/attributes/paragraph.js';
+import { SequenceFieldEvaluator } from '../../core/super-converter/field-references/shared/seq-evaluator.js';
+import {
+  normalizeSeqIdentifier,
+  parseSeqInstruction,
+  sequenceFieldAttrsFromParsed,
+} from '../../core/super-converter/field-references/shared/seq-instruction.js';
+
+export type SequenceFieldUpdateScope =
+  | { kind: 'all' }
+  | { kind: 'range'; from: number; to: number }
+  | { kind: 'identifier'; identifier: string };
+
+type SequenceFieldAttrs = Record<string, unknown> & {
+  instruction: string;
+  identifier: string;
+  fieldArgument: string;
+  sequenceMode: 'next' | 'current';
+  hideResult: boolean;
+  restartNumber: number | null;
+  restartLevel: number | null;
+  format: string;
+  hasGeneralFormat: boolean;
+  pageNumberFieldFormat: PageNumberFieldFormat | null;
+  numericPictureFormat: { picture: string } | null;
+  resolvedNumber?: string;
+  resolvedNumberIsCurrent?: boolean;
+};
+
+export function updateSequenceFieldsInTransaction(args: {
+  tr: Transaction;
+  schema: Schema;
+  scope?: SequenceFieldUpdateScope;
+  converterContext?: ConverterContext;
+}): { changed: boolean; updated: number } {
+  const { tr, scope = { kind: 'all' }, converterContext } = args;
+  const sequenceFieldType = args.schema.nodes.sequenceField;
+  if (!sequenceFieldType) return { changed: false, updated: 0 };
+
+  const evaluator = new SequenceFieldEvaluator();
+  let changed = false;
+  let updated = 0;
+
+  // Body-only by design: tr.doc is the main story document. Header/footer and
+  // note editors render correctly via layout, but are not rewritten by this API path.
+  tr.doc.descendants((node, pos) => {
+    if (node.type.name === 'paragraph') {
+      evaluator.enterParagraph({
+        paragraphHeadingLevel: resolveNodeHeadingLevel(node, converterContext),
+      });
+      return true;
+    }
+
+    if (node.type !== sequenceFieldType) return true;
+
+    const nextAttrs = buildEvaluatedSequenceAttrs(node);
+    const evaluation = evaluator.evaluateField({
+      identifier: nextAttrs.identifier,
+      instruction: nextAttrs.instruction,
+      fieldArgument: nextAttrs.fieldArgument,
+      sequenceMode: nextAttrs.sequenceMode,
+      hideResult: nextAttrs.hideResult,
+      restartNumber: nextAttrs.restartNumber,
+      restartLevel: nextAttrs.restartLevel,
+      format: nextAttrs.format,
+      hasGeneralFormat: nextAttrs.hasGeneralFormat,
+      pageNumberFieldFormat: nextAttrs.pageNumberFieldFormat,
+      numericPictureFormat: nextAttrs.numericPictureFormat,
+      cachedText: typeof node.attrs.resolvedNumber === 'string' ? node.attrs.resolvedNumber : '',
+    });
+
+    if (!shouldWriteSequenceField(node, pos, scope, nextAttrs.identifier)) return true;
+
+    nextAttrs.resolvedNumber = evaluation.text;
+    nextAttrs.resolvedNumberIsCurrent = true;
+
+    if (!attrsEqual(node.attrs, nextAttrs)) {
+      tr.setNodeMarkup(resolveCurrentTransactionPos(tr, pos, node), undefined, nextAttrs);
+      changed = true;
+    }
+    updated += 1;
+    return true;
+  });
+
+  return { changed, updated };
+}
+
+export function getSequenceFieldUpdaterConverterContext(editor: unknown): ConverterContext | undefined {
+  const converter = (editor as { converter?: Partial<ConverterContext> } | null | undefined)?.converter;
+  if (!converter?.translatedLinkedStyles) return undefined;
+
+  return {
+    translatedLinkedStyles: converter.translatedLinkedStyles,
+    translatedNumbering: converter.translatedNumbering ?? {},
+    docx: converter.docx,
+  } as ConverterContext;
+}
+
+function resolveNodeHeadingLevel(node: ProseMirrorNode, converterContext?: ConverterContext): number | undefined {
+  const paragraphProperties = node.attrs?.paragraphProperties;
+  if (converterContext) {
+    return resolveParagraphHeadingLevel(
+      isRecord(paragraphProperties) ? (paragraphProperties as ParagraphProperties) : undefined,
+      converterContext,
+    );
+  }
+
+  // Without style data, skip SEQ \s heading resets rather than applying a
+  // partial heuristic that can diverge from the rendered layout.
+  return undefined;
+}
+
+function buildEvaluatedSequenceAttrs(node: ProseMirrorNode): SequenceFieldAttrs {
+  const instruction = typeof node.attrs.instruction === 'string' ? node.attrs.instruction : '';
+  const parsed = parseSeqInstruction(instruction);
+  const parsedAttrs = sequenceFieldAttrsFromParsed(parsed);
+
+  return {
+    ...node.attrs,
+    instruction,
+    ...parsedAttrs,
+    identifier: parsedAttrs.identifier || readStringAttr(node, 'identifier'),
+  };
+}
+
+function shouldWriteSequenceField(
+  node: ProseMirrorNode,
+  pos: number,
+  scope: SequenceFieldUpdateScope,
+  identifier: string,
+): boolean {
+  if (scope.kind === 'all') return true;
+  if (scope.kind === 'range') {
+    const end = pos + node.nodeSize;
+    return pos < scope.to && end > scope.from;
+  }
+
+  return normalizeSeqIdentifier(identifier) === normalizeSeqIdentifier(scope.identifier);
+}
+
+function readStringAttr(node: ProseMirrorNode, key: string): string {
+  const value = node.attrs?.[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function attrsEqual(left: Record<string, unknown>, right: Record<string, unknown>): boolean {
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if (!valuesEqual(left[key], right[key])) return false;
+  }
+  return true;
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (!isRecord(left) || !isRecord(right)) return false;
+
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if (!valuesEqual(left[key], right[key])) return false;
+  }
+  return true;
+}
+
+function resolveCurrentTransactionPos(tr: Transaction, pos: number, node: ProseMirrorNode): number {
+  // This helper walks tr.doc, so positions are usually already current. When a
+  // caller provides a transaction with prior steps (for example fields.insert),
+  // mapping those current positions again can point inside text nodes.
+  const currentNode = tr.doc.nodeAt(pos);
+  if (currentNode?.type === node.type) return pos;
+  return tr.mapping.map(pos);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/caption-wrappers.seq-fields.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/caption-wrappers.seq-fields.test.ts
@@ -1,0 +1,108 @@
+import { Schema } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
+import { describe, expect, it } from 'vitest';
+import type { Editor } from '../../core/Editor.js';
+import { findAllCaptions } from '../helpers/caption-resolver.js';
+import { captionsConfigureWrapper, captionsInsertWrapper } from './caption-wrappers.js';
+import { registerBuiltInExecutors } from './register-executors.js';
+
+registerBuiltInExecutors();
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { sdBlockId: { default: null }, paragraphProperties: { default: null } },
+      toDOM: () => ['p', 0],
+    },
+    text: { group: 'inline' },
+    hardBreak: { group: 'inline', inline: true, atom: true, toDOM: () => ['br'] },
+    tab: { group: 'inline', inline: true, atom: true, toDOM: () => ['span'] },
+    sequenceField: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        instruction: { default: '' },
+        identifier: { default: '' },
+        fieldArgument: { default: '' },
+        sequenceMode: { default: 'next' },
+        hideResult: { default: false },
+        restartNumber: { default: null },
+        restartLevel: { default: null },
+        format: { default: 'Arabic' },
+        hasGeneralFormat: { default: false },
+        pageNumberFieldFormat: { default: null },
+        numericPictureFormat: { default: null },
+        resolvedNumber: { default: '' },
+        resolvedNumberIsCurrent: { default: false },
+        sdBlockId: { default: null },
+      },
+      toDOM: () => ['span', 0],
+    },
+  },
+});
+
+function createEditor(): Editor {
+  const doc = schema.nodes.doc.create(null, [
+    schema.nodes.paragraph.create({ sdBlockId: 'anchor-1' }, schema.text('Anchor 1')),
+    schema.nodes.paragraph.create({ sdBlockId: 'anchor-2' }, schema.text('Anchor 2')),
+  ]);
+  const editor = {
+    schema,
+    state: EditorState.create({ schema, doc }),
+    converter: {
+      translatedLinkedStyles: { docDefaults: {}, styles: {} },
+      translatedNumbering: {},
+    },
+    view: { dispatch: () => {} },
+    dispatch(tr) {
+      this.state = this.state.apply(tr);
+    },
+  };
+  return editor as unknown as Editor;
+}
+
+function insertCaption(editor: Editor, anchorId: string, text: string) {
+  return captionsInsertWrapper(editor, {
+    label: 'Figure',
+    adjacentTo: { kind: 'block', nodeType: 'paragraph', nodeId: anchorId },
+    position: 'below',
+    text,
+  });
+}
+
+describe('caption wrappers SEQ fields', () => {
+  it('captions.insert recomputes SEQ numbers for inserted captions', () => {
+    const editor = createEditor();
+
+    expect(insertCaption(editor, 'anchor-1', 'One').success).toBe(true);
+    expect(insertCaption(editor, 'anchor-2', 'Two').success).toBe(true);
+
+    const captions = findAllCaptions(editor.state.doc).filter((caption) => caption.label === 'Figure');
+    expect(captions.map((caption) => caption.number)).toEqual(['1', '2']);
+  });
+
+  it('captions.configure updates matching SEQ format attrs and recomputes values', () => {
+    const editor = createEditor();
+    insertCaption(editor, 'anchor-1', 'One');
+    insertCaption(editor, 'anchor-2', 'Two');
+
+    const result = captionsConfigureWrapper(editor, { label: 'Figure', format: 'lowerRoman' });
+
+    expect(result.success).toBe(true);
+    const fields: any[] = [];
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'sequenceField') fields.push(node);
+      return true;
+    });
+    expect(fields.map((field) => field.attrs.instruction)).toEqual(['SEQ Figure \\* roman', 'SEQ Figure \\* roman']);
+    expect(fields.map((field) => field.attrs.pageNumberFieldFormat)).toEqual([
+      { format: 'lowerRoman' },
+      { format: 'lowerRoman' },
+    ]);
+    expect(fields.map((field) => field.attrs.resolvedNumber)).toEqual(['i', 'ii']);
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/caption-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/caption-wrappers.ts
@@ -31,6 +31,14 @@ import { rejectTrackedMode } from '../helpers/mutation-helpers.js';
 import { Fragment } from 'prosemirror-model';
 import { clearIndexCache } from '../helpers/index-cache.js';
 import { buildTextWithTabs } from '../helpers/text-with-tabs.js';
+import {
+  getSequenceFieldUpdaterConverterContext,
+  updateSequenceFieldsInTransaction,
+} from '../helpers/sequence-field-updater.js';
+import {
+  parseSeqInstruction,
+  sequenceFieldAttrsFromParsed,
+} from '../../core/super-converter/field-references/shared/seq-instruction.js';
 
 // ---------------------------------------------------------------------------
 // Result helpers
@@ -130,12 +138,14 @@ export function captionsInsertWrapper(
 
       // Add SEQ field if the node type exists
       if (schema.nodes.sequenceField) {
+        const instruction = `SEQ ${label} \\* ARABIC`;
+        const parsed = parseSeqInstruction(instruction);
         children.push(
           schema.nodes.sequenceField.create({
-            instruction: `SEQ ${label} \\* ARABIC`,
-            identifier: label,
-            format: 'ARABIC',
+            instruction,
+            ...sequenceFieldAttrsFromParsed(parsed),
             resolvedNumber: '',
+            resolvedNumberIsCurrent: false,
             sdBlockId: `seq-${Date.now()}`,
           }),
         );
@@ -155,6 +165,12 @@ export function captionsInsertWrapper(
 
       const { tr } = editor.state;
       tr.insert(pos, captionParagraph);
+      updateSequenceFieldsInTransaction({
+        tr,
+        schema,
+        scope: { kind: 'identifier', identifier: label },
+        converterContext: getSequenceFieldUpdaterConverterContext(editor),
+      });
       editor.dispatch(tr);
       clearIndexCache(editor);
       return true;
@@ -268,18 +284,33 @@ export function captionsConfigureWrapper(
 
         const format = CAPTION_FORMAT_TO_OOXML[input.format ?? 'decimal'] ?? 'ARABIC';
         const newInstruction = `SEQ ${input.label} \\* ${format}`;
-        if (node.attrs.instruction === newInstruction && node.attrs.format === format) return true;
+        const parsed = parseSeqInstruction(newInstruction);
+        const parsedAttrs = sequenceFieldAttrsFromParsed(parsed);
+        if (
+          node.attrs.instruction === newInstruction &&
+          node.attrs.format === format &&
+          JSON.stringify(node.attrs.pageNumberFieldFormat) === JSON.stringify(parsedAttrs.pageNumberFieldFormat)
+        ) {
+          return true;
+        }
 
         tr.setNodeMarkup(tr.mapping.map(pos), undefined, {
           ...node.attrs,
           instruction: newInstruction,
-          format,
+          ...parsedAttrs,
+          resolvedNumberIsCurrent: false,
         });
         changed = true;
         return true;
       });
 
       if (!changed) return false;
+      updateSequenceFieldsInTransaction({
+        tr,
+        schema: editor.schema,
+        scope: { kind: 'identifier', identifier: input.label },
+        converterContext: getSequenceFieldUpdaterConverterContext(editor),
+      });
       editor.dispatch(tr);
       clearIndexCache(editor);
       return true;

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
@@ -44,6 +44,21 @@ const schema = new Schema({
       },
       toDOM: () => ['span', 0],
     },
+    'total-page-number': {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      content: 'text*',
+      attrs: {
+        instruction: { default: null },
+        importedCachedText: { default: null },
+        resolvedText: { default: null },
+        pageNumberFormat: { default: null },
+        pageNumberZeroPadding: { default: null },
+        pageNumberNumericPicture: { default: null },
+      },
+      toDOM: () => ['span', 0],
+    },
   },
 });
 
@@ -73,10 +88,39 @@ function createEditorWithSectionPageCount(
   return editor as unknown as Editor;
 }
 
-function createEditorForInsert(sectionPageCount?: number): Editor {
+function createEditorWithTotalPageNumber(
+  pageCount: number | undefined,
+  initialValue = '1',
+  attrs: Record<string, unknown> = {},
+): Editor {
+  const field = schema.nodes['total-page-number'].create(
+    { instruction: 'NUMPAGES', resolvedText: initialValue, ...attrs },
+    schema.text(initialValue),
+  );
+  const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, field);
+  const doc = schema.nodes.doc.create(null, paragraph);
+
+  const editor = {
+    schema,
+    state: EditorState.create({ schema, doc }),
+    currentTotalPages: pageCount,
+    options: {},
+    view: { dispatch: () => {} },
+    dispatch(tr) {
+      this.state = this.state.apply(tr);
+    },
+  };
+
+  return editor as unknown as Editor;
+}
+
+function createEditorForInsert(sectionPageCount?: number, isHeaderOrFooter = false): Editor {
   const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, schema.text('x'));
   const doc = schema.nodes.doc.create(null, paragraph);
-  const options = sectionPageCount == null ? {} : { sectionPageCount };
+  const options = {
+    ...(sectionPageCount == null ? {} : { sectionPageCount }),
+    ...(isHeaderOrFooter ? { isHeaderOrFooter: true } : {}),
+  };
 
   const editor = {
     schema,
@@ -177,5 +221,92 @@ describe('fieldsRebuildWrapper SECTIONPAGES fields', () => {
     expect(updatedField?.type.name).toBe('section-page-count');
     expect(updatedField?.attrs.resolvedText).toBe('3');
     expect(updatedField?.textContent).toBe('3');
+  });
+});
+
+describe('fieldsRebuildWrapper NUMPAGES fields', () => {
+  it('inserts NUMPAGES as a total-page-number node with numeric picture attrs in headers/footers', () => {
+    const editor = createEditorForInsert(undefined, true);
+
+    const result = fieldsInsertWrapper(editor, {
+      mode: 'raw',
+      instruction: 'NUMPAGES \\# "#,##0"',
+      at: { kind: 'text', segments: [{ blockId: 'block-1', range: { start: 0, end: 0 } }] },
+    });
+
+    expect(result.success).toBe(true);
+    const insertedField = editor.state.doc.nodeAt(1);
+    expect(insertedField?.type.name).toBe('total-page-number');
+    expect(insertedField?.attrs).toMatchObject({
+      instruction: 'NUMPAGES \\# "#,##0"',
+      pageNumberNumericPicture: '#,##0',
+    });
+  });
+
+  it('preserves quoted NUMPAGES numeric picture whitespace during insert', () => {
+    const editor = createEditorForInsert(undefined, true);
+
+    const result = fieldsInsertWrapper(editor, {
+      mode: 'raw',
+      instruction: 'NUMPAGES \\# "#   pages"',
+      at: { kind: 'text', segments: [{ blockId: 'block-1', range: { start: 0, end: 0 } }] },
+    });
+
+    expect(result.success).toBe(true);
+    const insertedField = editor.state.doc.nodeAt(1);
+    expect(insertedField?.type.name).toBe('total-page-number');
+    expect(insertedField?.attrs).toMatchObject({
+      instruction: 'NUMPAGES \\# "#   pages"',
+      pageNumberNumericPicture: '#   pages',
+    });
+  });
+
+  it('inserts NUMPAGES as a total-page-number node with general format attrs in headers/footers', () => {
+    const editor = createEditorForInsert(undefined, true);
+
+    const result = fieldsInsertWrapper(editor, {
+      mode: 'raw',
+      instruction: 'NUMPAGES \\* Ordinal',
+      at: { kind: 'text', segments: [{ blockId: 'block-1', range: { start: 0, end: 0 } }] },
+    });
+
+    expect(result.success).toBe(true);
+    const insertedField = editor.state.doc.nodeAt(1);
+    expect(insertedField?.type.name).toBe('total-page-number');
+    expect(insertedField?.attrs).toMatchObject({
+      instruction: 'NUMPAGES \\* Ordinal',
+      pageNumberFormat: 'ordinal',
+    });
+  });
+
+  it('formats rebuilt total-page-number values with pageNumberFormat', () => {
+    const editor = createEditorWithTotalPageNumber(4, '1', { pageNumberFormat: 'upperRoman' });
+
+    const result = fieldsRebuildWrapper(editor, {
+      target: { kind: 'field', blockId: 'block-1', occurrenceIndex: 0, nestingDepth: 0 },
+    });
+
+    expect(result.success).toBe(true);
+    const updatedField = editor.state.doc.nodeAt(1);
+    expect(updatedField?.type.name).toBe('total-page-number');
+    expect(updatedField?.attrs.resolvedText).toBe('IV');
+    expect(updatedField?.textContent).toBe('IV');
+  });
+
+  it('formats rebuilt total-page-number values with numeric picture switches', () => {
+    const editor = createEditorWithTotalPageNumber(1234, '1', {
+      pageNumberFormat: 'decimal',
+      pageNumberNumericPicture: '#,##0 pages',
+    });
+
+    const result = fieldsRebuildWrapper(editor, {
+      target: { kind: 'field', blockId: 'block-1', occurrenceIndex: 0, nestingDepth: 0 },
+    });
+
+    expect(result.success).toBe(true);
+    const updatedField = editor.state.doc.nodeAt(1);
+    expect(updatedField?.type.name).toBe('total-page-number');
+    expect(updatedField?.attrs.resolvedText).toBe('1,234 pages');
+    expect(updatedField?.textContent).toBe('1,234 pages');
   });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.seq-fields.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.seq-fields.test.ts
@@ -1,0 +1,149 @@
+import { Schema } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
+import { describe, expect, it } from 'vitest';
+import type { Editor } from '../../core/Editor.js';
+import { fieldsInsertWrapper, fieldsRebuildWrapper } from './field-wrappers.js';
+import { registerBuiltInExecutors } from './register-executors.js';
+
+registerBuiltInExecutors();
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { sdBlockId: { default: null }, paragraphProperties: { default: null } },
+      toDOM: () => ['p', 0],
+    },
+    text: { group: 'inline' },
+    sequenceField: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        instruction: { default: '' },
+        identifier: { default: '' },
+        fieldArgument: { default: '' },
+        sequenceMode: { default: 'next' },
+        hideResult: { default: false },
+        restartNumber: { default: null },
+        restartLevel: { default: null },
+        format: { default: 'Arabic' },
+        hasGeneralFormat: { default: false },
+        pageNumberFieldFormat: { default: null },
+        numericPictureFormat: { default: null },
+        resolvedNumber: { default: '' },
+        resolvedNumberIsCurrent: { default: false },
+        sdBlockId: { default: null },
+      },
+      toDOM: () => ['span', 0],
+    },
+  },
+});
+
+function createEditor(doc = schema.nodes.doc.create(null, [paragraph('block-1', 'A')])): Editor {
+  const editor = {
+    schema,
+    state: EditorState.create({ schema, doc }),
+    converter: {
+      translatedLinkedStyles: { docDefaults: {}, styles: {} },
+      translatedNumbering: {},
+    },
+    view: { dispatch: () => {} },
+    dispatch(tr) {
+      this.state = this.state.apply(tr);
+    },
+  };
+  return editor as unknown as Editor;
+}
+
+function paragraph(id: string, text?: string) {
+  return schema.nodes.paragraph.create({ sdBlockId: id }, text ? schema.text(text) : null);
+}
+
+function seq(instruction: string, attrs: Record<string, unknown> = {}) {
+  return schema.nodes.sequenceField.create({ instruction, ...attrs });
+}
+
+function fieldInsertInput(instruction: string) {
+  return {
+    mode: 'raw' as const,
+    instruction,
+    at: {
+      segments: [{ blockId: 'block-1', range: { start: 1, end: 1 } }],
+    },
+  };
+}
+
+function sequenceFields(editor: Editor) {
+  const fields: any[] = [];
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === 'sequenceField') fields.push(node);
+    return true;
+  });
+  return fields;
+}
+
+describe('field wrappers SEQ fields', () => {
+  it('fields.insert raw SEQ creates parsed attrs and a computed result', () => {
+    const editor = createEditor();
+
+    const result = fieldsInsertWrapper(editor, fieldInsertInput('SEQ Figure \\* ARABIC'));
+
+    expect(result.success).toBe(true);
+    const [field] = sequenceFields(editor);
+    expect(field.attrs.identifier).toBe('Figure');
+    expect(field.attrs.pageNumberFieldFormat).toEqual({ format: 'decimal' });
+    expect(field.attrs.resolvedNumber).toBe('1');
+    expect(field.attrs.resolvedNumberIsCurrent).toBe(true);
+  });
+
+  it('fields.insert recomputes existing matching SEQ fields in document order', () => {
+    const firstCaption = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, [
+      seq('SEQ Figure \\* ARABIC', { resolvedNumber: '9' }),
+      schema.text('A'),
+    ]);
+    const doc = schema.nodes.doc.create(null, [firstCaption]);
+    const editor = createEditor(doc);
+
+    const result = fieldsInsertWrapper(editor, fieldInsertInput('SEQ Figure \\* ARABIC'));
+
+    expect(result.success).toBe(true);
+    expect(sequenceFields(editor).map((node) => node.attrs.resolvedNumber)).toEqual(['1', '2']);
+  });
+
+  it('fields.rebuild recomputes stale SEQ resolvedNumber values for the full document', () => {
+    const doc = schema.nodes.doc.create(null, [
+      schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, [
+        seq('SEQ Figure \\* ARABIC', { resolvedNumber: '9' }),
+        seq('SEQ Figure \\* ARABIC', { resolvedNumber: '9' }),
+      ]),
+    ]);
+    const editor = createEditor(doc);
+
+    const result = fieldsRebuildWrapper(editor, {
+      target: { kind: 'field', blockId: 'block-1', occurrenceIndex: 0, nestingDepth: 0 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(sequenceFields(editor).map((node) => node.attrs.resolvedNumber)).toEqual(['1', '2']);
+  });
+
+  it('fields.rebuild succeeds when SEQ values are already current', () => {
+    const doc = schema.nodes.doc.create(null, [
+      schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, [
+        seq('SEQ Figure \\* ARABIC', { resolvedNumber: '1', resolvedNumberIsCurrent: true }),
+        seq('SEQ Figure \\* ARABIC', { resolvedNumber: '2', resolvedNumberIsCurrent: true }),
+      ]),
+    ]);
+    const editor = createEditor(doc);
+
+    const result = fieldsRebuildWrapper(editor, {
+      target: { kind: 'field', blockId: 'block-1', occurrenceIndex: 0, nestingDepth: 0 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(sequenceFields(editor).map((node) => node.attrs.resolvedNumber)).toEqual(['1', '2']);
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
@@ -15,6 +15,7 @@ import type {
   MutationOptions,
   ReceiptFailureCode,
 } from '@superdoc/document-api';
+import { formatPageNumberFieldValue } from '@superdoc/contracts';
 import { buildDiscoveryResult } from '@superdoc/document-api';
 import {
   findAllFields,
@@ -31,6 +32,16 @@ import { DocumentApiAdapterError } from '../errors.js';
 import { getWordStatistics, resolveDocumentStatFieldValue, resolveMainBodyEditor } from '../helpers/word-statistics.js';
 import { resolveSectionPageCountFieldValue } from '../helpers/section-page-count.js';
 import { parsePageNumberFieldSwitches } from '../../core/super-converter/field-references/shared/page-number-field-switches.js';
+import { getPageNumberFieldFormat } from '../../core/layout-adapter/converters/inline-converters/page-number-field-format.js';
+import {
+  isSeqInstruction,
+  parseSeqInstruction,
+  sequenceFieldAttrsFromParsed,
+} from '../../core/super-converter/field-references/shared/seq-instruction.js';
+import {
+  getSequenceFieldUpdaterConverterContext,
+  updateSequenceFieldsInTransaction,
+} from '../helpers/sequence-field-updater.js';
 
 // ---------------------------------------------------------------------------
 // Result helpers
@@ -110,7 +121,7 @@ export function fieldsInsertWrapper(
   }
 
   if (fieldType === 'NUMPAGES') {
-    return insertNumPagesField(editor, resolved, options);
+    return insertNumPagesField(editor, input, resolved, options);
   }
 
   if (fieldType === 'SECTIONPAGES') {
@@ -164,6 +175,7 @@ function insertDocumentStatField(
 
 function insertNumPagesField(
   editor: Editor,
+  input: FieldInsertInput,
   resolved: { from: number },
   options?: MutationOptions,
 ): FieldMutationResult {
@@ -181,10 +193,12 @@ function insertNumPagesField(
     );
   }
 
+  const parsedInstruction = parsePageNumberFieldSwitches(input.instruction, 'NUMPAGES');
+
   const receipt = executeDomainCommand(
     editor,
     (): boolean => {
-      const node = nodeType.create({});
+      const node = nodeType.create(parsedInstruction);
       const { tr } = editor.state;
       tr.insert(resolved.from, node);
       editor.dispatch(tr);
@@ -265,15 +279,35 @@ function insertRawField(
     editor,
     (): boolean => {
       const fieldType = extractFieldType(input.instruction);
-      const node = fieldNodeType.create({
-        instruction: input.instruction,
-        identifier: fieldType,
-        format: 'ARABIC',
-        resolvedNumber: '',
-        sdBlockId: `field-${Date.now()}`,
-      });
+      const isSeq = isSeqInstruction(input.instruction);
+      const parsed = isSeq ? parseSeqInstruction(input.instruction) : null;
+      const node = fieldNodeType.create(
+        parsed
+          ? {
+              instruction: input.instruction,
+              ...sequenceFieldAttrsFromParsed(parsed),
+              resolvedNumber: '',
+              resolvedNumberIsCurrent: false,
+              sdBlockId: `field-${Date.now()}`,
+            }
+          : {
+              instruction: input.instruction,
+              identifier: fieldType,
+              format: 'ARABIC',
+              resolvedNumber: '',
+              sdBlockId: `field-${Date.now()}`,
+            },
+      );
       const { tr } = editor.state;
       tr.insert(resolved.from, node);
+      if (parsed) {
+        updateSequenceFieldsInTransaction({
+          tr,
+          schema: editor.schema,
+          scope: { kind: 'identifier', identifier: parsed.identifier },
+          converterContext: getSequenceFieldUpdaterConverterContext(editor),
+        });
+      }
       editor.dispatch(tr);
       clearIndexCache(editor);
       return true;
@@ -318,6 +352,10 @@ export function fieldsRebuildWrapper(
     return rebuildSectionPageCount(editor, resolved, address, options);
   }
 
+  if (node.type.name === 'sequenceField' && isSeqInstruction((node.attrs?.instruction as string) ?? '')) {
+    return rebuildSequenceFields(editor, address, options);
+  }
+
   // Default: clear resolvedNumber to force re-evaluation (sequence fields, etc.)
   const receipt = executeDomainCommand(
     editor,
@@ -337,6 +375,29 @@ export function fieldsRebuildWrapper(
   );
 
   if (!receiptApplied(receipt)) return fieldFailure('NO_OP', 'Rebuild produced no change.');
+  return fieldSuccess(address);
+}
+
+function rebuildSequenceFields(editor: Editor, address: FieldAddress, options?: MutationOptions): FieldMutationResult {
+  executeDomainCommand(
+    editor,
+    () => {
+      const { tr } = editor.state;
+      const result = updateSequenceFieldsInTransaction({
+        tr,
+        schema: editor.schema,
+        scope: { kind: 'all' },
+        converterContext: getSequenceFieldUpdaterConverterContext(editor),
+      });
+      if (result.changed) {
+        editor.dispatch(tr);
+        clearIndexCache(editor);
+      }
+      return true;
+    },
+    { expectedRevision: options?.expectedRevision },
+  );
+
   return fieldSuccess(address);
 }
 
@@ -397,7 +458,10 @@ function rebuildTotalPageNumber(
 
   if (stats.pages == null) return fieldSuccess(address);
 
-  const freshValue = String(stats.pages);
+  const node = editor.state.doc.nodeAt(resolved.pos);
+  if (!node) return fieldFailure('TARGET_NOT_FOUND', 'Node not found.');
+
+  const freshValue = formatPageNumberFieldValue(stats.pages, getPageNumberFieldFormat(node.attrs));
 
   const receipt = executeDomainCommand(
     editor,

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
@@ -1,4 +1,5 @@
 import { Extension } from '@core/Extension.js';
+import { formatPageNumberFieldValue } from '@superdoc/contracts';
 import { findFieldsInRange } from '../../document-api-adapters/helpers/field-resolver.js';
 import { findAllTocNodes } from '../../document-api-adapters/helpers/toc-resolver.js';
 import {
@@ -7,9 +8,19 @@ import {
   resolveMainBodyEditor,
 } from '../../document-api-adapters/helpers/word-statistics.js';
 import { resolveSectionPageCountFieldValue } from '../../document-api-adapters/helpers/section-page-count.js';
+import {
+  getSequenceFieldUpdaterConverterContext,
+  updateSequenceFieldsInTransaction,
+} from '../../document-api-adapters/helpers/sequence-field-updater.js';
+import { getPageNumberFieldFormat } from '../../core/layout-adapter/converters/inline-converters/page-number-field-format.js';
 
 /** Stat-field types refreshed by F9 when the doc has no TOCs. */
 const UPDATABLE_FIELD_TYPES = new Set(['NUMWORDS', 'NUMCHARS', 'NUMPAGES', 'SECTIONPAGES']);
+
+function resolveTotalPageNumberFieldValue(stats, node) {
+  if (stats.pages == null) return null;
+  return formatPageNumberFieldValue(stats.pages, getPageNumberFieldFormat(node.attrs));
+}
 
 /**
  * @module FieldUpdate
@@ -40,6 +51,8 @@ export const FieldUpdate = Extension.create({
         () =>
         ({ editor, state, tr: outerTr, dispatch }) => {
           const { from, to } = state.selection;
+          const originalSelectionFields = findFieldsInRange(state.doc, from, to);
+          const selectionHadSeq = originalSelectionFields.some((field) => field.fieldType === 'SEQ');
           let tocPathRan = false;
 
           // toc.update dispatches its own transaction per TOC; CommandService
@@ -85,14 +98,21 @@ export const FieldUpdate = Extension.create({
             }
           }
 
-          const fields = findFieldsInRange(state.doc, from, to);
+          const activeState = tocPathRan && editor?.state?.doc ? editor.state : state;
+          const activeDoc = activeState.doc ?? state.doc;
+          const activeSchema = activeState.schema ?? state.schema;
+          const activeFrom = Math.min(from, activeDoc.content.size);
+          const activeTo = to >= state.doc.content.size ? activeDoc.content.size : Math.min(to, activeDoc.content.size);
+
+          const fields = findFieldsInRange(activeDoc, activeFrom, activeTo);
           const updatable = fields.filter((f) => UPDATABLE_FIELD_TYPES.has(f.fieldType));
-          if (updatable.length === 0) return tocPathRan;
+          const hasSeqSelection = selectionHadSeq || fields.some((field) => field.fieldType === 'SEQ');
+          if (updatable.length === 0 && !hasSeqSelection) return tocPathRan;
 
           const mainEditor = resolveMainBodyEditor(editor);
           const stats = getWordStatistics(mainEditor);
 
-          const tr = state.tr;
+          const tr = activeState.tr;
           let changed = false;
 
           // Process in reverse position order so earlier positions stay valid
@@ -106,14 +126,16 @@ export const FieldUpdate = Extension.create({
             const freshValue =
               field.fieldType === 'SECTIONPAGES'
                 ? resolveSectionPageCountFieldValue(editor, node)
-                : resolveDocumentStatFieldValue(field.fieldType, stats);
+                : field.fieldType === 'NUMPAGES' && node.type.name === 'total-page-number'
+                  ? resolveTotalPageNumberFieldValue(stats, node)
+                  : resolveDocumentStatFieldValue(field.fieldType, stats);
             if (freshValue == null) continue;
 
             if (node.type.name === 'total-page-number' || node.type.name === 'section-page-count') {
               // Page-count fields store their display value as a text child,
               // not just an attr. Replace the entire node so both the text
               // content and resolvedText stay in sync.
-              const textChild = freshValue ? state.schema.text(freshValue) : null;
+              const textChild = freshValue ? activeSchema.text(freshValue) : null;
               const newNode = node.type.create({ ...node.attrs, resolvedText: freshValue }, textChild);
               tr.replaceWith(field.pos, field.pos + node.nodeSize, newNode);
               changed = true;
@@ -127,6 +149,16 @@ export const FieldUpdate = Extension.create({
               });
               changed = true;
             }
+          }
+
+          if (hasSeqSelection) {
+            const result = updateSequenceFieldsInTransaction({
+              tr,
+              schema: activeSchema,
+              scope: { kind: 'all' },
+              converterContext: getSequenceFieldUpdaterConverterContext(editor),
+            });
+            changed = changed || result.changed;
           }
 
           if (!changed) return tocPathRan;

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
@@ -308,6 +308,42 @@ const mixedSchema = new Schema({
       },
       toDOM: () => ['span', 0],
     },
+    'total-page-number': {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      content: 'text*',
+      attrs: {
+        instruction: { default: null },
+        importedCachedText: { default: null },
+        resolvedText: { default: null },
+        pageNumberFormat: { default: null },
+        pageNumberZeroPadding: { default: null },
+        pageNumberNumericPicture: { default: null },
+      },
+      toDOM: () => ['span', 0],
+    },
+    sequenceField: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        instruction: { default: '' },
+        identifier: { default: '' },
+        fieldArgument: { default: '' },
+        sequenceMode: { default: 'next' },
+        hideResult: { default: false },
+        restartNumber: { default: null },
+        restartLevel: { default: null },
+        format: { default: 'Arabic' },
+        hasGeneralFormat: { default: false },
+        pageNumberFieldFormat: { default: null },
+        numericPictureFormat: { default: null },
+        resolvedNumber: { default: '' },
+        resolvedNumberIsCurrent: { default: false },
+      },
+      toDOM: () => ['span', 0],
+    },
     text: { group: 'inline' },
   },
 });
@@ -429,6 +465,44 @@ describe('updateFieldsInSelection — TOC + stat fields combined (regression)', 
     expect(updatedField.textContent).toBe('004');
   });
 
+  it('updates NUMPAGES fields with preserved numeric picture formatting', () => {
+    const para = (children) => mixedSchema.nodes.paragraph.create({}, children);
+    const totalPageNumberField = mixedSchema.nodes['total-page-number'].create(
+      {
+        instruction: 'NUMPAGES \\# "#,##0 pages"',
+        pageNumberNumericPicture: '#,##0 pages',
+        resolvedText: '1 pages',
+      },
+      mixedSchema.text('1 pages'),
+    );
+    const doc = mixedSchema.nodes.doc.create({}, [para([totalPageNumberField])]);
+    const editorState = EditorState.create({ schema: mixedSchema, doc });
+    const editor = {
+      currentTotalPages: 1234,
+      state: editorState,
+    };
+
+    const commands = FieldUpdate.config.addCommands.call({ editor });
+    const command = commands.updateFieldsInSelection();
+    const outerTr = editorState.tr;
+    const dispatch = vi.fn();
+    const state = {
+      doc,
+      selection: { from: 0, to: doc.content.size },
+      schema: mixedSchema,
+      tr: outerTr,
+    };
+
+    const result = command({ editor, state, tr: outerTr, dispatch });
+
+    expect(result).toBe(true);
+    const updatedDoc = dispatch.mock.calls[0][0].doc;
+    const updatedField = updatedDoc.nodeAt(1);
+    expect(updatedField.type.name).toBe('total-page-number');
+    expect(updatedField.attrs.resolvedText).toBe('1,234 pages');
+    expect(updatedField.textContent).toBe('1,234 pages');
+  });
+
   it('leaves SECTIONPAGES fields unchanged when section page context is unavailable', () => {
     const para = (children) => mixedSchema.nodes.paragraph.create({}, children);
     const sectionPageCountField = mixedSchema.nodes['section-page-count'].create(
@@ -463,6 +537,98 @@ describe('updateFieldsInSelection — TOC + stat fields combined (regression)', 
     const unchangedField = editorState.doc.nodeAt(1);
     expect(unchangedField.attrs.resolvedText).toBe('3');
     expect(unchangedField.textContent).toBe('3');
+  });
+
+  it('recomputes stale SEQ fields when the selection contains SEQ', () => {
+    const para = (children) => mixedSchema.nodes.paragraph.create({}, children);
+    const seq = (instruction) =>
+      mixedSchema.nodes.sequenceField.create({
+        instruction,
+        identifier: 'Figure',
+        resolvedNumber: '9',
+      });
+    const doc = mixedSchema.nodes.doc.create({}, [para([seq('SEQ Figure')]), para([seq('SEQ Figure')])]);
+    const editorState = EditorState.create({ schema: mixedSchema, doc });
+    const editor = {
+      state: editorState,
+      converter: { translatedLinkedStyles: { docDefaults: {}, styles: {} }, translatedNumbering: {} },
+    };
+
+    const commands = FieldUpdate.config.addCommands.call({ editor });
+    const command = commands.updateFieldsInSelection();
+    const dispatch = vi.fn();
+    const result = command({
+      editor,
+      state: { doc, selection: { from: 0, to: doc.content.size }, schema: mixedSchema, tr: editorState.tr },
+      tr: editorState.tr,
+      dispatch,
+    });
+
+    expect(result).toBe(true);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const updatedValues = [];
+    dispatch.mock.calls[0][0].doc.descendants((node) => {
+      if (node.type.name === 'sequenceField') updatedValues.push(node.attrs.resolvedNumber);
+      return true;
+    });
+    expect(updatedValues).toEqual(['1', '2']);
+  });
+
+  it('updates SEQ from fresh state after TOC update dispatches its own transaction', () => {
+    const para = (children) => mixedSchema.nodes.paragraph.create({}, children);
+    const text = (t) => mixedSchema.text(t);
+    const toc = mixedSchema.nodes.tableOfContents.create({ sdBlockId: 'toc-1' }, [para([text('entry')])]);
+    const seqField = mixedSchema.nodes.sequenceField.create({
+      instruction: 'SEQ Figure',
+      identifier: 'Figure',
+      resolvedNumber: '9',
+    });
+    const doc = mixedSchema.nodes.doc.create({}, [toc, para([seqField])]);
+    let editorState = EditorState.create({ schema: mixedSchema, doc });
+    const editor = {
+      doc: {
+        toc: {
+          update: vi.fn(() => {
+            // Simulate toc.update dispatching independently before the SEQ
+            // path runs. The later SEQ transaction must be based on this fresh
+            // state, preserving the TOC edit and the shifted SEQ position.
+            editorState = editorState.apply(editorState.tr.insertText(' updated', 7));
+            return { success: true };
+          }),
+        },
+      },
+      get state() {
+        return editorState;
+      },
+      converter: { translatedLinkedStyles: { docDefaults: {}, styles: {} }, translatedNumbering: {} },
+    };
+
+    const commands = FieldUpdate.config.addCommands.call({ editor });
+    const command = commands.updateFieldsInSelection();
+    const outerTr = editorState.tr;
+    outerTr.setMeta = vi.fn(outerTr.setMeta.bind(outerTr));
+    const dispatch = vi.fn();
+    const seqPos = toc.nodeSize + 1;
+    const result = command({
+      editor,
+      state: { doc, selection: { from: seqPos, to: seqPos + seqField.nodeSize }, schema: mixedSchema, tr: outerTr },
+      tr: outerTr,
+      dispatch,
+    });
+
+    expect(result).toBe(true);
+    expect(editor.doc.toc.update).toHaveBeenCalledTimes(1);
+    expect(outerTr.setMeta).toHaveBeenCalledWith('preventDispatch', true);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    const dispatchedDoc = dispatch.mock.calls[0][0].doc;
+    expect(dispatchedDoc.textContent).toContain('entry updated');
+    const seqValues = [];
+    dispatchedDoc.descendants((node) => {
+      if (node.type.name === 'sequenceField') seqValues.push(node.attrs.resolvedNumber);
+      return true;
+    });
+    expect(seqValues).toEqual(['1']);
   });
 });
 

--- a/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
+++ b/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
@@ -2,6 +2,7 @@ import { Node } from '@core/Node.js';
 import { Attribute } from '@core/Attribute.js';
 import { isHeadless } from '@utils/headless-helpers.js';
 import { formatPageNumberFieldValue, formatSectionPageNumberText } from '@superdoc/contracts';
+import { getPageNumberFieldFormat } from '../../core/layout-adapter/converters/inline-converters/page-number-field-format.js';
 /**
  * Configuration options for PageNumber
  * @typedef {Object} PageNumberOptions
@@ -139,6 +140,7 @@ export const PageNumber = Node.create({
  * @property {string|null} [instruction=null] @internal - Original NUMPAGES field instruction when switched
  * @property {string|null} [pageNumberFormat=null] @internal - Normalized field switch format
  * @property {number|null} [pageNumberZeroPadding=null] @internal - Zero-padding width from numeric picture switch
+ * @property {string|null} [pageNumberNumericPicture=null] @internal - Raw numeric picture switch
  */
 
 /**
@@ -183,6 +185,10 @@ export const TotalPageCount = Node.create({
         rendered: false,
       },
       pageNumberZeroPadding: {
+        default: null,
+        rendered: false,
+      },
+      pageNumberNumericPicture: {
         default: null,
         rendered: false,
       },
@@ -384,13 +390,16 @@ const getNodeAttributes = (nodeName, editor, node = null) => {
         ariaLabel: 'Page number node',
       };
     }
-    case 'total-page-number':
+    case 'total-page-number': {
+      const totalPageCount =
+        Number(editor.options.totalPageCount || editor.options.parentEditor?.currentTotalPages || 1) || 1;
       return {
-        text: editor.options.totalPageCount || editor.options.parentEditor?.currentTotalPages || '1',
+        text: formatPageNumberFieldValue(totalPageCount, getPageNumberFieldFormat(node?.attrs)),
         className: 'sd-editor-auto-total-pages',
         dataId: 'auto-total-pages',
         ariaLabel: 'Total page count node',
       };
+    }
     case 'section-page-count': {
       const sectionPageCount = editor.options.sectionPageCount;
       const cachedText = node?.attrs?.resolvedText ?? node?.attrs?.importedCachedText ?? node?.textContent ?? '1';

--- a/packages/super-editor/src/editors/v1/extensions/page-number/page-number.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/page-number/page-number.test.js
@@ -318,6 +318,25 @@ describe('AutoPageNumberNodeView', () => {
     expect(nodeView.dom.getAttribute('data-id')).toBe('auto-total-pages');
   });
 
+  it('renders formatted total page count node in edit mode', () => {
+    const doc = {
+      resolve: vi.fn().mockReturnValue({ nodeBefore: null, nodeAfter: null }),
+      nodeAt: vi.fn().mockReturnValue({ isText: false, attrs: { marksAsAttrs: [] } }),
+    };
+    const tr = { setNodeMarkup: vi.fn().mockReturnValue({}) };
+    const state = { doc, tr };
+    const editor = {
+      options: { totalPageCount: 12, parentEditor: { currentTotalPages: 12 } },
+      state,
+      view: { state, dispatch: vi.fn() },
+    };
+
+    const node = { type: { name: 'total-page-number' }, attrs: { pageNumberNumericPicture: '000' } };
+    const nodeView = new AutoPageNumberNodeView(node, () => 7, [], editor);
+
+    expect(nodeView.dom.textContent).toBe('012');
+  });
+
   it('renders formatted section page count node', () => {
     const doc = {
       resolve: vi.fn().mockReturnValue({ nodeBefore: null, nodeAfter: null }),

--- a/packages/super-editor/src/editors/v1/extensions/page-reference/page-reference.js
+++ b/packages/super-editor/src/editors/v1/extensions/page-reference/page-reference.js
@@ -32,6 +32,38 @@ export const PageReference = Node.create({
         default: '',
         rendered: false,
       },
+      instructionTokens: {
+        default: null,
+        rendered: false,
+      },
+      bookmarkId: {
+        default: '',
+        rendered: false,
+      },
+      hasHyperlinkSwitch: {
+        default: false,
+        rendered: false,
+      },
+      hasRelativePositionSwitch: {
+        default: false,
+        rendered: false,
+      },
+      pageNumberFieldFormat: {
+        default: null,
+        rendered: false,
+      },
+      numericPictureFormat: {
+        default: null,
+        rendered: false,
+      },
+      fieldResultFormat: {
+        default: null,
+        rendered: false,
+      },
+      fieldRunProperties: {
+        default: null,
+        rendered: false,
+      },
     };
   },
 

--- a/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.js
+++ b/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.js
@@ -38,6 +38,22 @@ export const SequenceField = Node.create({
         default: '',
         rendered: false,
       },
+      fieldArgument: {
+        default: '',
+        rendered: false,
+      },
+      sequenceMode: {
+        default: 'next',
+        rendered: false,
+      },
+      hideResult: {
+        default: false,
+        rendered: false,
+      },
+      restartNumber: {
+        default: null,
+        rendered: false,
+      },
       format: {
         default: 'ARABIC',
         rendered: false,
@@ -46,8 +62,24 @@ export const SequenceField = Node.create({
         default: null,
         rendered: false,
       },
+      hasGeneralFormat: {
+        default: false,
+        rendered: false,
+      },
+      pageNumberFieldFormat: {
+        default: null,
+        rendered: false,
+      },
+      numericPictureFormat: {
+        default: null,
+        rendered: false,
+      },
       resolvedNumber: {
         default: '',
+        rendered: false,
+      },
+      resolvedNumberIsCurrent: {
+        default: false,
         rendered: false,
       },
       sdBlockId: {
@@ -66,7 +98,7 @@ export const SequenceField = Node.create({
   },
 
   renderDOM({ node, htmlAttributes }) {
-    const text = node.attrs.resolvedNumber || '0';
+    const text = node.attrs.resolvedNumber || '';
     return ['span', Attribute.mergeAttributes(this.options.htmlAttributes, htmlAttributes), text];
   },
 });

--- a/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { initTestEditor } from '@tests/helpers/helpers.js';
+
+describe('SequenceField extension', () => {
+  it('keeps the legacy ARABIC schema default for format', () => {
+    const { editor } = initTestEditor({ mode: 'text', content: '<p></p>', isHeadless: true });
+    const node = editor.schema.nodes.sequenceField.create({ instruction: 'SEQ Figure' });
+
+    expect(node.attrs.format).toBe('ARABIC');
+
+    editor.destroy();
+  });
+});

--- a/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.js
+++ b/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.js
@@ -159,7 +159,8 @@ export function createTextElement(textContent, textAlign, width, height, options
       });
     }
     if (part.fieldType === 'NUMPAGES') {
-      return totalPages != null ? String(totalPages) : '1';
+      const count = totalPages ?? 1;
+      return part.pageNumberFormat ? formatPageNumber(count, part.pageNumberFormat) : String(count);
     }
     if (part.fieldType === 'SECTIONPAGES') {
       if (sectionPageCount == null) return part.text ?? '1';

--- a/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.test.js
@@ -214,6 +214,30 @@ describe('svg-utils', () => {
         expect(span.textContent).toBe('10');
       });
 
+      it('should format NUMPAGES field type with pageNumberFormat', () => {
+        const textContent = {
+          parts: [{ text: '', fieldType: 'NUMPAGES', pageNumberFormat: 'upperRoman', formatting: {} }],
+        };
+        const result = createTextElement(textContent, 'left', 100, 50, {
+          totalPages: 9,
+        });
+
+        const span = result.querySelector('span');
+        expect(span.textContent).toBe('IX');
+      });
+
+      it('should format NUMPAGES field type with ordinal pageNumberFormat', () => {
+        const textContent = {
+          parts: [{ text: '', fieldType: 'NUMPAGES', pageNumberFormat: 'ordinal', formatting: {} }],
+        };
+        const result = createTextElement(textContent, 'left', 100, 50, {
+          totalPages: 12,
+        });
+
+        const span = result.querySelector('span');
+        expect(span.textContent).toBe('12th');
+      });
+
       it('should default PAGE to "1" when pageNumber not provided', () => {
         const textContent = {
           parts: [{ text: '', fieldType: 'PAGE', formatting: {} }],

--- a/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
+++ b/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
@@ -14,7 +14,14 @@ import type {
   InlineNodeAttributes,
   ShapeNodeAttributes,
 } from '../../core/types/NodeCategories.js';
-import type { ImageHyperlink, PageNumberFormat, StructuredContentLockMode } from '@superdoc/contracts';
+import type {
+  FieldResultFormat,
+  ImageHyperlink,
+  NumericPictureFormat,
+  PageNumberFieldFormat,
+  PageNumberFormat,
+  StructuredContentLockMode,
+} from '@superdoc/contracts';
 
 // ============================================
 // SHARED TYPES
@@ -938,6 +945,22 @@ export interface PageReferenceAttrs extends InlineNodeAttributes {
   marksAsAttrs?: unknown[] | null;
   /** Field instruction */
   instruction?: string;
+  /** @internal Raw field instruction tokens for lossless export */
+  instructionTokens?: Array<{ type: string; text?: string }> | null;
+  /** @internal Parsed bookmark target */
+  bookmarkId?: string;
+  /** @internal Whether the instruction has a \h switch */
+  hasHyperlinkSwitch?: boolean;
+  /** @internal Whether the instruction has a \p switch */
+  hasRelativePositionSwitch?: boolean;
+  /** @internal Parsed page number format for PAGEREF output */
+  pageNumberFieldFormat?: PageNumberFieldFormat | null;
+  /** @internal Parsed numeric picture format for PAGEREF output */
+  numericPictureFormat?: NumericPictureFormat | null;
+  /** @internal Parsed field result formatting switch */
+  fieldResultFormat?: FieldResultFormat | null;
+  /** @internal Parsed run properties from the first instruction run for CHARFORMAT */
+  fieldRunProperties?: unknown | null;
 }
 
 // ============================================

--- a/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
+++ b/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
@@ -986,9 +986,11 @@ export interface TotalPageCountAttrs extends InlineNodeAttributes {
   /** @internal Original NUMPAGES field instruction when switched */
   instruction?: string | null;
   /** @internal Normalized field switch format */
-  pageNumberFormat?: string | null;
+  pageNumberFormat?: PageNumberFormat | null;
   /** @internal Zero-padding width from numeric picture switch */
   pageNumberZeroPadding?: number | null;
+  /** @internal Raw numeric picture switch */
+  pageNumberNumericPicture?: string | null;
 }
 
 /** Section page count node attributes */


### PR DESCRIPTION
## Summary

Wires `PAGEREF` cross-reference fields through to dynamic resolution against the paginated layout. Previously a `PAGEREF` rendered only its baked field-result text; now it displays the target bookmark's **actual** page number, honoring the field's formatting switches and relative-position behavior, and updates as pagination changes.

This builds on top of `luccas/sd-3029-feature-section-page-numbering` and reuses its page-number formatting primitives.

## What changed

### Instruction parsing (super-converter)
- New shared `parsePageRefInstruction` parser (`field-references/shared/pageref-instruction.js`)
  tokenizes a `PAGEREF` instruction into typed switches:
  - `\h` — hyperlink
  - `\p` — relative position ("above"/"below"/"on page N")
  - `\*` — general format (roman, alphabetic, CHARFORMAT/MERGEFORMAT, …)
  - `\#` — numeric picture
  - bookmark id
- Results are stored as typed node attrs on the `PageReference` node (`instructionTokens`, `bookmarkId`, `hasHyperlinkSwitch`, `hasRelativePositionSwitch`, `pageNumberFieldFormat`, `numericPictureFormat`, `fieldResultFormat`, `fieldRunProperties`).
- The first `instrText` run's `rPr` is captured to support `CHARFORMAT` field run properties.

### Anchor resolution (contracts)
- New `buildPageRefAnchorMap` locates each bookmark target within the resolved layout, mapping a bookmark name → `PageRefLocation` (page + display metadata). It resolves via fragment PM ranges with paragraph/table run-range fallbacks, and tolerates bookmark start/end marker lead distance (`MAX_BOOKMARK_MARKER_LEAD_DISTANCE`). Handles list items, table cells, and split rows/lines.

### Resolve-time text (layout-resolved)
- `resolveLayout` now resolves `PAGEREF` run text: formats the target display number (numeric picture / general format), emits relative-position text, and bumps the paint cache version when the resolved page changes so repaints stay correct.
- New `resolvePageRefText` helper centralizes the run-text resolution.
- Body page-token resolution is gated behind the `SD_BODY_PAGE_TOKENS` flag.

### Numeric picture formatting (contracts)
- New `formatIntegerWithNumericPicture` implements the Word `\#` picture subset: `0`/`#` placeholders, grouping (`,`), sign slots (`+`/`-`), fractional digits, and multi-section selection (positive;negative;zero). Unsupported ECMA features (backtick numbered-item refs, localized separators, fractional rounding) are explicitly documented as out of scope.

### Export fidelity (translator)
- `pageReference-translator` preserves instruction tokens for lossless export and applies captured `fieldRunProperties` for `CHARFORMAT` fields via the `w:rPr` translator.

### Presentation bridge
- `PresentationEditor` exposes bookmark/anchor data needed for resolution.

## Testing
- New/updated unit tests across `page-ref-anchor`, `page-number-formatting`, `resolveLayout`, `pageref-instruction`, `pageReference-translator`, `page-reference` converter, `layout-adapter`, and `PresentationEditor` (≈2,600 lines added, heavily test-weighted).
