### PR TITLE
feat(seq-fields): import, resolve, and export SEQ sequence fields (SD-3018)

### DIFF
--- a/packages/layout-engine/contracts/src/index.ts
+++ b/packages/layout-engine/contracts/src/index.ts
@@ -449,7 +449,7 @@ export type TextRun = RunMarks & {
   visualPlaceholder?: SdtVisualPlaceholder;
   link?: FlowRunLink;
   /** Token annotations for dynamic content (page numbers, etc.). */
-  token?: 'pageNumber' | 'totalPageCount' | 'pageReference' | 'sectionPageCount';
+  token?: 'pageNumber' | 'totalPageCount' | 'pageReference' | 'sectionPageCount' | 'seq';
   /** Explicit formatting requested by PAGE/NUMPAGES/SECTIONPAGES field switches. */
   pageNumberFieldFormat?: PageNumberFieldFormat;
   /** Absolute ProseMirror position (inclusive) of first character in this run. */
@@ -468,6 +468,21 @@ export type TextRun = RunMarks & {
     numericPictureFormat?: NumericPictureFormat;
     /** CHARFORMAT / MERGEFORMAT, if present. */
     fieldResultFormat?: FieldResultFormat;
+  };
+  /** Metadata for SEQ tokens (resolved by super-editor before layout measurement). */
+  seqMetadata?: {
+    identifier: string;
+    instruction?: string;
+    fieldArgument?: string;
+    sequenceMode?: 'next' | 'current';
+    hideResult?: boolean;
+    restartNumber?: number | null;
+    restartLevel?: number | null;
+    format?: string;
+    hasGeneralFormat?: boolean;
+    pageNumberFieldFormat?: PageNumberFieldFormat | null;
+    numericPictureFormat?: NumericPictureFormat | null;
+    cachedText?: string;
   };
   /** Tracked-change metadata from ProseMirror marks. */
   trackedChange?: TrackedChangeMeta;

--- a/packages/layout-engine/contracts/src/page-number-formatting.test.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.test.ts
@@ -14,6 +14,19 @@ describe('page number formatting', () => {
     expect(formatPageNumber(28, 'upperLetter')).toBe('BB');
     expect(formatPageNumber(703, 'lowerLetter')).toBe('a'.repeat(28));
     expect(formatPageNumber(12, 'numberInDash')).toBe('- 12 -');
+    expect(formatPageNumber(1, 'ordinal')).toBe('1st');
+    expect(formatPageNumber(2, 'ordinal')).toBe('2nd');
+    expect(formatPageNumber(3, 'ordinal')).toBe('3rd');
+    expect(formatPageNumber(4, 'ordinal')).toBe('4th');
+    expect(formatPageNumber(11, 'ordinal')).toBe('11th');
+    expect(formatPageNumber(12, 'ordinal')).toBe('12th');
+    expect(formatPageNumber(13, 'ordinal')).toBe('13th');
+    expect(formatPageNumber(21, 'ordinal')).toBe('21st');
+    expect(formatPageNumber(22, 'ordinal')).toBe('22nd');
+    expect(formatPageNumber(23, 'ordinal')).toBe('23rd');
+    expect(formatPageNumber(111, 'ordinal')).toBe('111th');
+    expect(formatPageNumber(112, 'ordinal')).toBe('112th');
+    expect(formatPageNumber(113, 'ordinal')).toBe('113th');
   });
 
   it('normalizes page numbers before formatting', () => {
@@ -33,6 +46,16 @@ describe('page number formatting', () => {
   it('applies decimal zero padding for field values', () => {
     expect(formatPageNumberFieldValue(7, { format: 'decimal', zeroPadding: 3 })).toBe('007');
     expect(formatPageNumberFieldValue(7, { format: 'lowerRoman', zeroPadding: 3 })).toBe('vii');
+  });
+
+  it('formats ordinal field values', () => {
+    expect(formatPageNumberFieldValue(32, { format: 'ordinal' })).toBe('32nd');
+  });
+
+  it('uses numeric pictures before enum format and zero padding', () => {
+    expect(formatPageNumberFieldValue(1234, { numericPicture: '#,##0' })).toBe('1,234');
+    expect(formatPageNumberFieldValue(7, { format: 'ordinal', zeroPadding: 3, numericPicture: '00' })).toBe('07');
+    expect(formatPageNumberFieldValue(0, { numericPicture: '00' })).toBe('01');
   });
 
   it('formats integer values with numeric pictures', () => {

--- a/packages/layout-engine/contracts/src/page-number-formatting.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.ts
@@ -1,6 +1,7 @@
 export type PageNumberFieldFormat = {
-  format?: 'decimal' | 'upperRoman' | 'lowerRoman' | 'upperLetter' | 'lowerLetter' | 'numberInDash';
+  format?: 'decimal' | 'upperRoman' | 'lowerRoman' | 'upperLetter' | 'lowerLetter' | 'numberInDash' | 'ordinal';
   zeroPadding?: number;
+  numericPicture?: string;
 };
 
 export type PageNumberFormat = NonNullable<PageNumberFieldFormat['format']>;
@@ -31,6 +32,22 @@ function toUpperLetter(value: number): string {
   return String.fromCharCode(65 + index).repeat(repeatCount);
 }
 
+function toOrdinal(value: number): string {
+  const remainder = value % 100;
+  if (remainder >= 11 && remainder <= 13) return `${value}th`;
+
+  switch (value % 10) {
+    case 1:
+      return `${value}st`;
+    case 2:
+      return `${value}nd`;
+    case 3:
+      return `${value}rd`;
+    default:
+      return `${value}th`;
+  }
+}
+
 export function formatPageNumber(pageNumber: number, format: PageNumberFormat): string {
   const value = Math.max(1, Math.trunc(Number.isFinite(pageNumber) ? pageNumber : 1));
 
@@ -45,6 +62,8 @@ export function formatPageNumber(pageNumber: number, format: PageNumberFormat): 
       return toUpperLetter(value).toLowerCase();
     case 'numberInDash':
       return `- ${value} -`;
+    case 'ordinal':
+      return toOrdinal(value);
     case 'decimal':
     default:
       return String(value);
@@ -52,6 +71,11 @@ export function formatPageNumber(pageNumber: number, format: PageNumberFormat): 
 }
 
 export function formatPageNumberFieldValue(pageNumber: number, fieldFormat?: PageNumberFieldFormat): string {
+  if (fieldFormat?.numericPicture) {
+    const value = Math.max(1, Math.trunc(Number.isFinite(pageNumber) ? pageNumber : 1));
+    return formatIntegerWithNumericPicture(value, fieldFormat.numericPicture);
+  }
+
   const format = fieldFormat?.format ?? 'decimal';
   const formatted = formatPageNumber(pageNumber, format);
   return fieldFormat?.zeroPadding && format === 'decimal'
@@ -101,7 +125,7 @@ export function formatSectionPageNumberText(args: {
 }
 
 /**
- * Formats integer field values with a Word numeric picture subset used by PAGEREF.
+ * Formats integer page field values with a Word numeric picture subset.
  * Unsupported ECMA features are intentionally out of scope here: backtick
  * numbered-item references, localized separators, and fractional rounding.
  */

--- a/packages/layout-engine/layout-engine/src/index.ts
+++ b/packages/layout-engine/layout-engine/src/index.ts
@@ -30,6 +30,7 @@ import type {
   NormalizedColumnLayout,
   DocumentBackground,
   HeaderFooterResolutionSection,
+  PageNumberFormat,
 } from '@superdoc/contracts';
 import {
   buildLayoutSourceIdentityForFragment,
@@ -1427,8 +1428,7 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
   // Paginator encapsulation for page/column helpers
   let pageCount = 0;
   // Page numbering state
-  let activeNumberFormat: 'decimal' | 'lowerLetter' | 'upperLetter' | 'lowerRoman' | 'upperRoman' | 'numberInDash' =
-    'decimal';
+  let activeNumberFormat: PageNumberFormat = 'decimal';
   let activePageCounter = 1;
   let activeSectionPageCounterStart = activePageCounter;
   let pendingNumbering: SectionNumbering | null = null;

--- a/packages/layout-engine/layout-engine/src/resolvePageTokens.test.ts
+++ b/packages/layout-engine/layout-engine/src/resolvePageTokens.test.ts
@@ -299,4 +299,70 @@ describe('resolveTokensInBlock', () => {
     expect((block.runs[0] as TextRun).token).toBeUndefined();
     expect((block.runs[0] as TextRun).pageNumberFieldFormat).toBeUndefined();
   });
+
+  it('should apply run-local total page count zero padding', () => {
+    const block: ParagraphBlock = {
+      kind: 'paragraph',
+      id: 'test-total-count-zero-padding-format',
+      runs: [
+        {
+          text: '0',
+          token: 'totalPageCount',
+          pageNumberFieldFormat: { format: 'decimal', zeroPadding: 3 },
+          fontFamily: 'Arial',
+          fontSize: 12,
+        } as TextRun,
+      ],
+    };
+
+    const wasModified = resolveTokensInBlock(block, 1, 7);
+
+    expect(wasModified).toBe(true);
+    expect((block.runs[0] as TextRun).text).toBe('007');
+    expect((block.runs[0] as TextRun).token).toBeUndefined();
+  });
+
+  it('should apply run-local total page count grouping picture', () => {
+    const block: ParagraphBlock = {
+      kind: 'paragraph',
+      id: 'test-total-count-picture-format',
+      runs: [
+        {
+          text: '0',
+          token: 'totalPageCount',
+          pageNumberFieldFormat: { numericPicture: '#,##0' },
+          fontFamily: 'Arial',
+          fontSize: 12,
+        } as TextRun,
+      ],
+    };
+
+    const wasModified = resolveTokensInBlock(block, 1, 1234);
+
+    expect(wasModified).toBe(true);
+    expect((block.runs[0] as TextRun).text).toBe('1,234');
+    expect((block.runs[0] as TextRun).token).toBeUndefined();
+  });
+
+  it('should apply run-local total page count ordinal format', () => {
+    const block: ParagraphBlock = {
+      kind: 'paragraph',
+      id: 'test-total-count-ordinal-format',
+      runs: [
+        {
+          text: '0',
+          token: 'totalPageCount',
+          pageNumberFieldFormat: { format: 'ordinal' },
+          fontFamily: 'Arial',
+          fontSize: 12,
+        } as TextRun,
+      ],
+    };
+
+    const wasModified = resolveTokensInBlock(block, 1, 22);
+
+    expect(wasModified).toBe(true);
+    expect((block.runs[0] as TextRun).text).toBe('22nd');
+    expect((block.runs[0] as TextRun).token).toBeUndefined();
+  });
 });

--- a/packages/layout-engine/layout-engine/src/resolvePageTokens.ts
+++ b/packages/layout-engine/layout-engine/src/resolvePageTokens.ts
@@ -335,9 +335,12 @@ export function resolveTokensInBlock(block: ParagraphBlock, pageNumber: number, 
         blockModified = true;
       } else if (run.token === 'totalPageCount') {
         // Replace placeholder text with total page count
-        run.text = totalPagesStr;
+        run.text = run.pageNumberFieldFormat
+          ? formatPageNumberFieldValue(totalPages, run.pageNumberFieldFormat)
+          : totalPagesStr;
         // Clear token metadata to treat as normal text after resolution
         delete run.token;
+        delete run.pageNumberFieldFormat;
         blockModified = true;
       }
       // Note: pageReference tokens are handled by resolvePageRefs.ts

--- a/packages/layout-engine/measuring/dom/src/index.test.ts
+++ b/packages/layout-engine/measuring/dom/src/index.test.ts
@@ -8,8 +8,10 @@ import type {
   DrawingMeasure,
   DrawingBlock,
   TableMeasure,
+  TextRun,
 } from '@superdoc/contracts';
 import { EMPTY_SDT_PLACEHOLDER_TEXT } from '@superdoc/contracts';
+import { resolvePhysicalFamily } from '@superdoc/font-system';
 
 const expectParagraphMeasure = (measure: Measure): ParagraphMeasure => {
   expect(measure.kind).toBe('paragraph');
@@ -81,6 +83,91 @@ describe('measureBlock', () => {
       // lineHeight should be at least ascent + descent (+ safety margin)
       expect(measure.lines[0].lineHeight).toBeGreaterThanOrEqual(measure.lines[0].ascent + measure.lines[0].descent);
       expect(measure.totalHeight).toBe(measure.lines[0].lineHeight);
+    });
+
+    it('does not count empty text runs as justification spaces', async () => {
+      const visibleRuns = [
+        {
+          text: '1. Confidential Information. In connection with ',
+          fontFamily: 'Arial',
+          fontSize: 16,
+        },
+      ];
+      const withoutEmptyRuns: FlowBlock = {
+        kind: 'paragraph',
+        id: 'without-empty-runs',
+        runs: visibleRuns,
+        attrs: { alignment: 'justify' },
+      };
+      const withEmptyRuns: FlowBlock = {
+        kind: 'paragraph',
+        id: 'with-empty-runs',
+        runs: [
+          { text: '', fontFamily: 'Arial', fontSize: 16 },
+          { text: '', fontFamily: 'Arial', fontSize: 16 },
+          { text: '', fontFamily: 'Arial', fontSize: 16 },
+          ...visibleRuns,
+        ],
+        attrs: { alignment: 'justify' },
+      };
+
+      const baseMeasure = expectParagraphMeasure(await measureBlock(withoutEmptyRuns, 1000));
+      const emptyPrefixMeasure = expectParagraphMeasure(await measureBlock(withEmptyRuns, 1000));
+
+      expect(emptyPrefixMeasure.lines).toHaveLength(1);
+      expect(emptyPrefixMeasure.lines[0].width).toBeCloseTo(baseMeasure.lines[0].width, 3);
+      expect(emptyPrefixMeasure.lines[0].spaceCount).toBe(baseMeasure.lines[0].spaceCount);
+      expect(emptyPrefixMeasure.lines[0].segments).toEqual([
+        {
+          runIndex: 3,
+          fromChar: 0,
+          toChar: visibleRuns[0].text.length,
+          width: expect.any(Number),
+        },
+      ]);
+    });
+
+    it('keeps empty-only paragraphs measurable without phantom spaces', async () => {
+      const block: FlowBlock = {
+        kind: 'paragraph',
+        id: 'empty-only-runs',
+        runs: [
+          { text: '', fontFamily: 'Arial', fontSize: 16 },
+          { text: '', fontFamily: 'Arial', fontSize: 16 },
+        ],
+        attrs: {},
+      };
+
+      const measure = expectParagraphMeasure(await measureBlock(block, 1000));
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.lines[0].width).toBe(0);
+      expect(measure.lines[0].spaceCount).toBeUndefined();
+      expect(measure.lines[0].segments).toEqual([]);
+      expect(measure.totalHeight).toBeGreaterThan(0);
+    });
+
+    it('does not let skipped empty runs inflate visible line height', async () => {
+      const visibleBlock: FlowBlock = {
+        kind: 'paragraph',
+        id: 'visible-small-run',
+        runs: [{ text: 'visible', fontFamily: 'Arial', fontSize: 12 }],
+        attrs: {},
+      };
+      const emptyPrefixBlock: FlowBlock = {
+        kind: 'paragraph',
+        id: 'empty-large-prefix-run',
+        runs: [
+          { text: '', fontFamily: 'Arial', fontSize: 48 },
+          { text: 'visible', fontFamily: 'Arial', fontSize: 12 },
+        ],
+        attrs: {},
+      };
+
+      const visibleMeasure = expectParagraphMeasure(await measureBlock(visibleBlock, 1000));
+      const emptyPrefixMeasure = expectParagraphMeasure(await measureBlock(emptyPrefixBlock, 1000));
+
+      expect(emptyPrefixMeasure.lines[0].lineHeight).toBeCloseTo(visibleMeasure.lines[0].lineHeight, 3);
     });
 
     // SD-3330: a line containing only tabs must be measured at the run's font size,
@@ -744,7 +831,7 @@ describe('measureBlock', () => {
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
       expect(ctx).not.toBeNull();
-      ctx!.font = '16px Arial';
+      ctx!.font = `16px ${resolvePhysicalFamily('Arial')}`;
       const transformedPlaceholderText = EMPTY_SDT_PLACEHOLDER_TEXT.toUpperCase();
       const transformedWidth = ctx!.measureText(transformedPlaceholderText).width;
       const untransformedWidth = ctx!.measureText(EMPTY_SDT_PLACEHOLDER_TEXT).width;

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -2198,6 +2198,10 @@ async function measureParagraphBlock(
     // Handle text runs
     lastFontSize = run.fontSize;
     hasSeenTextRun = true;
+    if (run.text === '') {
+      pendingRunSpacing = 0;
+      continue;
+    }
     const { font } = buildFontString(run, fontContext);
     const tabSegments = run.text.split('\t');
 

--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -6946,6 +6946,31 @@ describe('DomPainter', () => {
       resolvePartText({ text: '3', fieldType: 'SECTIONPAGES' }, { pageNumber: 1, totalPages: 9, section: 'body' }),
     ).toBe('3');
   });
+
+  it('formats NUMPAGES drawing text with supported pageNumberFormat', () => {
+    const painter = new DomPainter();
+    const resolvePartText = (
+      painter as unknown as {
+        resolveShapeTextPartText: (
+          part: { text: string; fieldType: string; pageNumberFormat?: string },
+          context: { pageNumber: number; totalPages: number; section: 'body' },
+        ) => string;
+      }
+    ).resolveShapeTextPartText.bind(painter);
+
+    expect(
+      resolvePartText(
+        { text: '9', fieldType: 'NUMPAGES', pageNumberFormat: 'upperRoman' },
+        { pageNumber: 1, totalPages: 9, section: 'body' },
+      ),
+    ).toBe('IX');
+    expect(
+      resolvePartText(
+        { text: '9', fieldType: 'NUMPAGES', pageNumberFormat: 'ordinal' },
+        { pageNumber: 1, totalPages: 12, section: 'body' },
+      ),
+    ).toBe('12th');
+  });
   describe('resolved paragraph rendering', () => {
     it('renders resolved paragraph lines with precomputed indent styles', () => {
       const paragraphBlock: FlowBlock = {

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -3158,7 +3158,8 @@ export class DomPainter {
       return context?.pageNumberText ?? String(context?.pageNumber ?? 1);
     }
     if (part.fieldType === 'NUMPAGES') {
-      return String(context?.totalPages ?? 1);
+      const totalPages = context?.totalPages ?? 1;
+      return part.pageNumberFormat ? formatPageNumber(totalPages, part.pageNumberFormat) : String(totalPages);
     }
     if (part.fieldType === 'SECTIONPAGES') {
       if (context?.sectionPageCount == null) return part.text ?? '1';

--- a/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.test.ts
+++ b/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.test.ts
@@ -311,6 +311,28 @@ describe('HeaderFooterEditorManager', () => {
     expect(sectionPages.textContent).toBe('IV');
   });
 
+  it('refreshes total page count DOM text with node numeric picture format', () => {
+    const editor = createMockEditor();
+    const manager = new HeaderFooterEditorManager(editor);
+    const descriptor = { id: 'rId-header-default', kind: 'header' } as const;
+    const host = document.createElement('div');
+
+    const sectionEditor = manager.ensureEditorSync(descriptor, { editorHost: host });
+    expect(sectionEditor).toBeDefined();
+    const totalPages = document.createElement('span');
+    totalPages.dataset.id = 'auto-total-pages';
+    totalPages.textContent = '1';
+    sectionEditor!.view.dom.appendChild(totalPages);
+    (sectionEditor!.view as unknown as { posAtDOM: ReturnType<typeof vi.fn> }).posAtDOM = vi.fn(() => 0);
+    (sectionEditor as unknown as { state: { doc: { nodeAt: ReturnType<typeof vi.fn> } } }).state = {
+      doc: { nodeAt: vi.fn(() => ({ attrs: { pageNumberNumericPicture: '000' } })) },
+    };
+
+    manager.ensureEditorSync(descriptor, { editorHost: host, totalPageCount: 12 });
+
+    expect(totalPages.textContent).toBe('012');
+  });
+
   it('refreshes chapter-prefixed page number DOM text with node pageNumberFormat', () => {
     const editor = createMockEditor();
     const manager = new HeaderFooterEditorManager(editor);

--- a/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.ts
+++ b/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.ts
@@ -2,6 +2,7 @@ import { toFlowBlocks } from '@core/layout-adapter';
 import { getAtomNodeTypes as getAtomNodeTypesFromSchema } from '../presentation-editor/utils/SchemaNodeTypes.js';
 import {
   formatPageNumber,
+  formatPageNumberFieldValue,
   formatSectionPageNumberText,
   type FlowBlock,
   type PageNumberChapterSeparator,
@@ -14,6 +15,7 @@ import { EventEmitter } from '@core/EventEmitter.js';
 import { createHeaderFooterEditor, onHeaderFooterDataUpdate } from '@extensions/pagination/pagination-helpers.js';
 import type { ConverterContext } from '@core/layout-adapter/converter-context.js';
 import { buildStoryKey } from '../../document-api-adapters/story-runtime/story-key.js';
+import { getPageNumberFieldFormat } from '../layout-adapter/converters/inline-converters/page-number-field-format.js';
 
 const HEADER_FOOTER_VARIANTS = ['default', 'first', 'even', 'odd'] as const;
 const DEFAULT_HEADER_FOOTER_HEIGHT = 100;
@@ -504,7 +506,7 @@ export class HeaderFooterEditorManager extends EventEmitter {
       typeof opts.currentPageChapterSeparator === 'string'
         ? (opts.currentPageChapterSeparator as PageNumberChapterSeparator)
         : undefined;
-    const totalPages = String(opts.totalPageCount || parentEditor?.currentTotalPages || '1');
+    const totalPages = Number(opts.totalPageCount || parentEditor?.currentTotalPages || 1) || 1;
     const sectionPages = opts.sectionPageCount;
 
     const pageNumberEls = container.querySelectorAll('[data-id="auto-page-number"]');
@@ -524,7 +526,9 @@ export class HeaderFooterEditorManager extends EventEmitter {
       if (el.textContent !== text) el.textContent = text;
     });
     totalPagesEls.forEach((el) => {
-      if (el.textContent !== totalPages) el.textContent = totalPages;
+      const pageNumberFieldFormat = this.#getPageNumberFieldFormatForDomNode(editor, el);
+      const text = formatPageNumberFieldValue(totalPages, pageNumberFieldFormat);
+      if (el.textContent !== text) el.textContent = text;
     });
     sectionPagesEls.forEach((el) => {
       if (sectionPages == null) return;
@@ -545,6 +549,18 @@ export class HeaderFooterEditorManager extends EventEmitter {
       return typeof format === 'string' ? (format as PageNumberFormat) : null;
     } catch {
       return null;
+    }
+  }
+
+  #getPageNumberFieldFormatForDomNode(editor: Editor, el: Element): ReturnType<typeof getPageNumberFieldFormat> {
+    try {
+      const view = editor.view;
+      if (!view) return undefined;
+      const pos = view.posAtDOM(el, 0);
+      const node = editor.state.doc.nodeAt(pos);
+      return getPageNumberFieldFormat(node?.attrs);
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/attributes/paragraph.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/attributes/paragraph.ts
@@ -203,6 +203,18 @@ const resolveHeadingLevel = (
   return undefined;
 };
 
+export const resolveParagraphHeadingLevel = (
+  paragraphProperties: ParagraphProperties | undefined,
+  converterContext?: ConverterContext,
+): number | undefined => {
+  const properties = paragraphProperties ?? {};
+  const resolvedParagraphProperties = converterContext
+    ? resolveParagraphProperties(converterContext, properties, converterContext.tableInfo)
+    : properties;
+
+  return resolveHeadingLevel(resolvedParagraphProperties.styleId, resolvedParagraphProperties, converterContext);
+};
+
 const TRACKED_CHANGE_KEYS = new Set(['trackInsert', 'trackDelete']);
 
 export const hasExplicitParagraphRunProperties = (

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.test.ts
@@ -11,6 +11,15 @@ describe('getPageNumberFieldFormat', () => {
     ).toEqual({ format: 'decimal', zeroPadding: 2 });
   });
 
+  it('threads ordinal and numeric-picture attributes for layout runs', () => {
+    expect(
+      getPageNumberFieldFormat({
+        pageNumberFormat: 'ordinal',
+        pageNumberNumericPicture: '#,##0',
+      }),
+    ).toEqual({ format: 'ordinal', numericPicture: '#,##0' });
+  });
+
   it('ignores invalid format attributes', () => {
     expect(getPageNumberFieldFormat(undefined)).toBeUndefined();
     expect(getPageNumberFieldFormat({ pageNumberFormat: 1, pageNumberZeroPadding: Number.NaN })).toBeUndefined();

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.ts
@@ -9,9 +9,14 @@ export function getPageNumberFieldFormat(
     typeof attrs.pageNumberZeroPadding === 'number' && Number.isFinite(attrs.pageNumberZeroPadding)
       ? attrs.pageNumberZeroPadding
       : undefined;
-  if (!format && !zeroPadding) return undefined;
+  const numericPicture =
+    typeof attrs.pageNumberNumericPicture === 'string' && attrs.pageNumberNumericPicture.length > 0
+      ? attrs.pageNumberNumericPicture
+      : undefined;
+  if (!format && !zeroPadding && !numericPicture) return undefined;
   return {
     ...(format ? { format: format as NonNullable<TextRun['pageNumberFieldFormat']>['format'] } : {}),
-    ...(zeroPadding ? { zeroPadding } : {}),
+    ...(zeroPadding != null ? { zeroPadding } : {}),
+    ...(numericPicture ? { numericPicture } : {}),
   };
 }

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/sequence-field.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/sequence-field.ts
@@ -4,18 +4,33 @@ import { textNodeToRun } from './text-run.js';
 import type { InlineConverterParams } from './common.js';
 
 /**
- * Converts a sequenceField PM node to a TextRun with the resolved sequence number.
+ * Converts a sequenceField PM node to a TextRun token for post-assembly resolution.
  */
 export function sequenceFieldNodeToRun(params: InlineConverterParams): TextRun | null {
   const { node, positions, sdtMetadata } = params;
 
   const attrs = (node.attrs ?? {}) as Record<string, unknown>;
-  const resolvedNumber = (attrs.resolvedNumber as string) || '0';
+  const cachedText = typeof attrs.resolvedNumber === 'string' ? attrs.resolvedNumber : '';
 
   const run = textNodeToRun({
     ...params,
-    node: { type: 'text', text: resolvedNumber, marks: [...(node.marks ?? [])] } as PMNode,
+    node: { type: 'text', text: cachedText || '1', marks: [...(node.marks ?? [])] } as PMNode,
   });
+  run.token = 'seq';
+  run.seqMetadata = {
+    identifier: String(attrs.identifier ?? ''),
+    instruction: String(attrs.instruction ?? ''),
+    fieldArgument: String(attrs.fieldArgument ?? ''),
+    sequenceMode: attrs.sequenceMode === 'current' ? 'current' : 'next',
+    hideResult: attrs.hideResult === true,
+    restartNumber: typeof attrs.restartNumber === 'number' ? attrs.restartNumber : null,
+    restartLevel: typeof attrs.restartLevel === 'number' ? attrs.restartLevel : null,
+    format: typeof attrs.format === 'string' ? attrs.format : undefined,
+    hasGeneralFormat: attrs.hasGeneralFormat === true,
+    pageNumberFieldFormat: readObjectAttr(attrs.pageNumberFieldFormat),
+    numericPictureFormat: readObjectAttr(attrs.numericPictureFormat),
+    cachedText,
+  };
 
   const pos = positions.get(node);
   if (pos) {
@@ -28,4 +43,8 @@ export function sequenceFieldNodeToRun(params: InlineConverterParams): TextRun |
   }
 
   return run;
+}
+
+function readObjectAttr<T extends object>(value: unknown): T | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as T) : null;
 }

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/internal.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/internal.ts
@@ -21,6 +21,7 @@ import {
 } from './sections/index.js';
 import { normalizePrefix, buildPositionMap, createBlockIdGenerator } from './utilities.js';
 import { stampTrackedChangeColors } from '@superdoc/contracts';
+import { resolveSequenceFieldTokens } from './resolve-sequence-fields.js';
 import {
   paragraphToFlowBlocks,
   contentBlockNodeToDrawingBlock,
@@ -295,6 +296,7 @@ export function toFlowBlocks(pmDoc: PMNode | object, options?: AdapterOptions): 
   // read it directly without invoking app callbacks. Passing `undefined`
   // clears stale colors from cached blocks when the host disables the feature.
   stampTrackedChangeColors(mergedBlocks, options?.resolveTrackedChangeColor);
+  resolveSequenceFieldTokens(mergedBlocks);
 
   // Commit cache cycle - swaps next to previous, retaining only blocks seen this render
   flowBlockCache?.commit();

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/resolve-sequence-fields.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/resolve-sequence-fields.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from 'vitest';
+import type { FlowBlock, ParagraphBlock, TableBlock, TextRun } from '@superdoc/contracts';
+import { toFlowBlocks as baseToFlowBlocks, FlowBlockCache } from './index.js';
+import { resolveSequenceFieldTokens } from './resolve-sequence-fields.js';
+import type { AdapterOptions, PMNode } from './index.js';
+
+const createDefaultConverterContext = () => ({
+  docx: {},
+  translatedLinkedStyles: {
+    docDefaults: {},
+    latentStyles: {},
+    styles: {},
+  },
+  translatedNumbering: {
+    abstracts: {},
+    definitions: {},
+  },
+});
+
+const toFlowBlocks = (pmDoc: PMNode | object, options: AdapterOptions = {}) =>
+  baseToFlowBlocks(pmDoc, { converterContext: createDefaultConverterContext(), ...options });
+
+const seq = (attrs: Record<string, unknown> = {}) => ({
+  type: 'sequenceField',
+  attrs: {
+    instruction: 'SEQ Figure',
+    identifier: 'Figure',
+    sequenceMode: 'next',
+    hideResult: false,
+    restartNumber: null,
+    restartLevel: null,
+    format: 'Arabic',
+    hasGeneralFormat: false,
+    pageNumberFieldFormat: null,
+    numericPictureFormat: null,
+    resolvedNumber: '',
+    ...attrs,
+  },
+});
+
+const paragraph = (content: PMNode['content'] = [], attrs: Record<string, unknown> = {}) => ({
+  type: 'paragraph',
+  attrs,
+  content,
+});
+
+const stableParagraph = (id: string, content: PMNode['content'] = []) =>
+  paragraph(content, { sdBlockId: id, sdBlockRev: 1 });
+
+const tableWithCellContent = (content: PMNode['content']) => ({
+  type: 'table',
+  content: [
+    {
+      type: 'tableRow',
+      content: [
+        {
+          type: 'tableCell',
+          content,
+        },
+      ],
+    },
+  ],
+});
+
+const textRuns = (blocks: FlowBlock[]): TextRun[] => {
+  const runs: TextRun[] = [];
+  const visit = (block: FlowBlock) => {
+    if (block.kind === 'paragraph') {
+      for (const run of (block as ParagraphBlock).runs) {
+        if ('text' in run) runs.push(run as TextRun);
+      }
+      return;
+    }
+    if (block.kind === 'table') {
+      for (const row of (block as TableBlock).rows) {
+        for (const cell of row.cells) {
+          for (const childBlock of cell.blocks ?? (cell.paragraph ? [cell.paragraph] : [])) {
+            visit(childBlock);
+          }
+        }
+      }
+      return;
+    }
+    if (block.kind === 'list') {
+      for (const item of block.items) {
+        visit(item.paragraph);
+      }
+    }
+  };
+  blocks.forEach(visit);
+  return runs;
+};
+
+const runTexts = (blocks: FlowBlock[]) => textRuns(blocks).map((run) => run.text);
+
+describe('resolveSequenceFieldTokens', () => {
+  it('renders two cached-empty sequence fields as 1 and 2', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [paragraph([seq()]), paragraph([seq()])],
+    });
+
+    expect(runTexts(blocks)).toEqual(['1', '2']);
+    expect(textRuns(blocks).map((run) => run.token)).toEqual(['seq', 'seq']);
+  });
+
+  it('keeps interleaved identifiers independent', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([seq({ identifier: 'Figure' })]),
+        paragraph([seq({ identifier: 'Table', instruction: 'SEQ Table' })]),
+        paragraph([seq({ identifier: 'Figure' })]),
+      ],
+    });
+
+    expect(runTexts(blocks)).toEqual(['1', '1', '2']);
+  });
+
+  it('repeats the prior display for current mode', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [paragraph([seq()]), paragraph([seq({ sequenceMode: 'current', instruction: 'SEQ Figure \\c' })])],
+    });
+
+    expect(runTexts(blocks)).toEqual(['1', '1']);
+  });
+
+  it('honors restartNumber and continues from it', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [paragraph([seq({ restartNumber: 10, instruction: 'SEQ Figure \\r 10' })]), paragraph([seq()])],
+    });
+
+    expect(runTexts(blocks)).toEqual(['10', '11']);
+  });
+
+  it('hides hidden results while still advancing the counter', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([seq()]),
+        paragraph([seq({ hideResult: true, instruction: 'SEQ Figure \\h' })]),
+        paragraph([seq()]),
+      ],
+    });
+
+    expect(runTexts(blocks)).toEqual(['1', '', '3']);
+  });
+
+  it('restarts after resolved heading-level paragraphs', () => {
+    const headingAttrs = { paragraphProperties: { outlineLvl: 0 } };
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([{ type: 'text', text: 'Chapter 1' }], headingAttrs),
+        paragraph([seq({ restartLevel: 1, instruction: 'SEQ Figure \\s 1' })]),
+        paragraph([seq({ restartLevel: 1, instruction: 'SEQ Figure \\s 1' })]),
+        paragraph([{ type: 'text', text: 'Chapter 2' }], headingAttrs),
+        paragraph([seq({ restartLevel: 1, instruction: 'SEQ Figure \\s 1' })]),
+      ],
+    });
+
+    expect(runTexts(blocks)).toEqual(['Chapter 1', '1', '2', 'Chapter 2', '1']);
+  });
+
+  it('applies page-number and numeric-picture formats', () => {
+    const roman = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([seq({ pageNumberFieldFormat: { format: 'lowerRoman' }, hasGeneralFormat: true })]),
+        paragraph([seq({ pageNumberFieldFormat: { format: 'lowerRoman' }, hasGeneralFormat: true })]),
+      ],
+    });
+    const picture = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([seq({ numericPictureFormat: { picture: '00' } })]),
+        paragraph([seq({ numericPictureFormat: { picture: '00' } })]),
+      ],
+    });
+
+    expect(runTexts(roman.blocks)).toEqual(['i', 'ii']);
+    expect(runTexts(picture.blocks)).toEqual(['01', '02']);
+  });
+
+  it('isolates counters across separate toFlowBlocks calls', () => {
+    const doc = { type: 'doc', content: [paragraph([seq()])] };
+
+    expect(runTexts(toFlowBlocks(doc).blocks)).toEqual(['1']);
+    expect(runTexts(toFlowBlocks(doc).blocks)).toEqual(['1']);
+  });
+
+  it('counts sequence fields inside table cells in document order', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [paragraph([seq()]), tableWithCellContent([paragraph([seq()])]), paragraph([seq()])],
+    });
+
+    expect(runTexts(blocks)).toEqual(['1', '2', '3']);
+  });
+
+  it('renumbers cache-hit paragraphs after a sequence field is inserted above them', () => {
+    const cache = new FlowBlockCache();
+    const firstDoc = {
+      type: 'doc',
+      content: [stableParagraph('p1', [seq()]), stableParagraph('p2', [seq()]), stableParagraph('p3', [seq()])],
+    };
+    expect(runTexts(toFlowBlocks(firstDoc, { flowBlockCache: cache }).blocks)).toEqual(['1', '2', '3']);
+
+    const secondDoc = {
+      type: 'doc',
+      content: [
+        stableParagraph('p1', [seq()]),
+        stableParagraph('inserted', [seq()]),
+        stableParagraph('p2', [seq()]),
+        stableParagraph('p3', [seq()]),
+      ],
+    };
+    const { blocks } = toFlowBlocks(secondDoc, { flowBlockCache: cache });
+
+    expect(cache.stats.hits).toBeGreaterThanOrEqual(3);
+    expect(runTexts(blocks)).toEqual(['1', '2', '3', '4']);
+  });
+
+  it('walks list item paragraphs when list blocks are present', () => {
+    const seqRun = (identifier = 'Figure'): TextRun => ({
+      text: '1',
+      token: 'seq',
+      seqMetadata: { identifier, cachedText: '' },
+      fontFamily: 'Times New Roman, serif',
+      fontSize: 12,
+    });
+    const blocks: FlowBlock[] = [
+      {
+        kind: 'list',
+        id: 'list-1',
+        listType: 'number',
+        items: [
+          {
+            id: 'item-1',
+            marker: { text: '1.', width: 10 },
+            paragraph: { kind: 'paragraph', id: 'p1', runs: [seqRun()] },
+          },
+          {
+            id: 'item-2',
+            marker: { text: '2.', width: 10 },
+            paragraph: { kind: 'paragraph', id: 'p2', runs: [seqRun()] },
+          },
+        ],
+      },
+    ];
+
+    resolveSequenceFieldTokens(blocks);
+
+    expect(runTexts(blocks)).toEqual(['1', '2']);
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/resolve-sequence-fields.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/resolve-sequence-fields.test.ts
@@ -148,6 +148,25 @@ describe('resolveSequenceFieldTokens', () => {
     expect(runTexts(blocks)).toEqual(['1', '', '3']);
   });
 
+  it('lets hidden restart-zero fields seed the next visible value at one', () => {
+    const { blocks } = toFlowBlocks({
+      type: 'doc',
+      content: [
+        paragraph([
+          seq({
+            instruction: 'seq level2 \\h \\r0',
+            identifier: 'level2',
+            hideResult: true,
+            restartNumber: 0,
+          }),
+        ]),
+        paragraph([seq({ instruction: 'seq level2 \\*arabic', identifier: 'level2', hasGeneralFormat: true })]),
+      ],
+    });
+
+    expect(runTexts(blocks)).toEqual(['', '1']);
+  });
+
   it('restarts after resolved heading-level paragraphs', () => {
     const headingAttrs = { paragraphProperties: { outlineLvl: 0 } };
     const { blocks } = toFlowBlocks({

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/resolve-sequence-fields.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/resolve-sequence-fields.ts
@@ -1,0 +1,60 @@
+import type { FlowBlock, ListBlock, ParagraphBlock, Run, TableBlock } from '@superdoc/contracts';
+import { SequenceFieldEvaluator } from '../super-converter/field-references/shared/seq-evaluator.js';
+
+/**
+ * Resolve SEQ token runs after all blocks have been assembled in document order.
+ * This keeps numbering cache-safe because cached paragraphs still contribute
+ * their preserved token metadata to the linear pass.
+ */
+export function resolveSequenceFieldTokens(blocks: FlowBlock[]): void {
+  const evaluator = new SequenceFieldEvaluator();
+  for (const block of blocks) {
+    resolveBlock(block, evaluator);
+  }
+}
+
+function resolveBlock(block: FlowBlock, evaluator: SequenceFieldEvaluator): void {
+  if (block.kind === 'paragraph') {
+    resolveParagraph(block as ParagraphBlock, evaluator);
+    return;
+  }
+
+  if (block.kind === 'table') {
+    resolveTable(block as TableBlock, evaluator);
+    return;
+  }
+
+  if (block.kind === 'list') {
+    resolveList(block as ListBlock, evaluator);
+  }
+}
+
+function resolveParagraph(block: ParagraphBlock, evaluator: SequenceFieldEvaluator): void {
+  evaluator.enterParagraph({ paragraphHeadingLevel: block.attrs?.headingLevel });
+  for (const run of block.runs) {
+    resolveRun(run, evaluator);
+  }
+}
+
+function resolveTable(block: TableBlock, evaluator: SequenceFieldEvaluator): void {
+  for (const row of block.rows) {
+    for (const cell of row.cells) {
+      const childBlocks = cell.blocks ?? (cell.paragraph ? [cell.paragraph] : []);
+      for (const childBlock of childBlocks) {
+        resolveBlock(childBlock, evaluator);
+      }
+    }
+  }
+}
+
+function resolveList(block: ListBlock, evaluator: SequenceFieldEvaluator): void {
+  for (const item of block.items) {
+    resolveParagraph(item.paragraph, evaluator);
+  }
+}
+
+function resolveRun(run: Run, evaluator: SequenceFieldEvaluator): void {
+  if ('token' in run && run.token === 'seq' && run.seqMetadata) {
+    run.text = evaluator.evaluateField(run.seqMetadata).text;
+  }
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/index.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/index.js
@@ -39,9 +39,6 @@ import { extractFieldKeyword } from '../field-keyword.js';
  * @returns {InstructionPreProcessor | null} The pre-processor function or null if not found.
  */
 export const getInstructionPreProcessor = (instruction) => {
-  const rawInstructionType = String(instruction ?? '')
-    .trim()
-    .split(/\s+/)[0];
   const instructionType = extractFieldKeyword(instruction);
   switch (instructionType) {
     case 'PAGE':
@@ -72,7 +69,6 @@ export const getInstructionPreProcessor = (instruction) => {
     case 'STYLEREF':
       return preProcessStylerefInstruction;
     case 'SEQ':
-      if (rawInstructionType !== 'SEQ') return null;
       return preProcessSeqInstruction;
     case 'CITATION':
       return preProcessCitationInstruction;

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/index.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/fld-preprocessors/index.test.js
@@ -87,10 +87,13 @@ describe('getInstructionPreProcessor', () => {
     expect(processor).toBe(preProcessSeqInstruction);
   });
 
-  it('should leave lowercase seq fields unprocessed to preserve cached numbering results', () => {
-    const processor = getInstructionPreProcessor('seq level2 \\*arabic');
-    expect(processor).toBeNull();
-  });
+  it.each(['seq level2 \\*arabic', 'Seq Figure \\* Arabic'])(
+    'should dispatch SEQ fields case-insensitively: %s',
+    (instruction) => {
+      const processor = getInstructionPreProcessor(instruction);
+      expect(processor).toBe(preProcessSeqInstruction);
+    },
+  );
 
   it('should return preProcessTocInstruction for TOC instruction', () => {
     const instruction = 'TOC \\o "1-3" \\h \\z \\u';

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -86,6 +86,44 @@ describe('preProcessNodesForFldChar', () => {
     },
   );
 
+  it('preserves complex NUMPAGES numeric picture switches', () => {
+    const { processedNodes } = preProcessNodesForFldChar(complexFieldNodes('NUMPAGES \\# "#,##0"', '1,234'), mockDocx);
+
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0]).toMatchObject({
+      name: 'sd:totalPageNumber',
+      attributes: {
+        instruction: 'NUMPAGES \\# "#,##0"',
+        pageNumberNumericPicture: '#,##0',
+        importedCachedText: '1,234',
+      },
+    });
+  });
+
+  it('preserves fldSimple NUMPAGES zero-padding switches', () => {
+    const { processedNodes } = preProcessNodesForFldChar(
+      [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': 'NUMPAGES \\# "000"' },
+          elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '007' }] }] }],
+        },
+      ],
+      mockDocx,
+    );
+
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0]).toMatchObject({
+      name: 'sd:totalPageNumber',
+      attributes: {
+        instruction: 'NUMPAGES \\# "000"',
+        pageNumberFormat: 'decimal',
+        pageNumberZeroPadding: 3,
+        importedCachedText: '007',
+      },
+    });
+  });
+
   it('preserves SECTIONPAGES field run properties when cached result has no run properties', () => {
     const fieldRunRPr = { name: 'w:rPr', elements: [{ name: 'w:i' }] };
     const { processedNodes } = preProcessNodesForFldChar(

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -143,15 +143,47 @@ describe('preProcessNodesForFldChar', () => {
     ]);
   });
 
-  it('should preserve cached visible result runs for lowercase seq fields', () => {
-    const { processedNodes } = preProcessNodesForFldChar(complexFieldNodes('seq level2 \\*arabic', '1'), mockDocx);
+  it.each([
+    ['uppercase complex', complexFieldNodes('SEQ Figure \\* ARABIC', '7'), 'SEQ Figure \\* ARABIC', true],
+    ['lowercase complex', complexFieldNodes('seq Figure \\* arabic', '8'), 'seq Figure \\* arabic', true],
+    [
+      'uppercase fldSimple',
+      [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': 'SEQ Figure \\* ARABIC' },
+          elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '9' }] }] }],
+        },
+      ],
+      'SEQ Figure \\* ARABIC',
+      false,
+    ],
+    [
+      'lowercase fldSimple',
+      [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': 'seq Figure \\* arabic' },
+          elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '10' }] }] }],
+        },
+      ],
+      'seq Figure \\* arabic',
+      false,
+    ],
+  ])('processes %s SEQ fields and preserves cached result runs', (_name, nodes, instruction, hasInstructionTokens) => {
+    const { processedNodes } = preProcessNodesForFldChar(nodes, mockDocx);
 
-    expect(processedNodes).toHaveLength(5);
-    expect(processedNodes.some((node) => node.name === 'sd:sequenceField')).toBe(false);
-    expect(processedNodes[3]).toEqual({
-      name: 'w:r',
-      elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1' }] }],
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0]).toMatchObject({
+      name: 'sd:sequenceField',
+      attributes: { instruction },
     });
+    expect(processedNodes[0].elements).toHaveLength(1);
+    expect(processedNodes[0].elements[0].name).toBe('w:r');
+    expect(processedNodes[0].elements[0].elements?.[0]?.name).toBe('w:t');
+    expect(processedNodes[0].attributes.instructionTokens).toEqual(
+      hasInstructionTokens ? [{ type: 'text', text: instruction }] : undefined,
+    );
   });
 
   it('should handle nested fields (PAGEREF within HYPERLINK)', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.js
@@ -182,7 +182,8 @@ function scanFieldSequence(nodes, beginIndex) {
     const instrTextEl = node.elements?.find((el) => el.name === 'w:instrText');
 
     if (instrTextEl) {
-      instrText += (instrTextEl.elements?.[0]?.text || '') + ' ';
+      const fragment = instrTextEl.elements?.[0]?.text || '';
+      instrText += shouldInsertSwitchBoundarySpace(instrText, fragment) ? ` ${fragment}` : fragment;
     }
 
     // Capture rPr from field sequence nodes (before separate) if we don't have one yet
@@ -218,6 +219,13 @@ function scanFieldSequence(nodes, beginIndex) {
     fieldRunRPr,
     endIndex,
   };
+}
+
+function shouldInsertSwitchBoundarySpace(existingInstruction, nextFragment) {
+  return (
+    (/\w$/.test(existingInstruction) && /^\\/.test(nextFragment)) ||
+    (/(^|\s)\\[#*]$/.test(existingInstruction) && /^\S/.test(nextFragment))
+  );
 }
 
 /**

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
@@ -28,6 +28,31 @@ describe('preProcessPageFieldsOnly', () => {
     ];
   }
 
+  function complexFieldNodesFromInstructionFragments(instructionFragments, cachedText = '1') {
+    return [
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }],
+      },
+      ...instructionFragments.map((text) => ({
+        name: 'w:r',
+        elements: [{ name: 'w:instrText', elements: [{ type: 'text', text }] }],
+      })),
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }],
+      },
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:t', elements: [{ type: 'text', text: cachedText }] }],
+      },
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }],
+      },
+    ];
+  }
+
   describe('complex field syntax (w:fldChar)', () => {
     it('should process PAGE field with fldChar syntax', () => {
       const nodes = [
@@ -133,6 +158,119 @@ describe('preProcessPageFieldsOnly', () => {
           pageNumberFormat: 'decimal',
           pageNumberZeroPadding: 2,
           importedCachedText: '05',
+        },
+      });
+    });
+
+    it('should preserve NUMPAGES quoted numeric picture whitespace across split instrText runs', () => {
+      const nodes = [
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'NUMPAGES \\# "#' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: '   pages"' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1   pages' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:totalPageNumber',
+        attributes: {
+          instruction: 'NUMPAGES \\# "#   pages"',
+          pageNumberNumericPicture: '#   pages',
+          importedCachedText: '1   pages',
+        },
+      });
+    });
+
+    it('should process NUMPAGES switches split at a run boundary without whitespace', () => {
+      const nodes = [
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'NUMPAGES' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: '\\# "000"' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:t', elements: [{ type: 'text', text: '007' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:totalPageNumber',
+        attributes: {
+          instruction: 'NUMPAGES \\# "000"',
+          pageNumberFormat: 'decimal',
+          pageNumberZeroPadding: 3,
+          importedCachedText: '007',
+        },
+      });
+    });
+
+    it('should process NUMPAGES numeric switches split between operator and argument', () => {
+      const result = preProcessPageFieldsOnly(
+        complexFieldNodesFromInstructionFragments(['NUMPAGES', '\\#', '"000"'], '007'),
+      );
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:totalPageNumber',
+        attributes: {
+          instruction: 'NUMPAGES \\# "000"',
+          pageNumberFormat: 'decimal',
+          pageNumberZeroPadding: 3,
+          importedCachedText: '007',
+        },
+      });
+    });
+
+    it('should process PAGE general-format switches split between operator and argument', () => {
+      const result = preProcessPageFieldsOnly(complexFieldNodesFromInstructionFragments(['PAGE', '\\*', 'Roman']));
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:autoPageNumber',
+        attributes: {
+          instruction: 'PAGE \\* Roman',
+          pageNumberFormat: 'upperRoman',
         },
       });
     });

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
@@ -8,6 +8,7 @@ export const GENERAL_FORMATS = new Map([
   ['alphabetic', 'lowerLetter'],
   ['ALPHABETIC', 'upperLetter'],
   ['ArabicDash', 'numberInDash'],
+  ['Ordinal', 'ordinal'],
 ]);
 
 export const CASE_INSENSITIVE_GENERAL_FORMATS = new Map([
@@ -18,17 +19,18 @@ export const CASE_INSENSITIVE_GENERAL_FORMATS = new Map([
 /**
  * @param {string} instruction
  * @param {'PAGE' | 'NUMPAGES' | 'SECTIONPAGES'} fieldType
- * @returns {{ instruction?: string, pageNumberFormat?: string, pageNumberZeroPadding?: number }}
+ * @returns {{ instruction?: string, pageNumberFormat?: string, pageNumberZeroPadding?: number, pageNumberNumericPicture?: string }}
  */
 export function parsePageNumberFieldSwitches(instruction, fieldType) {
-  const normalizedInstruction = typeof instruction === 'string' ? instruction.trim().replace(/\s+/g, ' ') : fieldType;
+  const switchInstruction = typeof instruction === 'string' ? instruction.trim() : fieldType;
+  const normalizedInstruction = normalizeInstructionWhitespace(switchInstruction);
   const result = {};
 
   if (normalizedInstruction && normalizedInstruction !== fieldType) {
     result.instruction = normalizedInstruction;
   }
 
-  for (const match of normalizedInstruction.matchAll(/\\\*\s+("[^"]+"|\S+)/g)) {
+  for (const match of switchInstruction.matchAll(/\\\*\s+("[^"]+"|\S+)/g)) {
     const rawValue = unquote(match[1]);
     const mapped = GENERAL_FORMATS.get(rawValue) ?? CASE_INSENSITIVE_GENERAL_FORMATS.get(rawValue.toLowerCase());
     if (mapped) {
@@ -37,13 +39,18 @@ export function parsePageNumberFieldSwitches(instruction, fieldType) {
     }
   }
 
-  for (const match of normalizedInstruction.matchAll(/\\#\s+("[^"]+"|\S+)/g)) {
+  for (const match of switchInstruction.matchAll(/\\#\s+("[^"]+"|\S+)/g)) {
     const picture = unquote(match[1]);
+    if (!picture) continue;
+
     if (/^0+$/.test(picture)) {
       result.pageNumberFormat ??= 'decimal';
       result.pageNumberZeroPadding = picture.length;
-      break;
+    } else {
+      result.pageNumberNumericPicture = picture;
     }
+
+    break;
   }
 
   return result;
@@ -51,12 +58,13 @@ export function parsePageNumberFieldSwitches(instruction, fieldType) {
 
 /**
  * @param {number} pageNumber
- * @param {{ pageNumberFormat?: string | null, pageNumberZeroPadding?: number | null }} attrs
+ * @param {{ pageNumberFormat?: string | null, pageNumberZeroPadding?: number | null, pageNumberNumericPicture?: string | null }} attrs
  */
 export function formatPageNumberFieldValue(pageNumber, attrs = {}) {
   return formatSharedPageNumberFieldValue(pageNumber, {
     format: attrs.pageNumberFormat || 'decimal',
     zeroPadding: attrs.pageNumberZeroPadding ?? undefined,
+    numericPicture: attrs.pageNumberNumericPicture ?? undefined,
   });
 }
 
@@ -65,4 +73,41 @@ export function formatPageNumberFieldValue(pageNumber, attrs = {}) {
  */
 function unquote(value) {
   return value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value;
+}
+
+/**
+ * Collapse field-code whitespace outside quoted switch arguments while
+ * preserving significant whitespace inside numeric-picture literals.
+ *
+ * @param {string} instruction
+ */
+function normalizeInstructionWhitespace(instruction) {
+  let normalized = '';
+  let inQuote = false;
+  let pendingSpace = false;
+
+  for (const char of instruction) {
+    if (char === '"') {
+      if (pendingSpace && normalized.length > 0) {
+        normalized += ' ';
+        pendingSpace = false;
+      }
+      normalized += char;
+      inQuote = !inQuote;
+      continue;
+    }
+
+    if (!inQuote && /\s/.test(char)) {
+      pendingSpace = true;
+      continue;
+    }
+
+    if (pendingSpace && normalized.length > 0) {
+      normalized += ' ';
+      pendingSpace = false;
+    }
+    normalized += char;
+  }
+
+  return normalized;
 }

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.test.js
@@ -14,8 +14,16 @@ describe('parsePageNumberFieldSwitches', () => {
     ['PAGE \\* ArabicDash', { instruction: 'PAGE \\* ArabicDash', pageNumberFormat: 'numberInDash' }],
     ['PAGE \\* arabicdash', { instruction: 'PAGE \\* arabicdash', pageNumberFormat: 'numberInDash' }],
     ['PAGE \\* ARABICDASH', { instruction: 'PAGE \\* ARABICDASH', pageNumberFormat: 'numberInDash' }],
+    ['PAGE \\* Ordinal', { instruction: 'PAGE \\* Ordinal', pageNumberFormat: 'ordinal' }],
   ])('parses general format switch %s', (instruction, expected) => {
     expect(parsePageNumberFieldSwitches(instruction, 'PAGE')).toEqual(expected);
+  });
+
+  it('parses NUMPAGES Ordinal format switches', () => {
+    expect(parsePageNumberFieldSwitches('NUMPAGES \\* Ordinal', 'NUMPAGES')).toEqual({
+      instruction: 'NUMPAGES \\* Ordinal',
+      pageNumberFormat: 'ordinal',
+    });
   });
 
   it.each([['PAGE \\* rOman'], ['PAGE \\* Alphabetic'], ['PAGE \\* aLpHaBeTiC']])(
@@ -29,6 +37,15 @@ describe('parsePageNumberFieldSwitches', () => {
     ['NUMPAGES \\# "00"', { instruction: 'NUMPAGES \\# "00"', pageNumberFormat: 'decimal', pageNumberZeroPadding: 2 }],
     ['NUMPAGES \\# 000', { instruction: 'NUMPAGES \\# 000', pageNumberFormat: 'decimal', pageNumberZeroPadding: 3 }],
   ])('parses zero-padding picture switch %s', (instruction, expected) => {
+    expect(parsePageNumberFieldSwitches(instruction, 'NUMPAGES')).toEqual(expected);
+  });
+
+  it.each([
+    ['NUMPAGES \\# "#,##0"', { instruction: 'NUMPAGES \\# "#,##0"', pageNumberNumericPicture: '#,##0' }],
+    ['NUMPAGES \\# #,##0', { instruction: 'NUMPAGES \\# #,##0', pageNumberNumericPicture: '#,##0' }],
+    ['NUMPAGES \\# "# pages"', { instruction: 'NUMPAGES \\# "# pages"', pageNumberNumericPicture: '# pages' }],
+    ['NUMPAGES \\# "#   pages"', { instruction: 'NUMPAGES \\# "#   pages"', pageNumberNumericPicture: '#   pages' }],
+  ])('preserves non-zero numeric picture switch %s', (instruction, expected) => {
     expect(parsePageNumberFieldSwitches(instruction, 'NUMPAGES')).toEqual(expected);
   });
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-evaluator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-evaluator.js
@@ -1,0 +1,163 @@
+import { formatIntegerWithNumericPicture, formatPageNumberFieldValue } from '@superdoc/contracts';
+import { normalizeSeqIdentifier } from './seq-instruction.js';
+
+/**
+ * @typedef {{
+ *   initialCounters?: Map<string, number>,
+ * }} SeqEvaluatorOptions
+ *
+ * Note: no `storyKey` is needed. One evaluator instance is created per linear
+ * pass over one story's ordered content, so per-story isolation is structural.
+ *
+ * @typedef {{
+ *   identifier: string,
+ *   instruction?: string,
+ *   fieldArgument?: string,
+ *   sequenceMode?: 'next' | 'current',
+ *   hideResult?: boolean,
+ *   restartNumber?: number | null,
+ *   restartLevel?: number | null,
+ *   format?: string,
+ *   hasGeneralFormat?: boolean,
+ *   pageNumberFieldFormat?: import('@superdoc/contracts').PageNumberFieldFormat | null,
+ *   numericPictureFormat?: { picture: string } | null,
+ *   cachedText?: string,
+ * }} SeqFieldInput
+ *
+ * @typedef {{
+ *   paragraphHeadingLevel?: number | null,
+ * }} SeqFieldContext
+ *
+ * @typedef {{
+ *   value: number | null,
+ *   text: string,
+ *   hidden: boolean,
+ * }} SeqFieldEvaluation
+ */
+
+export class SequenceFieldEvaluator {
+  /**
+   * @param {SeqEvaluatorOptions} options
+   */
+  constructor(options = {}) {
+    this.counters = new Map(options.initialCounters ?? []);
+    this.headingSerialsByLevel = new Map();
+    this.lastResetSerialByIdentifierLevel = new Map();
+  }
+
+  /**
+   * @param {SeqFieldContext} context
+   */
+  enterParagraph(context = {}) {
+    const level = context.paragraphHeadingLevel;
+    if (!isValidHeadingLevel(level)) return;
+
+    this.headingSerialsByLevel.set(level, (this.headingSerialsByLevel.get(level) ?? 0) + 1);
+    for (let deeperLevel = level + 1; deeperLevel <= 9; deeperLevel += 1) {
+      this.headingSerialsByLevel.delete(deeperLevel);
+    }
+  }
+
+  /**
+   * @param {SeqFieldInput} field
+   * @returns {SeqFieldEvaluation}
+   */
+  evaluateField(field) {
+    const identifier = normalizeSeqIdentifier(field?.identifier);
+    const cachedText = typeof field?.cachedText === 'string' ? field.cachedText : '';
+
+    if (!identifier) {
+      return { value: null, text: cachedText, hidden: false };
+    }
+
+    if (hasFieldArgument(field)) {
+      // A SEQ field argument references a bookmarked item elsewhere. Correct
+      // behavior needs bookmark position resolution; until Phase 7 wires that
+      // in, preserve cached text or conservatively repeat the current counter.
+      // This short-circuit intentionally bypasses \h suppression for now.
+      if (cachedText) return { value: null, text: cachedText, hidden: false };
+      if (!this.counters.has(identifier)) return { value: null, text: '', hidden: false };
+
+      const value = this.counters.get(identifier);
+      return { value, text: formatSeqValue(value, field), hidden: false };
+    }
+
+    const restartLevel = normalizeRestartLevel(field?.restartLevel);
+    if (restartLevel != null) {
+      const key = `${identifier}|${restartLevel}`;
+      const serial = this.headingSerialsByLevel.get(restartLevel) ?? 0;
+      const previousSerial = this.lastResetSerialByIdentifierLevel.get(key);
+      if (previousSerial === undefined || serial !== previousSerial) {
+        // ECMA says \s "resets to the heading level"; Word interprets this as
+        // restarting sequence numbering within each heading-N section.
+        this.counters.set(identifier, 0);
+        this.lastResetSerialByIdentifierLevel.set(key, serial);
+      }
+    }
+
+    const restartNumber = normalizeRestartNumber(field?.restartNumber);
+    let value;
+    if (restartNumber != null) {
+      this.counters.set(identifier, restartNumber);
+      value = restartNumber;
+    } else if (field?.sequenceMode === 'current') {
+      if (!this.counters.has(identifier)) {
+        return { value: 0, text: cachedText, hidden: false };
+      }
+      value = this.counters.get(identifier);
+    } else {
+      value = (this.counters.get(identifier) ?? 0) + 1;
+      this.counters.set(identifier, value);
+    }
+
+    const hidden = Boolean(field?.hideResult && !field.hasGeneralFormat && !field.numericPictureFormat);
+    return {
+      value,
+      text: hidden ? '' : formatSeqValue(value, field),
+      hidden,
+    };
+  }
+}
+
+/**
+ * @param {unknown} value
+ */
+function isValidHeadingLevel(value) {
+  return Number.isInteger(value) && value >= 1 && value <= 9;
+}
+
+/**
+ * @param {unknown} value
+ */
+function normalizeRestartLevel(value) {
+  return isValidHeadingLevel(value) ? value : null;
+}
+
+/**
+ * @param {unknown} value
+ */
+function normalizeRestartNumber(value) {
+  return Number.isFinite(value) && Number.isInteger(value) ? Math.trunc(value) : null;
+}
+
+/**
+ * @param {SeqFieldInput | undefined} field
+ */
+function hasFieldArgument(field) {
+  return typeof field?.fieldArgument === 'string' && field.fieldArgument.trim().length > 0;
+}
+
+/**
+ * @param {number} value
+ * @param {SeqFieldInput | undefined} field
+ */
+function formatSeqValue(value, field) {
+  const picture = field?.numericPictureFormat?.picture;
+  if (picture) {
+    return formatIntegerWithNumericPicture(value, picture);
+  }
+  if (field?.pageNumberFieldFormat) {
+    return formatPageNumberFieldValue(value, field.pageNumberFieldFormat);
+  }
+  return String(value);
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-evaluator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-evaluator.test.js
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+import { SequenceFieldEvaluator } from './seq-evaluator.js';
+
+describe('SequenceFieldEvaluator', () => {
+  it('numbers each identifier independently in document order', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 1, text: '1' });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 2, text: '2' });
+    expect(evaluator.evaluateField({ identifier: 'Table' })).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('treats explicit next mode as the default', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure', sequenceMode: 'next' })).toMatchObject({
+      value: 1,
+      text: '1',
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 2, text: '2' });
+  });
+
+  it('repeats the current value without incrementing', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.evaluateField({ identifier: 'Figure' });
+    expect(evaluator.evaluateField({ identifier: 'Figure', sequenceMode: 'current' })).toMatchObject({
+      value: 1,
+      text: '1',
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 2, text: '2' });
+  });
+
+  it('uses cached text or empty text for current mode before any prior value', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure', sequenceMode: 'current', cachedText: 'cached' })).toEqual({
+      value: 0,
+      text: 'cached',
+      hidden: false,
+    });
+    expect(evaluator.evaluateField({ identifier: 'Table', sequenceMode: 'current' })).toEqual({
+      value: 0,
+      text: '',
+      hidden: false,
+    });
+  });
+
+  it('applies explicit restart and continues from that value', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartNumber: 10 })).toMatchObject({
+      value: 10,
+      text: '10',
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 11, text: '11' });
+  });
+
+  it('hides text while still updating the counter', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 1, text: '1' });
+    expect(evaluator.evaluateField({ identifier: 'Figure', hideResult: true })).toEqual({
+      value: 2,
+      text: '',
+      hidden: true,
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 3, text: '3' });
+  });
+
+  it('does not hide text when a general format is present', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(
+      evaluator.evaluateField({
+        identifier: 'Figure',
+        hideResult: true,
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'decimal' },
+      }),
+    ).toEqual({ value: 1, text: '1', hidden: false });
+  });
+
+  it('restarts on the first heading-level reset field and when that heading level changes', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 1 })).toMatchObject({ value: 1, text: '1' });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 1 })).toMatchObject({ value: 2, text: '2' });
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 1 })).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('restarts for level 2 only when the level 2 serial changes', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 2 })).toMatchObject({ value: 1, text: '1' });
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 2 })).toMatchObject({ value: 2, text: '2' });
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 2 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 2 })).toMatchObject({ value: 1, text: '1' });
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 2 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 2 })).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('treats a deleted deeper heading serial as 0 for heading-level resets', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    evaluator.enterParagraph({ paragraphHeadingLevel: 3 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 3 })).toMatchObject({ value: 1, text: '1' });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 2, text: '2' });
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 3 })).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('lets explicit restart win over heading-level reset', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.enterParagraph({ paragraphHeadingLevel: 1 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', restartLevel: 1, restartNumber: 7 })).toMatchObject({
+      value: 7,
+      text: '7',
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 8, text: '8' });
+  });
+
+  it('repeats the current counter after explicit restart', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    evaluator.evaluateField({ identifier: 'Figure', restartNumber: 7 });
+    expect(evaluator.evaluateField({ identifier: 'Figure', sequenceMode: 'current' })).toMatchObject({
+      value: 7,
+      text: '7',
+    });
+  });
+
+  it('formats values with general and numeric-picture formats', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(
+      evaluator.evaluateField({ identifier: 'Roman', pageNumberFieldFormat: { format: 'lowerRoman' } }),
+    ).toMatchObject({ value: 1, text: 'i' });
+    expect(
+      evaluator.evaluateField({ identifier: 'Alpha', pageNumberFieldFormat: { format: 'upperLetter' } }),
+    ).toMatchObject({ value: 1, text: 'A' });
+    expect(
+      evaluator.evaluateField({ identifier: 'Dash', pageNumberFieldFormat: { format: 'numberInDash' } }),
+    ).toMatchObject({ value: 1, text: '- 1 -' });
+    expect(evaluator.evaluateField({ identifier: 'Picture', numericPictureFormat: { picture: '00' } })).toMatchObject({
+      value: 1,
+      text: '01',
+    });
+  });
+
+  it('gives numeric-picture formatting priority over general formatting', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(
+      evaluator.evaluateField({
+        identifier: 'Figure',
+        pageNumberFieldFormat: { format: 'lowerRoman' },
+        numericPictureFormat: { picture: '00' },
+      }),
+    ).toMatchObject({ value: 1, text: '01' });
+  });
+
+  it('defaults unknown formats to decimal display instead of cached text', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(
+      evaluator.evaluateField({
+        identifier: 'Figure',
+        format: 'OrdText',
+        hasGeneralFormat: true,
+        cachedText: 'cached',
+      }),
+    ).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('returns cached fallback for empty identifiers without mutating counters', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: '', cachedText: 'cached' })).toEqual({
+      value: null,
+      text: 'cached',
+      hidden: false,
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 1, text: '1' });
+  });
+
+  it('handles field arguments conservatively without mutating counters', () => {
+    const evaluator = new SequenceFieldEvaluator();
+
+    expect(evaluator.evaluateField({ identifier: 'Figure', fieldArgument: 'bookmark', cachedText: 'cached' })).toEqual({
+      value: null,
+      text: 'cached',
+      hidden: false,
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 1, text: '1' });
+    expect(evaluator.evaluateField({ identifier: 'Figure', fieldArgument: 'bookmark' })).toEqual({
+      value: 1,
+      text: '1',
+      hidden: false,
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 2, text: '2' });
+  });
+
+  it('can start from caller-provided initial counters', () => {
+    const evaluator = new SequenceFieldEvaluator({ initialCounters: new Map([['Figure', 4]]) });
+
+    expect(evaluator.evaluateField({ identifier: 'Figure', sequenceMode: 'current' })).toMatchObject({
+      value: 4,
+      text: '4',
+    });
+    expect(evaluator.evaluateField({ identifier: 'Figure' })).toMatchObject({ value: 5, text: '5' });
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.js
@@ -1,0 +1,209 @@
+import { extractFieldKeyword } from '../field-keyword.js';
+import { CASE_INSENSITIVE_GENERAL_FORMATS, GENERAL_FORMATS } from './page-number-field-switches.js';
+
+const TOKEN_PATTERN = /"((?:[^"\\]|\\.)*)"|\\[#*]|\\[^\s]+|[^\s]+/g;
+
+/**
+ * @typedef {'next' | 'current'} SeqMode
+ * @typedef {{ picture: string }} SeqNumericPictureFormat
+ * @typedef {{
+ *   instruction: string,
+ *   keyword: string,
+ *   identifier: string,
+ *   fieldArgument: string,
+ *   sequenceMode: SeqMode,
+ *   hideResult: boolean,
+ *   restartNumber: number | null,
+ *   restartLevel: number | null,
+ *   format: string,
+ *   pageNumberFieldFormat?: import('@superdoc/contracts').PageNumberFieldFormat,
+ *   numericPictureFormat: SeqNumericPictureFormat | null,
+ *   hasGeneralFormat: boolean,
+ *   unknownSwitches: string[],
+ * }} ParsedSeqInstruction
+ */
+
+/**
+ * @param {string} instruction
+ * @returns {ParsedSeqInstruction}
+ */
+export function parseSeqInstruction(instruction) {
+  const rawInstruction = typeof instruction === 'string' ? instruction : '';
+  const tokens = tokenizeInstruction(rawInstruction);
+  const keyword = tokens[0]?.value ?? '';
+  const result = createEmptyParse(rawInstruction, keyword);
+
+  if (extractFieldKeyword(rawInstruction) !== 'SEQ') {
+    return result;
+  }
+
+  let sawSwitch = false;
+
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index].value;
+    if (!token) continue;
+
+    if (token.startsWith('\\')) {
+      sawSwitch = true;
+      const normalized = token.toLowerCase();
+
+      if (normalized === '\\n') {
+        result.sequenceMode = 'next';
+        continue;
+      }
+
+      if (normalized === '\\c') {
+        result.sequenceMode = 'current';
+        continue;
+      }
+
+      if (normalized === '\\h') {
+        result.hideResult = true;
+        continue;
+      }
+
+      if (normalized === '\\r') {
+        const value = tokens[index + 1]?.value;
+        if (value != null && !value.startsWith('\\')) {
+          const parsed = parseInteger(value);
+          if (parsed != null) result.restartNumber = parsed;
+          index += 1;
+        }
+        continue;
+      }
+
+      if (normalized === '\\s') {
+        const value = tokens[index + 1]?.value;
+        if (value != null && !value.startsWith('\\')) {
+          const parsed = parseInteger(value);
+          if (parsed != null && parsed >= 1 && parsed <= 9) result.restartLevel = parsed;
+          index += 1;
+        }
+        continue;
+      }
+
+      if (token === '\\*') {
+        const value = tokens[index + 1]?.value;
+        if (value != null && !value.startsWith('\\')) {
+          result.format = value;
+          result.hasGeneralFormat = true;
+          applyGeneralFormat(result, value);
+          index += 1;
+        } else {
+          result.unknownSwitches.push(token);
+        }
+        continue;
+      }
+
+      if (token === '\\#') {
+        const value = tokens[index + 1]?.value;
+        if (value != null && !value.startsWith('\\')) {
+          if (result.numericPictureFormat == null) {
+            result.numericPictureFormat = { picture: value };
+          } else {
+            result.unknownSwitches.push(token, value);
+          }
+          index += 1;
+        } else {
+          result.unknownSwitches.push(token);
+        }
+        continue;
+      }
+
+      result.unknownSwitches.push(token);
+      // Unknown switch arity is ambiguous; preserve the adjacent value token
+      // when present so later phases do not silently drop raw instruction data.
+      const value = tokens[index + 1]?.value;
+      if (value != null && !value.startsWith('\\')) {
+        result.unknownSwitches.push(value);
+        index += 1;
+      }
+      continue;
+    }
+
+    if (!result.identifier) {
+      result.identifier = normalizeSeqIdentifier(token);
+      continue;
+    }
+
+    if (!sawSwitch && !result.fieldArgument) {
+      result.fieldArgument = token;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * @param {string} instruction
+ */
+export function isSeqInstruction(instruction) {
+  return extractFieldKeyword(instruction) === 'SEQ';
+}
+
+/**
+ * @param {unknown} identifier
+ */
+export function normalizeSeqIdentifier(identifier) {
+  return typeof identifier === 'string' ? identifier.trim() : '';
+}
+
+/**
+ * @param {string} instruction
+ */
+function tokenizeInstruction(instruction) {
+  const tokens = [];
+  for (const match of instruction.matchAll(TOKEN_PATTERN)) {
+    tokens.push({ value: match[1] !== undefined ? unescapeQuotedToken(match[1]) : match[0] });
+  }
+  return tokens;
+}
+
+/**
+ * @param {string} instruction
+ * @param {string} keyword
+ * @returns {ParsedSeqInstruction}
+ */
+function createEmptyParse(instruction, keyword) {
+  return {
+    instruction,
+    keyword,
+    identifier: '',
+    fieldArgument: '',
+    sequenceMode: 'next',
+    hideResult: false,
+    restartNumber: null,
+    restartLevel: null,
+    format: 'Arabic',
+    numericPictureFormat: null,
+    hasGeneralFormat: false,
+    unknownSwitches: [],
+  };
+}
+
+/**
+ * @param {string} value
+ */
+function parseInteger(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || !Number.isInteger(number)) return null;
+  return Math.trunc(number);
+}
+
+/**
+ * @param {ParsedSeqInstruction} result
+ * @param {string} value
+ */
+function applyGeneralFormat(result, value) {
+  const mapped = GENERAL_FORMATS.get(value) ?? CASE_INSENSITIVE_GENERAL_FORMATS.get(value.toLowerCase());
+  if (mapped) {
+    result.pageNumberFieldFormat = { format: mapped };
+  }
+}
+
+/**
+ * @param {string} value
+ */
+function unescapeQuotedToken(value) {
+  return value.replace(/\\(["\\])/g, '$1');
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.js
@@ -45,7 +45,8 @@ export function parseSeqInstruction(instruction) {
 
     if (token.startsWith('\\')) {
       sawSwitch = true;
-      const normalized = token.toLowerCase();
+      const attachedValueSwitch = parseAttachedNumericSwitch(token);
+      const normalized = (attachedValueSwitch?.switchToken ?? token).toLowerCase();
 
       if (normalized === '\\n') {
         result.sequenceMode = 'next';
@@ -63,21 +64,21 @@ export function parseSeqInstruction(instruction) {
       }
 
       if (normalized === '\\r') {
-        const value = tokens[index + 1]?.value;
-        if (value != null && !value.startsWith('\\')) {
+        const value = attachedValueSwitch?.value ?? tokens[index + 1]?.value;
+        if (value != null && (attachedValueSwitch || !value.startsWith('\\'))) {
           const parsed = parseInteger(value);
           if (parsed != null) result.restartNumber = parsed;
-          index += 1;
+          if (!attachedValueSwitch) index += 1;
         }
         continue;
       }
 
       if (normalized === '\\s') {
-        const value = tokens[index + 1]?.value;
-        if (value != null && !value.startsWith('\\')) {
+        const value = attachedValueSwitch?.value ?? tokens[index + 1]?.value;
+        if (value != null && (attachedValueSwitch || !value.startsWith('\\'))) {
           const parsed = parseInteger(value);
           if (parsed != null && parsed >= 1 && parsed <= 9) result.restartLevel = parsed;
-          index += 1;
+          if (!attachedValueSwitch) index += 1;
         }
         continue;
       }
@@ -188,6 +189,21 @@ function parseInteger(value) {
   const number = Number(value);
   if (!Number.isFinite(number) || !Number.isInteger(number)) return null;
   return Math.trunc(number);
+}
+
+/**
+ * Word often serializes numeric SEQ switches without a separating space
+ * (`\r0`, `\s1`). Normalize those into the same path as `\r 0` / `\s 1`.
+ *
+ * @param {string} token
+ */
+function parseAttachedNumericSwitch(token) {
+  const match = /^\\([rRsS])([+-]?\d+(?:\.\d+)?)$/.exec(token);
+  if (!match) return null;
+  return {
+    switchToken: `\\${match[1]}`,
+    value: match[2],
+  };
 }
 
 /**

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.js
@@ -1,7 +1,7 @@
 import { extractFieldKeyword } from '../field-keyword.js';
 import { CASE_INSENSITIVE_GENERAL_FORMATS, GENERAL_FORMATS } from './page-number-field-switches.js';
 
-const TOKEN_PATTERN = /"((?:[^"\\]|\\.)*)"|\\[#*]|\\[^\s]+|[^\s]+/g;
+const TOKEN_PATTERN = /"((?:[^"\\]|\\.)*)"|\\[#*](?=\s|$)|\\[^\s]+|[^\s]+/g;
 
 /**
  * @typedef {'next' | 'current'} SeqMode
@@ -96,28 +96,30 @@ export function parseSeqInstruction(instruction) {
         continue;
       }
 
-      if (token === '\\*') {
-        const value = tokens[index + 1]?.value;
-        if (value != null && !value.startsWith('\\')) {
+      const attachedGeneralFormat = parseAttachedGeneralFormatSwitch(token);
+      if (normalized === '\\*' || attachedGeneralFormat != null) {
+        const value = attachedGeneralFormat ?? tokens[index + 1]?.value;
+        if (value != null && (attachedGeneralFormat != null || !value.startsWith('\\'))) {
           result.format = value;
           result.hasGeneralFormat = true;
           applyGeneralFormat(result, value);
-          index += 1;
+          if (attachedGeneralFormat == null) index += 1;
         } else {
           result.unknownSwitches.push(token);
         }
         continue;
       }
 
-      if (token === '\\#') {
-        const value = tokens[index + 1]?.value;
-        if (value != null && !value.startsWith('\\')) {
+      const attachedNumericPicture = parseAttachedNumericPictureSwitch(token);
+      if (normalized === '\\#' || attachedNumericPicture != null) {
+        const value = attachedNumericPicture ?? tokens[index + 1]?.value;
+        if (value != null && (attachedNumericPicture != null || !value.startsWith('\\'))) {
           if (result.numericPictureFormat == null) {
             result.numericPictureFormat = { picture: value };
           } else {
             result.unknownSwitches.push(token, value);
           }
-          index += 1;
+          if (attachedNumericPicture == null) index += 1;
         } else {
           result.unknownSwitches.push(token);
         }
@@ -238,6 +240,38 @@ function parseAttachedNumericSwitch(token) {
     switchToken: `\\${match[1]}`,
     value: match[2],
   };
+}
+
+/**
+ * Word can serialize general-format switches without a separating space
+ * (`\*roman`). Normalize those into the same path as `\* roman`.
+ *
+ * @param {string} token
+ */
+function parseAttachedGeneralFormatSwitch(token) {
+  const match = /^\\\*(\S+)$/.exec(token);
+  return normalizeAttachedSwitchValue(match?.[1]);
+}
+
+/**
+ * Keep attached numeric picture switches (`\#00`) equivalent to `\# 00`.
+ *
+ * @param {string} token
+ */
+function parseAttachedNumericPictureSwitch(token) {
+  const match = /^\\#(\S+)$/.exec(token);
+  return normalizeAttachedSwitchValue(match?.[1]);
+}
+
+/**
+ * @param {string | undefined} value
+ */
+function normalizeAttachedSwitchValue(value) {
+  if (value == null) return null;
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return unescapeQuotedToken(value.slice(1, -1));
+  }
+  return value;
 }
 
 /**

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.js
@@ -21,6 +21,19 @@ const TOKEN_PATTERN = /"((?:[^"\\]|\\.)*)"|\\[#*]|\\[^\s]+|[^\s]+/g;
  *   hasGeneralFormat: boolean,
  *   unknownSwitches: string[],
  * }} ParsedSeqInstruction
+ *
+ * @typedef {{
+ *   identifier: string,
+ *   fieldArgument: string,
+ *   sequenceMode: SeqMode,
+ *   hideResult: boolean,
+ *   restartNumber: number | null,
+ *   restartLevel: number | null,
+ *   format: string,
+ *   hasGeneralFormat: boolean,
+ *   pageNumberFieldFormat: import('@superdoc/contracts').PageNumberFieldFormat | null,
+ *   numericPictureFormat: SeqNumericPictureFormat | null,
+ * }} SequenceFieldParsedAttrs
  */
 
 /**
@@ -147,6 +160,27 @@ export function isSeqInstruction(instruction) {
  */
 export function normalizeSeqIdentifier(identifier) {
   return typeof identifier === 'string' ? identifier.trim() : '';
+}
+
+/**
+ * Project parsed SEQ instruction metadata into sequenceField PM attrs.
+ *
+ * @param {ParsedSeqInstruction} parsed
+ * @returns {SequenceFieldParsedAttrs}
+ */
+export function sequenceFieldAttrsFromParsed(parsed) {
+  return {
+    identifier: parsed.identifier,
+    fieldArgument: parsed.fieldArgument,
+    sequenceMode: parsed.sequenceMode,
+    hideResult: parsed.hideResult,
+    restartNumber: parsed.restartNumber,
+    restartLevel: parsed.restartLevel,
+    format: parsed.hasGeneralFormat ? parsed.format : 'ARABIC',
+    hasGeneralFormat: parsed.hasGeneralFormat,
+    pageNumberFieldFormat: parsed.pageNumberFieldFormat ?? null,
+    numericPictureFormat: parsed.numericPictureFormat,
+  };
 }
 
 /**

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.test.js
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { isSeqInstruction, normalizeSeqIdentifier, parseSeqInstruction } from './seq-instruction.js';
+
+describe('parseSeqInstruction', () => {
+  it.each([
+    ['SEQ Figure', { keyword: 'SEQ', identifier: 'Figure', sequenceMode: 'next', format: 'Arabic' }],
+    ['seq Figure', { keyword: 'seq', identifier: 'Figure', sequenceMode: 'next', format: 'Arabic' }],
+    ['Seq Figure \\n', { keyword: 'Seq', identifier: 'Figure', sequenceMode: 'next' }],
+    ['SEQ Figure \\c', { identifier: 'Figure', sequenceMode: 'current' }],
+    ['SEQ Figure \\h', { identifier: 'Figure', hideResult: true }],
+    ['SEQ Figure \\r 10', { identifier: 'Figure', restartNumber: 10 }],
+    ['SEQ Figure \\s 1', { identifier: 'Figure', restartLevel: 1 }],
+    ['SEQ Figure bookmarkName', { identifier: 'Figure', fieldArgument: 'bookmarkName' }],
+    ['SEQ Figure "bookmark name"', { identifier: 'Figure', fieldArgument: 'bookmark name' }],
+    [
+      'SEQ Figure \\* roman',
+      {
+        identifier: 'Figure',
+        format: 'roman',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'lowerRoman' },
+      },
+    ],
+    [
+      'SEQ Figure \\* ALPHABETIC',
+      {
+        identifier: 'Figure',
+        format: 'ALPHABETIC',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'upperLetter' },
+      },
+    ],
+    [
+      'SEQ Figure \\* ArabicDash',
+      {
+        identifier: 'Figure',
+        format: 'ArabicDash',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'numberInDash' },
+      },
+    ],
+    ['SEQ Figure \\# "00"', { identifier: 'Figure', numericPictureFormat: { picture: '00' } }],
+    ['SEQ Figure \\# "#,##0"', { identifier: 'Figure', numericPictureFormat: { picture: '#,##0' } }],
+    [
+      'SEQ Figure \\r 10 \\* roman \\h',
+      {
+        identifier: 'Figure',
+        restartNumber: 10,
+        format: 'roman',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'lowerRoman' },
+        hideResult: true,
+      },
+    ],
+    ['SEQ Figure \\c \\n', { identifier: 'Figure', sequenceMode: 'next' }],
+    ['SEQ Figure \\r nope \\s 99', { identifier: 'Figure', restartNumber: null, restartLevel: null }],
+  ])('parses %s', (instruction, expected) => {
+    expect(parseSeqInstruction(instruction)).toMatchObject({
+      instruction,
+      fieldArgument: '',
+      hideResult: false,
+      restartNumber: null,
+      restartLevel: null,
+      numericPictureFormat: null,
+      hasGeneralFormat: false,
+      unknownSwitches: [],
+      ...expected,
+    });
+  });
+
+  it('returns a safe empty parse for non-SEQ instructions', () => {
+    expect(parseSeqInstruction('PAGEREF bookmark')).toEqual({
+      instruction: 'PAGEREF bookmark',
+      keyword: 'PAGEREF',
+      identifier: '',
+      fieldArgument: '',
+      sequenceMode: 'next',
+      hideResult: false,
+      restartNumber: null,
+      restartLevel: null,
+      format: 'Arabic',
+      numericPictureFormat: null,
+      hasGeneralFormat: false,
+      unknownSwitches: [],
+    });
+  });
+
+  it('uses the shared keyword extractor for SEQ dispatch', () => {
+    expect(parseSeqInstruction('"SEQ" Figure')).toMatchObject({
+      keyword: 'SEQ',
+      identifier: '',
+      sequenceMode: 'next',
+      format: 'Arabic',
+    });
+  });
+
+  it('preserves the original instruction string without trimming', () => {
+    expect(parseSeqInstruction('  SEQ Figure  \\n  ')).toMatchObject({
+      instruction: '  SEQ Figure  \\n  ',
+      keyword: 'SEQ',
+      identifier: 'Figure',
+    });
+  });
+
+  it('keeps unknown general formats without page-number mapping', () => {
+    const parsed = parseSeqInstruction('SEQ Figure \\* OrdText');
+    expect(parsed).toMatchObject({
+      format: 'OrdText',
+      hasGeneralFormat: true,
+    });
+    expect(parsed).not.toHaveProperty('pageNumberFieldFormat');
+  });
+
+  it('preserves unknown switches as raw tokens', () => {
+    expect(parseSeqInstruction('SEQ Figure \\z value \\q').unknownSwitches).toEqual(['\\z', 'value', '\\q']);
+  });
+
+  it('preserves only the first numeric picture and records later numeric switches as unknown', () => {
+    expect(parseSeqInstruction('SEQ Figure \\# "00" \\# "000"')).toMatchObject({
+      numericPictureFormat: { picture: '00' },
+      unknownSwitches: ['\\#', '000'],
+    });
+  });
+
+  it('parses quoted identifiers and switch values', () => {
+    expect(parseSeqInstruction('SEQ "Figure Set" \\* "Roman" \\# "00"')).toMatchObject({
+      identifier: 'Figure Set',
+      format: 'Roman',
+      pageNumberFieldFormat: { format: 'upperRoman' },
+      numericPictureFormat: { picture: '00' },
+    });
+  });
+
+  it('unescapes quoted tokens without rewriting unquoted tokens', () => {
+    expect(parseSeqInstruction('SEQ "Figure \\"Set\\""').identifier).toBe('Figure "Set"');
+    expect(parseSeqInstruction('SEQ Figure\\\\Set').identifier).toBe('Figure\\\\Set');
+  });
+});
+
+describe('isSeqInstruction', () => {
+  it('matches SEQ instructions case-insensitively', () => {
+    expect(isSeqInstruction('SEQ Figure')).toBe(true);
+    expect(isSeqInstruction('seq Figure')).toBe(true);
+    expect(isSeqInstruction('PAGEREF target')).toBe(false);
+  });
+});
+
+describe('normalizeSeqIdentifier', () => {
+  it('trims string identifiers and ignores non-strings', () => {
+    expect(normalizeSeqIdentifier(' Figure ')).toBe('Figure');
+    expect(normalizeSeqIdentifier(null)).toBe('');
+  });
+});

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.test.js
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isSeqInstruction, normalizeSeqIdentifier, parseSeqInstruction } from './seq-instruction.js';
+import {
+  isSeqInstruction,
+  normalizeSeqIdentifier,
+  parseSeqInstruction,
+  sequenceFieldAttrsFromParsed,
+} from './seq-instruction.js';
 
 describe('parseSeqInstruction', () => {
   it.each([
@@ -154,5 +159,35 @@ describe('normalizeSeqIdentifier', () => {
   it('trims string identifiers and ignores non-strings', () => {
     expect(normalizeSeqIdentifier(' Figure ')).toBe('Figure');
     expect(normalizeSeqIdentifier(null)).toBe('');
+  });
+});
+
+describe('sequenceFieldAttrsFromParsed', () => {
+  it('projects parsed SEQ metadata into normalized sequenceField attrs', () => {
+    const attrs = sequenceFieldAttrsFromParsed(parseSeqInstruction('SEQ Figure \\r 3 \\* roman'));
+
+    expect(attrs).toEqual({
+      identifier: 'Figure',
+      fieldArgument: '',
+      sequenceMode: 'next',
+      hideResult: false,
+      restartNumber: 3,
+      restartLevel: null,
+      format: 'roman',
+      hasGeneralFormat: true,
+      pageNumberFieldFormat: { format: 'lowerRoman' },
+      numericPictureFormat: null,
+    });
+  });
+
+  it('keeps the parser default separate from the legacy PM attr default', () => {
+    const parsed = parseSeqInstruction('SEQ Figure');
+
+    expect(parsed.format).toBe('Arabic');
+    expect(sequenceFieldAttrsFromParsed(parsed)).toMatchObject({
+      format: 'ARABIC',
+      pageNumberFieldFormat: null,
+      numericPictureFormat: null,
+    });
   });
 });

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.test.js
@@ -9,7 +9,12 @@ describe('parseSeqInstruction', () => {
     ['SEQ Figure \\c', { identifier: 'Figure', sequenceMode: 'current' }],
     ['SEQ Figure \\h', { identifier: 'Figure', hideResult: true }],
     ['SEQ Figure \\r 10', { identifier: 'Figure', restartNumber: 10 }],
+    ['SEQ Figure \\r0', { identifier: 'Figure', restartNumber: 0 }],
+    ['SEQ Figure \\R0', { identifier: 'Figure', restartNumber: 0 }],
     ['SEQ Figure \\s 1', { identifier: 'Figure', restartLevel: 1 }],
+    ['SEQ Figure \\s1', { identifier: 'Figure', restartLevel: 1 }],
+    ['SEQ Figure \\S1', { identifier: 'Figure', restartLevel: 1 }],
+    ['seq level2 \\h \\r0', { keyword: 'seq', identifier: 'level2', hideResult: true, restartNumber: 0 }],
     ['SEQ Figure bookmarkName', { identifier: 'Figure', fieldArgument: 'bookmarkName' }],
     ['SEQ Figure "bookmark name"', { identifier: 'Figure', fieldArgument: 'bookmark name' }],
     [

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/seq-instruction.test.js
@@ -32,6 +32,34 @@ describe('parseSeqInstruction', () => {
       },
     ],
     [
+      'SEQ Figure \\*roman',
+      {
+        identifier: 'Figure',
+        format: 'roman',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'lowerRoman' },
+      },
+    ],
+    [
+      'seq level2 \\*arabic',
+      {
+        keyword: 'seq',
+        identifier: 'level2',
+        format: 'arabic',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'decimal' },
+      },
+    ],
+    [
+      'SEQ Figure \\*"Roman"',
+      {
+        identifier: 'Figure',
+        format: 'Roman',
+        hasGeneralFormat: true,
+        pageNumberFieldFormat: { format: 'upperRoman' },
+      },
+    ],
+    [
       'SEQ Figure \\* ALPHABETIC',
       {
         identifier: 'Figure',
@@ -50,6 +78,8 @@ describe('parseSeqInstruction', () => {
       },
     ],
     ['SEQ Figure \\# "00"', { identifier: 'Figure', numericPictureFormat: { picture: '00' } }],
+    ['SEQ Figure \\#00', { identifier: 'Figure', numericPictureFormat: { picture: '00' } }],
+    ['SEQ Figure \\#"00"', { identifier: 'Figure', numericPictureFormat: { picture: '00' } }],
     ['SEQ Figure \\# "#,##0"', { identifier: 'Figure', numericPictureFormat: { picture: '#,##0' } }],
     [
       'SEQ Figure \\r 10 \\* roman \\h',

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
@@ -18,6 +18,7 @@ import { autoPageHandlerEntity, autoTotalPageCountEntity, sectionPageCountEntity
 import { documentStatFieldHandlerEntity } from './documentStatFieldImporter.js';
 import { pageReferenceEntity } from './pageReferenceImporter.js';
 import { crossReferenceEntity } from './crossReferenceImporter.js';
+import { sequenceFieldEntity } from './sequenceFieldImporter.js';
 import { pictNodeHandlerEntity } from './pictNodeImporter.js';
 import { importCommentData } from './documentCommentsImporter.js';
 import { buildTrackedChangeIdMap, buildTrackedChangeIdMapsByPart } from './trackedChangeIdMapper.js';
@@ -376,6 +377,7 @@ export const defaultNodeListHandler = () => {
     documentStatFieldHandlerEntity,
     pageReferenceEntity,
     crossReferenceEntity,
+    sequenceFieldEntity,
     permStartHandlerEntity,
     permEndHandlerEntity,
     mathNodeHandlerEntity,

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.integration.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.integration.test.js
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { defaultNodeListHandler } from './docxImporter.js';
+import { sequenceFieldEntity } from './sequenceFieldImporter.js';
+import { preProcessNodesForFldChar } from '../../field-references/index.js';
+
+const createEditorStub = () => ({
+  schema: {
+    nodes: {
+      run: { isInline: true, spec: { group: 'inline' } },
+      sequenceField: { isInline: true, spec: { group: 'inline', atom: true } },
+    },
+  },
+});
+
+describe('sequenceField v2 importer wiring', () => {
+  it('registers sequenceFieldEntity before passthrough in defaultNodeListHandler', () => {
+    const entities = defaultNodeListHandler().handlerEntities;
+    expect(entities).toContain(sequenceFieldEntity);
+    expect(entities.indexOf(sequenceFieldEntity)).toBeLessThan(
+      entities.findIndex((entity) => entity.handlerName === 'passthroughNodeHandler'),
+    );
+  });
+
+  it.each([
+    ['uppercase complex', 'SEQ Figure \\n \\r 10 \\s 2 \\h \\* roman', '10', 'next', 'roman'],
+    ['lowercase complex', 'seq Figure \\c \\r 10 \\s 2 \\h \\* arabic', '11', 'current', 'arabic'],
+    ['uppercase fldSimple', 'SEQ Figure \\n \\r 10 \\s 2 \\h \\* roman', '12', 'next', 'roman'],
+    ['lowercase fldSimple', 'seq Figure \\c \\r 10 \\s 2 \\h \\* arabic', '13', 'current', 'arabic'],
+  ])(
+    'imports %s SEQ fields through the real preprocessor and v2 route',
+    (_name, instruction, cachedText, sequenceMode, format) => {
+      const paragraph = _name.includes('fldSimple')
+        ? buildFldSimpleSeqParagraph(instruction, cachedText)
+        : buildComplexSeqParagraph(instruction, cachedText);
+
+      const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+      const nodeListHandler = defaultNodeListHandler();
+      const pmNodes = nodeListHandler.handler({
+        nodes: processedNodes,
+        docx: {},
+        editor: createEditorStub(),
+        path: [],
+      });
+
+      const sequenceField = collectNodesOfType(pmNodes[0], 'sequenceField')[0];
+      expect(sequenceField).toBeTruthy();
+      expect(sequenceField.attrs).toMatchObject({
+        instruction,
+        identifier: 'Figure',
+        format,
+        sequenceMode,
+        restartLevel: 2,
+        restartNumber: 10,
+        hideResult: true,
+        resolvedNumber: cachedText,
+        resolvedNumberIsCurrent: false,
+      });
+    },
+  );
+
+  it('imports sequence field arguments and numeric formats onto PM attrs', () => {
+    const instruction = 'SEQ Figure bookmark \\# "00"';
+    const paragraph = buildComplexSeqParagraph(instruction, '07');
+
+    const { processedNodes } = preProcessNodesForFldChar([paragraph], {});
+    const nodeListHandler = defaultNodeListHandler();
+    const pmNodes = nodeListHandler.handler({
+      nodes: processedNodes,
+      docx: {},
+      editor: createEditorStub(),
+      path: [],
+    });
+
+    const sequenceField = collectNodesOfType(pmNodes[0], 'sequenceField')[0];
+    expect(sequenceField.attrs).toMatchObject({
+      instruction,
+      identifier: 'Figure',
+      fieldArgument: 'bookmark',
+      numericPictureFormat: { picture: '00' },
+      hasGeneralFormat: false,
+      pageNumberFieldFormat: null,
+      resolvedNumber: '07',
+      resolvedNumberIsCurrent: false,
+    });
+  });
+});
+
+function buildComplexSeqParagraph(instruction, cachedText) {
+  const run = (inner) => ({ name: 'w:r', elements: inner });
+  return {
+    name: 'w:p',
+    elements: [
+      run([{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }]),
+      run([{ name: 'w:instrText', elements: [{ type: 'text', text: instruction }] }]),
+      run([{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }]),
+      run([{ name: 'w:t', elements: [{ type: 'text', text: cachedText }] }]),
+      run([{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }]),
+    ],
+  };
+}
+
+function buildFldSimpleSeqParagraph(instruction, cachedText) {
+  return {
+    name: 'w:p',
+    elements: [
+      {
+        name: 'w:fldSimple',
+        attributes: { 'w:instr': instruction },
+        elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: cachedText }] }] }],
+      },
+    ],
+  };
+}
+
+function collectNodesOfType(root, type) {
+  const out = [];
+  const visit = (node) => {
+    if (!node) return;
+    if (node.type === type) out.push(node);
+    if (Array.isArray(node.content)) node.content.forEach(visit);
+  };
+  visit(root);
+  return out;
+}

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/sequenceFieldImporter.js
@@ -1,0 +1,7 @@
+import { generateV2HandlerEntity } from '@core/super-converter/v3/handlers/utils';
+import { translator } from '../../v3/handlers/sd/sequenceField/sequenceField-translator.js';
+
+/**
+ * @type {import("./docxImporter").NodeHandlerEntry}
+ */
+export const sequenceFieldEntity = generateV2HandlerEntity('sequenceFieldNodeHandler', translator);

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequence-field-export-routing.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequence-field-export-routing.test.js
@@ -30,6 +30,16 @@ function hasFieldCharType(node, fieldType) {
   );
 }
 
+function resultTexts(exported) {
+  const separateIndex = exported.findIndex((node) => hasFieldCharType(node, 'separate'));
+  const endIndex = exported.findIndex((node) => hasFieldCharType(node, 'end'));
+  return exported
+    .slice(separateIndex + 1, endIndex)
+    .flatMap((node) => node?.elements ?? [])
+    .filter((element) => element?.name === 'w:t')
+    .map((element) => element?.elements?.[0]?.text);
+}
+
 describe('sequenceField export routing', () => {
   it('extracts cached result text from run-wrapped field content', () => {
     const encoded = sequenceFieldTranslator.encode({
@@ -86,6 +96,50 @@ describe('sequenceField export routing', () => {
     expect(resultRun).toBeTruthy();
   });
 
+  it('exports current resolvedNumber instead of stale cached child content', () => {
+    const exported = exportSchemaToJson({
+      node: buildSequenceFieldNode({
+        attrs: { resolvedNumber: '12', resolvedNumberIsCurrent: true },
+        content: [{ type: 'run', attrs: {}, content: [{ type: 'text', text: '3' }] }],
+      }),
+    });
+
+    expect(resultTexts(exported)).toEqual(['12']);
+  });
+
+  it('exports no result runs for current hidden or empty output', () => {
+    const exported = exportSchemaToJson({
+      node: buildSequenceFieldNode({
+        attrs: { resolvedNumber: '', resolvedNumberIsCurrent: true },
+        content: [{ type: 'run', attrs: {}, content: [{ type: 'text', text: '3' }] }],
+      }),
+    });
+
+    expect(resultTexts(exported)).toEqual([]);
+  });
+
+  it('preserves imported cached child content when resolvedNumber is not current', () => {
+    const exported = exportSchemaToJson({
+      node: buildSequenceFieldNode({
+        attrs: { resolvedNumber: '12', resolvedNumberIsCurrent: false },
+        content: [{ type: 'run', attrs: {}, content: [{ type: 'text', text: '3' }] }],
+      }),
+    });
+
+    expect(resultTexts(exported)).toEqual(['3']);
+  });
+
+  it('falls back to non-current resolvedNumber when no cached child content exists', () => {
+    const exported = exportSchemaToJson({
+      node: buildSequenceFieldNode({
+        attrs: { resolvedNumber: '12', resolvedNumberIsCurrent: false },
+        content: [],
+      }),
+    });
+
+    expect(resultTexts(exported)).toEqual(['12']);
+  });
+
   it('exports sequenceField nodes as fldChar + instrText runs', () => {
     const exported = exportSchemaToJson({
       node: buildSequenceFieldNode(),
@@ -102,6 +156,32 @@ describe('sequenceField export routing', () => {
     const instructionElement = instructionRun?.elements?.find((element) => element?.name === 'w:instrText');
 
     expect(instructionElement?.elements?.[0]?.text).toBe(SEQUENCE_FIELD_INSTRUCTION);
+  });
+
+  it('preserves raw split instructionTokens during export', () => {
+    const instructionTokens = [
+      { type: 'text', text: 'SEQ Figure ' },
+      { type: 'text', text: '\\* roman' },
+    ];
+    const exported = exportSchemaToJson({
+      node: buildSequenceFieldNode({
+        attrs: {
+          instruction: 'SEQ Figure \\* roman',
+          instructionTokens,
+          resolvedNumber: '1',
+          resolvedNumberIsCurrent: true,
+        },
+      }),
+    });
+
+    const instructionRun = exported.find(
+      (node) => node?.name === 'w:r' && node?.elements?.some((element) => element?.name === 'w:instrText'),
+    );
+    const instructionTexts = instructionRun?.elements
+      ?.filter((element) => element?.name === 'w:instrText')
+      .map((element) => element?.elements?.[0]?.text);
+
+    expect(instructionTexts).toEqual(['SEQ Figure ', '\\* roman']);
   });
 
   it('expands run-wrapped sequenceField nodes into field-code runs', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequence-field-export-routing.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequence-field-export-routing.test.js
@@ -51,6 +51,39 @@ describe('sequenceField export routing', () => {
     });
 
     expect(encoded.attrs.resolvedNumber).toBe('1');
+    expect(encoded.attrs.resolvedNumberIsCurrent).toBe(false);
+    expect(encoded.attrs.identifier).toBe('level2');
+    expect(encoded.attrs.format).toBe('arabic');
+  });
+
+  it('round-trips lowercase SEQ cached result text before recompute', () => {
+    const encoded = sequenceFieldTranslator.encode({
+      nodes: [
+        {
+          name: 'sd:sequenceField',
+          attributes: { instruction: 'seq Figure \\* arabic' },
+          elements: [
+            {
+              type: 'run',
+              content: [{ type: 'text', text: '42', marks: [] }],
+            },
+          ],
+        },
+      ],
+      nodeListHandler: {
+        handler: () => [{ type: 'run', content: [{ type: 'text', text: '42', marks: [] }] }],
+      },
+    });
+
+    const exported = exportSchemaToJson({ node: encoded });
+    const resultRun = exported.find(
+      (node) =>
+        node?.name === 'w:r' &&
+        node?.elements?.some((element) => element?.name === 'w:t' && element?.elements?.[0]?.text === '42'),
+    );
+
+    expect(encoded.attrs.resolvedNumberIsCurrent).toBe(false);
+    expect(resultRun).toBeTruthy();
   });
 
   it('exports sequenceField nodes as fldChar + instrText runs', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequenceField-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequenceField-translator.js
@@ -59,7 +59,7 @@ const encode = (params) => {
 const decode = (params) => {
   const { node } = params;
   const outputMarks = processOutputMarks(node.attrs?.marksAsAttrs || []);
-  const contentNodes = (node.content ?? []).flatMap((n) => exportSchemaToJson({ ...params, node: n }));
+  const contentNodes = buildResultContentNodes(params, outputMarks);
   const instructionElements = buildInstructionElements(node.attrs?.instruction, node.attrs?.instructionTokens);
 
   return [
@@ -91,6 +91,46 @@ const decode = (params) => {
     },
   ];
 };
+
+/**
+ * @param {import('@translator').SCDecoderConfig} params
+ * @param {Array<any>} outputMarks
+ * @returns {Array<any>}
+ */
+function buildResultContentNodes(params, outputMarks) {
+  const { node } = params;
+  const resolvedNumber = node.attrs?.resolvedNumber;
+  const hasCurrentResult = node.attrs?.resolvedNumberIsCurrent === true;
+
+  if (hasCurrentResult) {
+    return typeof resolvedNumber === 'string' && resolvedNumber.length > 0
+      ? [buildResolvedNumberRun(resolvedNumber, outputMarks)]
+      : [];
+  }
+
+  if (Array.isArray(node.content) && node.content.length > 0) {
+    return node.content.flatMap((n) => exportSchemaToJson({ ...params, node: n }));
+  }
+
+  return typeof resolvedNumber === 'string' && resolvedNumber.length > 0
+    ? [buildResolvedNumberRun(resolvedNumber, outputMarks)]
+    : [];
+}
+
+/**
+ * @param {string} text
+ * @param {Array<any>} outputMarks
+ * @returns {any}
+ */
+function buildResolvedNumberRun(text, outputMarks) {
+  return {
+    name: 'w:r',
+    elements: [
+      { name: 'w:rPr', elements: outputMarks },
+      { name: 'w:t', elements: [{ type: 'text', text }] },
+    ],
+  };
+}
 
 /**
  * Extracts resolved text from processed content.

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequenceField-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequenceField-translator.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { NodeTranslator } from '@translator';
 import { exportSchemaToJson, processOutputMarks } from '../../../../exporter.js';
+import { parseSeqInstruction } from '../../../../field-references/shared/seq-instruction.js';
 import { buildInstructionElements } from '../shared/index.js';
 
 /** @type {import('@translator').XmlNodeName} */
@@ -24,17 +25,26 @@ const encode = (params) => {
   });
 
   const instruction = node.attributes?.instruction || '';
-  const { identifier, format, restartLevel } = parseSeqInstruction(instruction);
+  const parsed = parseSeqInstruction(instruction);
 
   return {
     type: SD_NODE_NAME,
     attrs: {
       instruction,
       instructionTokens: node.attributes?.instructionTokens || null,
-      identifier,
-      format,
-      restartLevel,
+      // Raw instruction remains the export source of truth; these parsed attrs support import-time routing and later evaluation.
+      identifier: parsed.identifier,
+      fieldArgument: parsed.fieldArgument,
+      sequenceMode: parsed.sequenceMode,
+      hideResult: parsed.hideResult,
+      restartNumber: parsed.restartNumber,
+      restartLevel: parsed.restartLevel,
+      format: parsed.format,
+      hasGeneralFormat: parsed.hasGeneralFormat,
+      pageNumberFieldFormat: parsed.pageNumberFieldFormat ?? null,
+      numericPictureFormat: parsed.numericPictureFormat,
       resolvedNumber: extractResolvedText(processedText),
+      resolvedNumberIsCurrent: false,
       marksAsAttrs: node.marks || [],
     },
     content: processedText,
@@ -81,30 +91,6 @@ const decode = (params) => {
     },
   ];
 };
-
-/**
- * Parses a SEQ instruction into its components.
- * @param {string} instruction
- * @returns {{ identifier: string; format: string; restartLevel: number | null }}
- */
-function parseSeqInstruction(instruction) {
-  const parts = instruction.trim().split(/\s+/);
-  const identifier = parts[1] || '';
-  let format = 'ARABIC';
-  let restartLevel = null;
-
-  for (let i = 2; i < parts.length; i++) {
-    if (parts[i] === '\\*' && parts[i + 1]) {
-      format = parts[i + 1];
-      i++;
-    } else if (parts[i] === '\\s' && parts[i + 1]) {
-      restartLevel = parseInt(parts[i + 1], 10) || null;
-      i++;
-    }
-  }
-
-  return { identifier, format, restartLevel };
-}
 
 /**
  * Extracts resolved text from processed content.

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequenceField-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/sequenceField/sequenceField-translator.js
@@ -1,7 +1,10 @@
 // @ts-check
 import { NodeTranslator } from '@translator';
 import { exportSchemaToJson, processOutputMarks } from '../../../../exporter.js';
-import { parseSeqInstruction } from '../../../../field-references/shared/seq-instruction.js';
+import {
+  parseSeqInstruction,
+  sequenceFieldAttrsFromParsed,
+} from '../../../../field-references/shared/seq-instruction.js';
 import { buildInstructionElements } from '../shared/index.js';
 
 /** @type {import('@translator').XmlNodeName} */
@@ -26,6 +29,7 @@ const encode = (params) => {
 
   const instruction = node.attributes?.instruction || '';
   const parsed = parseSeqInstruction(instruction);
+  const parsedAttrs = sequenceFieldAttrsFromParsed(parsed);
 
   return {
     type: SD_NODE_NAME,
@@ -33,16 +37,7 @@ const encode = (params) => {
       instruction,
       instructionTokens: node.attributes?.instructionTokens || null,
       // Raw instruction remains the export source of truth; these parsed attrs support import-time routing and later evaluation.
-      identifier: parsed.identifier,
-      fieldArgument: parsed.fieldArgument,
-      sequenceMode: parsed.sequenceMode,
-      hideResult: parsed.hideResult,
-      restartNumber: parsed.restartNumber,
-      restartLevel: parsed.restartLevel,
-      format: parsed.format,
-      hasGeneralFormat: parsed.hasGeneralFormat,
-      pageNumberFieldFormat: parsed.pageNumberFieldFormat ?? null,
-      numericPictureFormat: parsed.numericPictureFormat,
+      ...parsedAttrs,
       resolvedNumber: extractResolvedText(processedText),
       resolvedNumberIsCurrent: false,
       marksAsAttrs: node.marks || [],

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.js
@@ -66,6 +66,9 @@ function getPageNumberFieldAttrs(node) {
   if (node.attributes?.pageNumberZeroPadding != null) {
     attrs.pageNumberZeroPadding = Number(node.attributes.pageNumberZeroPadding);
   }
+  if (node.attributes?.pageNumberNumericPicture) {
+    attrs.pageNumberNumericPicture = node.attributes.pageNumberNumericPicture;
+  }
   return attrs;
 }
 
@@ -82,7 +85,7 @@ function resolveCachedPageCount(params, node) {
   const cacheMap = params.statFieldCacheMap;
   if (cacheMap?.has?.('NUMPAGES')) {
     const pageCount = Number(cacheMap.get('NUMPAGES'));
-    if (node.attrs?.pageNumberFormat || node.attrs?.pageNumberZeroPadding) {
+    if (node.attrs?.pageNumberFormat || node.attrs?.pageNumberZeroPadding || node.attrs?.pageNumberNumericPicture) {
       return formatPageNumberFieldValue(pageCount, node.attrs);
     }
     return String(cacheMap.get('NUMPAGES'));

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.test.js
@@ -89,6 +89,30 @@ describe('sd:totalPageNumber translator', () => {
           {
             name: 'sd:totalPageNumber',
             attributes: {
+              instruction: 'NUMPAGES \\# "#,##0"',
+              pageNumberNumericPicture: '#,##0',
+            },
+            elements: [],
+          },
+        ],
+      });
+
+      expect(result.attrs).toEqual({
+        marksAsAttrs: [],
+        importedCachedText: null,
+        instruction: 'NUMPAGES \\# "#,##0"',
+        pageNumberNumericPicture: '#,##0',
+      });
+    });
+
+    it('preserves imported zero-padding field attributes', () => {
+      vi.mocked(parseMarks).mockReturnValue([]);
+
+      const result = config.encode({
+        nodes: [
+          {
+            name: 'sd:totalPageNumber',
+            attributes: {
               instruction: 'NUMPAGES \\# "00"',
               pageNumberFormat: 'decimal',
               pageNumberZeroPadding: 2,
@@ -186,6 +210,39 @@ describe('sd:totalPageNumber translator', () => {
       expect(result[3].elements[1].elements[0].text).toBe('07');
     });
 
+    it('round-trips an imported numeric-picture attr through PM attrs and exported cached text', () => {
+      vi.mocked(parseMarks).mockReturnValue([]);
+      vi.mocked(processOutputMarks).mockReturnValue([]);
+
+      const imported = config.encode({
+        nodes: [
+          {
+            name: 'sd:totalPageNumber',
+            attributes: {
+              instruction: 'NUMPAGES \\# "#,##0"',
+              pageNumberNumericPicture: '#,##0',
+              importedCachedText: '1,000',
+            },
+            elements: [],
+          },
+        ],
+      });
+
+      expect(imported.attrs).toMatchObject({
+        instruction: 'NUMPAGES \\# "#,##0"',
+        pageNumberNumericPicture: '#,##0',
+        importedCachedText: '1,000',
+      });
+
+      const exported = config.decode({
+        node: imported,
+        statFieldCacheMap: new Map([['NUMPAGES', 1234]]),
+      });
+
+      expect(exported[1].elements[1].elements[0].text).toBe(' NUMPAGES \\# "#,##0"');
+      expect(exported[3].elements[1].elements[0].text).toBe('1,234');
+    });
+
     it('falls back to resolvedText when cache map is absent', () => {
       vi.mocked(processOutputMarks).mockReturnValue([]);
 
@@ -236,11 +293,11 @@ describe('sd:totalPageNumber translator', () => {
       const result = config.decode({
         node: {
           type: 'total-page-number',
-          attrs: { instruction: 'NUMPAGES \\# "00"', importedCachedText: '07' },
+          attrs: { instruction: 'NUMPAGES \\# "#   pages"', importedCachedText: '7   pages' },
         },
       });
 
-      expect(result[1].elements[1].elements[0].text).toBe(' NUMPAGES \\# "00"');
+      expect(result[1].elements[1].elements[0].text).toBe(' NUMPAGES \\# "#   pages"');
     });
   });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/caption-resolver.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/caption-resolver.test.ts
@@ -81,4 +81,39 @@ describe('caption resolver', () => {
     expect(seqCaption?.instruction).toBe('SEQ Figure \\* ARABIC');
     expect(seqCaption?.label).toBe('Figure');
   });
+
+  it('detects lowercase seq fields by SEQ field fallback', () => {
+    ({ editor } = initTestEditor({
+      content: docData.docx,
+      media: docData.media,
+      mediaFiles: docData.mediaFiles,
+      fonts: docData.fonts,
+      useImmediateSetTimeout: false,
+    }));
+
+    const sequenceField = editor.schema.nodes.sequenceField.create({
+      instruction: 'seq Figure \\* arabic',
+      identifier: 'Figure',
+      format: 'arabic',
+      resolvedNumber: '1',
+      marksAsAttrs: [],
+      sdBlockId: 'seq-caption-node-lowercase',
+    });
+
+    const captionParagraph = editor.schema.nodes.paragraph.create(
+      {
+        sdBlockId: 'caption-seq-only-lowercase',
+      },
+      [sequenceField, editor.schema.text(': Caption with lowercase seq')],
+    );
+
+    editor.dispatch(editor.state.tr.insert(editor.state.doc.content.size, captionParagraph));
+
+    const captions = findAllCaptions(editor.state.doc);
+    const seqCaption = captions.find((caption) => caption.nodeId === 'caption-seq-only-lowercase');
+
+    expect(seqCaption).toBeTruthy();
+    expect(seqCaption?.instruction).toBe('seq Figure \\* arabic');
+    expect(seqCaption?.label).toBe('Figure');
+  });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/caption-resolver.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/caption-resolver.ts
@@ -11,6 +11,7 @@ import type { Editor } from '../../core/Editor.js';
 import type { CaptionAddress, CaptionDomain, CaptionInfo, DiscoveryItem } from '@superdoc/document-api';
 import { buildDiscoveryItem, buildResolvedHandle } from '@superdoc/document-api';
 import { DocumentApiAdapterError } from '../errors.js';
+import { isSeqInstruction } from '../../core/super-converter/field-references/shared/seq-instruction.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -54,7 +55,7 @@ function isCaptionParagraph(node: ProseMirrorNode): boolean {
   const seqField = findSeqField(node);
   if (!seqField) return false;
   const instruction = (seqField.attrs?.instruction as string) ?? '';
-  return instruction.trim().startsWith('SEQ ');
+  return isSeqInstruction(instruction);
 }
 
 function findSeqField(node: ProseMirrorNode): ProseMirrorNode | null {

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.test.ts
@@ -22,6 +22,17 @@ const schema = new Schema({
         resolvedText: { default: null },
       },
     },
+    'total-page-number': {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      content: 'text*',
+      attrs: {
+        instruction: { default: null },
+        importedCachedText: { default: null },
+        resolvedText: { default: null },
+      },
+    },
     sequenceField: {
       group: 'inline',
       inline: true,
@@ -38,6 +49,13 @@ const schema = new Schema({
 function createDocWithSectionPageCount(attrs: Record<string, unknown>, text?: string): ProseMirrorNode {
   const content = text ? schema.text(text) : undefined;
   const field = schema.nodes['section-page-count'].create(attrs, content);
+  const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, field);
+  return schema.nodes.doc.create(null, paragraph);
+}
+
+function createDocWithTotalPageNumber(attrs: Record<string, unknown>, text?: string): ProseMirrorNode {
+  const content = text ? schema.text(text) : undefined;
+  const field = schema.nodes['total-page-number'].create(attrs, content);
   const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, field);
   return schema.nodes.doc.create(null, paragraph);
 }
@@ -71,6 +89,24 @@ describe('field-resolver synthetic section page count fields', () => {
         instruction: 'SECTIONPAGES',
         fieldType: 'SECTIONPAGES',
         resolvedText: '4',
+      },
+    ]);
+  });
+});
+
+describe('field-resolver synthetic total page number fields', () => {
+  it('discovers total-page-number with imported switched instruction', () => {
+    const doc = createDocWithTotalPageNumber({ instruction: 'NUMPAGES \\# "#,##0"', resolvedText: '1,234' });
+
+    expect(findAllFields(doc)).toEqual([
+      {
+        pos: 1,
+        blockId: 'block-1',
+        occurrenceIndex: 0,
+        nestingDepth: 0,
+        instruction: 'NUMPAGES \\# "#,##0"',
+        fieldType: 'NUMPAGES',
+        resolvedText: '1,234',
       },
     ]);
   });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.test.ts
@@ -22,6 +22,16 @@ const schema = new Schema({
         resolvedText: { default: null },
       },
     },
+    sequenceField: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        instruction: { default: '' },
+        identifier: { default: '' },
+        resolvedNumber: { default: '' },
+      },
+    },
   },
 });
 
@@ -63,5 +73,27 @@ describe('field-resolver synthetic section page count fields', () => {
         resolvedText: '4',
       },
     ]);
+  });
+});
+
+describe('field-resolver sequence fields', () => {
+  it('uses sequenceField.resolvedNumber as resolvedText', () => {
+    const field = schema.nodes.sequenceField.create({
+      instruction: 'SEQ Figure \\* ARABIC',
+      identifier: 'Figure',
+      resolvedNumber: '2',
+    });
+    const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-seq' }, field);
+    const doc = schema.nodes.doc.create(null, paragraph);
+
+    expect(findAllFields(doc)).toContainEqual({
+      pos: 1,
+      blockId: 'block-seq',
+      occurrenceIndex: 0,
+      nestingDepth: 0,
+      instruction: 'SEQ Figure \\* ARABIC',
+      fieldType: 'SEQ',
+      resolvedText: '2',
+    });
   });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.ts
@@ -56,7 +56,14 @@ const SYNTHETIC_FIELD_NODE_TYPES: Record<
   string,
   { fieldType: string; instruction: string; resolveInstruction?: (node: ProseMirrorNode) => string }
 > = {
-  'total-page-number': { fieldType: 'NUMPAGES', instruction: 'NUMPAGES' },
+  'total-page-number': {
+    fieldType: 'NUMPAGES',
+    instruction: 'NUMPAGES',
+    resolveInstruction: (node) =>
+      typeof node.attrs?.instruction === 'string' && node.attrs.instruction.trim()
+        ? node.attrs.instruction
+        : 'NUMPAGES',
+  },
   'section-page-count': {
     fieldType: 'SECTIONPAGES',
     instruction: 'SECTIONPAGES',

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.ts
@@ -112,7 +112,10 @@ export function findAllFields(doc: ProseMirrorNode): ResolvedField[] {
     blockOccurrenceCounters.set(blockId, counter + 1);
 
     const fieldType = extractFieldType(instruction);
-    const resolvedText = (node.attrs?.resolvedText as string) ?? '';
+    const resolvedText =
+      node.type.name === 'sequenceField'
+        ? ((node.attrs?.resolvedNumber as string) ?? '')
+        : ((node.attrs?.resolvedText as string) ?? '');
 
     results.push({
       pos,

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.test.ts
@@ -1,0 +1,180 @@
+import { Schema, type Node as ProseMirrorNode } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
+import { describe, expect, it } from 'vitest';
+import { updateSequenceFieldsInTransaction } from './sequence-field-updater.js';
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      attrs: {
+        sdBlockId: { default: null },
+        paragraphProperties: { default: null },
+        styleName: { default: null },
+      },
+    },
+    text: { group: 'inline' },
+    sequenceField: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        instruction: { default: '' },
+        identifier: { default: '' },
+        fieldArgument: { default: '' },
+        sequenceMode: { default: 'next' },
+        hideResult: { default: false },
+        restartNumber: { default: null },
+        restartLevel: { default: null },
+        format: { default: 'Arabic' },
+        hasGeneralFormat: { default: false },
+        pageNumberFieldFormat: { default: null },
+        numericPictureFormat: { default: null },
+        resolvedNumber: { default: '' },
+        resolvedNumberIsCurrent: { default: false },
+        sdBlockId: { default: null },
+      },
+    },
+  },
+});
+
+function seq(instruction: string, attrs: Record<string, unknown> = {}) {
+  return schema.nodes.sequenceField.create({
+    instruction,
+    ...attrs,
+  });
+}
+
+function p(...content: ProseMirrorNode[]) {
+  return schema.nodes.paragraph.create({}, content);
+}
+
+function resolvedNumbers(doc: ProseMirrorNode): string[] {
+  const values: string[] = [];
+  doc.descendants((node) => {
+    if (node.type.name === 'sequenceField') values.push(node.attrs.resolvedNumber as string);
+    return true;
+  });
+  return values;
+}
+
+function updateDoc(doc: ProseMirrorNode, options: Parameters<typeof updateSequenceFieldsInTransaction>[0] = {} as any) {
+  const state = EditorState.create({ schema, doc });
+  const tr = state.tr;
+  const result = updateSequenceFieldsInTransaction({
+    tr,
+    schema,
+    ...options,
+  });
+  return { result, doc: tr.doc };
+}
+
+describe('updateSequenceFieldsInTransaction', () => {
+  it('recomputes all SEQ fields in document order and marks them current', () => {
+    const doc = schema.nodes.doc.create(null, [
+      p(seq('SEQ Figure \\* ARABIC', { resolvedNumber: '9' })),
+      p(seq('SEQ Figure \\* ARABIC', { resolvedNumber: '9' })),
+      p(seq('SEQ Table \\* ARABIC', { resolvedNumber: '9' })),
+    ]);
+
+    const updated = updateDoc(doc);
+
+    expect(updated.result).toEqual({ changed: true, updated: 3 });
+    expect(resolvedNumbers(updated.doc)).toEqual(['1', '2', '1']);
+    updated.doc.descendants((node) => {
+      if (node.type.name === 'sequenceField') expect(node.attrs.resolvedNumberIsCurrent).toBe(true);
+      return true;
+    });
+  });
+
+  it('evaluates fields before a range but only writes overlapping nodes', () => {
+    const first = p(seq('SEQ Figure'));
+    const second = p(seq('SEQ Figure'));
+    const doc = schema.nodes.doc.create(null, [first, second]);
+    const secondPos = first.nodeSize + 1;
+
+    const updated = updateDoc(doc, { scope: { kind: 'range', from: secondPos, to: secondPos + second.nodeSize } });
+
+    expect(updated.result).toEqual({ changed: true, updated: 1 });
+    expect(resolvedNumbers(updated.doc)).toEqual(['', '2']);
+  });
+
+  it('updates only the requested identifier while preserving shared counter evaluation', () => {
+    const doc = schema.nodes.doc.create(null, [
+      p(seq('SEQ Figure')),
+      p(seq('SEQ Table')),
+      p(seq('SEQ Figure')),
+      p(seq('SEQ Table')),
+    ]);
+
+    const updated = updateDoc(doc, { scope: { kind: 'identifier', identifier: 'Table' } });
+
+    expect(updated.result).toEqual({ changed: true, updated: 2 });
+    expect(resolvedNumbers(updated.doc)).toEqual(['', '1', '', '2']);
+  });
+
+  it('uses shared style-aware heading resolution for restart-level fields when converter context is available', () => {
+    const heading = schema.nodes.paragraph.create({
+      paragraphProperties: { styleId: 'HeadingOne' },
+    });
+    const caption1 = p(seq('SEQ Figure \\s 1'));
+    const heading2 = schema.nodes.paragraph.create({
+      paragraphProperties: { styleId: 'HeadingOne' },
+    });
+    const caption2 = p(seq('SEQ Figure \\s 1'));
+    const doc = schema.nodes.doc.create(null, [heading, caption1, heading2, caption2]);
+
+    const updated = updateDoc(doc, {
+      converterContext: {
+        translatedLinkedStyles: {
+          docDefaults: {},
+          styles: {
+            HeadingOne: { name: 'Custom Heading', paragraphProperties: { outlineLvl: 0 } },
+          },
+        },
+        translatedNumbering: {},
+      } as any,
+    });
+
+    expect(resolvedNumbers(updated.doc)).toEqual(['1', '1']);
+  });
+
+  it('skips restart-level heading resets when converter context is unavailable', () => {
+    const heading = schema.nodes.paragraph.create({
+      paragraphProperties: { outlineLvl: 0 },
+    });
+    const caption1 = p(seq('SEQ Figure \\s 1'));
+    const heading2 = schema.nodes.paragraph.create({
+      paragraphProperties: { outlineLvl: 0 },
+    });
+    const caption2 = p(seq('SEQ Figure \\s 1'));
+    const doc = schema.nodes.doc.create(null, [heading, caption1, heading2, caption2]);
+
+    const updated = updateDoc(doc);
+
+    expect(resolvedNumbers(updated.doc)).toEqual(['1', '2']);
+  });
+
+  it('parses stale attrs from the raw instruction before writing current results', () => {
+    const doc = schema.nodes.doc.create(null, [
+      p(
+        seq('SEQ Figure \\r 7 \\* roman', {
+          identifier: 'Stale',
+          restartNumber: null,
+          format: 'Arabic',
+        }),
+      ),
+    ]);
+
+    const updated = updateDoc(doc);
+    const field = updated.doc.nodeAt(1);
+
+    expect(field?.attrs.identifier).toBe('Figure');
+    expect(field?.attrs.restartNumber).toBe(7);
+    expect(field?.attrs.format).toBe('roman');
+    expect(field?.attrs.pageNumberFieldFormat).toEqual({ format: 'lowerRoman' });
+    expect(field?.attrs.resolvedNumber).toBe('vii');
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.test.ts
@@ -177,4 +177,17 @@ describe('updateSequenceFieldsInTransaction', () => {
     expect(field?.attrs.pageNumberFieldFormat).toEqual({ format: 'lowerRoman' });
     expect(field?.attrs.resolvedNumber).toBe('vii');
   });
+
+  it('handles field arguments conservatively without advancing counters', () => {
+    const doc = schema.nodes.doc.create(null, [
+      p(seq('SEQ Figure')),
+      p(seq('SEQ Figure bookmark', { resolvedNumber: 'cached' })),
+      p(seq('SEQ Figure bookmark')),
+      p(seq('SEQ Figure')),
+    ]);
+
+    const updated = updateDoc(doc);
+
+    expect(resolvedNumbers(updated.doc)).toEqual(['1', 'cached', '1', '2']);
+  });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.ts
@@ -1,0 +1,187 @@
+import type { Schema, Node as ProseMirrorNode } from 'prosemirror-model';
+import type { Transaction } from 'prosemirror-state';
+import type { PageNumberFieldFormat } from '@superdoc/contracts';
+import type { ParagraphProperties } from '@superdoc/style-engine/ooxml';
+import type { ConverterContext } from '../../core/layout-adapter/converter-context.js';
+import { resolveParagraphHeadingLevel } from '../../core/layout-adapter/attributes/paragraph.js';
+import { SequenceFieldEvaluator } from '../../core/super-converter/field-references/shared/seq-evaluator.js';
+import {
+  normalizeSeqIdentifier,
+  parseSeqInstruction,
+} from '../../core/super-converter/field-references/shared/seq-instruction.js';
+
+export type SequenceFieldUpdateScope =
+  | { kind: 'all' }
+  | { kind: 'range'; from: number; to: number }
+  | { kind: 'identifier'; identifier: string };
+
+type SequenceFieldAttrs = Record<string, unknown> & {
+  instruction: string;
+  identifier: string;
+  fieldArgument: string;
+  sequenceMode: 'next' | 'current';
+  hideResult: boolean;
+  restartNumber: number | null;
+  restartLevel: number | null;
+  format: string;
+  hasGeneralFormat: boolean;
+  pageNumberFieldFormat: PageNumberFieldFormat | null;
+  numericPictureFormat: { picture: string } | null;
+  resolvedNumber?: string;
+  resolvedNumberIsCurrent?: boolean;
+};
+
+export function updateSequenceFieldsInTransaction(args: {
+  tr: Transaction;
+  schema: Schema;
+  scope?: SequenceFieldUpdateScope;
+  converterContext?: ConverterContext;
+}): { changed: boolean; updated: number } {
+  const { tr, scope = { kind: 'all' }, converterContext } = args;
+  const sequenceFieldType = args.schema.nodes.sequenceField;
+  if (!sequenceFieldType) return { changed: false, updated: 0 };
+
+  const evaluator = new SequenceFieldEvaluator();
+  let changed = false;
+  let updated = 0;
+
+  // Body-only by design: tr.doc is the main story document. Header/footer and
+  // note editors render correctly via layout, but are not rewritten by this API path.
+  tr.doc.descendants((node, pos) => {
+    if (node.type.name === 'paragraph') {
+      evaluator.enterParagraph({
+        paragraphHeadingLevel: resolveNodeHeadingLevel(node, converterContext),
+      });
+      return true;
+    }
+
+    if (node.type !== sequenceFieldType) return true;
+
+    const nextAttrs = buildEvaluatedSequenceAttrs(node);
+    const evaluation = evaluator.evaluateField({
+      identifier: nextAttrs.identifier,
+      instruction: nextAttrs.instruction,
+      fieldArgument: nextAttrs.fieldArgument,
+      sequenceMode: nextAttrs.sequenceMode,
+      hideResult: nextAttrs.hideResult,
+      restartNumber: nextAttrs.restartNumber,
+      restartLevel: nextAttrs.restartLevel,
+      format: nextAttrs.format,
+      hasGeneralFormat: nextAttrs.hasGeneralFormat,
+      pageNumberFieldFormat: nextAttrs.pageNumberFieldFormat,
+      numericPictureFormat: nextAttrs.numericPictureFormat,
+      cachedText: typeof node.attrs.resolvedNumber === 'string' ? node.attrs.resolvedNumber : '',
+    });
+
+    if (!shouldWriteSequenceField(node, pos, scope, nextAttrs.identifier)) return true;
+
+    nextAttrs.resolvedNumber = evaluation.text;
+    nextAttrs.resolvedNumberIsCurrent = true;
+
+    if (!attrsEqual(node.attrs, nextAttrs)) {
+      tr.setNodeMarkup(resolveCurrentTransactionPos(tr, pos, node), undefined, nextAttrs);
+      changed = true;
+    }
+    updated += 1;
+    return true;
+  });
+
+  return { changed, updated };
+}
+
+export function getSequenceFieldUpdaterConverterContext(editor: unknown): ConverterContext | undefined {
+  const converter = (editor as { converter?: Partial<ConverterContext> } | null | undefined)?.converter;
+  if (!converter?.translatedLinkedStyles) return undefined;
+
+  return {
+    translatedLinkedStyles: converter.translatedLinkedStyles,
+    translatedNumbering: converter.translatedNumbering ?? {},
+    docx: converter.docx,
+  } as ConverterContext;
+}
+
+function resolveNodeHeadingLevel(node: ProseMirrorNode, converterContext?: ConverterContext): number | undefined {
+  const paragraphProperties = node.attrs?.paragraphProperties;
+  if (converterContext) {
+    return resolveParagraphHeadingLevel(
+      isRecord(paragraphProperties) ? (paragraphProperties as ParagraphProperties) : undefined,
+      converterContext,
+    );
+  }
+
+  // Without style data, skip SEQ \s heading resets rather than applying a
+  // partial heuristic that can diverge from the rendered layout.
+  return undefined;
+}
+
+function buildEvaluatedSequenceAttrs(node: ProseMirrorNode): SequenceFieldAttrs {
+  const instruction = typeof node.attrs.instruction === 'string' ? node.attrs.instruction : '';
+  const parsed = parseSeqInstruction(instruction);
+
+  return {
+    ...node.attrs,
+    instruction,
+    identifier: parsed.identifier || readStringAttr(node, 'identifier'),
+    fieldArgument: parsed.fieldArgument,
+    sequenceMode: parsed.sequenceMode,
+    hideResult: parsed.hideResult,
+    restartNumber: parsed.restartNumber,
+    restartLevel: parsed.restartLevel,
+    format: parsed.format,
+    hasGeneralFormat: parsed.hasGeneralFormat,
+    pageNumberFieldFormat: parsed.pageNumberFieldFormat ?? null,
+    numericPictureFormat: parsed.numericPictureFormat,
+  };
+}
+
+function shouldWriteSequenceField(
+  node: ProseMirrorNode,
+  pos: number,
+  scope: SequenceFieldUpdateScope,
+  identifier: string,
+): boolean {
+  if (scope.kind === 'all') return true;
+  if (scope.kind === 'range') {
+    const end = pos + node.nodeSize;
+    return pos < scope.to && end > scope.from;
+  }
+
+  return normalizeSeqIdentifier(identifier) === normalizeSeqIdentifier(scope.identifier);
+}
+
+function readStringAttr(node: ProseMirrorNode, key: string): string {
+  const value = node.attrs?.[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function attrsEqual(left: Record<string, unknown>, right: Record<string, unknown>): boolean {
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if (!valuesEqual(left[key], right[key])) return false;
+  }
+  return true;
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (!isRecord(left) || !isRecord(right)) return false;
+
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if (!valuesEqual(left[key], right[key])) return false;
+  }
+  return true;
+}
+
+function resolveCurrentTransactionPos(tr: Transaction, pos: number, node: ProseMirrorNode): number {
+  // This helper walks tr.doc, so positions are usually already current. When a
+  // caller provides a transaction with prior steps (for example fields.insert),
+  // mapping those current positions again can point inside text nodes.
+  const currentNode = tr.doc.nodeAt(pos);
+  if (currentNode?.type === node.type) return pos;
+  return tr.mapping.map(pos);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/sequence-field-updater.ts
@@ -8,6 +8,7 @@ import { SequenceFieldEvaluator } from '../../core/super-converter/field-referen
 import {
   normalizeSeqIdentifier,
   parseSeqInstruction,
+  sequenceFieldAttrsFromParsed,
 } from '../../core/super-converter/field-references/shared/seq-instruction.js';
 
 export type SequenceFieldUpdateScope =
@@ -117,20 +118,13 @@ function resolveNodeHeadingLevel(node: ProseMirrorNode, converterContext?: Conve
 function buildEvaluatedSequenceAttrs(node: ProseMirrorNode): SequenceFieldAttrs {
   const instruction = typeof node.attrs.instruction === 'string' ? node.attrs.instruction : '';
   const parsed = parseSeqInstruction(instruction);
+  const parsedAttrs = sequenceFieldAttrsFromParsed(parsed);
 
   return {
     ...node.attrs,
     instruction,
-    identifier: parsed.identifier || readStringAttr(node, 'identifier'),
-    fieldArgument: parsed.fieldArgument,
-    sequenceMode: parsed.sequenceMode,
-    hideResult: parsed.hideResult,
-    restartNumber: parsed.restartNumber,
-    restartLevel: parsed.restartLevel,
-    format: parsed.format,
-    hasGeneralFormat: parsed.hasGeneralFormat,
-    pageNumberFieldFormat: parsed.pageNumberFieldFormat ?? null,
-    numericPictureFormat: parsed.numericPictureFormat,
+    ...parsedAttrs,
+    identifier: parsedAttrs.identifier || readStringAttr(node, 'identifier'),
   };
 }
 

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/caption-wrappers.seq-fields.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/caption-wrappers.seq-fields.test.ts
@@ -1,0 +1,108 @@
+import { Schema } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
+import { describe, expect, it } from 'vitest';
+import type { Editor } from '../../core/Editor.js';
+import { findAllCaptions } from '../helpers/caption-resolver.js';
+import { captionsConfigureWrapper, captionsInsertWrapper } from './caption-wrappers.js';
+import { registerBuiltInExecutors } from './register-executors.js';
+
+registerBuiltInExecutors();
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { sdBlockId: { default: null }, paragraphProperties: { default: null } },
+      toDOM: () => ['p', 0],
+    },
+    text: { group: 'inline' },
+    hardBreak: { group: 'inline', inline: true, atom: true, toDOM: () => ['br'] },
+    tab: { group: 'inline', inline: true, atom: true, toDOM: () => ['span'] },
+    sequenceField: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        instruction: { default: '' },
+        identifier: { default: '' },
+        fieldArgument: { default: '' },
+        sequenceMode: { default: 'next' },
+        hideResult: { default: false },
+        restartNumber: { default: null },
+        restartLevel: { default: null },
+        format: { default: 'Arabic' },
+        hasGeneralFormat: { default: false },
+        pageNumberFieldFormat: { default: null },
+        numericPictureFormat: { default: null },
+        resolvedNumber: { default: '' },
+        resolvedNumberIsCurrent: { default: false },
+        sdBlockId: { default: null },
+      },
+      toDOM: () => ['span', 0],
+    },
+  },
+});
+
+function createEditor(): Editor {
+  const doc = schema.nodes.doc.create(null, [
+    schema.nodes.paragraph.create({ sdBlockId: 'anchor-1' }, schema.text('Anchor 1')),
+    schema.nodes.paragraph.create({ sdBlockId: 'anchor-2' }, schema.text('Anchor 2')),
+  ]);
+  const editor = {
+    schema,
+    state: EditorState.create({ schema, doc }),
+    converter: {
+      translatedLinkedStyles: { docDefaults: {}, styles: {} },
+      translatedNumbering: {},
+    },
+    view: { dispatch: () => {} },
+    dispatch(tr) {
+      this.state = this.state.apply(tr);
+    },
+  };
+  return editor as unknown as Editor;
+}
+
+function insertCaption(editor: Editor, anchorId: string, text: string) {
+  return captionsInsertWrapper(editor, {
+    label: 'Figure',
+    adjacentTo: { kind: 'block', nodeType: 'paragraph', nodeId: anchorId },
+    position: 'below',
+    text,
+  });
+}
+
+describe('caption wrappers SEQ fields', () => {
+  it('captions.insert recomputes SEQ numbers for inserted captions', () => {
+    const editor = createEditor();
+
+    expect(insertCaption(editor, 'anchor-1', 'One').success).toBe(true);
+    expect(insertCaption(editor, 'anchor-2', 'Two').success).toBe(true);
+
+    const captions = findAllCaptions(editor.state.doc).filter((caption) => caption.label === 'Figure');
+    expect(captions.map((caption) => caption.number)).toEqual(['1', '2']);
+  });
+
+  it('captions.configure updates matching SEQ format attrs and recomputes values', () => {
+    const editor = createEditor();
+    insertCaption(editor, 'anchor-1', 'One');
+    insertCaption(editor, 'anchor-2', 'Two');
+
+    const result = captionsConfigureWrapper(editor, { label: 'Figure', format: 'lowerRoman' });
+
+    expect(result.success).toBe(true);
+    const fields: any[] = [];
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'sequenceField') fields.push(node);
+      return true;
+    });
+    expect(fields.map((field) => field.attrs.instruction)).toEqual(['SEQ Figure \\* roman', 'SEQ Figure \\* roman']);
+    expect(fields.map((field) => field.attrs.pageNumberFieldFormat)).toEqual([
+      { format: 'lowerRoman' },
+      { format: 'lowerRoman' },
+    ]);
+    expect(fields.map((field) => field.attrs.resolvedNumber)).toEqual(['i', 'ii']);
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/caption-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/caption-wrappers.ts
@@ -31,6 +31,11 @@ import { rejectTrackedMode } from '../helpers/mutation-helpers.js';
 import { Fragment } from 'prosemirror-model';
 import { clearIndexCache } from '../helpers/index-cache.js';
 import { buildTextWithTabs } from '../helpers/text-with-tabs.js';
+import {
+  getSequenceFieldUpdaterConverterContext,
+  updateSequenceFieldsInTransaction,
+} from '../helpers/sequence-field-updater.js';
+import { parseSeqInstruction } from '../../core/super-converter/field-references/shared/seq-instruction.js';
 
 // ---------------------------------------------------------------------------
 // Result helpers
@@ -130,12 +135,23 @@ export function captionsInsertWrapper(
 
       // Add SEQ field if the node type exists
       if (schema.nodes.sequenceField) {
+        const instruction = `SEQ ${label} \\* ARABIC`;
+        const parsed = parseSeqInstruction(instruction);
         children.push(
           schema.nodes.sequenceField.create({
-            instruction: `SEQ ${label} \\* ARABIC`,
-            identifier: label,
-            format: 'ARABIC',
+            instruction,
+            identifier: parsed.identifier,
+            fieldArgument: parsed.fieldArgument,
+            sequenceMode: parsed.sequenceMode,
+            hideResult: parsed.hideResult,
+            restartNumber: parsed.restartNumber,
+            restartLevel: parsed.restartLevel,
+            format: parsed.format,
+            hasGeneralFormat: parsed.hasGeneralFormat,
+            pageNumberFieldFormat: parsed.pageNumberFieldFormat ?? null,
+            numericPictureFormat: parsed.numericPictureFormat,
             resolvedNumber: '',
+            resolvedNumberIsCurrent: false,
             sdBlockId: `seq-${Date.now()}`,
           }),
         );
@@ -155,6 +171,12 @@ export function captionsInsertWrapper(
 
       const { tr } = editor.state;
       tr.insert(pos, captionParagraph);
+      updateSequenceFieldsInTransaction({
+        tr,
+        schema,
+        scope: { kind: 'identifier', identifier: label },
+        converterContext: getSequenceFieldUpdaterConverterContext(editor),
+      });
       editor.dispatch(tr);
       clearIndexCache(editor);
       return true;
@@ -268,18 +290,36 @@ export function captionsConfigureWrapper(
 
         const format = CAPTION_FORMAT_TO_OOXML[input.format ?? 'decimal'] ?? 'ARABIC';
         const newInstruction = `SEQ ${input.label} \\* ${format}`;
-        if (node.attrs.instruction === newInstruction && node.attrs.format === format) return true;
+        const parsed = parseSeqInstruction(newInstruction);
+        const pageNumberFieldFormat = parsed.pageNumberFieldFormat ?? { format: 'decimal' };
+        if (
+          node.attrs.instruction === newInstruction &&
+          node.attrs.format === format &&
+          JSON.stringify(node.attrs.pageNumberFieldFormat) === JSON.stringify(pageNumberFieldFormat)
+        ) {
+          return true;
+        }
 
         tr.setNodeMarkup(tr.mapping.map(pos), undefined, {
           ...node.attrs,
           instruction: newInstruction,
           format,
+          pageNumberFieldFormat,
+          hasGeneralFormat: true,
+          numericPictureFormat: null,
+          resolvedNumberIsCurrent: false,
         });
         changed = true;
         return true;
       });
 
       if (!changed) return false;
+      updateSequenceFieldsInTransaction({
+        tr,
+        schema: editor.schema,
+        scope: { kind: 'identifier', identifier: input.label },
+        converterContext: getSequenceFieldUpdaterConverterContext(editor),
+      });
       editor.dispatch(tr);
       clearIndexCache(editor);
       return true;

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/caption-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/caption-wrappers.ts
@@ -35,7 +35,10 @@ import {
   getSequenceFieldUpdaterConverterContext,
   updateSequenceFieldsInTransaction,
 } from '../helpers/sequence-field-updater.js';
-import { parseSeqInstruction } from '../../core/super-converter/field-references/shared/seq-instruction.js';
+import {
+  parseSeqInstruction,
+  sequenceFieldAttrsFromParsed,
+} from '../../core/super-converter/field-references/shared/seq-instruction.js';
 
 // ---------------------------------------------------------------------------
 // Result helpers
@@ -140,16 +143,7 @@ export function captionsInsertWrapper(
         children.push(
           schema.nodes.sequenceField.create({
             instruction,
-            identifier: parsed.identifier,
-            fieldArgument: parsed.fieldArgument,
-            sequenceMode: parsed.sequenceMode,
-            hideResult: parsed.hideResult,
-            restartNumber: parsed.restartNumber,
-            restartLevel: parsed.restartLevel,
-            format: parsed.format,
-            hasGeneralFormat: parsed.hasGeneralFormat,
-            pageNumberFieldFormat: parsed.pageNumberFieldFormat ?? null,
-            numericPictureFormat: parsed.numericPictureFormat,
+            ...sequenceFieldAttrsFromParsed(parsed),
             resolvedNumber: '',
             resolvedNumberIsCurrent: false,
             sdBlockId: `seq-${Date.now()}`,
@@ -291,11 +285,11 @@ export function captionsConfigureWrapper(
         const format = CAPTION_FORMAT_TO_OOXML[input.format ?? 'decimal'] ?? 'ARABIC';
         const newInstruction = `SEQ ${input.label} \\* ${format}`;
         const parsed = parseSeqInstruction(newInstruction);
-        const pageNumberFieldFormat = parsed.pageNumberFieldFormat ?? { format: 'decimal' };
+        const parsedAttrs = sequenceFieldAttrsFromParsed(parsed);
         if (
           node.attrs.instruction === newInstruction &&
           node.attrs.format === format &&
-          JSON.stringify(node.attrs.pageNumberFieldFormat) === JSON.stringify(pageNumberFieldFormat)
+          JSON.stringify(node.attrs.pageNumberFieldFormat) === JSON.stringify(parsedAttrs.pageNumberFieldFormat)
         ) {
           return true;
         }
@@ -303,10 +297,7 @@ export function captionsConfigureWrapper(
         tr.setNodeMarkup(tr.mapping.map(pos), undefined, {
           ...node.attrs,
           instruction: newInstruction,
-          format,
-          pageNumberFieldFormat,
-          hasGeneralFormat: true,
-          numericPictureFormat: null,
+          ...parsedAttrs,
           resolvedNumberIsCurrent: false,
         });
         changed = true;

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
@@ -44,6 +44,21 @@ const schema = new Schema({
       },
       toDOM: () => ['span', 0],
     },
+    'total-page-number': {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      content: 'text*',
+      attrs: {
+        instruction: { default: null },
+        importedCachedText: { default: null },
+        resolvedText: { default: null },
+        pageNumberFormat: { default: null },
+        pageNumberZeroPadding: { default: null },
+        pageNumberNumericPicture: { default: null },
+      },
+      toDOM: () => ['span', 0],
+    },
   },
 });
 
@@ -73,10 +88,39 @@ function createEditorWithSectionPageCount(
   return editor as unknown as Editor;
 }
 
-function createEditorForInsert(sectionPageCount?: number): Editor {
+function createEditorWithTotalPageNumber(
+  pageCount: number | undefined,
+  initialValue = '1',
+  attrs: Record<string, unknown> = {},
+): Editor {
+  const field = schema.nodes['total-page-number'].create(
+    { instruction: 'NUMPAGES', resolvedText: initialValue, ...attrs },
+    schema.text(initialValue),
+  );
+  const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, field);
+  const doc = schema.nodes.doc.create(null, paragraph);
+
+  const editor = {
+    schema,
+    state: EditorState.create({ schema, doc }),
+    currentTotalPages: pageCount,
+    options: {},
+    view: { dispatch: () => {} },
+    dispatch(tr) {
+      this.state = this.state.apply(tr);
+    },
+  };
+
+  return editor as unknown as Editor;
+}
+
+function createEditorForInsert(sectionPageCount?: number, isHeaderOrFooter = false): Editor {
   const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, schema.text('x'));
   const doc = schema.nodes.doc.create(null, paragraph);
-  const options = sectionPageCount == null ? {} : { sectionPageCount };
+  const options = {
+    ...(sectionPageCount == null ? {} : { sectionPageCount }),
+    ...(isHeaderOrFooter ? { isHeaderOrFooter: true } : {}),
+  };
 
   const editor = {
     schema,
@@ -177,5 +221,92 @@ describe('fieldsRebuildWrapper SECTIONPAGES fields', () => {
     expect(updatedField?.type.name).toBe('section-page-count');
     expect(updatedField?.attrs.resolvedText).toBe('3');
     expect(updatedField?.textContent).toBe('3');
+  });
+});
+
+describe('fieldsRebuildWrapper NUMPAGES fields', () => {
+  it('inserts NUMPAGES as a total-page-number node with numeric picture attrs in headers/footers', () => {
+    const editor = createEditorForInsert(undefined, true);
+
+    const result = fieldsInsertWrapper(editor, {
+      mode: 'raw',
+      instruction: 'NUMPAGES \\# "#,##0"',
+      at: { kind: 'text', segments: [{ blockId: 'block-1', range: { start: 0, end: 0 } }] },
+    });
+
+    expect(result.success).toBe(true);
+    const insertedField = editor.state.doc.nodeAt(1);
+    expect(insertedField?.type.name).toBe('total-page-number');
+    expect(insertedField?.attrs).toMatchObject({
+      instruction: 'NUMPAGES \\# "#,##0"',
+      pageNumberNumericPicture: '#,##0',
+    });
+  });
+
+  it('preserves quoted NUMPAGES numeric picture whitespace during insert', () => {
+    const editor = createEditorForInsert(undefined, true);
+
+    const result = fieldsInsertWrapper(editor, {
+      mode: 'raw',
+      instruction: 'NUMPAGES \\# "#   pages"',
+      at: { kind: 'text', segments: [{ blockId: 'block-1', range: { start: 0, end: 0 } }] },
+    });
+
+    expect(result.success).toBe(true);
+    const insertedField = editor.state.doc.nodeAt(1);
+    expect(insertedField?.type.name).toBe('total-page-number');
+    expect(insertedField?.attrs).toMatchObject({
+      instruction: 'NUMPAGES \\# "#   pages"',
+      pageNumberNumericPicture: '#   pages',
+    });
+  });
+
+  it('inserts NUMPAGES as a total-page-number node with general format attrs in headers/footers', () => {
+    const editor = createEditorForInsert(undefined, true);
+
+    const result = fieldsInsertWrapper(editor, {
+      mode: 'raw',
+      instruction: 'NUMPAGES \\* Ordinal',
+      at: { kind: 'text', segments: [{ blockId: 'block-1', range: { start: 0, end: 0 } }] },
+    });
+
+    expect(result.success).toBe(true);
+    const insertedField = editor.state.doc.nodeAt(1);
+    expect(insertedField?.type.name).toBe('total-page-number');
+    expect(insertedField?.attrs).toMatchObject({
+      instruction: 'NUMPAGES \\* Ordinal',
+      pageNumberFormat: 'ordinal',
+    });
+  });
+
+  it('formats rebuilt total-page-number values with pageNumberFormat', () => {
+    const editor = createEditorWithTotalPageNumber(4, '1', { pageNumberFormat: 'upperRoman' });
+
+    const result = fieldsRebuildWrapper(editor, {
+      target: { kind: 'field', blockId: 'block-1', occurrenceIndex: 0, nestingDepth: 0 },
+    });
+
+    expect(result.success).toBe(true);
+    const updatedField = editor.state.doc.nodeAt(1);
+    expect(updatedField?.type.name).toBe('total-page-number');
+    expect(updatedField?.attrs.resolvedText).toBe('IV');
+    expect(updatedField?.textContent).toBe('IV');
+  });
+
+  it('formats rebuilt total-page-number values with numeric picture switches', () => {
+    const editor = createEditorWithTotalPageNumber(1234, '1', {
+      pageNumberFormat: 'decimal',
+      pageNumberNumericPicture: '#,##0 pages',
+    });
+
+    const result = fieldsRebuildWrapper(editor, {
+      target: { kind: 'field', blockId: 'block-1', occurrenceIndex: 0, nestingDepth: 0 },
+    });
+
+    expect(result.success).toBe(true);
+    const updatedField = editor.state.doc.nodeAt(1);
+    expect(updatedField?.type.name).toBe('total-page-number');
+    expect(updatedField?.attrs.resolvedText).toBe('1,234 pages');
+    expect(updatedField?.textContent).toBe('1,234 pages');
   });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.seq-fields.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.seq-fields.test.ts
@@ -1,0 +1,149 @@
+import { Schema } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
+import { describe, expect, it } from 'vitest';
+import type { Editor } from '../../core/Editor.js';
+import { fieldsInsertWrapper, fieldsRebuildWrapper } from './field-wrappers.js';
+import { registerBuiltInExecutors } from './register-executors.js';
+
+registerBuiltInExecutors();
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { sdBlockId: { default: null }, paragraphProperties: { default: null } },
+      toDOM: () => ['p', 0],
+    },
+    text: { group: 'inline' },
+    sequenceField: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        instruction: { default: '' },
+        identifier: { default: '' },
+        fieldArgument: { default: '' },
+        sequenceMode: { default: 'next' },
+        hideResult: { default: false },
+        restartNumber: { default: null },
+        restartLevel: { default: null },
+        format: { default: 'Arabic' },
+        hasGeneralFormat: { default: false },
+        pageNumberFieldFormat: { default: null },
+        numericPictureFormat: { default: null },
+        resolvedNumber: { default: '' },
+        resolvedNumberIsCurrent: { default: false },
+        sdBlockId: { default: null },
+      },
+      toDOM: () => ['span', 0],
+    },
+  },
+});
+
+function createEditor(doc = schema.nodes.doc.create(null, [paragraph('block-1', 'A')])): Editor {
+  const editor = {
+    schema,
+    state: EditorState.create({ schema, doc }),
+    converter: {
+      translatedLinkedStyles: { docDefaults: {}, styles: {} },
+      translatedNumbering: {},
+    },
+    view: { dispatch: () => {} },
+    dispatch(tr) {
+      this.state = this.state.apply(tr);
+    },
+  };
+  return editor as unknown as Editor;
+}
+
+function paragraph(id: string, text?: string) {
+  return schema.nodes.paragraph.create({ sdBlockId: id }, text ? schema.text(text) : null);
+}
+
+function seq(instruction: string, attrs: Record<string, unknown> = {}) {
+  return schema.nodes.sequenceField.create({ instruction, ...attrs });
+}
+
+function fieldInsertInput(instruction: string) {
+  return {
+    mode: 'raw' as const,
+    instruction,
+    at: {
+      segments: [{ blockId: 'block-1', range: { start: 1, end: 1 } }],
+    },
+  };
+}
+
+function sequenceFields(editor: Editor) {
+  const fields: any[] = [];
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === 'sequenceField') fields.push(node);
+    return true;
+  });
+  return fields;
+}
+
+describe('field wrappers SEQ fields', () => {
+  it('fields.insert raw SEQ creates parsed attrs and a computed result', () => {
+    const editor = createEditor();
+
+    const result = fieldsInsertWrapper(editor, fieldInsertInput('SEQ Figure \\* ARABIC'));
+
+    expect(result.success).toBe(true);
+    const [field] = sequenceFields(editor);
+    expect(field.attrs.identifier).toBe('Figure');
+    expect(field.attrs.pageNumberFieldFormat).toEqual({ format: 'decimal' });
+    expect(field.attrs.resolvedNumber).toBe('1');
+    expect(field.attrs.resolvedNumberIsCurrent).toBe(true);
+  });
+
+  it('fields.insert recomputes existing matching SEQ fields in document order', () => {
+    const firstCaption = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, [
+      seq('SEQ Figure \\* ARABIC', { resolvedNumber: '9' }),
+      schema.text('A'),
+    ]);
+    const doc = schema.nodes.doc.create(null, [firstCaption]);
+    const editor = createEditor(doc);
+
+    const result = fieldsInsertWrapper(editor, fieldInsertInput('SEQ Figure \\* ARABIC'));
+
+    expect(result.success).toBe(true);
+    expect(sequenceFields(editor).map((node) => node.attrs.resolvedNumber)).toEqual(['1', '2']);
+  });
+
+  it('fields.rebuild recomputes stale SEQ resolvedNumber values for the full document', () => {
+    const doc = schema.nodes.doc.create(null, [
+      schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, [
+        seq('SEQ Figure \\* ARABIC', { resolvedNumber: '9' }),
+        seq('SEQ Figure \\* ARABIC', { resolvedNumber: '9' }),
+      ]),
+    ]);
+    const editor = createEditor(doc);
+
+    const result = fieldsRebuildWrapper(editor, {
+      target: { kind: 'field', blockId: 'block-1', occurrenceIndex: 0, nestingDepth: 0 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(sequenceFields(editor).map((node) => node.attrs.resolvedNumber)).toEqual(['1', '2']);
+  });
+
+  it('fields.rebuild succeeds when SEQ values are already current', () => {
+    const doc = schema.nodes.doc.create(null, [
+      schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, [
+        seq('SEQ Figure \\* ARABIC', { resolvedNumber: '1', resolvedNumberIsCurrent: true }),
+        seq('SEQ Figure \\* ARABIC', { resolvedNumber: '2', resolvedNumberIsCurrent: true }),
+      ]),
+    ]);
+    const editor = createEditor(doc);
+
+    const result = fieldsRebuildWrapper(editor, {
+      target: { kind: 'field', blockId: 'block-1', occurrenceIndex: 0, nestingDepth: 0 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(sequenceFields(editor).map((node) => node.attrs.resolvedNumber)).toEqual(['1', '2']);
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
@@ -15,6 +15,7 @@ import type {
   MutationOptions,
   ReceiptFailureCode,
 } from '@superdoc/document-api';
+import { formatPageNumberFieldValue } from '@superdoc/contracts';
 import { buildDiscoveryResult } from '@superdoc/document-api';
 import {
   findAllFields,
@@ -31,6 +32,7 @@ import { DocumentApiAdapterError } from '../errors.js';
 import { getWordStatistics, resolveDocumentStatFieldValue, resolveMainBodyEditor } from '../helpers/word-statistics.js';
 import { resolveSectionPageCountFieldValue } from '../helpers/section-page-count.js';
 import { parsePageNumberFieldSwitches } from '../../core/super-converter/field-references/shared/page-number-field-switches.js';
+import { getPageNumberFieldFormat } from '../../core/layout-adapter/converters/inline-converters/page-number-field-format.js';
 import {
   isSeqInstruction,
   parseSeqInstruction,
@@ -119,7 +121,7 @@ export function fieldsInsertWrapper(
   }
 
   if (fieldType === 'NUMPAGES') {
-    return insertNumPagesField(editor, resolved, options);
+    return insertNumPagesField(editor, input, resolved, options);
   }
 
   if (fieldType === 'SECTIONPAGES') {
@@ -173,6 +175,7 @@ function insertDocumentStatField(
 
 function insertNumPagesField(
   editor: Editor,
+  input: FieldInsertInput,
   resolved: { from: number },
   options?: MutationOptions,
 ): FieldMutationResult {
@@ -190,10 +193,12 @@ function insertNumPagesField(
     );
   }
 
+  const parsedInstruction = parsePageNumberFieldSwitches(input.instruction, 'NUMPAGES');
+
   const receipt = executeDomainCommand(
     editor,
     (): boolean => {
-      const node = nodeType.create({});
+      const node = nodeType.create(parsedInstruction);
       const { tr } = editor.state;
       tr.insert(resolved.from, node);
       editor.dispatch(tr);
@@ -453,7 +458,10 @@ function rebuildTotalPageNumber(
 
   if (stats.pages == null) return fieldSuccess(address);
 
-  const freshValue = String(stats.pages);
+  const node = editor.state.doc.nodeAt(resolved.pos);
+  if (!node) return fieldFailure('TARGET_NOT_FOUND', 'Node not found.');
+
+  const freshValue = formatPageNumberFieldValue(stats.pages, getPageNumberFieldFormat(node.attrs));
 
   const receipt = executeDomainCommand(
     editor,

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
@@ -31,6 +31,14 @@ import { DocumentApiAdapterError } from '../errors.js';
 import { getWordStatistics, resolveDocumentStatFieldValue, resolveMainBodyEditor } from '../helpers/word-statistics.js';
 import { resolveSectionPageCountFieldValue } from '../helpers/section-page-count.js';
 import { parsePageNumberFieldSwitches } from '../../core/super-converter/field-references/shared/page-number-field-switches.js';
+import {
+  isSeqInstruction,
+  parseSeqInstruction,
+} from '../../core/super-converter/field-references/shared/seq-instruction.js';
+import {
+  getSequenceFieldUpdaterConverterContext,
+  updateSequenceFieldsInTransaction,
+} from '../helpers/sequence-field-updater.js';
 
 // ---------------------------------------------------------------------------
 // Result helpers
@@ -265,15 +273,44 @@ function insertRawField(
     editor,
     (): boolean => {
       const fieldType = extractFieldType(input.instruction);
-      const node = fieldNodeType.create({
-        instruction: input.instruction,
-        identifier: fieldType,
-        format: 'ARABIC',
-        resolvedNumber: '',
-        sdBlockId: `field-${Date.now()}`,
-      });
+      const isSeq = isSeqInstruction(input.instruction);
+      const parsed = isSeq ? parseSeqInstruction(input.instruction) : null;
+      const node = fieldNodeType.create(
+        parsed
+          ? {
+              instruction: input.instruction,
+              identifier: parsed.identifier,
+              fieldArgument: parsed.fieldArgument,
+              sequenceMode: parsed.sequenceMode,
+              hideResult: parsed.hideResult,
+              restartNumber: parsed.restartNumber,
+              restartLevel: parsed.restartLevel,
+              format: parsed.format,
+              hasGeneralFormat: parsed.hasGeneralFormat,
+              pageNumberFieldFormat: parsed.pageNumberFieldFormat ?? null,
+              numericPictureFormat: parsed.numericPictureFormat,
+              resolvedNumber: '',
+              resolvedNumberIsCurrent: false,
+              sdBlockId: `field-${Date.now()}`,
+            }
+          : {
+              instruction: input.instruction,
+              identifier: fieldType,
+              format: 'ARABIC',
+              resolvedNumber: '',
+              sdBlockId: `field-${Date.now()}`,
+            },
+      );
       const { tr } = editor.state;
       tr.insert(resolved.from, node);
+      if (parsed) {
+        updateSequenceFieldsInTransaction({
+          tr,
+          schema: editor.schema,
+          scope: { kind: 'identifier', identifier: parsed.identifier },
+          converterContext: getSequenceFieldUpdaterConverterContext(editor),
+        });
+      }
       editor.dispatch(tr);
       clearIndexCache(editor);
       return true;
@@ -318,6 +355,10 @@ export function fieldsRebuildWrapper(
     return rebuildSectionPageCount(editor, resolved, address, options);
   }
 
+  if (node.type.name === 'sequenceField' && isSeqInstruction((node.attrs?.instruction as string) ?? '')) {
+    return rebuildSequenceFields(editor, address, options);
+  }
+
   // Default: clear resolvedNumber to force re-evaluation (sequence fields, etc.)
   const receipt = executeDomainCommand(
     editor,
@@ -337,6 +378,29 @@ export function fieldsRebuildWrapper(
   );
 
   if (!receiptApplied(receipt)) return fieldFailure('NO_OP', 'Rebuild produced no change.');
+  return fieldSuccess(address);
+}
+
+function rebuildSequenceFields(editor: Editor, address: FieldAddress, options?: MutationOptions): FieldMutationResult {
+  executeDomainCommand(
+    editor,
+    () => {
+      const { tr } = editor.state;
+      const result = updateSequenceFieldsInTransaction({
+        tr,
+        schema: editor.schema,
+        scope: { kind: 'all' },
+        converterContext: getSequenceFieldUpdaterConverterContext(editor),
+      });
+      if (result.changed) {
+        editor.dispatch(tr);
+        clearIndexCache(editor);
+      }
+      return true;
+    },
+    { expectedRevision: options?.expectedRevision },
+  );
+
   return fieldSuccess(address);
 }
 

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
@@ -34,6 +34,7 @@ import { parsePageNumberFieldSwitches } from '../../core/super-converter/field-r
 import {
   isSeqInstruction,
   parseSeqInstruction,
+  sequenceFieldAttrsFromParsed,
 } from '../../core/super-converter/field-references/shared/seq-instruction.js';
 import {
   getSequenceFieldUpdaterConverterContext,
@@ -279,16 +280,7 @@ function insertRawField(
         parsed
           ? {
               instruction: input.instruction,
-              identifier: parsed.identifier,
-              fieldArgument: parsed.fieldArgument,
-              sequenceMode: parsed.sequenceMode,
-              hideResult: parsed.hideResult,
-              restartNumber: parsed.restartNumber,
-              restartLevel: parsed.restartLevel,
-              format: parsed.format,
-              hasGeneralFormat: parsed.hasGeneralFormat,
-              pageNumberFieldFormat: parsed.pageNumberFieldFormat ?? null,
-              numericPictureFormat: parsed.numericPictureFormat,
+              ...sequenceFieldAttrsFromParsed(parsed),
               resolvedNumber: '',
               resolvedNumberIsCurrent: false,
               sdBlockId: `field-${Date.now()}`,

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
@@ -89,7 +89,13 @@ export const FieldUpdate = Extension.create({
             }
           }
 
-          const fields = findFieldsInRange(state.doc, from, to);
+          const activeState = tocPathRan && editor?.state?.doc ? editor.state : state;
+          const activeDoc = activeState.doc ?? state.doc;
+          const activeSchema = activeState.schema ?? state.schema;
+          const activeFrom = Math.min(from, activeDoc.content.size);
+          const activeTo = to >= state.doc.content.size ? activeDoc.content.size : Math.min(to, activeDoc.content.size);
+
+          const fields = findFieldsInRange(activeDoc, activeFrom, activeTo);
           const updatable = fields.filter((f) => UPDATABLE_FIELD_TYPES.has(f.fieldType));
           const hasSeqSelection = fields.some((field) => field.fieldType === 'SEQ');
           if (updatable.length === 0 && !hasSeqSelection) return tocPathRan;
@@ -97,7 +103,7 @@ export const FieldUpdate = Extension.create({
           const mainEditor = resolveMainBodyEditor(editor);
           const stats = getWordStatistics(mainEditor);
 
-          const tr = state.tr;
+          const tr = activeState.tr;
           let changed = false;
 
           // Process in reverse position order so earlier positions stay valid
@@ -118,7 +124,7 @@ export const FieldUpdate = Extension.create({
               // Page-count fields store their display value as a text child,
               // not just an attr. Replace the entire node so both the text
               // content and resolvedText stay in sync.
-              const textChild = freshValue ? state.schema.text(freshValue) : null;
+              const textChild = freshValue ? activeSchema.text(freshValue) : null;
               const newNode = node.type.create({ ...node.attrs, resolvedText: freshValue }, textChild);
               tr.replaceWith(field.pos, field.pos + node.nodeSize, newNode);
               changed = true;
@@ -137,7 +143,7 @@ export const FieldUpdate = Extension.create({
           if (hasSeqSelection) {
             const result = updateSequenceFieldsInTransaction({
               tr,
-              schema: state.schema,
+              schema: activeSchema,
               scope: { kind: 'all' },
               converterContext: getSequenceFieldUpdaterConverterContext(editor),
             });

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
@@ -44,6 +44,8 @@ export const FieldUpdate = Extension.create({
         () =>
         ({ editor, state, tr: outerTr, dispatch }) => {
           const { from, to } = state.selection;
+          const originalSelectionFields = findFieldsInRange(state.doc, from, to);
+          const selectionHadSeq = originalSelectionFields.some((field) => field.fieldType === 'SEQ');
           let tocPathRan = false;
 
           // toc.update dispatches its own transaction per TOC; CommandService
@@ -97,7 +99,7 @@ export const FieldUpdate = Extension.create({
 
           const fields = findFieldsInRange(activeDoc, activeFrom, activeTo);
           const updatable = fields.filter((f) => UPDATABLE_FIELD_TYPES.has(f.fieldType));
-          const hasSeqSelection = fields.some((field) => field.fieldType === 'SEQ');
+          const hasSeqSelection = selectionHadSeq || fields.some((field) => field.fieldType === 'SEQ');
           if (updatable.length === 0 && !hasSeqSelection) return tocPathRan;
 
           const mainEditor = resolveMainBodyEditor(editor);

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
@@ -1,4 +1,5 @@
 import { Extension } from '@core/Extension.js';
+import { formatPageNumberFieldValue } from '@superdoc/contracts';
 import { findFieldsInRange } from '../../document-api-adapters/helpers/field-resolver.js';
 import { findAllTocNodes } from '../../document-api-adapters/helpers/toc-resolver.js';
 import {
@@ -11,9 +12,15 @@ import {
   getSequenceFieldUpdaterConverterContext,
   updateSequenceFieldsInTransaction,
 } from '../../document-api-adapters/helpers/sequence-field-updater.js';
+import { getPageNumberFieldFormat } from '../../core/layout-adapter/converters/inline-converters/page-number-field-format.js';
 
 /** Stat-field types refreshed by F9 when the doc has no TOCs. */
 const UPDATABLE_FIELD_TYPES = new Set(['NUMWORDS', 'NUMCHARS', 'NUMPAGES', 'SECTIONPAGES']);
+
+function resolveTotalPageNumberFieldValue(stats, node) {
+  if (stats.pages == null) return null;
+  return formatPageNumberFieldValue(stats.pages, getPageNumberFieldFormat(node.attrs));
+}
 
 /**
  * @module FieldUpdate
@@ -119,7 +126,9 @@ export const FieldUpdate = Extension.create({
             const freshValue =
               field.fieldType === 'SECTIONPAGES'
                 ? resolveSectionPageCountFieldValue(editor, node)
-                : resolveDocumentStatFieldValue(field.fieldType, stats);
+                : field.fieldType === 'NUMPAGES' && node.type.name === 'total-page-number'
+                  ? resolveTotalPageNumberFieldValue(stats, node)
+                  : resolveDocumentStatFieldValue(field.fieldType, stats);
             if (freshValue == null) continue;
 
             if (node.type.name === 'total-page-number' || node.type.name === 'section-page-count') {

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
@@ -7,6 +7,10 @@ import {
   resolveMainBodyEditor,
 } from '../../document-api-adapters/helpers/word-statistics.js';
 import { resolveSectionPageCountFieldValue } from '../../document-api-adapters/helpers/section-page-count.js';
+import {
+  getSequenceFieldUpdaterConverterContext,
+  updateSequenceFieldsInTransaction,
+} from '../../document-api-adapters/helpers/sequence-field-updater.js';
 
 /** Stat-field types refreshed by F9 when the doc has no TOCs. */
 const UPDATABLE_FIELD_TYPES = new Set(['NUMWORDS', 'NUMCHARS', 'NUMPAGES', 'SECTIONPAGES']);
@@ -87,7 +91,8 @@ export const FieldUpdate = Extension.create({
 
           const fields = findFieldsInRange(state.doc, from, to);
           const updatable = fields.filter((f) => UPDATABLE_FIELD_TYPES.has(f.fieldType));
-          if (updatable.length === 0) return tocPathRan;
+          const hasSeqSelection = fields.some((field) => field.fieldType === 'SEQ');
+          if (updatable.length === 0 && !hasSeqSelection) return tocPathRan;
 
           const mainEditor = resolveMainBodyEditor(editor);
           const stats = getWordStatistics(mainEditor);
@@ -127,6 +132,16 @@ export const FieldUpdate = Extension.create({
               });
               changed = true;
             }
+          }
+
+          if (hasSeqSelection) {
+            const result = updateSequenceFieldsInTransaction({
+              tr,
+              schema: state.schema,
+              scope: { kind: 'all' },
+              converterContext: getSequenceFieldUpdaterConverterContext(editor),
+            });
+            changed = changed || result.changed;
           }
 
           if (!changed) return tocPathRan;

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
@@ -521,8 +521,7 @@ describe('updateFieldsInSelection — TOC + stat fields combined (regression)', 
     expect(updatedValues).toEqual(['1', '2']);
   });
 
-  it('updates TOC and SEQ fields on the same F9 command without merging TOC transactions', () => {
-    const tocUpdate = vi.fn(() => ({ success: true }));
+  it('updates SEQ from fresh state after TOC update dispatches its own transaction', () => {
     const para = (children) => mixedSchema.nodes.paragraph.create({}, children);
     const text = (t) => mixedSchema.text(t);
     const toc = mixedSchema.nodes.tableOfContents.create({ sdBlockId: 'toc-1' }, [para([text('entry')])]);
@@ -532,10 +531,22 @@ describe('updateFieldsInSelection — TOC + stat fields combined (regression)', 
       resolvedNumber: '9',
     });
     const doc = mixedSchema.nodes.doc.create({}, [toc, para([seqField])]);
-    const editorState = EditorState.create({ schema: mixedSchema, doc });
+    let editorState = EditorState.create({ schema: mixedSchema, doc });
     const editor = {
-      doc: { toc: { update: tocUpdate } },
-      state: editorState,
+      doc: {
+        toc: {
+          update: vi.fn(() => {
+            // Simulate toc.update dispatching independently before the SEQ
+            // path runs. The later SEQ transaction must be based on this fresh
+            // state, preserving the TOC edit and the shifted SEQ position.
+            editorState = editorState.apply(editorState.tr.insertText(' updated', 7));
+            return { success: true };
+          }),
+        },
+      },
+      get state() {
+        return editorState;
+      },
       converter: { translatedLinkedStyles: { docDefaults: {}, styles: {} }, translatedNumbering: {} },
     };
 
@@ -552,10 +563,18 @@ describe('updateFieldsInSelection — TOC + stat fields combined (regression)', 
     });
 
     expect(result).toBe(true);
-    expect(tocUpdate).toHaveBeenCalledTimes(1);
+    expect(editor.doc.toc.update).toHaveBeenCalledTimes(1);
     expect(outerTr.setMeta).toHaveBeenCalledWith('preventDispatch', true);
     expect(dispatch).toHaveBeenCalledTimes(1);
-    expect(dispatch.mock.calls[0][0].doc.nodeAt(toc.nodeSize + 1).attrs.resolvedNumber).toBe('1');
+
+    const dispatchedDoc = dispatch.mock.calls[0][0].doc;
+    expect(dispatchedDoc.textContent).toContain('entry updated');
+    const seqValues = [];
+    dispatchedDoc.descendants((node) => {
+      if (node.type.name === 'sequenceField') seqValues.push(node.attrs.resolvedNumber);
+      return true;
+    });
+    expect(seqValues).toEqual(['1']);
   });
 });
 

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
@@ -308,6 +308,21 @@ const mixedSchema = new Schema({
       },
       toDOM: () => ['span', 0],
     },
+    'total-page-number': {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      content: 'text*',
+      attrs: {
+        instruction: { default: null },
+        importedCachedText: { default: null },
+        resolvedText: { default: null },
+        pageNumberFormat: { default: null },
+        pageNumberZeroPadding: { default: null },
+        pageNumberNumericPicture: { default: null },
+      },
+      toDOM: () => ['span', 0],
+    },
     sequenceField: {
       group: 'inline',
       inline: true,
@@ -448,6 +463,44 @@ describe('updateFieldsInSelection — TOC + stat fields combined (regression)', 
     const updatedField = updatedDoc.nodeAt(1);
     expect(updatedField.attrs.resolvedText).toBe('004');
     expect(updatedField.textContent).toBe('004');
+  });
+
+  it('updates NUMPAGES fields with preserved numeric picture formatting', () => {
+    const para = (children) => mixedSchema.nodes.paragraph.create({}, children);
+    const totalPageNumberField = mixedSchema.nodes['total-page-number'].create(
+      {
+        instruction: 'NUMPAGES \\# "#,##0 pages"',
+        pageNumberNumericPicture: '#,##0 pages',
+        resolvedText: '1 pages',
+      },
+      mixedSchema.text('1 pages'),
+    );
+    const doc = mixedSchema.nodes.doc.create({}, [para([totalPageNumberField])]);
+    const editorState = EditorState.create({ schema: mixedSchema, doc });
+    const editor = {
+      currentTotalPages: 1234,
+      state: editorState,
+    };
+
+    const commands = FieldUpdate.config.addCommands.call({ editor });
+    const command = commands.updateFieldsInSelection();
+    const outerTr = editorState.tr;
+    const dispatch = vi.fn();
+    const state = {
+      doc,
+      selection: { from: 0, to: doc.content.size },
+      schema: mixedSchema,
+      tr: outerTr,
+    };
+
+    const result = command({ editor, state, tr: outerTr, dispatch });
+
+    expect(result).toBe(true);
+    const updatedDoc = dispatch.mock.calls[0][0].doc;
+    const updatedField = updatedDoc.nodeAt(1);
+    expect(updatedField.type.name).toBe('total-page-number');
+    expect(updatedField.attrs.resolvedText).toBe('1,234 pages');
+    expect(updatedField.textContent).toBe('1,234 pages');
   });
 
   it('leaves SECTIONPAGES fields unchanged when section page context is unavailable', () => {

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
@@ -308,6 +308,27 @@ const mixedSchema = new Schema({
       },
       toDOM: () => ['span', 0],
     },
+    sequenceField: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {
+        instruction: { default: '' },
+        identifier: { default: '' },
+        fieldArgument: { default: '' },
+        sequenceMode: { default: 'next' },
+        hideResult: { default: false },
+        restartNumber: { default: null },
+        restartLevel: { default: null },
+        format: { default: 'Arabic' },
+        hasGeneralFormat: { default: false },
+        pageNumberFieldFormat: { default: null },
+        numericPictureFormat: { default: null },
+        resolvedNumber: { default: '' },
+        resolvedNumberIsCurrent: { default: false },
+      },
+      toDOM: () => ['span', 0],
+    },
     text: { group: 'inline' },
   },
 });
@@ -463,6 +484,78 @@ describe('updateFieldsInSelection — TOC + stat fields combined (regression)', 
     const unchangedField = editorState.doc.nodeAt(1);
     expect(unchangedField.attrs.resolvedText).toBe('3');
     expect(unchangedField.textContent).toBe('3');
+  });
+
+  it('recomputes stale SEQ fields when the selection contains SEQ', () => {
+    const para = (children) => mixedSchema.nodes.paragraph.create({}, children);
+    const seq = (instruction) =>
+      mixedSchema.nodes.sequenceField.create({
+        instruction,
+        identifier: 'Figure',
+        resolvedNumber: '9',
+      });
+    const doc = mixedSchema.nodes.doc.create({}, [para([seq('SEQ Figure')]), para([seq('SEQ Figure')])]);
+    const editorState = EditorState.create({ schema: mixedSchema, doc });
+    const editor = {
+      state: editorState,
+      converter: { translatedLinkedStyles: { docDefaults: {}, styles: {} }, translatedNumbering: {} },
+    };
+
+    const commands = FieldUpdate.config.addCommands.call({ editor });
+    const command = commands.updateFieldsInSelection();
+    const dispatch = vi.fn();
+    const result = command({
+      editor,
+      state: { doc, selection: { from: 0, to: doc.content.size }, schema: mixedSchema, tr: editorState.tr },
+      tr: editorState.tr,
+      dispatch,
+    });
+
+    expect(result).toBe(true);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const updatedValues = [];
+    dispatch.mock.calls[0][0].doc.descendants((node) => {
+      if (node.type.name === 'sequenceField') updatedValues.push(node.attrs.resolvedNumber);
+      return true;
+    });
+    expect(updatedValues).toEqual(['1', '2']);
+  });
+
+  it('updates TOC and SEQ fields on the same F9 command without merging TOC transactions', () => {
+    const tocUpdate = vi.fn(() => ({ success: true }));
+    const para = (children) => mixedSchema.nodes.paragraph.create({}, children);
+    const text = (t) => mixedSchema.text(t);
+    const toc = mixedSchema.nodes.tableOfContents.create({ sdBlockId: 'toc-1' }, [para([text('entry')])]);
+    const seqField = mixedSchema.nodes.sequenceField.create({
+      instruction: 'SEQ Figure',
+      identifier: 'Figure',
+      resolvedNumber: '9',
+    });
+    const doc = mixedSchema.nodes.doc.create({}, [toc, para([seqField])]);
+    const editorState = EditorState.create({ schema: mixedSchema, doc });
+    const editor = {
+      doc: { toc: { update: tocUpdate } },
+      state: editorState,
+      converter: { translatedLinkedStyles: { docDefaults: {}, styles: {} }, translatedNumbering: {} },
+    };
+
+    const commands = FieldUpdate.config.addCommands.call({ editor });
+    const command = commands.updateFieldsInSelection();
+    const outerTr = editorState.tr;
+    outerTr.setMeta = vi.fn(outerTr.setMeta.bind(outerTr));
+    const dispatch = vi.fn();
+    const result = command({
+      editor,
+      state: { doc, selection: { from: 0, to: doc.content.size }, schema: mixedSchema, tr: outerTr },
+      tr: outerTr,
+      dispatch,
+    });
+
+    expect(result).toBe(true);
+    expect(tocUpdate).toHaveBeenCalledTimes(1);
+    expect(outerTr.setMeta).toHaveBeenCalledWith('preventDispatch', true);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch.mock.calls[0][0].doc.nodeAt(toc.nodeSize + 1).attrs.resolvedNumber).toBe('1');
   });
 });
 

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
@@ -555,9 +555,10 @@ describe('updateFieldsInSelection — TOC + stat fields combined (regression)', 
     const outerTr = editorState.tr;
     outerTr.setMeta = vi.fn(outerTr.setMeta.bind(outerTr));
     const dispatch = vi.fn();
+    const seqPos = toc.nodeSize + 1;
     const result = command({
       editor,
-      state: { doc, selection: { from: 0, to: doc.content.size }, schema: mixedSchema, tr: outerTr },
+      state: { doc, selection: { from: seqPos, to: seqPos + seqField.nodeSize }, schema: mixedSchema, tr: outerTr },
       tr: outerTr,
       dispatch,
     });

--- a/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
+++ b/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
@@ -2,6 +2,7 @@ import { Node } from '@core/Node.js';
 import { Attribute } from '@core/Attribute.js';
 import { isHeadless } from '@utils/headless-helpers.js';
 import { formatPageNumberFieldValue, formatSectionPageNumberText } from '@superdoc/contracts';
+import { getPageNumberFieldFormat } from '../../core/layout-adapter/converters/inline-converters/page-number-field-format.js';
 /**
  * Configuration options for PageNumber
  * @typedef {Object} PageNumberOptions
@@ -139,6 +140,7 @@ export const PageNumber = Node.create({
  * @property {string|null} [instruction=null] @internal - Original NUMPAGES field instruction when switched
  * @property {string|null} [pageNumberFormat=null] @internal - Normalized field switch format
  * @property {number|null} [pageNumberZeroPadding=null] @internal - Zero-padding width from numeric picture switch
+ * @property {string|null} [pageNumberNumericPicture=null] @internal - Raw numeric picture switch
  */
 
 /**
@@ -183,6 +185,10 @@ export const TotalPageCount = Node.create({
         rendered: false,
       },
       pageNumberZeroPadding: {
+        default: null,
+        rendered: false,
+      },
+      pageNumberNumericPicture: {
         default: null,
         rendered: false,
       },
@@ -384,13 +390,16 @@ const getNodeAttributes = (nodeName, editor, node = null) => {
         ariaLabel: 'Page number node',
       };
     }
-    case 'total-page-number':
+    case 'total-page-number': {
+      const totalPageCount =
+        Number(editor.options.totalPageCount || editor.options.parentEditor?.currentTotalPages || 1) || 1;
       return {
-        text: editor.options.totalPageCount || editor.options.parentEditor?.currentTotalPages || '1',
+        text: formatPageNumberFieldValue(totalPageCount, getPageNumberFieldFormat(node?.attrs)),
         className: 'sd-editor-auto-total-pages',
         dataId: 'auto-total-pages',
         ariaLabel: 'Total page count node',
       };
+    }
     case 'section-page-count': {
       const sectionPageCount = editor.options.sectionPageCount;
       const cachedText = node?.attrs?.resolvedText ?? node?.attrs?.importedCachedText ?? node?.textContent ?? '1';

--- a/packages/super-editor/src/editors/v1/extensions/page-number/page-number.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/page-number/page-number.test.js
@@ -318,6 +318,25 @@ describe('AutoPageNumberNodeView', () => {
     expect(nodeView.dom.getAttribute('data-id')).toBe('auto-total-pages');
   });
 
+  it('renders formatted total page count node in edit mode', () => {
+    const doc = {
+      resolve: vi.fn().mockReturnValue({ nodeBefore: null, nodeAfter: null }),
+      nodeAt: vi.fn().mockReturnValue({ isText: false, attrs: { marksAsAttrs: [] } }),
+    };
+    const tr = { setNodeMarkup: vi.fn().mockReturnValue({}) };
+    const state = { doc, tr };
+    const editor = {
+      options: { totalPageCount: 12, parentEditor: { currentTotalPages: 12 } },
+      state,
+      view: { state, dispatch: vi.fn() },
+    };
+
+    const node = { type: { name: 'total-page-number' }, attrs: { pageNumberNumericPicture: '000' } };
+    const nodeView = new AutoPageNumberNodeView(node, () => 7, [], editor);
+
+    expect(nodeView.dom.textContent).toBe('012');
+  });
+
   it('renders formatted section page count node', () => {
     const doc = {
       resolve: vi.fn().mockReturnValue({ nodeBefore: null, nodeAfter: null }),

--- a/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.js
+++ b/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.js
@@ -98,7 +98,7 @@ export const SequenceField = Node.create({
   },
 
   renderDOM({ node, htmlAttributes }) {
-    const text = node.attrs.resolvedNumber || '0';
+    const text = node.attrs.resolvedNumber || '';
     return ['span', Attribute.mergeAttributes(this.options.htmlAttributes, htmlAttributes), text];
   },
 });

--- a/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.js
+++ b/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.js
@@ -38,16 +38,48 @@ export const SequenceField = Node.create({
         default: '',
         rendered: false,
       },
+      fieldArgument: {
+        default: '',
+        rendered: false,
+      },
+      sequenceMode: {
+        default: 'next',
+        rendered: false,
+      },
+      hideResult: {
+        default: false,
+        rendered: false,
+      },
+      restartNumber: {
+        default: null,
+        rendered: false,
+      },
       format: {
-        default: 'ARABIC',
+        default: 'Arabic',
         rendered: false,
       },
       restartLevel: {
         default: null,
         rendered: false,
       },
+      hasGeneralFormat: {
+        default: false,
+        rendered: false,
+      },
+      pageNumberFieldFormat: {
+        default: null,
+        rendered: false,
+      },
+      numericPictureFormat: {
+        default: null,
+        rendered: false,
+      },
       resolvedNumber: {
         default: '',
+        rendered: false,
+      },
+      resolvedNumberIsCurrent: {
+        default: false,
         rendered: false,
       },
       sdBlockId: {

--- a/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.js
+++ b/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.js
@@ -55,7 +55,7 @@ export const SequenceField = Node.create({
         rendered: false,
       },
       format: {
-        default: 'Arabic',
+        default: 'ARABIC',
         rendered: false,
       },
       restartLevel: {

--- a/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/sequence-field/sequence-field.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { initTestEditor } from '@tests/helpers/helpers.js';
+
+describe('SequenceField extension', () => {
+  it('keeps the legacy ARABIC schema default for format', () => {
+    const { editor } = initTestEditor({ mode: 'text', content: '<p></p>', isHeadless: true });
+    const node = editor.schema.nodes.sequenceField.create({ instruction: 'SEQ Figure' });
+
+    expect(node.attrs.format).toBe('ARABIC');
+
+    editor.destroy();
+  });
+});

--- a/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.js
+++ b/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.js
@@ -159,7 +159,8 @@ export function createTextElement(textContent, textAlign, width, height, options
       });
     }
     if (part.fieldType === 'NUMPAGES') {
-      return totalPages != null ? String(totalPages) : '1';
+      const count = totalPages ?? 1;
+      return part.pageNumberFormat ? formatPageNumber(count, part.pageNumberFormat) : String(count);
     }
     if (part.fieldType === 'SECTIONPAGES') {
       if (sectionPageCount == null) return part.text ?? '1';

--- a/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.test.js
@@ -214,6 +214,30 @@ describe('svg-utils', () => {
         expect(span.textContent).toBe('10');
       });
 
+      it('should format NUMPAGES field type with pageNumberFormat', () => {
+        const textContent = {
+          parts: [{ text: '', fieldType: 'NUMPAGES', pageNumberFormat: 'upperRoman', formatting: {} }],
+        };
+        const result = createTextElement(textContent, 'left', 100, 50, {
+          totalPages: 9,
+        });
+
+        const span = result.querySelector('span');
+        expect(span.textContent).toBe('IX');
+      });
+
+      it('should format NUMPAGES field type with ordinal pageNumberFormat', () => {
+        const textContent = {
+          parts: [{ text: '', fieldType: 'NUMPAGES', pageNumberFormat: 'ordinal', formatting: {} }],
+        };
+        const result = createTextElement(textContent, 'left', 100, 50, {
+          totalPages: 12,
+        });
+
+        const span = result.querySelector('span');
+        expect(span.textContent).toBe('12th');
+      });
+
       it('should default PAGE to "1" when pageNumber not provided', () => {
         const textContent = {
           parts: [{ text: '', fieldType: 'PAGE', formatting: {} }],

--- a/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
+++ b/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
@@ -986,9 +986,11 @@ export interface TotalPageCountAttrs extends InlineNodeAttributes {
   /** @internal Original NUMPAGES field instruction when switched */
   instruction?: string | null;
   /** @internal Normalized field switch format */
-  pageNumberFormat?: string | null;
+  pageNumberFormat?: PageNumberFormat | null;
   /** @internal Zero-padding width from numeric picture switch */
   pageNumberZeroPadding?: number | null;
+  /** @internal Raw numeric picture switch */
+  pageNumberNumericPicture?: string | null;
 }
 
 /** Section page count node attributes */


### PR DESCRIPTION
### Summary

Adds end-to-end support for Word **`SEQ` (sequence) fields** — the mechanism behind caption numbering (`Figure 1`, `Table 2`, …) and other auto-incrementing counters. SEQ numbers are now parsed from OOXML on import, resolved live during layout in document order, recomputed through the Document API and F9, and written back on export.

The design centers on **two shared, framework-agnostic primitives** (an instruction parser and a stateful evaluator) that every code path — import, layout, Document API, export — reuses, so numbering semantics live in exactly one place.

### What changed

**Shared SEQ primitives** (`super-converter/field-references/shared/`)
- `seq-instruction.js` — tokenizer + parser for `SEQ <id> <switches>`. Handles `\n` (next), `\c` (current), `\h` (hide), `\r N` (restart-at), `\s N` (restart-at-heading-level), `\* FORMAT` (general format), `\# picture` (numeric picture), attached numeric switches (`\r0`, `\s1`), quoted/escaped tokens, and general-format mapping. Exposes `isSeqInstruction`, `normalizeSeqIdentifier`, and `sequenceFieldAttrsFromParsed` (projects parsed metadata into PM node attrs).
- `seq-evaluator.js` — `SequenceFieldEvaluator`: one instance per linear pass over a story. Maintains per-identifier counters, heading-level serials for `\s` resets, restart-number/level handling, current-vs-next mode, `\h` suppression, and value formatting (numeric picture / page-number format / plain). Field-argument (bookmark-reference) SEQ is conservatively stubbed pending bookmark resolution.

**Import** (`v2/importer/`, `v3/handlers/sd/sequenceField/`)
- Registered `sequenceFieldEntity` in `docxImporter` so SEQ fields import via the v3 translator.
- SEQ keyword detection is now case-insensitive (`extractFieldKeyword`), replacing the brittle `startsWith('SEQ ')` checks.
- The translator now stores full parsed metadata on the node (identifier, mode, switches, formats) while keeping the **raw instruction as the export source of truth**.

**Layout resolution** (`layout-adapter/`)
- New `TextRun` contract fields: `token: 'seq'` and `seqMetadata`.
- `sequence-field.ts` converter emits a SEQ **token** (with cached text as fallback) instead of baking in a number at conversion time.
- `resolve-sequence-fields.ts` runs a single linear pass over fully-assembled `FlowBlock[]` (paragraphs, tables, lists) after block assembly, resolving each SEQ token in document order. This is **cache-safe**: cached paragraphs still contribute their preserved token metadata to the pass.

**Document API** (`document-api-adapters/`)
- `sequence-field-updater.ts` — `updateSequenceFieldsInTransaction` recomputes SEQ nodes within a transaction, scoped to `all` / `range` / `identifier`, resolving heading levels via the converter context. Body-story only by design.
- Wired into caption `insert`/`configure`, field `insert`/`rebuild`, and `field-resolver` (returns `resolvedNumber` for sequence fields). `caption-resolver` now uses `isSeqInstruction`.

**Export**
- The translator emits the current resolved SEQ result (`resolvedNumberIsCurrent`) when present, falling back to existing content/cached number, with marks preserved.

**F9 / field-update** (`extensions/field-update/`)
- F9 now recomputes SEQ fields, including after TOC edits change document state; SEQ selection is preserved across the TOC update path.

**Schema** (`extensions/sequence-field/`)
- Added attrs: `fieldArgument`, `sequenceMode`, `hideResult`, `restartNumber`, `hasGeneralFormat`, `pageNumberFieldFormat`, `numericPictureFormat`, `resolvedNumberIsCurrent`. Empty SEQ now renders as `''` rather than `'0'`.

### Testing

New unit + integration coverage across the stack: `seq-instruction`, `seq-evaluator`, `resolve-sequence-fields`, `sequenceFieldImporter.integration`, `sequence-field-export-routing`, `sequence-field-updater`, caption/field plan-engine wrappers (`*.seq-fields.test.ts`), `field-update`, `caption-resolver`, and `field-resolver`. (~1,300 lines of tests added.)
