### PR TITLE
feat(columns): render explicit columns at authored widths with per-column gaps (SD-2629)

### DIFF
--- a/packages/layout-engine/contracts/src/column-layout.test.ts
+++ b/packages/layout-engine/contracts/src/column-layout.test.ts
@@ -153,7 +153,7 @@ describe('normalizeColumnLayout', () => {
   });
 });
 
-describe('getColumnGeometry + geometry helpers (SD-2629, behavior-preserving)', () => {
+describe('getColumnGeometry + geometry helpers (SD-2629)', () => {
   it('mirrors equal-width normalized output (uniform gap, content-relative x)', () => {
     const geom = getColumnGeometry(normalizeColumnLayout({ count: 2, gap: 24 }, 624));
     expect(geom).toEqual([

--- a/packages/layout-engine/contracts/src/column-layout.test.ts
+++ b/packages/layout-engine/contracts/src/column-layout.test.ts
@@ -100,13 +100,15 @@ describe('normalizeColumnLayout', () => {
     });
   });
 
-  it('scales explicit widths to the available width', () => {
+  it('does not scale explicit widths; authored widths are preserved (SD-2629 step 4)', () => {
+    // Word renders authored column widths as-is and leaves trailing space when they underfill, so
+    // [100, 200] in a 600px content area stays [100, 200] rather than stretching to [200, 400].
     expect(normalizeColumnLayout({ count: 2, gap: 24, widths: [100, 200], equalWidth: false }, 624)).toEqual({
       count: 2,
       gap: 24,
-      widths: [200, 400],
+      widths: [100, 200],
       equalWidth: false,
-      width: 400,
+      width: 200,
     });
   });
 
@@ -160,13 +162,13 @@ describe('getColumnGeometry + geometry helpers (SD-2629, behavior-preserving)', 
     ]);
   });
 
-  it('mirrors explicit (scaled) widths', () => {
+  it('mirrors explicit widths without scaling (SD-2629 step 4)', () => {
     const geom = getColumnGeometry(
       normalizeColumnLayout({ count: 2, gap: 24, widths: [100, 200], equalWidth: false }, 624),
     );
     expect(geom).toEqual([
-      { index: 0, x: 0, width: 200, gapAfter: 24 },
-      { index: 1, x: 224, width: 400, gapAfter: 0 },
+      { index: 0, x: 0, width: 100, gapAfter: 24 },
+      { index: 1, x: 124, width: 200, gapAfter: 0 },
     ]);
   });
 
@@ -195,10 +197,11 @@ describe('getColumnGeometry + geometry helpers (SD-2629, behavior-preserving)', 
     expect(getColumnAtX(geom, 96 + 100, 96)).toBe(0);
   });
 
-  it('does NOT let per-column gaps drive geometry yet (step 1 is behavior-preserving)', () => {
-    // `gaps` is raw explicit-mode input; geometry still uses the scalar gap until the step-4 flip.
+  it('lets per-column gaps drive geometry (SD-2629 step 4)', () => {
+    // gaps[i] is the gap after column i; geometry uses it instead of the uniform scalar gap.
     const geom = getColumnGeometry({ count: 2, gap: 24, widths: [300, 300], gaps: [999], width: 300 });
-    expect(geom[0].gapAfter).toBe(24);
+    expect(geom[0].gapAfter).toBe(999);
+    expect(geom[1].x).toBe(300 + 999);
   });
 });
 

--- a/packages/layout-engine/contracts/src/column-layout.test.ts
+++ b/packages/layout-engine/contracts/src/column-layout.test.ts
@@ -203,6 +203,18 @@ describe('getColumnGeometry + geometry helpers (SD-2629)', () => {
     expect(geom[0].gapAfter).toBe(999);
     expect(geom[1].x).toBe(300 + 999);
   });
+
+  it('expands an equal-mode layout with no widths array to `count` columns (SD-2629 regression)', () => {
+    // A hand-built equal-mode layout (column-balancing) carries only the scalar `width`, no widths
+    // array. Geometry must still yield `count` columns; collapsing to a single column mapped every
+    // index past 0 onto column 0's x, stacking balanced multi-column content on the left margin.
+    const geom = getColumnGeometry({ count: 2, gap: 48, width: 288 });
+    expect(geom).toEqual([
+      { index: 0, x: 0, width: 288, gapAfter: 48 },
+      { index: 1, x: 336, width: 288, gapAfter: 0 },
+    ]);
+    expect(getColumnX(geom, 1, 96)).toBe(432);
+  });
 });
 
 describe('columnLayoutsEqual', () => {

--- a/packages/layout-engine/contracts/src/column-layout.test.ts
+++ b/packages/layout-engine/contracts/src/column-layout.test.ts
@@ -300,6 +300,24 @@ describe('resolveColumnLayout (SD-2629)', () => {
     // Omitted equalWidth is equal mode too.
     expect(resolveColumnLayout({ count: 2, gap: 20, widths: [100, 200] })).toEqual({ count: 2, gap: 20 });
   });
+
+  it('drops unusable widths by record, not by position, and stays idempotent (SD-2629)', () => {
+    // resolveColumnCount counts usable widths ([192, 384] -> 2). A positional slice would keep the
+    // leading 0 and drop the valid 384 ([0, 192]); that metadata re-resolves to count 1, so the
+    // fill (count 2) and the render metadata disagree. Record-filtering keeps [192, 384].
+    const resolved = resolveColumnLayout({ count: 3, gap: 20, widths: [0, 192, 384], equalWidth: false });
+    expect(resolved).toEqual({ count: 2, gap: 20, widths: [192, 384], equalWidth: false });
+    // Resolving the resolved metadata is a no-op (idempotent), which the positional slice was not.
+    expect(resolveColumnLayout(resolved)).toEqual(resolved);
+  });
+
+  it('keeps the gap following each surviving column when an unusable width is dropped (SD-2629)', () => {
+    // gaps[i] is the gap after column i. Dropping the leading 0-width column must keep the gap that
+    // sits between the surviving columns (after col 1 = 30), not the dropped column's gap (10).
+    expect(
+      resolveColumnLayout({ count: 3, gap: 20, widths: [0, 192, 384], gaps: [10, 30], equalWidth: false }),
+    ).toEqual({ count: 2, gap: 20, widths: [192, 384], gaps: [30], equalWidth: false });
+  });
 });
 
 describe('columnRenderLayoutsEqual (SD-2629)', () => {

--- a/packages/layout-engine/contracts/src/column-layout.test.ts
+++ b/packages/layout-engine/contracts/src/column-layout.test.ts
@@ -112,6 +112,20 @@ describe('normalizeColumnLayout', () => {
     });
   });
 
+  it('does not scale DOWN overfull explicit widths either; authored widths overflow (SD-2629, Word-verified)', () => {
+    // Word keeps authored explicit widths even when they EXCEED the content area: a Word probe of two
+    // 360pt columns + 36pt gap in a 468pt content box renders both at 360pt, with column 2 overflowing
+    // off the page edge (Word re-saves the w:cols unchanged). So normalize must not scale down either -
+    // [200, 400] in a 300px content box stays [200, 400] (overfull), matching Word's overflow.
+    expect(normalizeColumnLayout({ count: 2, gap: 24, widths: [200, 400], equalWidth: false }, 300)).toEqual({
+      count: 2,
+      gap: 24,
+      widths: [200, 400],
+      equalWidth: false,
+      width: 400,
+    });
+  });
+
   it('ignores widths when equalWidth is omitted and divides evenly (SD-2324: omitted = equal mode)', () => {
     // Omitted equalWidth is equal mode in Word; any widths present are not authoritative.
     expect(normalizeColumnLayout({ count: 2, gap: 24, widths: [100, 200] }, 624)).toEqual({

--- a/packages/layout-engine/contracts/src/column-layout.ts
+++ b/packages/layout-engine/contracts/src/column-layout.ts
@@ -112,19 +112,19 @@ export function resolveColumnLayout(input: ColumnLayout): ColumnLayout {
 }
 
 /**
- * Build resolved per-column geometry from already-resolved widths and the uniform scalar gap.
- * SD-2629 step 1 keeps this behavior-preserving: it mirrors today's normalized output (scaled
- * widths, uniform gap). Per-column `gaps` do NOT drive geometry until the semantic flip (step 4).
+ * Build resolved per-column geometry from already-resolved widths. The gap after each column is its
+ * own `gaps[i]` when provided (SD-2629 step 4), falling back to the uniform scalar gap; the last
+ * column has no following gap. The separator sits at the midpoint of that column's own gap.
  */
-function buildColumnGeometry(widths: number[], gap: number, withSeparator: boolean): ColumnGeometry[] {
+function buildColumnGeometry(widths: number[], gap: number, withSeparator: boolean, gaps?: number[]): ColumnGeometry[] {
   const geometry: ColumnGeometry[] = [];
   let x = 0;
   for (let i = 0; i < widths.length; i += 1) {
     const width = widths[i];
     const isLast = i === widths.length - 1;
-    const gapAfter = isLast ? 0 : gap;
+    const gapAfter = isLast ? 0 : (gaps?.[i] ?? gap);
     const col: ColumnGeometry = { index: i, x, width, gapAfter };
-    if (withSeparator && !isLast) col.separatorX = x + width + gap / 2;
+    if (withSeparator && !isLast) col.separatorX = x + width + gapAfter / 2;
     geometry.push(col);
     x += width + gapAfter;
   }
@@ -156,11 +156,17 @@ export function normalizeColumnLayout(
     widths.push(...Array.from({ length: count - widths.length }, () => fallbackWidth));
   }
 
-  const totalExplicitWidth = widths.reduce((sum, width) => sum + width, 0);
-  if (availableWidth > 0 && totalExplicitWidth > 0) {
-    const scale = availableWidth / totalExplicitWidth;
-    widths = widths.map((width) => Math.max(1, width * scale));
+  // Floor each column to >= 1px. Explicit widths are NOT scaled to fill the content area: Word
+  // renders authored widths as-is (a 2880tw column stays 2880tw, leaving trailing space when the
+  // columns underfill), so scaling them up would distort the document. Equal-mode widths already
+  // divide availableWidth evenly. (SD-2629 step 4)
+  if (availableWidth > 0) {
+    widths = widths.map((value) => Math.max(1, value));
   }
+
+  // Per-column gaps drive geometry in explicit mode (step 4); equal mode uses the uniform gap.
+  const gaps =
+    explicitWidths.length > 0 && Array.isArray(input?.gaps) ? input.gaps.slice(0, Math.max(0, count - 1)) : undefined;
 
   const width = widths.reduce((max, value) => Math.max(max, value), 0);
 
@@ -177,6 +183,7 @@ export function normalizeColumnLayout(
     count,
     gap,
     ...(widths.length > 0 ? { widths } : {}),
+    ...(gaps && gaps.length > 0 ? { gaps } : {}),
     ...(input?.equalWidth !== undefined ? { equalWidth: input.equalWidth } : {}),
     ...(input?.withSeparator !== undefined ? { withSeparator: input.withSeparator } : {}),
     width,
@@ -192,7 +199,7 @@ export function normalizeColumnLayout(
 export function getColumnGeometry(normalized: NormalizedColumnLayout): ColumnGeometry[] {
   const widths =
     Array.isArray(normalized.widths) && normalized.widths.length > 0 ? normalized.widths : [normalized.width];
-  return buildColumnGeometry(widths, normalized.gap, Boolean(normalized.withSeparator));
+  return buildColumnGeometry(widths, normalized.gap, Boolean(normalized.withSeparator), normalized.gaps);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/layout-engine/contracts/src/column-layout.ts
+++ b/packages/layout-engine/contracts/src/column-layout.ts
@@ -197,8 +197,16 @@ export function normalizeColumnLayout(
  * widths and per-column `gaps`, falling back to the uniform gap when no per-column gaps exist.
  */
 export function getColumnGeometry(normalized: NormalizedColumnLayout): ColumnGeometry[] {
+  // A geometry must have exactly `count` columns. normalizeColumnLayout always emits one width per
+  // column, but a hand-built equal-mode layout may carry only the scalar `width` with no widths array
+  // (e.g. column-balancing constructs its input directly). Expand that to `count` equal columns
+  // instead of collapsing to a single [width] column, which would map every column index past 0 onto
+  // column 0's x and stack later columns on the left margin. (SD-2629)
+  const count = Number.isFinite(normalized.count) ? Math.max(1, Math.floor(normalized.count)) : 1;
   const widths =
-    Array.isArray(normalized.widths) && normalized.widths.length > 0 ? normalized.widths : [normalized.width];
+    Array.isArray(normalized.widths) && normalized.widths.length > 0
+      ? normalized.widths
+      : new Array(count).fill(normalized.width);
   return buildColumnGeometry(widths, normalized.gap, Boolean(normalized.withSeparator), normalized.gaps);
 }
 

--- a/packages/layout-engine/contracts/src/column-layout.ts
+++ b/packages/layout-engine/contracts/src/column-layout.ts
@@ -193,8 +193,8 @@ export function normalizeColumnLayout(
 /**
  * Resolve per-column geometry for an already-normalized layout. This is the SD-2629 consumer API:
  * fill/positioning/separators/hit-testing/footnotes/floating anchors/balancing should read this
- * single source rather than re-deriving from `widths`/`gap`. Behavior-preserving in step 1: it
- * mirrors today's normalized widths + scalar gap; per-column `gaps` drive it only after the flip.
+ * single source rather than re-deriving from `widths`/`gap`. Geometry uses the resolved (unscaled)
+ * widths and per-column `gaps`, falling back to the uniform gap when no per-column gaps exist.
  */
 export function getColumnGeometry(normalized: NormalizedColumnLayout): ColumnGeometry[] {
   const widths =

--- a/packages/layout-engine/contracts/src/column-layout.ts
+++ b/packages/layout-engine/contracts/src/column-layout.ts
@@ -87,8 +87,23 @@ export function resolveColumnLayout(input: ColumnLayout): ColumnLayout {
   const resolved = cloneColumnLayout(input);
   resolved.count = count;
   if (resolveColumnMode(input) === 'explicit') {
-    if (Array.isArray(resolved.widths)) resolved.widths = resolved.widths.slice(0, count);
-    if (Array.isArray(resolved.gaps)) resolved.gaps = resolved.gaps.slice(0, Math.max(0, count - 1));
+    // Select widths the SAME way resolveColumnCount counts them: pair each width with the gap that
+    // follows it, keep only usable-width records (finite, > 0), then slice to the resolved count.
+    // A positional `widths.slice(0, count)` would keep an unusable leading entry and drop a usable
+    // later one (e.g. [0,192,384] -> count 2 -> [0,192]), producing metadata whose own usable-width
+    // count re-resolves smaller than the fill used (non-idempotent; fill and paint disagree).
+    if (Array.isArray(resolved.widths)) {
+      const rawGaps = Array.isArray(resolved.gaps) ? resolved.gaps : [];
+      const usable = resolved.widths
+        .map((width, i) => ({ width, gapAfter: rawGaps[i] }))
+        .filter((record) => typeof record.width === 'number' && Number.isFinite(record.width) && record.width > 0)
+        .slice(0, count);
+      resolved.widths = usable.map((record) => record.width);
+      // gaps[i] is the gap AFTER column i; the last surviving column has none, so keep count-1.
+      if (Array.isArray(resolved.gaps)) {
+        resolved.gaps = usable.slice(0, Math.max(0, count - 1)).map((record) => record.gapAfter ?? 0);
+      }
+    }
   } else {
     delete resolved.widths;
     delete resolved.gaps;

--- a/packages/layout-engine/contracts/src/graphic-placement.test.ts
+++ b/packages/layout-engine/contracts/src/graphic-placement.test.ts
@@ -167,4 +167,25 @@ describe('resolveAnchoredGraphicX', () => {
   it('defaults alignH to left and offsetH to zero', () => {
     expect(resolveAnchoredGraphicX({}, 0, columns, objectWidth, margins, pageWidth)).toBe(margins.left);
   });
+
+  describe('column-relative honors authored per-column geometry (SD-2629)', () => {
+    // Explicit unequal columns: col0 = 100px, gap-after-col0 = 40px, col1 = 300px. Column-relative
+    // anchors must follow the resolved geometry, not a uniform columnIndex * (width + gap) stride.
+    const unequal = { width: 300, gap: 20, count: 2, widths: [100, 300], gaps: [40] };
+
+    it('places a column-1 anchor at the authored column origin, not the uniform stride', () => {
+      // Geometry col1 x = 100 + 40 = 140; + left margin 72 = 212. The uniform stride would place it
+      // at 72 + (300 + 20) = 392; ignoring per-column gaps (scalar 20) would give 192.
+      expect(resolveAnchoredGraphicX({ alignH: 'left', offsetH: 0 }, 1, unequal, objectWidth, margins, pageWidth)).toBe(
+        212,
+      );
+    });
+
+    it('right-aligns within the authored column width, not the max column width', () => {
+      // col0 is 100px wide: right edge = 72 + 100 - 80 = 92. Using columns.width (300) would give 292.
+      expect(
+        resolveAnchoredGraphicX({ alignH: 'right', offsetH: 0 }, 0, unequal, objectWidth, margins, pageWidth),
+      ).toBe(92);
+    });
+  });
 });

--- a/packages/layout-engine/contracts/src/graphic-placement.test.ts
+++ b/packages/layout-engine/contracts/src/graphic-placement.test.ts
@@ -168,9 +168,10 @@ describe('resolveAnchoredGraphicX', () => {
     expect(resolveAnchoredGraphicX({}, 0, columns, objectWidth, margins, pageWidth)).toBe(margins.left);
   });
 
-  describe('column-relative honors authored per-column geometry (SD-2629)', () => {
-    // Explicit unequal columns: col0 = 100px, gap-after-col0 = 40px, col1 = 300px. Column-relative
-    // anchors must follow the resolved geometry, not a uniform columnIndex * (width + gap) stride.
+  describe('column-relative honors the authored per-column origin (SD-2629)', () => {
+    // Explicit unequal columns: col0 = 100px, gap-after-col0 = 40px, col1 = 300px. The column ORIGIN
+    // follows the resolved geometry (not a uniform columnIndex * (width + gap) stride); the available
+    // width stays the scalar (max) column width to match anchored-object measurement.
     const unequal = { width: 300, gap: 20, count: 2, widths: [100, 300], gaps: [40] };
 
     it('places a column-1 anchor at the authored column origin, not the uniform stride', () => {
@@ -181,11 +182,13 @@ describe('resolveAnchoredGraphicX', () => {
       );
     });
 
-    it('right-aligns within the authored column width, not the max column width', () => {
-      // col0 is 100px wide: right edge = 72 + 100 - 80 = 92. Using columns.width (300) would give 292.
+    it('right-aligns within the scalar (max) column width to match object measurement', () => {
+      // Available width is the scalar max (columns.width = 300), matching the measurement clamp, so a
+      // max-sized object is not pushed into the margin/gap: col0 right edge = 72 + 300 - 80 = 292.
+      // (Per-column width 100 would give 92, but the object was measured against the max width.)
       expect(
         resolveAnchoredGraphicX({ alignH: 'right', offsetH: 0 }, 0, unequal, objectWidth, margins, pageWidth),
-      ).toBe(92);
+      ).toBe(292);
     });
   });
 });

--- a/packages/layout-engine/contracts/src/graphic-placement.ts
+++ b/packages/layout-engine/contracts/src/graphic-placement.ts
@@ -1,4 +1,4 @@
-import { getColumnGeometry, getColumnX, getColumnWidth } from './column-layout.js';
+import { getColumnGeometry, getColumnX } from './column-layout.js';
 
 type AnchorVRelative = 'paragraph' | 'page' | 'margin';
 type AnchorHRelative = 'column' | 'page' | 'margin';
@@ -132,9 +132,9 @@ export function resolveAnchoredGraphicX(
   const contentWidth = pageWidth != null ? Math.max(1, pageWidth - (marginLeft + marginRight)) : columns.width;
 
   const contentLeft = marginLeft;
-  // Column origin/width from the resolved geometry so column-relative anchors honor per-column
-  // widths and gaps (SD-2629) rather than a uniform columnIndex * (width + gap) stride. Equal
-  // columns reduce to the old stride. Page/margin semantics are unchanged.
+  // Column ORIGIN from the resolved geometry so column-relative anchors honor per-column widths and
+  // gaps (SD-2629) rather than a uniform columnIndex * (width + gap) stride. Equal columns reduce to
+  // the old stride. Page/margin semantics are unchanged. (Available width stays scalar; see below.)
   const geometry = getColumnGeometry(columns);
 
   const relativeFrom = anchor.hRelativeFrom ?? 'column';
@@ -149,7 +149,12 @@ export function resolveAnchoredGraphicX(
     availableWidth = contentWidth;
   } else {
     baseX = getColumnX(geometry, columnIndex, contentLeft);
-    availableWidth = getColumnWidth(geometry, columnIndex);
+    // Available width is the scalar (max) column width, matching anchored-object MEASUREMENT, which
+    // clamps width to columns.width (layout-image / layout-drawing), not the per-column width.
+    // Centering / right-aligning against a narrower per-column width while the object was sized to
+    // the max width would push it into the margin or gap. The column ORIGIN above is already
+    // per-column; revisit this once per-column object measurement exists. (SD-2629)
+    availableWidth = columns.width;
   }
 
   if (alignH === 'left') {

--- a/packages/layout-engine/contracts/src/graphic-placement.ts
+++ b/packages/layout-engine/contracts/src/graphic-placement.ts
@@ -1,3 +1,5 @@
+import { getColumnGeometry, getColumnX, getColumnWidth } from './column-layout.js';
+
 type AnchorVRelative = 'paragraph' | 'page' | 'margin';
 type AnchorHRelative = 'column' | 'page' | 'margin';
 type AnchorAlignH = 'left' | 'center' | 'right';
@@ -7,6 +9,11 @@ export type ColumnLayoutForAnchor = {
   width: number;
   gap: number;
   count: number;
+  // Per-column widths/gaps from the resolved (normalized) columns. When present, column-relative
+  // anchor x honors them via getColumnGeometry instead of a uniform columnIndex * (width + gap)
+  // stride; equal columns reduce to the old stride. (SD-2629)
+  widths?: number[];
+  gaps?: number[];
 };
 
 /**
@@ -125,7 +132,10 @@ export function resolveAnchoredGraphicX(
   const contentWidth = pageWidth != null ? Math.max(1, pageWidth - (marginLeft + marginRight)) : columns.width;
 
   const contentLeft = marginLeft;
-  const columnLeft = contentLeft + columnIndex * (columns.width + columns.gap);
+  // Column origin/width from the resolved geometry so column-relative anchors honor per-column
+  // widths and gaps (SD-2629) rather than a uniform columnIndex * (width + gap) stride. Equal
+  // columns reduce to the old stride. Page/margin semantics are unchanged.
+  const geometry = getColumnGeometry(columns);
 
   const relativeFrom = anchor.hRelativeFrom ?? 'column';
 
@@ -138,8 +148,8 @@ export function resolveAnchoredGraphicX(
     baseX = contentLeft;
     availableWidth = contentWidth;
   } else {
-    baseX = columnLeft;
-    availableWidth = columns.width;
+    baseX = getColumnX(geometry, columnIndex, contentLeft);
+    availableWidth = getColumnWidth(geometry, columnIndex);
   }
 
   if (alignH === 'left') {

--- a/packages/layout-engine/layout-bridge/src/incrementalLayout.ts
+++ b/packages/layout-engine/layout-bridge/src/incrementalLayout.ts
@@ -15,6 +15,8 @@ import type {
 import {
   cloneColumnLayout,
   formatSectionPageNumberText,
+  getColumnGeometry,
+  getColumnX,
   normalizeColumnLayout,
   rescaleColumnWidths,
 } from '@superdoc/contracts';
@@ -249,22 +251,17 @@ const assignFootnotesToColumns = (
       if (fragment?.kind === 'table' && typeof fragment.columnIndex === 'number') {
         columnIndex = Math.max(0, Math.min(columns.count - 1, fragment.columnIndex));
       } else if (fragment && typeof fragment.x === 'number') {
-        const widths = Array.isArray(columns.widths) && columns.widths.length > 0 ? columns.widths : undefined;
-        if (widths) {
-          let cursorX = columns.left;
-          for (let index = 0; index < columns.count; index += 1) {
-            const columnWidth = widths[index] ?? columns.width;
-            if (fragment.x < cursorX + columnWidth + columns.gap / 2) {
-              columnIndex = index;
-              break;
-            }
-            cursorX += columnWidth + columns.gap;
-            columnIndex = Math.min(columns.count - 1, index + 1);
+        // Geometry-derived midpoint assignment: assign the ref to the column whose right edge plus
+        // half its own gap the fragment falls before. Per-column widths/gaps come from the resolved
+        // geometry, preserving the prior midpoint rule. The old uniform-stride branch was unreachable
+        // for count>1 (normalized columns always carry widths). (SD-2629 4c)
+        const geometry = getColumnGeometry(columns);
+        columnIndex = Math.max(0, geometry.length - 1);
+        for (const col of geometry) {
+          if (fragment.x < columns.left + col.x + col.width + col.gapAfter / 2) {
+            columnIndex = col.index;
+            break;
           }
-        } else {
-          const columnStride = columns.width + columns.gap;
-          const rawIndex = columnStride > 0 ? Math.floor((fragment.x - columns.left) / columnStride) : 0;
-          columnIndex = Math.max(0, Math.min(columns.count - 1, rawIndex));
         }
       }
     }
@@ -2031,8 +2028,9 @@ export async function incrementalLayout(
           slicesByColumn.forEach((columnSlices, rawColumnIndex) => {
             if (columnSlices.length === 0) return;
             const columnIndex = Math.max(0, Math.min(columns.count - 1, rawColumnIndex));
-            const columnStride = columns.width + columns.gap;
-            const columnX = columns.left + columnIndex * columnStride;
+            const columnX = getColumnX(getColumnGeometry(columns), columnIndex, columns.left);
+            // Placement width stays uniform (= the measurement width); per-column footnote
+            // measurement is a deliberate follow-up, not this pass. (SD-2629 4c; do not narrow here)
             const contentWidth = Math.min(columns.width, footnoteWidth);
             if (!Number.isFinite(contentWidth) || contentWidth <= 0) return;
 

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -137,9 +137,14 @@ export const isRtlBlock = (block: FlowBlock): boolean => {
 
 // Columns governing a hit at this page-relative y: prefer the mid-page column REGION it falls in (a
 // continuous section break can change columns within a page; page.columns is only the page-START
-// config, so the contract carries per-region geometry in page.columnRegions). columnRegions
-// yStart/yEnd are page-relative, the same frame as fragment.y. Falls back to page.columns, then the
-// document-wide layout.columns. Shared by determineColumn and determineTableColumn. (SD-2629)
+// config, so the contract carries per-region geometry in page.columnRegions, whose yStart/yEnd are
+// page-relative like fragment.y). Otherwise the page's own page.columns. layout.columns (the
+// document-wide / final-active config) is consulted ONLY when no page is supplied: a supplied page is
+// authoritative, and a page with no page.columns is single-column (the engine leaves it unset for
+// single-column pages; callers treat the undefined result as column 0). Deliberately NOT
+// `page.columns ?? layout.columns`: falling back to the document-wide columns for an existing
+// single-column page would reintroduce the cross-section mis-mapping this resolves. Shared by
+// determineColumn and determineTableColumn. (SD-2629)
 function resolveColumnsForHit(layout: Layout, page: Page | undefined, fragmentY?: number): ColumnLayout | undefined {
   if (page === undefined) return layout.columns;
   if (page.columnRegions && typeof fragmentY === 'number') {

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -12,6 +12,7 @@ import type {
   FlowBlock,
   Layout,
   Page,
+  ColumnLayout,
   Measure,
   Fragment,
   DrawingFragment,
@@ -134,17 +135,22 @@ export const isRtlBlock = (block: FlowBlock): boolean => {
   return getParagraphInlineDirection(block.attrs) === 'rtl';
 };
 
-export const determineColumn = (layout: Layout, fragmentX: number, page?: Page, fragmentY?: number): number => {
-  // Columns for THIS fragment: prefer the mid-page column REGION it sits in. A continuous section
-  // break can change columns within a single page, and page.columns is only the page-START config -
-  // the contract carries per-region geometry in page.columnRegions (yStart/yEnd are page-relative,
-  // the same frame as fragment.y). Fall back to page.columns, then the document-wide layout.columns.
-  // (SD-2629)
-  let columns = page !== undefined ? page.columns : layout.columns;
-  if (page?.columnRegions && typeof fragmentY === 'number') {
+// Columns governing a hit at this page-relative y: prefer the mid-page column REGION it falls in (a
+// continuous section break can change columns within a page; page.columns is only the page-START
+// config, so the contract carries per-region geometry in page.columnRegions). columnRegions
+// yStart/yEnd are page-relative, the same frame as fragment.y. Falls back to page.columns, then the
+// document-wide layout.columns. Shared by determineColumn and determineTableColumn. (SD-2629)
+function resolveColumnsForHit(layout: Layout, page: Page | undefined, fragmentY?: number): ColumnLayout | undefined {
+  if (page === undefined) return layout.columns;
+  if (page.columnRegions && typeof fragmentY === 'number') {
     const region = page.columnRegions.find((r) => fragmentY >= r.yStart && fragmentY < r.yEnd);
-    if (region) columns = region.columns;
+    if (region) return region.columns;
   }
+  return page.columns;
+}
+
+export const determineColumn = (layout: Layout, fragmentX: number, page?: Page, fragmentY?: number): number => {
+  const columns = resolveColumnsForHit(layout, page, fragmentY);
   if (!columns || columns.count <= 1) return 0;
   // Mirror the engine's placement coordinates: fragments sit at marginLeft + content-relative column
   // x over the CONTENT width (page width minus side margins), NOT the full page width from origin 0 -
@@ -161,9 +167,12 @@ export const determineColumn = (layout: Layout, fragmentX: number, page?: Page, 
   return getColumnAtX(geometry, fragmentX, marginLeft);
 };
 
-const determineTableColumn = (layout: Layout, fragment: TableFragment, page?: Page): number => {
+export const determineTableColumn = (layout: Layout, fragment: TableFragment, page?: Page): number => {
   if (typeof fragment.columnIndex === 'number') {
-    const count = (page?.columns ?? layout.columns)?.count ?? 1;
+    // Clamp against the count of the region the table sits in (by its y), not the page-START
+    // page.columns: a table laid out in a mid-page two-column region carries columnIndex 1 that the
+    // single-column page-start count would wrongly snap to 0. (SD-2629)
+    const count = resolveColumnsForHit(layout, page, fragment.y)?.count ?? 1;
     return Math.max(0, Math.min(Math.max(0, count - 1), fragment.columnIndex));
   }
   return determineColumn(layout, fragment.x, page, fragment.y);

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -26,8 +26,11 @@ import type {
 import {
   adjustAvailableWidthForTextIndent,
   computeLinePmRange,
+  getColumnAtX,
+  getColumnGeometry,
   getFirstLineIndentOffset,
   getParagraphInlineDirection,
+  normalizeColumnLayout,
 } from '@superdoc/contracts';
 import { charOffsetToPm, findCharacterAtX } from './text-measurement.js';
 import type { PageGeometryHelper } from './page-geometry-helper.js';
@@ -133,12 +136,12 @@ export const isRtlBlock = (block: FlowBlock): boolean => {
 export const determineColumn = (layout: Layout, fragmentX: number): number => {
   const columns = layout.columns;
   if (!columns || columns.count <= 1) return 0;
-  const usableWidth = layout.pageSize.w - columns.gap * (columns.count - 1);
-  const columnWidth = usableWidth / columns.count;
-  const span = columnWidth + columns.gap;
-  const relative = fragmentX;
-  const raw = Math.floor(relative / Math.max(span, 1));
-  return Math.max(0, Math.min(columns.count - 1, raw));
+  // Resolve the column boundaries from the single geometry source (SD-2629). This honors per-column
+  // widths for explicit columns instead of assuming a uniform stride. Coordinate assumptions are
+  // preserved from the prior implementation: contentWidth = pageSize.w (margins are not subtracted)
+  // and origin 0 (fragmentX is layout-absolute). getColumnAtX maps a gap to the preceding column.
+  const geometry = getColumnGeometry(normalizeColumnLayout(columns, layout.pageSize.w));
+  return getColumnAtX(geometry, fragmentX, 0);
 };
 
 const determineTableColumn = (layout: Layout, fragment: TableFragment): number => {

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -11,6 +11,7 @@
 import type {
   FlowBlock,
   Layout,
+  Page,
   Measure,
   Fragment,
   DrawingFragment,
@@ -133,23 +134,31 @@ export const isRtlBlock = (block: FlowBlock): boolean => {
   return getParagraphInlineDirection(block.attrs) === 'rtl';
 };
 
-export const determineColumn = (layout: Layout, fragmentX: number): number => {
-  const columns = layout.columns;
+export const determineColumn = (layout: Layout, fragmentX: number, page?: Page): number => {
+  const columns = page !== undefined ? page.columns : layout.columns;
   if (!columns || columns.count <= 1) return 0;
-  // Resolve the column boundaries from the single geometry source (SD-2629). This honors per-column
-  // widths for explicit columns instead of assuming a uniform stride. Coordinate assumptions are
-  // preserved from the prior implementation: contentWidth = pageSize.w (margins are not subtracted)
-  // and origin 0 (fragmentX is layout-absolute). getColumnAtX maps a gap to the preceding column.
-  const geometry = getColumnGeometry(normalizeColumnLayout(columns, layout.pageSize.w));
-  return getColumnAtX(geometry, fragmentX, 0);
+  // Resolve column boundaries from the single geometry source (SD-2629), honoring per-column widths
+  // for explicit columns. Mirror the engine's placement coordinates: fragments sit at marginLeft +
+  // content-relative column x over the CONTENT width (page width minus side margins), NOT the full
+  // page width from origin 0 - the latter mis-classifies clicks near boundaries once margins are
+  // non-zero (and for 3+ or asymmetric-margin layouts). Use the fragment's own page so multi-section
+  // docs with varying margins stay correct, falling back to the first page's margins when no page is
+  // supplied. getColumnAtX maps a gap to the preceding column.
+  const pageWidth = page?.size?.w ?? layout.pageSize.w;
+  const margins = page?.margins ?? layout.pages[0]?.margins;
+  const marginLeft = Math.max(0, margins?.left ?? 0);
+  const marginRight = Math.max(0, margins?.right ?? 0);
+  const contentWidth = Math.max(1, pageWidth - (marginLeft + marginRight));
+  const geometry = getColumnGeometry(normalizeColumnLayout(columns, contentWidth));
+  return getColumnAtX(geometry, fragmentX, marginLeft);
 };
 
-const determineTableColumn = (layout: Layout, fragment: TableFragment): number => {
+const determineTableColumn = (layout: Layout, fragment: TableFragment, page?: Page): number => {
   if (typeof fragment.columnIndex === 'number') {
-    const count = layout.columns?.count ?? 1;
+    const count = (page?.columns ?? layout.columns)?.count ?? 1;
     return Math.max(0, Math.min(Math.max(0, count - 1), fragment.columnIndex));
   }
-  return determineColumn(layout, fragment.x);
+  return determineColumn(layout, fragment.x, page);
 };
 
 // ---------------------------------------------------------------------------
@@ -698,7 +707,7 @@ export function resolvePositionHitFromDomPosition(
         if (domPos >= fragment.pmStart && domPos <= fragment.pmEnd) {
           blockId = fragment.blockId;
           pageIndex = pi;
-          column = determineColumn(layout, fragment.x);
+          column = determineColumn(layout, fragment.x, page);
           const blockIndex = findBlockIndexByFragmentId(blocks, fragment.blockId);
           if (blockIndex !== -1) {
             const measure = measures[blockIndex];
@@ -859,7 +868,7 @@ export function clickToPositionGeometry(
         return null;
       }
 
-      const column = determineColumn(layout, fragment.x);
+      const column = determineColumn(layout, fragment.x, layout.pages[pageIndex]);
 
       return {
         pos,
@@ -884,7 +893,7 @@ export function clickToPositionGeometry(
         layoutEpoch,
         blockId: fragment.blockId,
         pageIndex,
-        column: determineColumn(layout, fragment.x),
+        column: determineColumn(layout, fragment.x, layout.pages[pageIndex]),
         lineIndex: -1,
       };
     }
@@ -944,7 +953,7 @@ export function clickToPositionGeometry(
           layoutEpoch,
           blockId: tableHit.fragment.blockId,
           pageIndex,
-          column: determineTableColumn(layout, tableHit.fragment),
+          column: determineTableColumn(layout, tableHit.fragment, layout.pages[pageIndex]),
           lineIndex,
         };
       }
@@ -958,7 +967,7 @@ export function clickToPositionGeometry(
         layoutEpoch,
         blockId: tableHit.fragment.blockId,
         pageIndex,
-        column: determineTableColumn(layout, tableHit.fragment),
+        column: determineTableColumn(layout, tableHit.fragment, layout.pages[pageIndex]),
         lineIndex: 0,
       };
     }
@@ -979,7 +988,7 @@ export function clickToPositionGeometry(
       layoutEpoch,
       blockId: fragment.blockId,
       pageIndex,
-      column: determineColumn(layout, fragment.x),
+      column: determineColumn(layout, fragment.x, layout.pages[pageIndex]),
       lineIndex: -1,
     };
   }

--- a/packages/layout-engine/layout-bridge/src/position-hit.ts
+++ b/packages/layout-engine/layout-bridge/src/position-hit.ts
@@ -134,16 +134,24 @@ export const isRtlBlock = (block: FlowBlock): boolean => {
   return getParagraphInlineDirection(block.attrs) === 'rtl';
 };
 
-export const determineColumn = (layout: Layout, fragmentX: number, page?: Page): number => {
-  const columns = page !== undefined ? page.columns : layout.columns;
+export const determineColumn = (layout: Layout, fragmentX: number, page?: Page, fragmentY?: number): number => {
+  // Columns for THIS fragment: prefer the mid-page column REGION it sits in. A continuous section
+  // break can change columns within a single page, and page.columns is only the page-START config -
+  // the contract carries per-region geometry in page.columnRegions (yStart/yEnd are page-relative,
+  // the same frame as fragment.y). Fall back to page.columns, then the document-wide layout.columns.
+  // (SD-2629)
+  let columns = page !== undefined ? page.columns : layout.columns;
+  if (page?.columnRegions && typeof fragmentY === 'number') {
+    const region = page.columnRegions.find((r) => fragmentY >= r.yStart && fragmentY < r.yEnd);
+    if (region) columns = region.columns;
+  }
   if (!columns || columns.count <= 1) return 0;
-  // Resolve column boundaries from the single geometry source (SD-2629), honoring per-column widths
-  // for explicit columns. Mirror the engine's placement coordinates: fragments sit at marginLeft +
-  // content-relative column x over the CONTENT width (page width minus side margins), NOT the full
-  // page width from origin 0 - the latter mis-classifies clicks near boundaries once margins are
-  // non-zero (and for 3+ or asymmetric-margin layouts). Use the fragment's own page so multi-section
-  // docs with varying margins stay correct, falling back to the first page's margins when no page is
-  // supplied. getColumnAtX maps a gap to the preceding column.
+  // Mirror the engine's placement coordinates: fragments sit at marginLeft + content-relative column
+  // x over the CONTENT width (page width minus side margins), NOT the full page width from origin 0 -
+  // the latter mis-classifies clicks near boundaries once margins are non-zero (and for 3+ or
+  // asymmetric-margin layouts). Use the fragment's own page so multi-section docs with varying margins
+  // stay correct, falling back to the first page's margins when no page is supplied. getColumnAtX maps
+  // a gap to the preceding column.
   const pageWidth = page?.size?.w ?? layout.pageSize.w;
   const margins = page?.margins ?? layout.pages[0]?.margins;
   const marginLeft = Math.max(0, margins?.left ?? 0);
@@ -158,7 +166,7 @@ const determineTableColumn = (layout: Layout, fragment: TableFragment, page?: Pa
     const count = (page?.columns ?? layout.columns)?.count ?? 1;
     return Math.max(0, Math.min(Math.max(0, count - 1), fragment.columnIndex));
   }
-  return determineColumn(layout, fragment.x, page);
+  return determineColumn(layout, fragment.x, page, fragment.y);
 };
 
 // ---------------------------------------------------------------------------
@@ -707,7 +715,7 @@ export function resolvePositionHitFromDomPosition(
         if (domPos >= fragment.pmStart && domPos <= fragment.pmEnd) {
           blockId = fragment.blockId;
           pageIndex = pi;
-          column = determineColumn(layout, fragment.x, page);
+          column = determineColumn(layout, fragment.x, page, fragment.y);
           const blockIndex = findBlockIndexByFragmentId(blocks, fragment.blockId);
           if (blockIndex !== -1) {
             const measure = measures[blockIndex];
@@ -868,7 +876,7 @@ export function clickToPositionGeometry(
         return null;
       }
 
-      const column = determineColumn(layout, fragment.x, layout.pages[pageIndex]);
+      const column = determineColumn(layout, fragment.x, layout.pages[pageIndex], fragment.y);
 
       return {
         pos,
@@ -893,7 +901,7 @@ export function clickToPositionGeometry(
         layoutEpoch,
         blockId: fragment.blockId,
         pageIndex,
-        column: determineColumn(layout, fragment.x, layout.pages[pageIndex]),
+        column: determineColumn(layout, fragment.x, layout.pages[pageIndex], fragment.y),
         lineIndex: -1,
       };
     }
@@ -988,7 +996,7 @@ export function clickToPositionGeometry(
       layoutEpoch,
       blockId: fragment.blockId,
       pageIndex,
-      column: determineColumn(layout, fragment.x, layout.pages[pageIndex]),
+      column: determineColumn(layout, fragment.x, layout.pages[pageIndex], fragment.y),
       lineIndex: -1,
     };
   }

--- a/packages/layout-engine/layout-bridge/test/position-hit.test.ts
+++ b/packages/layout-engine/layout-bridge/test/position-hit.test.ts
@@ -110,4 +110,25 @@ describe('determineColumn (SD-2629: resolved per-column boundaries)', () => {
     // would wrongly return col 1.
     expect(determineColumn(layout, 540, page)).toBe(2);
   });
+
+  it('maps a hit to its mid-page column region, not the page-start columns (SD-2629)', () => {
+    // A continuous section break splits the page: region 0 (y 96-300) is single-column; region 1
+    // (y 300-700) is two-column. page.columns is only the page-START config (single column), so a
+    // fragment in region 1 must be resolved with the region's two-column geometry, by its y.
+    const page = {
+      columns: { count: 1, gap: 0 },
+      columnRegions: [
+        { yStart: 96, yEnd: 300, columns: { count: 1, gap: 0 } },
+        { yStart: 300, yEnd: 700, columns: { count: 2, gap: 24 } },
+      ],
+      margins: { left: 96, right: 96 },
+      size: { w: 816, h: 1056 },
+    } as unknown as Page;
+    const layout = { pageSize: { w: 816, h: 1056 }, columns: page.columns, pages: [page] } as unknown as Layout;
+    // y=400 is in the two-column region; x=450 is past col1's start (96 + 300 + 24 = 420) -> column 1.
+    expect(determineColumn(layout, 450, page, 400)).toBe(1);
+    // y=200 is in the single-column region -> column 0 at the same x (page.columns alone would always
+    // say 0; the region lookup is what makes the y=400 case return 1).
+    expect(determineColumn(layout, 450, page, 200)).toBe(0);
+  });
 });

--- a/packages/layout-engine/layout-bridge/test/position-hit.test.ts
+++ b/packages/layout-engine/layout-bridge/test/position-hit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { FlowBlock, ParagraphAttrs, Layout } from '@superdoc/contracts';
+import type { FlowBlock, ParagraphAttrs, Layout, Page } from '@superdoc/contracts';
 import { isRtlBlock, determineColumn } from '../src/position-hit';
 
 const paragraph = (attrs?: Record<string, unknown>): FlowBlock => ({
@@ -90,5 +90,24 @@ describe('determineColumn (SD-2629: resolved per-column boundaries)', () => {
     const layout = makeLayout({ count: 2, gap: 0, widths: [100, 400], equalWidth: false });
     expect(determineColumn(layout, 50)).toBe(0);
     expect(determineColumn(layout, 150)).toBe(1);
+  });
+
+  it('maps an absolute x using the page margins and content width, not full page from origin 0 (SD-2629)', () => {
+    // 3 equal columns in an 816px page with 96px side margins: content width 624 -> 192px columns.
+    // Column boundaries are absolute (marginLeft + content-relative x), so a click must be resolved
+    // over the content box. Resolving over the full page width from origin 0 (the prior behavior)
+    // mis-classifies clicks near the boundaries once margins are non-zero.
+    const page = {
+      columns: { count: 3, gap: 24 },
+      margins: { left: 96, right: 96 },
+      size: { w: 816, h: 1056 },
+    } as unknown as Page;
+    const layout = { pageSize: { w: 816, h: 1056 }, columns: page.columns, pages: [page] } as unknown as Layout;
+    // col1 starts at 96 + 192 + 24 = 312; x=300 is left of it -> col 0. Full-page math (boundary 280)
+    // would wrongly return col 1.
+    expect(determineColumn(layout, 300, page)).toBe(0);
+    // col2 starts at 96 + 2*(192+24) = 528; x=540 is past it -> col 2. Full-page math (boundary 560)
+    // would wrongly return col 1.
+    expect(determineColumn(layout, 540, page)).toBe(2);
   });
 });

--- a/packages/layout-engine/layout-bridge/test/position-hit.test.ts
+++ b/packages/layout-engine/layout-bridge/test/position-hit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { FlowBlock, ParagraphAttrs } from '@superdoc/contracts';
-import { isRtlBlock } from '../src/position-hit';
+import type { FlowBlock, ParagraphAttrs, Layout } from '@superdoc/contracts';
+import { isRtlBlock, determineColumn } from '../src/position-hit';
 
 const paragraph = (attrs?: Record<string, unknown>): FlowBlock => ({
   kind: 'paragraph',
@@ -65,5 +65,30 @@ describe('isRtlBlock', () => {
   it('falls back to paragraphProperties.rightToLeft when no other direction signal is present', () => {
     expect(isRtlBlock(paragraph({ paragraphProperties: { rightToLeft: true } }))).toBe(true);
     expect(isRtlBlock(paragraph({ paragraphProperties: { rightToLeft: false } }))).toBe(false);
+  });
+});
+
+describe('determineColumn (SD-2629: resolved per-column boundaries)', () => {
+  const makeLayout = (columns: Layout['columns']): Layout =>
+    ({ pageSize: { w: 600, h: 800 }, pages: [], columns }) as unknown as Layout;
+
+  it('returns 0 for single-column or missing columns', () => {
+    expect(determineColumn(makeLayout(undefined), 300)).toBe(0);
+    expect(determineColumn(makeLayout({ count: 1, gap: 0 }), 300)).toBe(0);
+  });
+
+  it('maps x to equal columns by uniform boundaries', () => {
+    // Two equal columns in a 600px page (gap 0): boundary at 300.
+    const layout = makeLayout({ count: 2, gap: 0 });
+    expect(determineColumn(layout, 100)).toBe(0);
+    expect(determineColumn(layout, 350)).toBe(1);
+  });
+
+  it('honors per-column widths for explicit columns, not a uniform stride', () => {
+    // Explicit unequal widths [100, 400] (gap 0): the boundary is at the authored 100px, not the
+    // equal-split 300px. x=150 lands in column 1, where a uniform stride would say column 0.
+    const layout = makeLayout({ count: 2, gap: 0, widths: [100, 400], equalWidth: false });
+    expect(determineColumn(layout, 50)).toBe(0);
+    expect(determineColumn(layout, 150)).toBe(1);
   });
 });

--- a/packages/layout-engine/layout-bridge/test/position-hit.test.ts
+++ b/packages/layout-engine/layout-bridge/test/position-hit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { FlowBlock, ParagraphAttrs, Layout, Page } from '@superdoc/contracts';
-import { isRtlBlock, determineColumn } from '../src/position-hit';
+import type { FlowBlock, ParagraphAttrs, Layout, Page, TableFragment } from '@superdoc/contracts';
+import { isRtlBlock, determineColumn, determineTableColumn } from '../src/position-hit';
 
 const paragraph = (attrs?: Record<string, unknown>): FlowBlock => ({
   kind: 'paragraph',
@@ -130,5 +130,27 @@ describe('determineColumn (SD-2629: resolved per-column boundaries)', () => {
     // y=200 is in the single-column region -> column 0 at the same x (page.columns alone would always
     // say 0; the region lookup is what makes the y=400 case return 1).
     expect(determineColumn(layout, 450, page, 200)).toBe(0);
+  });
+
+  it('clamps a table fragment columnIndex against its mid-page region count, not page-start (SD-2629)', () => {
+    // Table fragments carry columnIndex (the column they were laid out in). A table in a mid-page
+    // two-column region has columnIndex 1; clamping against the page-START single-column count would
+    // wrongly snap it to 0. Clamp against the region's count, selected by the fragment's y.
+    const page = {
+      columns: { count: 1, gap: 0 },
+      columnRegions: [
+        { yStart: 96, yEnd: 300, columns: { count: 1, gap: 0 } },
+        { yStart: 300, yEnd: 700, columns: { count: 2, gap: 24 } },
+      ],
+      margins: { left: 96, right: 96 },
+      size: { w: 816, h: 1056 },
+    } as unknown as Page;
+    const layout = { pageSize: { w: 816, h: 1056 }, columns: page.columns, pages: [page] } as unknown as Layout;
+    const tableInRegion = { kind: 'table', x: 96, y: 400, columnIndex: 1 } as unknown as TableFragment;
+    const tableInSingle = { kind: 'table', x: 96, y: 200, columnIndex: 1 } as unknown as TableFragment;
+    // y=400 is in the two-column region (count 2) -> columnIndex 1 is preserved.
+    expect(determineTableColumn(layout, tableInRegion, page)).toBe(1);
+    // y=200 is in the single-column region (count 1) -> columnIndex 1 clamps to 0.
+    expect(determineTableColumn(layout, tableInSingle, page)).toBe(0);
   });
 });

--- a/packages/layout-engine/layout-engine/src/column-balancing.test.ts
+++ b/packages/layout-engine/layout-engine/src/column-balancing.test.ts
@@ -376,6 +376,36 @@ describe('balanceSectionOnPage', () => {
     expect(col1).toBe(3);
   });
 
+  it('balances equal-width columns with non-uniform gaps using per-column geometry (SD-2629 F9)', () => {
+    // The headline SD-2629 case: equal column WIDTHS (so the equal-width guard admits balancing) but
+    // NON-UNIFORM gaps [0, 48]. Column x must follow the resolved per-column geometry, not a uniform
+    // stride. With 6 paragraphs across 3 columns (2 each): col1 sits at margin(96) + width(192) +
+    // gaps[0]=0 = 288 (a uniform scalar gap of 24 would wrongly place it at 312); col2 at
+    // 96 + 192 + 0 + 192 + gaps[1]=48 = 528.
+    const top = 96;
+    const { fragments, measureMap, blockSectionMap } = buildSectionFixture(2, 6, 20, top);
+
+    const result = balanceSectionOnPage({
+      fragments,
+      sectionIndex: 2,
+      sectionColumns: { count: 3, gap: 24, width: 192, widths: [192, 192, 192], gaps: [0, 48], equalWidth: false },
+      sectionHasExplicitColumnBreak: false,
+      blockSectionMap,
+      margins: { left: 96 },
+      topMargin: top,
+      columnWidth: 192,
+      availableHeight: 40,
+      measureMap,
+    });
+
+    expect(result).not.toBeNull();
+    const xs = [...new Set(fragments.map((f) => f.x))].sort((a, b) => a - b);
+    expect(xs).toEqual([96, 288, 528]);
+    // col1 is at the per-column position 288, never the uniform-stride 312.
+    expect(fragments.filter((f) => f.x === 288).length).toBe(2);
+    expect(fragments.filter((f) => f.x === 312).length).toBe(0);
+  });
+
   it('returns null and leaves fragments untouched when section has <= 1 column', () => {
     const { fragments, measureMap, blockSectionMap } = buildSectionFixture(2, 3);
     const snapshot = fragments.map((f) => ({ x: f.x, y: f.y }));

--- a/packages/layout-engine/layout-engine/src/column-balancing.ts
+++ b/packages/layout-engine/layout-engine/src/column-balancing.ts
@@ -6,6 +6,8 @@
  * matching Microsoft Word's behavior.
  */
 
+import { getColumnGeometry, getColumnX } from '@superdoc/contracts';
+
 // ============================================================================
 // Types and Interfaces
 // ============================================================================
@@ -628,6 +630,11 @@ export interface SectionColumnLayout {
   gap: number;
   width?: number;
   widths?: number[];
+  /**
+   * Per-column gaps (px), length count-1; explicit mode only. Drives geometry so equal-width
+   * sections with non-uniform gaps (e.g. F9) balance with correct column positions. (SD-2629)
+   */
+  gaps?: number[];
   equalWidth?: boolean;
 }
 
@@ -803,7 +810,17 @@ export function balanceSectionOnPage(args: BalanceSectionOnPageArgs): { maxY: nu
     DEFAULT_BALANCING_CONFIG,
   );
 
-  const columnX = (columnIndex: number): number => args.margins.left + columnIndex * (columnWidth + columnGap);
+  // Per-column x from the resolved geometry, not a uniform stride. SD-2629's core case is equal
+  // widths with NON-uniform gaps (e.g. F9), which the equal-width guard above still admits, so
+  // columnIndex * (width + gap) would mis-place later columns. Equal gaps reduce to the old stride.
+  const balancedGeometry = getColumnGeometry({
+    count: columnCount,
+    gap: columnGap,
+    width: columnWidth,
+    ...(Array.isArray(sectionColumns.widths) ? { widths: sectionColumns.widths } : {}),
+    ...(Array.isArray(sectionColumns.gaps) ? { gaps: sectionColumns.gaps } : {}),
+  });
+  const columnX = (columnIndex: number): number => getColumnX(balancedGeometry, columnIndex, args.margins.left);
 
   const colCursors = new Array<number>(columnCount).fill(sectionTopY);
   let maxY = sectionTopY;

--- a/packages/layout-engine/layout-engine/src/floating-objects.ts
+++ b/packages/layout-engine/layout-engine/src/floating-objects.ts
@@ -24,7 +24,7 @@ import type {
   TableWrap,
   ColumnLayoutForAnchor,
 } from '@superdoc/contracts';
-import { resolveAnchoredGraphicX } from '@superdoc/contracts';
+import { resolveAnchoredGraphicX, getColumnGeometry, getColumnWidth, getColumnX } from '@superdoc/contracts';
 
 type FloatBlock = ImageBlock | DrawingBlock;
 type FloatMeasure = ImageMeasure | DrawingMeasure;
@@ -234,8 +234,9 @@ export function createFloatingObjectManager(
       const leftFloats: ExclusionZone[] = [];
       const rightFloats: ExclusionZone[] = [];
 
-      // Use absolute coordinates for comparison - columnOrigin is the left edge of content
-      const columnOrigin = marginLeft + columnIndex * (currentColumns.width + currentColumns.gap);
+      // Use absolute coordinates for comparison - columnOrigin is the left edge of content.
+      // Resolved geometry honors per-column widths/gaps (SD-2629); equal columns match the old stride.
+      const columnOrigin = getColumnX(getColumnGeometry(currentColumns), columnIndex, marginLeft);
       const columnCenter = columnOrigin + baseWidth / 2;
 
       for (const zone of wrappingZones) {
@@ -374,7 +375,8 @@ function computeTableAnchorX(
   const contentWidth = pageWidth != null ? Math.max(1, pageWidth - (marginLeft + marginRight)) : columns.width;
 
   const contentLeft = marginLeft;
-  const columnLeft = contentLeft + columnIndex * (columns.width + columns.gap);
+  const geometry = getColumnGeometry(columns);
+  const columnLeft = getColumnX(geometry, columnIndex, contentLeft);
 
   const relativeFrom = anchor.hRelativeFrom ?? 'column';
 
@@ -395,7 +397,7 @@ function computeTableAnchorX(
   } else {
     // 'column' (default)
     baseX = columnLeft;
-    availableWidth = columns.width;
+    availableWidth = getColumnWidth(geometry, columnIndex);
   }
 
   // Handle table-specific alignment values (inside/outside map to left/right for now)

--- a/packages/layout-engine/layout-engine/src/floating-objects.ts
+++ b/packages/layout-engine/layout-engine/src/floating-objects.ts
@@ -24,7 +24,7 @@ import type {
   TableWrap,
   ColumnLayoutForAnchor,
 } from '@superdoc/contracts';
-import { resolveAnchoredGraphicX, getColumnGeometry, getColumnWidth, getColumnX } from '@superdoc/contracts';
+import { resolveAnchoredGraphicX, getColumnGeometry, getColumnX } from '@superdoc/contracts';
 
 type FloatBlock = ImageBlock | DrawingBlock;
 type FloatMeasure = ImageMeasure | DrawingMeasure;
@@ -397,7 +397,10 @@ function computeTableAnchorX(
   } else {
     // 'column' (default)
     baseX = columnLeft;
-    availableWidth = getColumnWidth(geometry, columnIndex);
+    // Scalar (max) column width, matching anchored-object measurement (clamped to columns.width).
+    // Per-column origin above is honored; per-column available width waits on per-column measurement
+    // so a max-sized object is not centered/right-aligned into the margin or gap. (SD-2629)
+    availableWidth = columns.width;
   }
 
   // Handle table-specific alignment values (inside/outside map to left/right for now)

--- a/packages/layout-engine/layout-engine/src/index.test.ts
+++ b/packages/layout-engine/layout-engine/src/index.test.ts
@@ -311,6 +311,29 @@ describe('layoutDocument', () => {
     expect(layout.pages[0].columns).toEqual({ count: 2, gap: 20, widths: [192, 384], equalWidth: false });
   });
 
+  it('places explicit columns at authored widths driven by per-column gaps (SD-2629 step 4)', () => {
+    // The step-4 flip: explicit widths are no longer scaled to fill the content box, and each
+    // column is positioned by its own gap. Three authored 192px columns (sum 576) sit in a 720px
+    // content box with per-column gaps [0, 48]; total 624 < 720 leaves trailing space (Word does
+    // not stretch authored widths). Per-column geometry:
+    //   col0 @ 40                                  (left margin)
+    //   col1 @ 40 + 192 + gaps[0]=0          = 232
+    //   col2 @ 40 + 192 + 0 + 192 + gaps[1]=48 = 472
+    // Before the flip, normalize scaled the widths to ~240px and applied the scalar gap (0),
+    // placing the columns at 40 / 280 / 520. This test fails on the pre-flip engine.
+    const options: LayoutOptions = {
+      pageSize: { w: 800, h: 800 },
+      margins: { top: 40, right: 40, bottom: 40, left: 40 },
+      columns: { count: 3, gap: 0, widths: [192, 192, 192], gaps: [0, 48], equalWidth: false },
+    };
+    // One 700px line per column: each 720px-tall column holds exactly one, filling all three.
+    const layout = layoutDocument([block], [makeMeasure([700, 700, 700])], options);
+
+    expect(layout.pages).toHaveLength(1);
+    const xs = layout.pages[0].fragments.map((fragment) => Math.round(fragment.x)).sort((a, b) => a - b);
+    expect(xs).toEqual([40, 232, 472]);
+  });
+
   it('does not set "page.columns" on single column layout', () => {
     const options: LayoutOptions = {
       pageSize: { w: 600, h: 800 },

--- a/packages/layout-engine/layout-engine/src/index.ts
+++ b/packages/layout-engine/layout-engine/src/index.ts
@@ -69,7 +69,12 @@ import { normalizeFragmentsForRegion } from './normalize-header-footer-fragments
 import { createPaginator, type PageState, type ConstraintBoundary } from './paginator.js';
 import { formatPageNumber } from './pageNumbering.js';
 import { shouldSuppressSpacingForEmpty, shouldSuppressOwnSpacing } from './layout-utils.js';
-import { balanceSectionOnPage, type BalancingFragment, type MeasureData } from './column-balancing.js';
+import {
+  balanceSectionOnPage,
+  type BalancingFragment,
+  type MeasureData,
+  type SectionColumnLayout,
+} from './column-balancing.js';
 import { cloneColumnLayout } from './column-utils.js';
 
 type PageSize = { w: number; h: number };
@@ -2297,14 +2302,7 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
           balanceResult = balanceSectionOnPage({
             fragments: state.page.fragments as BalancingFragment[],
             sectionIndex: endingSectionIndex!,
-            sectionColumns: {
-              count: normalized.count,
-              gap: normalized.gap,
-              width: normalized.width,
-              widths: endingSectionColumns!.widths,
-              gaps: normalized.gaps,
-              equalWidth: endingSectionColumns!.equalWidth,
-            },
+            sectionColumns: toBalancingColumns(normalized),
             sectionHasExplicitColumnBreak: false,
             blockSectionMap,
             margins: { left: activeLeftMargin },
@@ -3118,14 +3116,7 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
     balanceSectionOnPage({
       fragments: lastPageForSection.fragments as BalancingFragment[],
       sectionIndex: sectionIdx,
-      sectionColumns: {
-        count: normalized.count,
-        gap: normalized.gap,
-        width: normalized.width,
-        widths: sectionCols.widths,
-        gaps: normalized.gaps,
-        equalWidth: sectionCols.equalWidth,
-      },
+      sectionColumns: toBalancingColumns(normalized),
       sectionHasExplicitColumnBreak: false, // already filtered above
       blockSectionMap,
       margins: { left: sectionLeftMargin },
@@ -3503,6 +3494,22 @@ export function layoutHeaderFooter(
  */
 function normalizeColumns(input: ColumnLayout | undefined, contentWidth: number): NormalizedColumns {
   return normalizeColumnLayout(input, contentWidth, COLUMN_EPSILON);
+}
+
+// Build balanceSectionOnPage's column input from the RESOLVED (normalized) layout. Both balancing
+// call sites must source widths/gaps from `normalized` (sliced to the resolved count), never the raw
+// config: raw widths can be longer than the count, which makes the equal-width balancing guard read
+// surplus entries (vetoing balancing of columns that render equal) and builds phantom geometry
+// columns. Single builder so the two call sites cannot drift apart. (SD-2629)
+function toBalancingColumns(normalized: NormalizedColumns): SectionColumnLayout {
+  return {
+    count: normalized.count,
+    gap: normalized.gap,
+    width: normalized.width,
+    ...(Array.isArray(normalized.widths) ? { widths: normalized.widths } : {}),
+    ...(Array.isArray(normalized.gaps) ? { gaps: normalized.gaps } : {}),
+    ...(normalized.equalWidth !== undefined ? { equalWidth: normalized.equalWidth } : {}),
+  };
 }
 
 const _buildMeasureMap = (blocks: FlowBlock[], measures: Measure[]): Map<string, Measure> => {

--- a/packages/layout-engine/layout-engine/src/index.ts
+++ b/packages/layout-engine/layout-engine/src/index.ts
@@ -2302,6 +2302,7 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
               gap: normalized.gap,
               width: normalized.width,
               widths: endingSectionColumns!.widths,
+              gaps: normalized.gaps,
               equalWidth: endingSectionColumns!.equalWidth,
             },
             sectionHasExplicitColumnBreak: false,
@@ -3122,6 +3123,7 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
         gap: normalized.gap,
         width: normalized.width,
         widths: sectionCols.widths,
+        gaps: normalized.gaps,
         equalWidth: sectionCols.equalWidth,
       },
       sectionHasExplicitColumnBreak: false, // already filtered above

--- a/packages/layout-engine/painters/dom/src/renderer-column-separators.test.ts
+++ b/packages/layout-engine/painters/dom/src/renderer-column-separators.test.ts
@@ -97,18 +97,20 @@ describe('DomPainter renderColumnSeparators', () => {
       expect(seps.map((s) => s.style.left)).toEqual(['296px', '520px']);
     });
 
-    it('uses explicit column widths when drawing separators for page.columns', () => {
+    it('uses authored explicit column widths (unscaled) when drawing separators (SD-2629)', () => {
+      // Explicit widths are NOT scaled to fill: [200, 300] in a 576px available area stay [200, 300]
+      // (trailing space), so the separator sits after the authored 200px column, not a scaled one.
+      // (Old behavior scaled them up to [230.4, 345.6] and placed the separator near 350.)
       const page = buildPage({
-        columns: { count: 2, gap: 48, widths: [200, 952], equalWidth: false, withSeparator: true },
-        fragments: [fragAt(96), fragAt(244)],
+        columns: { count: 2, gap: 48, widths: [200, 300], equalWidth: false, withSeparator: true },
+        fragments: [fragAt(96), fragAt(360)],
       });
       paintOnce(buildLayout(page), mount);
 
       const seps = querySeparators(mount);
       expect(seps).toHaveLength(1);
-      // contentWidth=624, availableWidth=576. Explicit widths [200, 952] are
-      // normalized to [100, 476], so the separator belongs at 96 + 100 + 24 = 220.
-      expect(seps[0].style.left).toBe('220px');
+      // separator = leftMargin + authored width[0] + gap/2 = 96 + 200 + 24 = 320.
+      expect(seps[0].style.left).toBe('320px');
     });
 
     it('renders nothing when withSeparator is false', () => {


### PR DESCRIPTION
Explicit `<w:col>` widths now render at their authored size instead of being scaled to fill the content area, and each column is positioned by its own `w:space` gap.

This matches Word behavior: underfilled explicit columns leave trailing space, and overfilled explicit columns overflow rather than scaling down. Sections with non-uniform gaps no longer collapse those gaps into one uniform value.

Builds on the resolved column-geometry foundation from #3633.

- `normalizeColumnLayout` preserves explicit widths in both directions, underfilled and overfilled
- column geometry positions each column by its own gap
- hit-testing resolves columns against the page content box, including margins
- anchored graphics use the per-column origin while keeping scalar available width to match current image and drawing measurement
- balancing reads resolved widths and gaps through one builder, with coverage for non-uniform gaps
- `resolveColumnLayout` filters usable width/gap records before slicing, so malformed configs stay idempotent

Equal-width columns are unchanged. Explicit-column sections move only when their authored widths or gaps differ from the old force-filled geometry.

Review note: anchored graphics intentionally keep scalar available width for now because measurement is still scalar. Per-column available width should wait for per-column image and drawing measurement.

Verified:
- `pnpm check:types` clean
- layout corpus vs current `origin/main`: exactly one real geometry change, the intended explicit-column width flip; all other changes are run-to-run id noise
- Word probe confirmed overfull explicit columns do not scale down
