### PR TITLE
feat(numpages): apply field-switch formatting to total page count fields (SD-3327)

### DIFF
--- a/packages/layout-engine/contracts/src/page-number-formatting.test.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.test.ts
@@ -14,6 +14,16 @@ describe('page number formatting', () => {
     expect(formatPageNumber(28, 'upperLetter')).toBe('BB');
     expect(formatPageNumber(703, 'lowerLetter')).toBe('a'.repeat(28));
     expect(formatPageNumber(12, 'numberInDash')).toBe('- 12 -');
+    expect(formatPageNumber(1, 'ordinal')).toBe('1st');
+    expect(formatPageNumber(2, 'ordinal')).toBe('2nd');
+    expect(formatPageNumber(3, 'ordinal')).toBe('3rd');
+    expect(formatPageNumber(4, 'ordinal')).toBe('4th');
+    expect(formatPageNumber(11, 'ordinal')).toBe('11th');
+    expect(formatPageNumber(12, 'ordinal')).toBe('12th');
+    expect(formatPageNumber(13, 'ordinal')).toBe('13th');
+    expect(formatPageNumber(21, 'ordinal')).toBe('21st');
+    expect(formatPageNumber(22, 'ordinal')).toBe('22nd');
+    expect(formatPageNumber(23, 'ordinal')).toBe('23rd');
   });
 
   it('normalizes page numbers before formatting', () => {
@@ -33,6 +43,16 @@ describe('page number formatting', () => {
   it('applies decimal zero padding for field values', () => {
     expect(formatPageNumberFieldValue(7, { format: 'decimal', zeroPadding: 3 })).toBe('007');
     expect(formatPageNumberFieldValue(7, { format: 'lowerRoman', zeroPadding: 3 })).toBe('vii');
+  });
+
+  it('formats ordinal field values', () => {
+    expect(formatPageNumberFieldValue(32, { format: 'ordinal' })).toBe('32nd');
+  });
+
+  it('uses numeric pictures before enum format and zero padding', () => {
+    expect(formatPageNumberFieldValue(1234, { numericPicture: '#,##0' })).toBe('1,234');
+    expect(formatPageNumberFieldValue(7, { format: 'ordinal', zeroPadding: 3, numericPicture: '00' })).toBe('07');
+    expect(formatPageNumberFieldValue(0, { numericPicture: '00' })).toBe('01');
   });
 
   it('formats integer values with numeric pictures', () => {

--- a/packages/layout-engine/contracts/src/page-number-formatting.test.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.test.ts
@@ -24,6 +24,9 @@ describe('page number formatting', () => {
     expect(formatPageNumber(21, 'ordinal')).toBe('21st');
     expect(formatPageNumber(22, 'ordinal')).toBe('22nd');
     expect(formatPageNumber(23, 'ordinal')).toBe('23rd');
+    expect(formatPageNumber(111, 'ordinal')).toBe('111th');
+    expect(formatPageNumber(112, 'ordinal')).toBe('112th');
+    expect(formatPageNumber(113, 'ordinal')).toBe('113th');
   });
 
   it('normalizes page numbers before formatting', () => {

--- a/packages/layout-engine/contracts/src/page-number-formatting.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.ts
@@ -32,6 +32,22 @@ function toUpperLetter(value: number): string {
   return String.fromCharCode(65 + index).repeat(repeatCount);
 }
 
+function toOrdinal(value: number): string {
+  const remainder = value % 100;
+  if (remainder >= 11 && remainder <= 13) return `${value}th`;
+
+  switch (value % 10) {
+    case 1:
+      return `${value}st`;
+    case 2:
+      return `${value}nd`;
+    case 3:
+      return `${value}rd`;
+    default:
+      return `${value}th`;
+  }
+}
+
 export function formatPageNumber(pageNumber: number, format: PageNumberFormat): string {
   const value = Math.max(1, Math.trunc(Number.isFinite(pageNumber) ? pageNumber : 1));
 
@@ -46,6 +62,8 @@ export function formatPageNumber(pageNumber: number, format: PageNumberFormat): 
       return toUpperLetter(value).toLowerCase();
     case 'numberInDash':
       return `- ${value} -`;
+    case 'ordinal':
+      return toOrdinal(value);
     case 'decimal':
     default:
       return String(value);
@@ -53,6 +71,11 @@ export function formatPageNumber(pageNumber: number, format: PageNumberFormat): 
 }
 
 export function formatPageNumberFieldValue(pageNumber: number, fieldFormat?: PageNumberFieldFormat): string {
+  if (fieldFormat?.numericPicture) {
+    const value = Math.max(1, Math.trunc(Number.isFinite(pageNumber) ? pageNumber : 1));
+    return formatIntegerWithNumericPicture(value, fieldFormat.numericPicture);
+  }
+
   const format = fieldFormat?.format ?? 'decimal';
   const formatted = formatPageNumber(pageNumber, format);
   return fieldFormat?.zeroPadding && format === 'decimal'
@@ -102,7 +125,7 @@ export function formatSectionPageNumberText(args: {
 }
 
 /**
- * Formats integer field values with a Word numeric picture subset used by PAGEREF.
+ * Formats integer page field values with a Word numeric picture subset.
  * Unsupported ECMA features are intentionally out of scope here: backtick
  * numbered-item references, localized separators, and fractional rounding.
  */

--- a/packages/layout-engine/contracts/src/page-number-formatting.ts
+++ b/packages/layout-engine/contracts/src/page-number-formatting.ts
@@ -1,6 +1,7 @@
 export type PageNumberFieldFormat = {
-  format?: 'decimal' | 'upperRoman' | 'lowerRoman' | 'upperLetter' | 'lowerLetter' | 'numberInDash';
+  format?: 'decimal' | 'upperRoman' | 'lowerRoman' | 'upperLetter' | 'lowerLetter' | 'numberInDash' | 'ordinal';
   zeroPadding?: number;
+  numericPicture?: string;
 };
 
 export type PageNumberFormat = NonNullable<PageNumberFieldFormat['format']>;

--- a/packages/layout-engine/layout-engine/src/index.ts
+++ b/packages/layout-engine/layout-engine/src/index.ts
@@ -30,6 +30,7 @@ import type {
   NormalizedColumnLayout,
   DocumentBackground,
   HeaderFooterResolutionSection,
+  PageNumberFormat,
 } from '@superdoc/contracts';
 import {
   buildLayoutSourceIdentityForFragment,
@@ -1427,8 +1428,7 @@ export function layoutDocument(blocks: FlowBlock[], measures: Measure[], options
   // Paginator encapsulation for page/column helpers
   let pageCount = 0;
   // Page numbering state
-  let activeNumberFormat: 'decimal' | 'lowerLetter' | 'upperLetter' | 'lowerRoman' | 'upperRoman' | 'numberInDash' =
-    'decimal';
+  let activeNumberFormat: PageNumberFormat = 'decimal';
   let activePageCounter = 1;
   let activeSectionPageCounterStart = activePageCounter;
   let pendingNumbering: SectionNumbering | null = null;

--- a/packages/layout-engine/layout-engine/src/resolvePageTokens.test.ts
+++ b/packages/layout-engine/layout-engine/src/resolvePageTokens.test.ts
@@ -299,4 +299,70 @@ describe('resolveTokensInBlock', () => {
     expect((block.runs[0] as TextRun).token).toBeUndefined();
     expect((block.runs[0] as TextRun).pageNumberFieldFormat).toBeUndefined();
   });
+
+  it('should apply run-local total page count zero padding', () => {
+    const block: ParagraphBlock = {
+      kind: 'paragraph',
+      id: 'test-total-count-zero-padding-format',
+      runs: [
+        {
+          text: '0',
+          token: 'totalPageCount',
+          pageNumberFieldFormat: { format: 'decimal', zeroPadding: 3 },
+          fontFamily: 'Arial',
+          fontSize: 12,
+        } as TextRun,
+      ],
+    };
+
+    const wasModified = resolveTokensInBlock(block, 1, 7);
+
+    expect(wasModified).toBe(true);
+    expect((block.runs[0] as TextRun).text).toBe('007');
+    expect((block.runs[0] as TextRun).token).toBeUndefined();
+  });
+
+  it('should apply run-local total page count grouping picture', () => {
+    const block: ParagraphBlock = {
+      kind: 'paragraph',
+      id: 'test-total-count-picture-format',
+      runs: [
+        {
+          text: '0',
+          token: 'totalPageCount',
+          pageNumberFieldFormat: { numericPicture: '#,##0' },
+          fontFamily: 'Arial',
+          fontSize: 12,
+        } as TextRun,
+      ],
+    };
+
+    const wasModified = resolveTokensInBlock(block, 1, 1234);
+
+    expect(wasModified).toBe(true);
+    expect((block.runs[0] as TextRun).text).toBe('1,234');
+    expect((block.runs[0] as TextRun).token).toBeUndefined();
+  });
+
+  it('should apply run-local total page count ordinal format', () => {
+    const block: ParagraphBlock = {
+      kind: 'paragraph',
+      id: 'test-total-count-ordinal-format',
+      runs: [
+        {
+          text: '0',
+          token: 'totalPageCount',
+          pageNumberFieldFormat: { format: 'ordinal' },
+          fontFamily: 'Arial',
+          fontSize: 12,
+        } as TextRun,
+      ],
+    };
+
+    const wasModified = resolveTokensInBlock(block, 1, 22);
+
+    expect(wasModified).toBe(true);
+    expect((block.runs[0] as TextRun).text).toBe('22nd');
+    expect((block.runs[0] as TextRun).token).toBeUndefined();
+  });
 });

--- a/packages/layout-engine/layout-engine/src/resolvePageTokens.ts
+++ b/packages/layout-engine/layout-engine/src/resolvePageTokens.ts
@@ -335,9 +335,12 @@ export function resolveTokensInBlock(block: ParagraphBlock, pageNumber: number, 
         blockModified = true;
       } else if (run.token === 'totalPageCount') {
         // Replace placeholder text with total page count
-        run.text = totalPagesStr;
+        run.text = run.pageNumberFieldFormat
+          ? formatPageNumberFieldValue(totalPages, run.pageNumberFieldFormat)
+          : totalPagesStr;
         // Clear token metadata to treat as normal text after resolution
         delete run.token;
+        delete run.pageNumberFieldFormat;
         blockModified = true;
       }
       // Note: pageReference tokens are handled by resolvePageRefs.ts

--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -6964,6 +6964,12 @@ describe('DomPainter', () => {
         { pageNumber: 1, totalPages: 9, section: 'body' },
       ),
     ).toBe('IX');
+    expect(
+      resolvePartText(
+        { text: '9', fieldType: 'NUMPAGES', pageNumberFormat: 'ordinal' },
+        { pageNumber: 1, totalPages: 12, section: 'body' },
+      ),
+    ).toBe('12th');
   });
   describe('resolved paragraph rendering', () => {
     it('renders resolved paragraph lines with precomputed indent styles', () => {

--- a/packages/layout-engine/painters/dom/src/index.test.ts
+++ b/packages/layout-engine/painters/dom/src/index.test.ts
@@ -6946,6 +6946,25 @@ describe('DomPainter', () => {
       resolvePartText({ text: '3', fieldType: 'SECTIONPAGES' }, { pageNumber: 1, totalPages: 9, section: 'body' }),
     ).toBe('3');
   });
+
+  it('formats NUMPAGES drawing text with supported pageNumberFormat', () => {
+    const painter = new DomPainter();
+    const resolvePartText = (
+      painter as unknown as {
+        resolveShapeTextPartText: (
+          part: { text: string; fieldType: string; pageNumberFormat?: string },
+          context: { pageNumber: number; totalPages: number; section: 'body' },
+        ) => string;
+      }
+    ).resolveShapeTextPartText.bind(painter);
+
+    expect(
+      resolvePartText(
+        { text: '9', fieldType: 'NUMPAGES', pageNumberFormat: 'upperRoman' },
+        { pageNumber: 1, totalPages: 9, section: 'body' },
+      ),
+    ).toBe('IX');
+  });
   describe('resolved paragraph rendering', () => {
     it('renders resolved paragraph lines with precomputed indent styles', () => {
       const paragraphBlock: FlowBlock = {

--- a/packages/layout-engine/painters/dom/src/renderer.ts
+++ b/packages/layout-engine/painters/dom/src/renderer.ts
@@ -3158,7 +3158,8 @@ export class DomPainter {
       return context?.pageNumberText ?? String(context?.pageNumber ?? 1);
     }
     if (part.fieldType === 'NUMPAGES') {
-      return String(context?.totalPages ?? 1);
+      const totalPages = context?.totalPages ?? 1;
+      return part.pageNumberFormat ? formatPageNumber(totalPages, part.pageNumberFormat) : String(totalPages);
     }
     if (part.fieldType === 'SECTIONPAGES') {
       if (context?.sectionPageCount == null) return part.text ?? '1';

--- a/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.test.ts
+++ b/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.test.ts
@@ -311,6 +311,28 @@ describe('HeaderFooterEditorManager', () => {
     expect(sectionPages.textContent).toBe('IV');
   });
 
+  it('refreshes total page count DOM text with node numeric picture format', () => {
+    const editor = createMockEditor();
+    const manager = new HeaderFooterEditorManager(editor);
+    const descriptor = { id: 'rId-header-default', kind: 'header' } as const;
+    const host = document.createElement('div');
+
+    const sectionEditor = manager.ensureEditorSync(descriptor, { editorHost: host });
+    expect(sectionEditor).toBeDefined();
+    const totalPages = document.createElement('span');
+    totalPages.dataset.id = 'auto-total-pages';
+    totalPages.textContent = '1';
+    sectionEditor!.view.dom.appendChild(totalPages);
+    (sectionEditor!.view as unknown as { posAtDOM: ReturnType<typeof vi.fn> }).posAtDOM = vi.fn(() => 0);
+    (sectionEditor as unknown as { state: { doc: { nodeAt: ReturnType<typeof vi.fn> } } }).state = {
+      doc: { nodeAt: vi.fn(() => ({ attrs: { pageNumberNumericPicture: '000' } })) },
+    };
+
+    manager.ensureEditorSync(descriptor, { editorHost: host, totalPageCount: 12 });
+
+    expect(totalPages.textContent).toBe('012');
+  });
+
   it('refreshes chapter-prefixed page number DOM text with node pageNumberFormat', () => {
     const editor = createMockEditor();
     const manager = new HeaderFooterEditorManager(editor);

--- a/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.ts
+++ b/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.ts
@@ -6,7 +6,6 @@ import {
   formatSectionPageNumberText,
   type FlowBlock,
   type PageNumberChapterSeparator,
-  type PageNumberFieldFormat,
   type PageNumberFormat,
   type TrackedChangesMode,
 } from '@superdoc/contracts';
@@ -16,6 +15,7 @@ import { EventEmitter } from '@core/EventEmitter.js';
 import { createHeaderFooterEditor, onHeaderFooterDataUpdate } from '@extensions/pagination/pagination-helpers.js';
 import type { ConverterContext } from '@core/layout-adapter/converter-context.js';
 import { buildStoryKey } from '../../document-api-adapters/story-runtime/story-key.js';
+import { getPageNumberFieldFormat } from '../layout-adapter/converters/inline-converters/page-number-field-format.js';
 
 const HEADER_FOOTER_VARIANTS = ['default', 'first', 'even', 'odd'] as const;
 const DEFAULT_HEADER_FOOTER_HEIGHT = 100;
@@ -552,30 +552,13 @@ export class HeaderFooterEditorManager extends EventEmitter {
     }
   }
 
-  #getPageNumberFieldFormatForDomNode(editor: Editor, el: Element): PageNumberFieldFormat | undefined {
+  #getPageNumberFieldFormatForDomNode(editor: Editor, el: Element): ReturnType<typeof getPageNumberFieldFormat> {
     try {
       const view = editor.view;
       if (!view) return undefined;
       const pos = view.posAtDOM(el, 0);
       const node = editor.state.doc.nodeAt(pos);
-      const attrs = node?.attrs;
-      const format = typeof attrs?.pageNumberFormat === 'string' ? attrs.pageNumberFormat : undefined;
-      const zeroPadding =
-        typeof attrs?.pageNumberZeroPadding === 'number' && Number.isFinite(attrs.pageNumberZeroPadding)
-          ? attrs.pageNumberZeroPadding
-          : undefined;
-      const numericPicture =
-        typeof attrs?.pageNumberNumericPicture === 'string' && attrs.pageNumberNumericPicture.length > 0
-          ? attrs.pageNumberNumericPicture
-          : undefined;
-
-      if (!format && !zeroPadding && !numericPicture) return undefined;
-
-      return {
-        ...(format ? { format: format as PageNumberFieldFormat['format'] } : {}),
-        ...(zeroPadding != null ? { zeroPadding } : {}),
-        ...(numericPicture ? { numericPicture } : {}),
-      };
+      return getPageNumberFieldFormat(node?.attrs);
     } catch {
       return undefined;
     }

--- a/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.ts
+++ b/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.ts
@@ -2,9 +2,11 @@ import { toFlowBlocks } from '@core/layout-adapter';
 import { getAtomNodeTypes as getAtomNodeTypesFromSchema } from '../presentation-editor/utils/SchemaNodeTypes.js';
 import {
   formatPageNumber,
+  formatPageNumberFieldValue,
   formatSectionPageNumberText,
   type FlowBlock,
   type PageNumberChapterSeparator,
+  type PageNumberFieldFormat,
   type PageNumberFormat,
   type TrackedChangesMode,
 } from '@superdoc/contracts';
@@ -504,7 +506,7 @@ export class HeaderFooterEditorManager extends EventEmitter {
       typeof opts.currentPageChapterSeparator === 'string'
         ? (opts.currentPageChapterSeparator as PageNumberChapterSeparator)
         : undefined;
-    const totalPages = String(opts.totalPageCount || parentEditor?.currentTotalPages || '1');
+    const totalPages = Number(opts.totalPageCount || parentEditor?.currentTotalPages || 1) || 1;
     const sectionPages = opts.sectionPageCount;
 
     const pageNumberEls = container.querySelectorAll('[data-id="auto-page-number"]');
@@ -524,7 +526,9 @@ export class HeaderFooterEditorManager extends EventEmitter {
       if (el.textContent !== text) el.textContent = text;
     });
     totalPagesEls.forEach((el) => {
-      if (el.textContent !== totalPages) el.textContent = totalPages;
+      const pageNumberFieldFormat = this.#getPageNumberFieldFormatForDomNode(editor, el);
+      const text = formatPageNumberFieldValue(totalPages, pageNumberFieldFormat);
+      if (el.textContent !== text) el.textContent = text;
     });
     sectionPagesEls.forEach((el) => {
       if (sectionPages == null) return;
@@ -545,6 +549,35 @@ export class HeaderFooterEditorManager extends EventEmitter {
       return typeof format === 'string' ? (format as PageNumberFormat) : null;
     } catch {
       return null;
+    }
+  }
+
+  #getPageNumberFieldFormatForDomNode(editor: Editor, el: Element): PageNumberFieldFormat | undefined {
+    try {
+      const view = editor.view;
+      if (!view) return undefined;
+      const pos = view.posAtDOM(el, 0);
+      const node = editor.state.doc.nodeAt(pos);
+      const attrs = node?.attrs;
+      const format = typeof attrs?.pageNumberFormat === 'string' ? attrs.pageNumberFormat : undefined;
+      const zeroPadding =
+        typeof attrs?.pageNumberZeroPadding === 'number' && Number.isFinite(attrs.pageNumberZeroPadding)
+          ? attrs.pageNumberZeroPadding
+          : undefined;
+      const numericPicture =
+        typeof attrs?.pageNumberNumericPicture === 'string' && attrs.pageNumberNumericPicture.length > 0
+          ? attrs.pageNumberNumericPicture
+          : undefined;
+
+      if (!format && !zeroPadding && !numericPicture) return undefined;
+
+      return {
+        ...(format ? { format: format as PageNumberFieldFormat['format'] } : {}),
+        ...(zeroPadding != null ? { zeroPadding } : {}),
+        ...(numericPicture ? { numericPicture } : {}),
+      };
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.test.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.test.ts
@@ -11,6 +11,15 @@ describe('getPageNumberFieldFormat', () => {
     ).toEqual({ format: 'decimal', zeroPadding: 2 });
   });
 
+  it('threads ordinal and numeric-picture attributes for layout runs', () => {
+    expect(
+      getPageNumberFieldFormat({
+        pageNumberFormat: 'ordinal',
+        pageNumberNumericPicture: '#,##0',
+      }),
+    ).toEqual({ format: 'ordinal', numericPicture: '#,##0' });
+  });
+
   it('ignores invalid format attributes', () => {
     expect(getPageNumberFieldFormat(undefined)).toBeUndefined();
     expect(getPageNumberFieldFormat({ pageNumberFormat: 1, pageNumberZeroPadding: Number.NaN })).toBeUndefined();

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.ts
@@ -16,7 +16,7 @@ export function getPageNumberFieldFormat(
   if (!format && !zeroPadding && !numericPicture) return undefined;
   return {
     ...(format ? { format: format as NonNullable<TextRun['pageNumberFieldFormat']>['format'] } : {}),
-    ...(zeroPadding ? { zeroPadding } : {}),
+    ...(zeroPadding != null ? { zeroPadding } : {}),
     ...(numericPicture ? { numericPicture } : {}),
   };
 }

--- a/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.ts
+++ b/packages/super-editor/src/editors/v1/core/layout-adapter/converters/inline-converters/page-number-field-format.ts
@@ -9,9 +9,14 @@ export function getPageNumberFieldFormat(
     typeof attrs.pageNumberZeroPadding === 'number' && Number.isFinite(attrs.pageNumberZeroPadding)
       ? attrs.pageNumberZeroPadding
       : undefined;
-  if (!format && !zeroPadding) return undefined;
+  const numericPicture =
+    typeof attrs.pageNumberNumericPicture === 'string' && attrs.pageNumberNumericPicture.length > 0
+      ? attrs.pageNumberNumericPicture
+      : undefined;
+  if (!format && !zeroPadding && !numericPicture) return undefined;
   return {
     ...(format ? { format: format as NonNullable<TextRun['pageNumberFieldFormat']>['format'] } : {}),
     ...(zeroPadding ? { zeroPadding } : {}),
+    ...(numericPicture ? { numericPicture } : {}),
   };
 }

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessNodesForFldChar.test.js
@@ -86,6 +86,44 @@ describe('preProcessNodesForFldChar', () => {
     },
   );
 
+  it('preserves complex NUMPAGES numeric picture switches', () => {
+    const { processedNodes } = preProcessNodesForFldChar(complexFieldNodes('NUMPAGES \\# "#,##0"', '1,234'), mockDocx);
+
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0]).toMatchObject({
+      name: 'sd:totalPageNumber',
+      attributes: {
+        instruction: 'NUMPAGES \\# "#,##0"',
+        pageNumberNumericPicture: '#,##0',
+        importedCachedText: '1,234',
+      },
+    });
+  });
+
+  it('preserves fldSimple NUMPAGES zero-padding switches', () => {
+    const { processedNodes } = preProcessNodesForFldChar(
+      [
+        {
+          name: 'w:fldSimple',
+          attributes: { 'w:instr': 'NUMPAGES \\# "000"' },
+          elements: [{ name: 'w:r', elements: [{ name: 'w:t', elements: [{ type: 'text', text: '007' }] }] }],
+        },
+      ],
+      mockDocx,
+    );
+
+    expect(processedNodes).toHaveLength(1);
+    expect(processedNodes[0]).toMatchObject({
+      name: 'sd:totalPageNumber',
+      attributes: {
+        instruction: 'NUMPAGES \\# "000"',
+        pageNumberFormat: 'decimal',
+        pageNumberZeroPadding: 3,
+        importedCachedText: '007',
+      },
+    });
+  });
+
   it('preserves SECTIONPAGES field run properties when cached result has no run properties', () => {
     const fieldRunRPr = { name: 'w:rPr', elements: [{ name: 'w:i' }] };
     const { processedNodes } = preProcessNodesForFldChar(

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.js
@@ -182,7 +182,8 @@ function scanFieldSequence(nodes, beginIndex) {
     const instrTextEl = node.elements?.find((el) => el.name === 'w:instrText');
 
     if (instrTextEl) {
-      instrText += instrTextEl.elements?.[0]?.text || '';
+      const fragment = instrTextEl.elements?.[0]?.text || '';
+      instrText += shouldInsertSwitchBoundarySpace(instrText, fragment) ? ` ${fragment}` : fragment;
     }
 
     // Capture rPr from field sequence nodes (before separate) if we don't have one yet
@@ -218,6 +219,10 @@ function scanFieldSequence(nodes, beginIndex) {
     fieldRunRPr,
     endIndex,
   };
+}
+
+function shouldInsertSwitchBoundarySpace(existingInstruction, nextFragment) {
+  return /\w$/.test(existingInstruction) && /^\\/.test(nextFragment);
 }
 
 /**

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.js
@@ -222,7 +222,10 @@ function scanFieldSequence(nodes, beginIndex) {
 }
 
 function shouldInsertSwitchBoundarySpace(existingInstruction, nextFragment) {
-  return /\w$/.test(existingInstruction) && /^\\/.test(nextFragment);
+  return (
+    (/\w$/.test(existingInstruction) && /^\\/.test(nextFragment)) ||
+    (/(^|\s)\\[#*]$/.test(existingInstruction) && /^\S/.test(nextFragment))
+  );
 }
 
 /**

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.js
@@ -182,7 +182,7 @@ function scanFieldSequence(nodes, beginIndex) {
     const instrTextEl = node.elements?.find((el) => el.name === 'w:instrText');
 
     if (instrTextEl) {
-      instrText += (instrTextEl.elements?.[0]?.text || '') + ' ';
+      instrText += instrTextEl.elements?.[0]?.text || '';
     }
 
     // Capture rPr from field sequence nodes (before separate) if we don't have one yet

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
@@ -28,6 +28,31 @@ describe('preProcessPageFieldsOnly', () => {
     ];
   }
 
+  function complexFieldNodesFromInstructionFragments(instructionFragments, cachedText = '1') {
+    return [
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }],
+      },
+      ...instructionFragments.map((text) => ({
+        name: 'w:r',
+        elements: [{ name: 'w:instrText', elements: [{ type: 'text', text }] }],
+      })),
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }],
+      },
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:t', elements: [{ type: 'text', text: cachedText }] }],
+      },
+      {
+        name: 'w:r',
+        elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }],
+      },
+    ];
+  }
+
   describe('complex field syntax (w:fldChar)', () => {
     it('should process PAGE field with fldChar syntax', () => {
       const nodes = [
@@ -216,6 +241,36 @@ describe('preProcessPageFieldsOnly', () => {
           pageNumberFormat: 'decimal',
           pageNumberZeroPadding: 3,
           importedCachedText: '007',
+        },
+      });
+    });
+
+    it('should process NUMPAGES numeric switches split between operator and argument', () => {
+      const result = preProcessPageFieldsOnly(
+        complexFieldNodesFromInstructionFragments(['NUMPAGES', '\\#', '"000"'], '007'),
+      );
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:totalPageNumber',
+        attributes: {
+          instruction: 'NUMPAGES \\# "000"',
+          pageNumberFormat: 'decimal',
+          pageNumberZeroPadding: 3,
+          importedCachedText: '007',
+        },
+      });
+    });
+
+    it('should process PAGE general-format switches split between operator and argument', () => {
+      const result = preProcessPageFieldsOnly(complexFieldNodesFromInstructionFragments(['PAGE', '\\*', 'Roman']));
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:autoPageNumber',
+        attributes: {
+          instruction: 'PAGE \\* Roman',
+          pageNumberFormat: 'upperRoman',
         },
       });
     });

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
@@ -171,7 +171,7 @@ describe('preProcessPageFieldsOnly', () => {
       expect(result.processedNodes[0]).toMatchObject({
         name: 'sd:totalPageNumber',
         attributes: {
-          instruction: 'NUMPAGES \\# "# pages"',
+          instruction: 'NUMPAGES \\# "#   pages"',
           pageNumberNumericPicture: '#   pages',
           importedCachedText: '1   pages',
         },

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
@@ -137,6 +137,47 @@ describe('preProcessPageFieldsOnly', () => {
       });
     });
 
+    it('should preserve NUMPAGES quoted numeric picture whitespace across split instrText runs', () => {
+      const nodes = [
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'NUMPAGES \\# "#' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: '   pages"' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:t', elements: [{ type: 'text', text: '1   pages' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:totalPageNumber',
+        attributes: {
+          instruction: 'NUMPAGES \\# "# pages"',
+          pageNumberNumericPicture: '#   pages',
+          importedCachedText: '1   pages',
+        },
+      });
+    });
+
     it.each([' numpages ', ' NumPages ', ' NUMPAGES '])(
       'should process NUMPAGES field case-insensitively with fldChar syntax: %s',
       (instruction) => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/preProcessPageFieldsOnly.test.js
@@ -178,6 +178,48 @@ describe('preProcessPageFieldsOnly', () => {
       });
     });
 
+    it('should process NUMPAGES switches split at a run boundary without whitespace', () => {
+      const nodes = [
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'begin' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: 'NUMPAGES' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:instrText', elements: [{ type: 'text', text: '\\# "000"' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'separate' } }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:t', elements: [{ type: 'text', text: '007' }] }],
+        },
+        {
+          name: 'w:r',
+          elements: [{ name: 'w:fldChar', attributes: { 'w:fldCharType': 'end' } }],
+        },
+      ];
+
+      const result = preProcessPageFieldsOnly(nodes);
+
+      expect(result.processedNodes).toHaveLength(1);
+      expect(result.processedNodes[0]).toMatchObject({
+        name: 'sd:totalPageNumber',
+        attributes: {
+          instruction: 'NUMPAGES \\# "000"',
+          pageNumberFormat: 'decimal',
+          pageNumberZeroPadding: 3,
+          importedCachedText: '007',
+        },
+      });
+    });
+
     it.each([' numpages ', ' NumPages ', ' NUMPAGES '])(
       'should process NUMPAGES field case-insensitively with fldChar syntax: %s',
       (instruction) => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
@@ -8,6 +8,7 @@ export const GENERAL_FORMATS = new Map([
   ['alphabetic', 'lowerLetter'],
   ['ALPHABETIC', 'upperLetter'],
   ['ArabicDash', 'numberInDash'],
+  ['Ordinal', 'ordinal'],
 ]);
 
 export const CASE_INSENSITIVE_GENERAL_FORMATS = new Map([
@@ -18,17 +19,18 @@ export const CASE_INSENSITIVE_GENERAL_FORMATS = new Map([
 /**
  * @param {string} instruction
  * @param {'PAGE' | 'NUMPAGES' | 'SECTIONPAGES'} fieldType
- * @returns {{ instruction?: string, pageNumberFormat?: string, pageNumberZeroPadding?: number }}
+ * @returns {{ instruction?: string, pageNumberFormat?: string, pageNumberZeroPadding?: number, pageNumberNumericPicture?: string }}
  */
 export function parsePageNumberFieldSwitches(instruction, fieldType) {
-  const normalizedInstruction = typeof instruction === 'string' ? instruction.trim().replace(/\s+/g, ' ') : fieldType;
+  const switchInstruction = typeof instruction === 'string' ? instruction.trim() : fieldType;
+  const normalizedInstruction = switchInstruction.replace(/\s+/g, ' ');
   const result = {};
 
   if (normalizedInstruction && normalizedInstruction !== fieldType) {
     result.instruction = normalizedInstruction;
   }
 
-  for (const match of normalizedInstruction.matchAll(/\\\*\s+("[^"]+"|\S+)/g)) {
+  for (const match of switchInstruction.matchAll(/\\\*\s+("[^"]+"|\S+)/g)) {
     const rawValue = unquote(match[1]);
     const mapped = GENERAL_FORMATS.get(rawValue) ?? CASE_INSENSITIVE_GENERAL_FORMATS.get(rawValue.toLowerCase());
     if (mapped) {
@@ -37,13 +39,18 @@ export function parsePageNumberFieldSwitches(instruction, fieldType) {
     }
   }
 
-  for (const match of normalizedInstruction.matchAll(/\\#\s+("[^"]+"|\S+)/g)) {
+  for (const match of switchInstruction.matchAll(/\\#\s+("[^"]+"|\S+)/g)) {
     const picture = unquote(match[1]);
+    if (!picture) continue;
+
     if (/^0+$/.test(picture)) {
       result.pageNumberFormat ??= 'decimal';
       result.pageNumberZeroPadding = picture.length;
-      break;
+    } else {
+      result.pageNumberNumericPicture = picture;
     }
+
+    break;
   }
 
   return result;

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
@@ -23,7 +23,7 @@ export const CASE_INSENSITIVE_GENERAL_FORMATS = new Map([
  */
 export function parsePageNumberFieldSwitches(instruction, fieldType) {
   const switchInstruction = typeof instruction === 'string' ? instruction.trim() : fieldType;
-  const normalizedInstruction = switchInstruction.replace(/\s+/g, ' ');
+  const normalizedInstruction = normalizeInstructionWhitespace(switchInstruction);
   const result = {};
 
   if (normalizedInstruction && normalizedInstruction !== fieldType) {
@@ -73,4 +73,41 @@ export function formatPageNumberFieldValue(pageNumber, attrs = {}) {
  */
 function unquote(value) {
   return value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value;
+}
+
+/**
+ * Collapse field-code whitespace outside quoted switch arguments while
+ * preserving significant whitespace inside numeric-picture literals.
+ *
+ * @param {string} instruction
+ */
+function normalizeInstructionWhitespace(instruction) {
+  let normalized = '';
+  let inQuote = false;
+  let pendingSpace = false;
+
+  for (const char of instruction) {
+    if (char === '"') {
+      if (pendingSpace && normalized.length > 0) {
+        normalized += ' ';
+        pendingSpace = false;
+      }
+      normalized += char;
+      inQuote = !inQuote;
+      continue;
+    }
+
+    if (!inQuote && /\s/.test(char)) {
+      pendingSpace = true;
+      continue;
+    }
+
+    if (pendingSpace && normalized.length > 0) {
+      normalized += ' ';
+      pendingSpace = false;
+    }
+    normalized += char;
+  }
+
+  return normalized;
 }

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.js
@@ -58,12 +58,13 @@ export function parsePageNumberFieldSwitches(instruction, fieldType) {
 
 /**
  * @param {number} pageNumber
- * @param {{ pageNumberFormat?: string | null, pageNumberZeroPadding?: number | null }} attrs
+ * @param {{ pageNumberFormat?: string | null, pageNumberZeroPadding?: number | null, pageNumberNumericPicture?: string | null }} attrs
  */
 export function formatPageNumberFieldValue(pageNumber, attrs = {}) {
   return formatSharedPageNumberFieldValue(pageNumber, {
     format: attrs.pageNumberFormat || 'decimal',
     zeroPadding: attrs.pageNumberZeroPadding ?? undefined,
+    numericPicture: attrs.pageNumberNumericPicture ?? undefined,
   });
 }
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.test.js
@@ -44,7 +44,7 @@ describe('parsePageNumberFieldSwitches', () => {
     ['NUMPAGES \\# "#,##0"', { instruction: 'NUMPAGES \\# "#,##0"', pageNumberNumericPicture: '#,##0' }],
     ['NUMPAGES \\# #,##0', { instruction: 'NUMPAGES \\# #,##0', pageNumberNumericPicture: '#,##0' }],
     ['NUMPAGES \\# "# pages"', { instruction: 'NUMPAGES \\# "# pages"', pageNumberNumericPicture: '# pages' }],
-    ['NUMPAGES \\# "#   pages"', { instruction: 'NUMPAGES \\# "# pages"', pageNumberNumericPicture: '#   pages' }],
+    ['NUMPAGES \\# "#   pages"', { instruction: 'NUMPAGES \\# "#   pages"', pageNumberNumericPicture: '#   pages' }],
   ])('preserves non-zero numeric picture switch %s', (instruction, expected) => {
     expect(parsePageNumberFieldSwitches(instruction, 'NUMPAGES')).toEqual(expected);
   });

--- a/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/field-references/shared/page-number-field-switches.test.js
@@ -14,8 +14,16 @@ describe('parsePageNumberFieldSwitches', () => {
     ['PAGE \\* ArabicDash', { instruction: 'PAGE \\* ArabicDash', pageNumberFormat: 'numberInDash' }],
     ['PAGE \\* arabicdash', { instruction: 'PAGE \\* arabicdash', pageNumberFormat: 'numberInDash' }],
     ['PAGE \\* ARABICDASH', { instruction: 'PAGE \\* ARABICDASH', pageNumberFormat: 'numberInDash' }],
+    ['PAGE \\* Ordinal', { instruction: 'PAGE \\* Ordinal', pageNumberFormat: 'ordinal' }],
   ])('parses general format switch %s', (instruction, expected) => {
     expect(parsePageNumberFieldSwitches(instruction, 'PAGE')).toEqual(expected);
+  });
+
+  it('parses NUMPAGES Ordinal format switches', () => {
+    expect(parsePageNumberFieldSwitches('NUMPAGES \\* Ordinal', 'NUMPAGES')).toEqual({
+      instruction: 'NUMPAGES \\* Ordinal',
+      pageNumberFormat: 'ordinal',
+    });
   });
 
   it.each([['PAGE \\* rOman'], ['PAGE \\* Alphabetic'], ['PAGE \\* aLpHaBeTiC']])(
@@ -29,6 +37,15 @@ describe('parsePageNumberFieldSwitches', () => {
     ['NUMPAGES \\# "00"', { instruction: 'NUMPAGES \\# "00"', pageNumberFormat: 'decimal', pageNumberZeroPadding: 2 }],
     ['NUMPAGES \\# 000', { instruction: 'NUMPAGES \\# 000', pageNumberFormat: 'decimal', pageNumberZeroPadding: 3 }],
   ])('parses zero-padding picture switch %s', (instruction, expected) => {
+    expect(parsePageNumberFieldSwitches(instruction, 'NUMPAGES')).toEqual(expected);
+  });
+
+  it.each([
+    ['NUMPAGES \\# "#,##0"', { instruction: 'NUMPAGES \\# "#,##0"', pageNumberNumericPicture: '#,##0' }],
+    ['NUMPAGES \\# #,##0', { instruction: 'NUMPAGES \\# #,##0', pageNumberNumericPicture: '#,##0' }],
+    ['NUMPAGES \\# "# pages"', { instruction: 'NUMPAGES \\# "# pages"', pageNumberNumericPicture: '# pages' }],
+    ['NUMPAGES \\# "#   pages"', { instruction: 'NUMPAGES \\# "# pages"', pageNumberNumericPicture: '#   pages' }],
+  ])('preserves non-zero numeric picture switch %s', (instruction, expected) => {
     expect(parsePageNumberFieldSwitches(instruction, 'NUMPAGES')).toEqual(expected);
   });
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.js
@@ -66,6 +66,9 @@ function getPageNumberFieldAttrs(node) {
   if (node.attributes?.pageNumberZeroPadding != null) {
     attrs.pageNumberZeroPadding = Number(node.attributes.pageNumberZeroPadding);
   }
+  if (node.attributes?.pageNumberNumericPicture) {
+    attrs.pageNumberNumericPicture = node.attributes.pageNumberNumericPicture;
+  }
   return attrs;
 }
 
@@ -82,7 +85,7 @@ function resolveCachedPageCount(params, node) {
   const cacheMap = params.statFieldCacheMap;
   if (cacheMap?.has?.('NUMPAGES')) {
     const pageCount = Number(cacheMap.get('NUMPAGES'));
-    if (node.attrs?.pageNumberFormat || node.attrs?.pageNumberZeroPadding) {
+    if (node.attrs?.pageNumberFormat || node.attrs?.pageNumberZeroPadding || node.attrs?.pageNumberNumericPicture) {
       return formatPageNumberFieldValue(pageCount, node.attrs);
     }
     return String(cacheMap.get('NUMPAGES'));

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.test.js
@@ -293,11 +293,11 @@ describe('sd:totalPageNumber translator', () => {
       const result = config.decode({
         node: {
           type: 'total-page-number',
-          attrs: { instruction: 'NUMPAGES \\# "00"', importedCachedText: '07' },
+          attrs: { instruction: 'NUMPAGES \\# "#   pages"', importedCachedText: '7   pages' },
         },
       });
 
-      expect(result[1].elements[1].elements[0].text).toBe(' NUMPAGES \\# "00"');
+      expect(result[1].elements[1].elements[0].text).toBe(' NUMPAGES \\# "#   pages"');
     });
   });
 });

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/sd/totalPageNumber/totalPageNumber-translator.test.js
@@ -89,6 +89,30 @@ describe('sd:totalPageNumber translator', () => {
           {
             name: 'sd:totalPageNumber',
             attributes: {
+              instruction: 'NUMPAGES \\# "#,##0"',
+              pageNumberNumericPicture: '#,##0',
+            },
+            elements: [],
+          },
+        ],
+      });
+
+      expect(result.attrs).toEqual({
+        marksAsAttrs: [],
+        importedCachedText: null,
+        instruction: 'NUMPAGES \\# "#,##0"',
+        pageNumberNumericPicture: '#,##0',
+      });
+    });
+
+    it('preserves imported zero-padding field attributes', () => {
+      vi.mocked(parseMarks).mockReturnValue([]);
+
+      const result = config.encode({
+        nodes: [
+          {
+            name: 'sd:totalPageNumber',
+            attributes: {
               instruction: 'NUMPAGES \\# "00"',
               pageNumberFormat: 'decimal',
               pageNumberZeroPadding: 2,
@@ -184,6 +208,39 @@ describe('sd:totalPageNumber translator', () => {
         'w:fldCharType': 'begin',
       });
       expect(result[3].elements[1].elements[0].text).toBe('07');
+    });
+
+    it('round-trips an imported numeric-picture attr through PM attrs and exported cached text', () => {
+      vi.mocked(parseMarks).mockReturnValue([]);
+      vi.mocked(processOutputMarks).mockReturnValue([]);
+
+      const imported = config.encode({
+        nodes: [
+          {
+            name: 'sd:totalPageNumber',
+            attributes: {
+              instruction: 'NUMPAGES \\# "#,##0"',
+              pageNumberNumericPicture: '#,##0',
+              importedCachedText: '1,000',
+            },
+            elements: [],
+          },
+        ],
+      });
+
+      expect(imported.attrs).toMatchObject({
+        instruction: 'NUMPAGES \\# "#,##0"',
+        pageNumberNumericPicture: '#,##0',
+        importedCachedText: '1,000',
+      });
+
+      const exported = config.decode({
+        node: imported,
+        statFieldCacheMap: new Map([['NUMPAGES', 1234]]),
+      });
+
+      expect(exported[1].elements[1].elements[0].text).toBe(' NUMPAGES \\# "#,##0"');
+      expect(exported[3].elements[1].elements[0].text).toBe('1,234');
     });
 
     it('falls back to resolvedText when cache map is absent', () => {

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.test.ts
@@ -22,6 +22,17 @@ const schema = new Schema({
         resolvedText: { default: null },
       },
     },
+    'total-page-number': {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      content: 'text*',
+      attrs: {
+        instruction: { default: null },
+        importedCachedText: { default: null },
+        resolvedText: { default: null },
+      },
+    },
     sequenceField: {
       group: 'inline',
       inline: true,
@@ -38,6 +49,13 @@ const schema = new Schema({
 function createDocWithSectionPageCount(attrs: Record<string, unknown>, text?: string): ProseMirrorNode {
   const content = text ? schema.text(text) : undefined;
   const field = schema.nodes['section-page-count'].create(attrs, content);
+  const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, field);
+  return schema.nodes.doc.create(null, paragraph);
+}
+
+function createDocWithTotalPageNumber(attrs: Record<string, unknown>, text?: string): ProseMirrorNode {
+  const content = text ? schema.text(text) : undefined;
+  const field = schema.nodes['total-page-number'].create(attrs, content);
   const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, field);
   return schema.nodes.doc.create(null, paragraph);
 }
@@ -71,6 +89,24 @@ describe('field-resolver synthetic section page count fields', () => {
         instruction: 'SECTIONPAGES',
         fieldType: 'SECTIONPAGES',
         resolvedText: '4',
+      },
+    ]);
+  });
+});
+
+describe('field-resolver synthetic total page number fields', () => {
+  it('discovers total-page-number with imported switched instruction', () => {
+    const doc = createDocWithTotalPageNumber({ instruction: 'NUMPAGES \\# "#,##0"', resolvedText: '1,234' });
+
+    expect(findAllFields(doc)).toEqual([
+      {
+        pos: 1,
+        blockId: 'block-1',
+        occurrenceIndex: 0,
+        nestingDepth: 0,
+        instruction: 'NUMPAGES \\# "#,##0"',
+        fieldType: 'NUMPAGES',
+        resolvedText: '1,234',
       },
     ]);
   });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/field-resolver.ts
@@ -56,7 +56,14 @@ const SYNTHETIC_FIELD_NODE_TYPES: Record<
   string,
   { fieldType: string; instruction: string; resolveInstruction?: (node: ProseMirrorNode) => string }
 > = {
-  'total-page-number': { fieldType: 'NUMPAGES', instruction: 'NUMPAGES' },
+  'total-page-number': {
+    fieldType: 'NUMPAGES',
+    instruction: 'NUMPAGES',
+    resolveInstruction: (node) =>
+      typeof node.attrs?.instruction === 'string' && node.attrs.instruction.trim()
+        ? node.attrs.instruction
+        : 'NUMPAGES',
+  },
   'section-page-count': {
     fieldType: 'SECTIONPAGES',
     instruction: 'SECTIONPAGES',

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
@@ -256,7 +256,7 @@ describe('fieldsRebuildWrapper NUMPAGES fields', () => {
     const insertedField = editor.state.doc.nodeAt(1);
     expect(insertedField?.type.name).toBe('total-page-number');
     expect(insertedField?.attrs).toMatchObject({
-      instruction: 'NUMPAGES \\# "# pages"',
+      instruction: 'NUMPAGES \\# "#   pages"',
       pageNumberNumericPicture: '#   pages',
     });
   });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
@@ -243,6 +243,24 @@ describe('fieldsRebuildWrapper NUMPAGES fields', () => {
     });
   });
 
+  it('preserves quoted NUMPAGES numeric picture whitespace during insert', () => {
+    const editor = createEditorForInsert(undefined, true);
+
+    const result = fieldsInsertWrapper(editor, {
+      mode: 'raw',
+      instruction: 'NUMPAGES \\# "#   pages"',
+      at: { kind: 'text', segments: [{ blockId: 'block-1', range: { start: 0, end: 0 } }] },
+    });
+
+    expect(result.success).toBe(true);
+    const insertedField = editor.state.doc.nodeAt(1);
+    expect(insertedField?.type.name).toBe('total-page-number');
+    expect(insertedField?.attrs).toMatchObject({
+      instruction: 'NUMPAGES \\# "# pages"',
+      pageNumberNumericPicture: '#   pages',
+    });
+  });
+
   it('inserts NUMPAGES as a total-page-number node with general format attrs in headers/footers', () => {
     const editor = createEditorForInsert(undefined, true);
 

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
@@ -44,6 +44,21 @@ const schema = new Schema({
       },
       toDOM: () => ['span', 0],
     },
+    'total-page-number': {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      content: 'text*',
+      attrs: {
+        instruction: { default: null },
+        importedCachedText: { default: null },
+        resolvedText: { default: null },
+        pageNumberFormat: { default: null },
+        pageNumberZeroPadding: { default: null },
+        pageNumberNumericPicture: { default: null },
+      },
+      toDOM: () => ['span', 0],
+    },
   },
 });
 
@@ -64,6 +79,32 @@ function createEditorWithSectionPageCount(
     schema,
     state: EditorState.create({ schema, doc }),
     options,
+    view: { dispatch: () => {} },
+    dispatch(tr) {
+      this.state = this.state.apply(tr);
+    },
+  };
+
+  return editor as unknown as Editor;
+}
+
+function createEditorWithTotalPageNumber(
+  pageCount: number | undefined,
+  initialValue = '1',
+  attrs: Record<string, unknown> = {},
+): Editor {
+  const field = schema.nodes['total-page-number'].create(
+    { instruction: 'NUMPAGES', resolvedText: initialValue, ...attrs },
+    schema.text(initialValue),
+  );
+  const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, field);
+  const doc = schema.nodes.doc.create(null, paragraph);
+
+  const editor = {
+    schema,
+    state: EditorState.create({ schema, doc }),
+    currentTotalPages: pageCount,
+    options: {},
     view: { dispatch: () => {} },
     dispatch(tr) {
       this.state = this.state.apply(tr);
@@ -177,5 +218,38 @@ describe('fieldsRebuildWrapper SECTIONPAGES fields', () => {
     expect(updatedField?.type.name).toBe('section-page-count');
     expect(updatedField?.attrs.resolvedText).toBe('3');
     expect(updatedField?.textContent).toBe('3');
+  });
+});
+
+describe('fieldsRebuildWrapper NUMPAGES fields', () => {
+  it('formats rebuilt total-page-number values with pageNumberFormat', () => {
+    const editor = createEditorWithTotalPageNumber(4, '1', { pageNumberFormat: 'upperRoman' });
+
+    const result = fieldsRebuildWrapper(editor, {
+      target: { kind: 'field', blockId: 'block-1', occurrenceIndex: 0, nestingDepth: 0 },
+    });
+
+    expect(result.success).toBe(true);
+    const updatedField = editor.state.doc.nodeAt(1);
+    expect(updatedField?.type.name).toBe('total-page-number');
+    expect(updatedField?.attrs.resolvedText).toBe('IV');
+    expect(updatedField?.textContent).toBe('IV');
+  });
+
+  it('formats rebuilt total-page-number values with numeric picture switches', () => {
+    const editor = createEditorWithTotalPageNumber(1234, '1', {
+      pageNumberFormat: 'decimal',
+      pageNumberNumericPicture: '#,##0 pages',
+    });
+
+    const result = fieldsRebuildWrapper(editor, {
+      target: { kind: 'field', blockId: 'block-1', occurrenceIndex: 0, nestingDepth: 0 },
+    });
+
+    expect(result.success).toBe(true);
+    const updatedField = editor.state.doc.nodeAt(1);
+    expect(updatedField?.type.name).toBe('total-page-number');
+    expect(updatedField?.attrs.resolvedText).toBe('1,234 pages');
+    expect(updatedField?.textContent).toBe('1,234 pages');
   });
 });

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.section-pages.test.ts
@@ -114,10 +114,13 @@ function createEditorWithTotalPageNumber(
   return editor as unknown as Editor;
 }
 
-function createEditorForInsert(sectionPageCount?: number): Editor {
+function createEditorForInsert(sectionPageCount?: number, isHeaderOrFooter = false): Editor {
   const paragraph = schema.nodes.paragraph.create({ sdBlockId: 'block-1' }, schema.text('x'));
   const doc = schema.nodes.doc.create(null, paragraph);
-  const options = sectionPageCount == null ? {} : { sectionPageCount };
+  const options = {
+    ...(sectionPageCount == null ? {} : { sectionPageCount }),
+    ...(isHeaderOrFooter ? { isHeaderOrFooter: true } : {}),
+  };
 
   const editor = {
     schema,
@@ -222,6 +225,42 @@ describe('fieldsRebuildWrapper SECTIONPAGES fields', () => {
 });
 
 describe('fieldsRebuildWrapper NUMPAGES fields', () => {
+  it('inserts NUMPAGES as a total-page-number node with numeric picture attrs in headers/footers', () => {
+    const editor = createEditorForInsert(undefined, true);
+
+    const result = fieldsInsertWrapper(editor, {
+      mode: 'raw',
+      instruction: 'NUMPAGES \\# "#,##0"',
+      at: { kind: 'text', segments: [{ blockId: 'block-1', range: { start: 0, end: 0 } }] },
+    });
+
+    expect(result.success).toBe(true);
+    const insertedField = editor.state.doc.nodeAt(1);
+    expect(insertedField?.type.name).toBe('total-page-number');
+    expect(insertedField?.attrs).toMatchObject({
+      instruction: 'NUMPAGES \\# "#,##0"',
+      pageNumberNumericPicture: '#,##0',
+    });
+  });
+
+  it('inserts NUMPAGES as a total-page-number node with general format attrs in headers/footers', () => {
+    const editor = createEditorForInsert(undefined, true);
+
+    const result = fieldsInsertWrapper(editor, {
+      mode: 'raw',
+      instruction: 'NUMPAGES \\* Ordinal',
+      at: { kind: 'text', segments: [{ blockId: 'block-1', range: { start: 0, end: 0 } }] },
+    });
+
+    expect(result.success).toBe(true);
+    const insertedField = editor.state.doc.nodeAt(1);
+    expect(insertedField?.type.name).toBe('total-page-number');
+    expect(insertedField?.attrs).toMatchObject({
+      instruction: 'NUMPAGES \\* Ordinal',
+      pageNumberFormat: 'ordinal',
+    });
+  });
+
   it('formats rebuilt total-page-number values with pageNumberFormat', () => {
     const editor = createEditorWithTotalPageNumber(4, '1', { pageNumberFormat: 'upperRoman' });
 

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
@@ -141,7 +141,7 @@ export function fieldsInsertWrapper(
   }
 
   if (fieldType === 'NUMPAGES') {
-    return insertNumPagesField(editor, resolved, options);
+    return insertNumPagesField(editor, input, resolved, options);
   }
 
   if (fieldType === 'SECTIONPAGES') {
@@ -195,6 +195,7 @@ function insertDocumentStatField(
 
 function insertNumPagesField(
   editor: Editor,
+  input: FieldInsertInput,
   resolved: { from: number },
   options?: MutationOptions,
 ): FieldMutationResult {
@@ -212,10 +213,13 @@ function insertNumPagesField(
     );
   }
 
+  const normalizedInstruction = input.instruction.trim().replace(/\s+/g, ' ');
+  const parsedInstruction = parsePageNumberFieldSwitches(normalizedInstruction, 'NUMPAGES');
+
   const receipt = executeDomainCommand(
     editor,
     (): boolean => {
-      const node = nodeType.create({});
+      const node = nodeType.create(parsedInstruction);
       const { tr } = editor.state;
       tr.insert(resolved.from, node);
       editor.dispatch(tr);

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
@@ -15,7 +15,7 @@ import type {
   MutationOptions,
   ReceiptFailureCode,
 } from '@superdoc/document-api';
-import { formatPageNumberFieldValue, type PageNumberFieldFormat } from '@superdoc/contracts';
+import { formatPageNumberFieldValue } from '@superdoc/contracts';
 import { buildDiscoveryResult } from '@superdoc/document-api';
 import {
   findAllFields,
@@ -32,6 +32,7 @@ import { DocumentApiAdapterError } from '../errors.js';
 import { getWordStatistics, resolveDocumentStatFieldValue, resolveMainBodyEditor } from '../helpers/word-statistics.js';
 import { resolveSectionPageCountFieldValue } from '../helpers/section-page-count.js';
 import { parsePageNumberFieldSwitches } from '../../core/super-converter/field-references/shared/page-number-field-switches.js';
+import { getPageNumberFieldFormat } from '../../core/layout-adapter/converters/inline-converters/page-number-field-format.js';
 import {
   isSeqInstruction,
   parseSeqInstruction,
@@ -90,27 +91,6 @@ export function fieldsGetWrapper(editor: Editor, input: FieldGetInput): FieldInf
 
 /** Field types that use the documentStatField node representation. */
 const DOCUMENT_STAT_FIELD_TYPES = new Set(['NUMWORDS', 'NUMCHARS']);
-
-function getTotalPageNumberFieldFormat(attrs: Record<string, unknown> | undefined): PageNumberFieldFormat | undefined {
-  if (!attrs) return undefined;
-  const format = typeof attrs.pageNumberFormat === 'string' ? attrs.pageNumberFormat : undefined;
-  const zeroPadding =
-    typeof attrs.pageNumberZeroPadding === 'number' && Number.isFinite(attrs.pageNumberZeroPadding)
-      ? attrs.pageNumberZeroPadding
-      : undefined;
-  const numericPicture =
-    typeof attrs.pageNumberNumericPicture === 'string' && attrs.pageNumberNumericPicture.length > 0
-      ? attrs.pageNumberNumericPicture
-      : undefined;
-
-  if (!format && !zeroPadding && !numericPicture) return undefined;
-
-  return {
-    ...(format ? { format: format as PageNumberFieldFormat['format'] } : {}),
-    ...(zeroPadding ? { zeroPadding } : {}),
-    ...(numericPicture ? { numericPicture } : {}),
-  };
-}
 
 export function fieldsInsertWrapper(
   editor: Editor,
@@ -481,7 +461,7 @@ function rebuildTotalPageNumber(
   const node = editor.state.doc.nodeAt(resolved.pos);
   if (!node) return fieldFailure('TARGET_NOT_FOUND', 'Node not found.');
 
-  const freshValue = formatPageNumberFieldValue(stats.pages, getTotalPageNumberFieldFormat(node.attrs));
+  const freshValue = formatPageNumberFieldValue(stats.pages, getPageNumberFieldFormat(node.attrs));
 
   const receipt = executeDomainCommand(
     editor,

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
@@ -15,6 +15,7 @@ import type {
   MutationOptions,
   ReceiptFailureCode,
 } from '@superdoc/document-api';
+import { formatPageNumberFieldValue, type PageNumberFieldFormat } from '@superdoc/contracts';
 import { buildDiscoveryResult } from '@superdoc/document-api';
 import {
   findAllFields,
@@ -89,6 +90,27 @@ export function fieldsGetWrapper(editor: Editor, input: FieldGetInput): FieldInf
 
 /** Field types that use the documentStatField node representation. */
 const DOCUMENT_STAT_FIELD_TYPES = new Set(['NUMWORDS', 'NUMCHARS']);
+
+function getTotalPageNumberFieldFormat(attrs: Record<string, unknown> | undefined): PageNumberFieldFormat | undefined {
+  if (!attrs) return undefined;
+  const format = typeof attrs.pageNumberFormat === 'string' ? attrs.pageNumberFormat : undefined;
+  const zeroPadding =
+    typeof attrs.pageNumberZeroPadding === 'number' && Number.isFinite(attrs.pageNumberZeroPadding)
+      ? attrs.pageNumberZeroPadding
+      : undefined;
+  const numericPicture =
+    typeof attrs.pageNumberNumericPicture === 'string' && attrs.pageNumberNumericPicture.length > 0
+      ? attrs.pageNumberNumericPicture
+      : undefined;
+
+  if (!format && !zeroPadding && !numericPicture) return undefined;
+
+  return {
+    ...(format ? { format: format as PageNumberFieldFormat['format'] } : {}),
+    ...(zeroPadding ? { zeroPadding } : {}),
+    ...(numericPicture ? { numericPicture } : {}),
+  };
+}
 
 export function fieldsInsertWrapper(
   editor: Editor,
@@ -453,7 +475,10 @@ function rebuildTotalPageNumber(
 
   if (stats.pages == null) return fieldSuccess(address);
 
-  const freshValue = String(stats.pages);
+  const node = editor.state.doc.nodeAt(resolved.pos);
+  if (!node) return fieldFailure('TARGET_NOT_FOUND', 'Node not found.');
+
+  const freshValue = formatPageNumberFieldValue(stats.pages, getTotalPageNumberFieldFormat(node.attrs));
 
   const receipt = executeDomainCommand(
     editor,

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/field-wrappers.ts
@@ -213,8 +213,7 @@ function insertNumPagesField(
     );
   }
 
-  const normalizedInstruction = input.instruction.trim().replace(/\s+/g, ' ');
-  const parsedInstruction = parsePageNumberFieldSwitches(normalizedInstruction, 'NUMPAGES');
+  const parsedInstruction = parsePageNumberFieldSwitches(input.instruction, 'NUMPAGES');
 
   const receipt = executeDomainCommand(
     editor,

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
@@ -1,4 +1,5 @@
 import { Extension } from '@core/Extension.js';
+import { formatPageNumberFieldValue } from '@superdoc/contracts';
 import { findFieldsInRange } from '../../document-api-adapters/helpers/field-resolver.js';
 import { findAllTocNodes } from '../../document-api-adapters/helpers/toc-resolver.js';
 import {
@@ -14,6 +15,31 @@ import {
 
 /** Stat-field types refreshed by F9 when the doc has no TOCs. */
 const UPDATABLE_FIELD_TYPES = new Set(['NUMWORDS', 'NUMCHARS', 'NUMPAGES', 'SECTIONPAGES']);
+
+function getTotalPageNumberFieldFormat(attrs) {
+  const format = typeof attrs?.pageNumberFormat === 'string' ? attrs.pageNumberFormat : undefined;
+  const zeroPadding =
+    typeof attrs?.pageNumberZeroPadding === 'number' && Number.isFinite(attrs.pageNumberZeroPadding)
+      ? attrs.pageNumberZeroPadding
+      : undefined;
+  const numericPicture =
+    typeof attrs?.pageNumberNumericPicture === 'string' && attrs.pageNumberNumericPicture.length > 0
+      ? attrs.pageNumberNumericPicture
+      : undefined;
+
+  if (!format && !zeroPadding && !numericPicture) return undefined;
+
+  return {
+    ...(format ? { format } : {}),
+    ...(zeroPadding ? { zeroPadding } : {}),
+    ...(numericPicture ? { numericPicture } : {}),
+  };
+}
+
+function resolveTotalPageNumberFieldValue(stats, node) {
+  if (stats.pages == null) return null;
+  return formatPageNumberFieldValue(stats.pages, getTotalPageNumberFieldFormat(node.attrs));
+}
 
 /**
  * @module FieldUpdate
@@ -119,7 +145,9 @@ export const FieldUpdate = Extension.create({
             const freshValue =
               field.fieldType === 'SECTIONPAGES'
                 ? resolveSectionPageCountFieldValue(editor, node)
-                : resolveDocumentStatFieldValue(field.fieldType, stats);
+                : field.fieldType === 'NUMPAGES' && node.type.name === 'total-page-number'
+                  ? resolveTotalPageNumberFieldValue(stats, node)
+                  : resolveDocumentStatFieldValue(field.fieldType, stats);
             if (freshValue == null) continue;
 
             if (node.type.name === 'total-page-number' || node.type.name === 'section-page-count') {

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.js
@@ -12,33 +12,14 @@ import {
   getSequenceFieldUpdaterConverterContext,
   updateSequenceFieldsInTransaction,
 } from '../../document-api-adapters/helpers/sequence-field-updater.js';
+import { getPageNumberFieldFormat } from '../../core/layout-adapter/converters/inline-converters/page-number-field-format.js';
 
 /** Stat-field types refreshed by F9 when the doc has no TOCs. */
 const UPDATABLE_FIELD_TYPES = new Set(['NUMWORDS', 'NUMCHARS', 'NUMPAGES', 'SECTIONPAGES']);
 
-function getTotalPageNumberFieldFormat(attrs) {
-  const format = typeof attrs?.pageNumberFormat === 'string' ? attrs.pageNumberFormat : undefined;
-  const zeroPadding =
-    typeof attrs?.pageNumberZeroPadding === 'number' && Number.isFinite(attrs.pageNumberZeroPadding)
-      ? attrs.pageNumberZeroPadding
-      : undefined;
-  const numericPicture =
-    typeof attrs?.pageNumberNumericPicture === 'string' && attrs.pageNumberNumericPicture.length > 0
-      ? attrs.pageNumberNumericPicture
-      : undefined;
-
-  if (!format && !zeroPadding && !numericPicture) return undefined;
-
-  return {
-    ...(format ? { format } : {}),
-    ...(zeroPadding ? { zeroPadding } : {}),
-    ...(numericPicture ? { numericPicture } : {}),
-  };
-}
-
 function resolveTotalPageNumberFieldValue(stats, node) {
   if (stats.pages == null) return null;
-  return formatPageNumberFieldValue(stats.pages, getTotalPageNumberFieldFormat(node.attrs));
+  return formatPageNumberFieldValue(stats.pages, getPageNumberFieldFormat(node.attrs));
 }
 
 /**

--- a/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/field-update/field-update.test.js
@@ -308,6 +308,21 @@ const mixedSchema = new Schema({
       },
       toDOM: () => ['span', 0],
     },
+    'total-page-number': {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      content: 'text*',
+      attrs: {
+        instruction: { default: null },
+        importedCachedText: { default: null },
+        resolvedText: { default: null },
+        pageNumberFormat: { default: null },
+        pageNumberZeroPadding: { default: null },
+        pageNumberNumericPicture: { default: null },
+      },
+      toDOM: () => ['span', 0],
+    },
     sequenceField: {
       group: 'inline',
       inline: true,
@@ -448,6 +463,44 @@ describe('updateFieldsInSelection — TOC + stat fields combined (regression)', 
     const updatedField = updatedDoc.nodeAt(1);
     expect(updatedField.attrs.resolvedText).toBe('004');
     expect(updatedField.textContent).toBe('004');
+  });
+
+  it('updates NUMPAGES fields with preserved numeric picture formatting', () => {
+    const para = (children) => mixedSchema.nodes.paragraph.create({}, children);
+    const totalPageNumberField = mixedSchema.nodes['total-page-number'].create(
+      {
+        instruction: 'NUMPAGES \\# "#,##0 pages"',
+        pageNumberNumericPicture: '#,##0 pages',
+        resolvedText: '1 pages',
+      },
+      mixedSchema.text('1 pages'),
+    );
+    const doc = mixedSchema.nodes.doc.create({}, [para([totalPageNumberField])]);
+    const editorState = EditorState.create({ schema: mixedSchema, doc });
+    const editor = {
+      currentTotalPages: 1234,
+      state: editorState,
+    };
+
+    const commands = FieldUpdate.config.addCommands.call({ editor });
+    const command = commands.updateFieldsInSelection();
+    const outerTr = editorState.tr;
+    const dispatch = vi.fn();
+    const state = {
+      doc,
+      selection: { from: 0, to: doc.content.size },
+      schema: mixedSchema,
+      tr: outerTr,
+    };
+
+    const result = command({ editor, state, tr: outerTr, dispatch });
+
+    expect(result).toBe(true);
+    const updatedDoc = dispatch.mock.calls[0][0].doc;
+    const updatedField = updatedDoc.nodeAt(1);
+    expect(updatedField.type.name).toBe('total-page-number');
+    expect(updatedField.attrs.resolvedText).toBe('1,234 pages');
+    expect(updatedField.textContent).toBe('1,234 pages');
   });
 
   it('leaves SECTIONPAGES fields unchanged when section page context is unavailable', () => {

--- a/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
+++ b/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
@@ -2,6 +2,7 @@ import { Node } from '@core/Node.js';
 import { Attribute } from '@core/Attribute.js';
 import { isHeadless } from '@utils/headless-helpers.js';
 import { formatPageNumberFieldValue, formatSectionPageNumberText } from '@superdoc/contracts';
+import { getPageNumberFieldFormat } from '../../core/layout-adapter/converters/inline-converters/page-number-field-format.js';
 /**
  * Configuration options for PageNumber
  * @typedef {Object} PageNumberOptions
@@ -428,26 +429,6 @@ const getNodeAttributes = (nodeName, editor, node = null) => {
       return {};
   }
 };
-
-function getPageNumberFieldFormat(attrs) {
-  const format = typeof attrs?.pageNumberFormat === 'string' ? attrs.pageNumberFormat : undefined;
-  const zeroPadding =
-    typeof attrs?.pageNumberZeroPadding === 'number' && Number.isFinite(attrs.pageNumberZeroPadding)
-      ? attrs.pageNumberZeroPadding
-      : undefined;
-  const numericPicture =
-    typeof attrs?.pageNumberNumericPicture === 'string' && attrs.pageNumberNumericPicture.length > 0
-      ? attrs.pageNumberNumericPicture
-      : undefined;
-
-  if (!format && !zeroPadding && !numericPicture) return undefined;
-
-  return {
-    ...(format ? { format } : {}),
-    ...(zeroPadding != null ? { zeroPadding } : {}),
-    ...(numericPicture ? { numericPicture } : {}),
-  };
-}
 
 export class AutoPageNumberNodeView {
   constructor(node, getPos, decorations, editor, htmlAttributes = {}) {

--- a/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
+++ b/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
@@ -139,6 +139,7 @@ export const PageNumber = Node.create({
  * @property {string|null} [instruction=null] @internal - Original NUMPAGES field instruction when switched
  * @property {string|null} [pageNumberFormat=null] @internal - Normalized field switch format
  * @property {number|null} [pageNumberZeroPadding=null] @internal - Zero-padding width from numeric picture switch
+ * @property {string|null} [pageNumberNumericPicture=null] @internal - Raw numeric picture switch
  */
 
 /**
@@ -183,6 +184,10 @@ export const TotalPageCount = Node.create({
         rendered: false,
       },
       pageNumberZeroPadding: {
+        default: null,
+        rendered: false,
+      },
+      pageNumberNumericPicture: {
         default: null,
         rendered: false,
       },

--- a/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
+++ b/packages/super-editor/src/editors/v1/extensions/page-number/page-number.js
@@ -389,13 +389,16 @@ const getNodeAttributes = (nodeName, editor, node = null) => {
         ariaLabel: 'Page number node',
       };
     }
-    case 'total-page-number':
+    case 'total-page-number': {
+      const totalPageCount =
+        Number(editor.options.totalPageCount || editor.options.parentEditor?.currentTotalPages || 1) || 1;
       return {
-        text: editor.options.totalPageCount || editor.options.parentEditor?.currentTotalPages || '1',
+        text: formatPageNumberFieldValue(totalPageCount, getPageNumberFieldFormat(node?.attrs)),
         className: 'sd-editor-auto-total-pages',
         dataId: 'auto-total-pages',
         ariaLabel: 'Total page count node',
       };
+    }
     case 'section-page-count': {
       const sectionPageCount = editor.options.sectionPageCount;
       const cachedText = node?.attrs?.resolvedText ?? node?.attrs?.importedCachedText ?? node?.textContent ?? '1';
@@ -425,6 +428,26 @@ const getNodeAttributes = (nodeName, editor, node = null) => {
       return {};
   }
 };
+
+function getPageNumberFieldFormat(attrs) {
+  const format = typeof attrs?.pageNumberFormat === 'string' ? attrs.pageNumberFormat : undefined;
+  const zeroPadding =
+    typeof attrs?.pageNumberZeroPadding === 'number' && Number.isFinite(attrs.pageNumberZeroPadding)
+      ? attrs.pageNumberZeroPadding
+      : undefined;
+  const numericPicture =
+    typeof attrs?.pageNumberNumericPicture === 'string' && attrs.pageNumberNumericPicture.length > 0
+      ? attrs.pageNumberNumericPicture
+      : undefined;
+
+  if (!format && !zeroPadding && !numericPicture) return undefined;
+
+  return {
+    ...(format ? { format } : {}),
+    ...(zeroPadding != null ? { zeroPadding } : {}),
+    ...(numericPicture ? { numericPicture } : {}),
+  };
+}
 
 export class AutoPageNumberNodeView {
   constructor(node, getPos, decorations, editor, htmlAttributes = {}) {

--- a/packages/super-editor/src/editors/v1/extensions/page-number/page-number.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/page-number/page-number.test.js
@@ -318,6 +318,25 @@ describe('AutoPageNumberNodeView', () => {
     expect(nodeView.dom.getAttribute('data-id')).toBe('auto-total-pages');
   });
 
+  it('renders formatted total page count node in edit mode', () => {
+    const doc = {
+      resolve: vi.fn().mockReturnValue({ nodeBefore: null, nodeAfter: null }),
+      nodeAt: vi.fn().mockReturnValue({ isText: false, attrs: { marksAsAttrs: [] } }),
+    };
+    const tr = { setNodeMarkup: vi.fn().mockReturnValue({}) };
+    const state = { doc, tr };
+    const editor = {
+      options: { totalPageCount: 12, parentEditor: { currentTotalPages: 12 } },
+      state,
+      view: { state, dispatch: vi.fn() },
+    };
+
+    const node = { type: { name: 'total-page-number' }, attrs: { pageNumberNumericPicture: '000' } };
+    const nodeView = new AutoPageNumberNodeView(node, () => 7, [], editor);
+
+    expect(nodeView.dom.textContent).toBe('012');
+  });
+
   it('renders formatted section page count node', () => {
     const doc = {
       resolve: vi.fn().mockReturnValue({ nodeBefore: null, nodeAfter: null }),

--- a/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.js
+++ b/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.js
@@ -159,7 +159,8 @@ export function createTextElement(textContent, textAlign, width, height, options
       });
     }
     if (part.fieldType === 'NUMPAGES') {
-      return totalPages != null ? String(totalPages) : '1';
+      const count = totalPages ?? 1;
+      return part.pageNumberFormat ? formatPageNumber(count, part.pageNumberFormat) : String(count);
     }
     if (part.fieldType === 'SECTIONPAGES') {
       if (sectionPageCount == null) return part.text ?? '1';

--- a/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.test.js
@@ -226,6 +226,18 @@ describe('svg-utils', () => {
         expect(span.textContent).toBe('IX');
       });
 
+      it('should format NUMPAGES field type with ordinal pageNumberFormat', () => {
+        const textContent = {
+          parts: [{ text: '', fieldType: 'NUMPAGES', pageNumberFormat: 'ordinal', formatting: {} }],
+        };
+        const result = createTextElement(textContent, 'left', 100, 50, {
+          totalPages: 12,
+        });
+
+        const span = result.querySelector('span');
+        expect(span.textContent).toBe('12th');
+      });
+
       it('should default PAGE to "1" when pageNumber not provided', () => {
         const textContent = {
           parts: [{ text: '', fieldType: 'PAGE', formatting: {} }],

--- a/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/shared/svg-utils.test.js
@@ -214,6 +214,18 @@ describe('svg-utils', () => {
         expect(span.textContent).toBe('10');
       });
 
+      it('should format NUMPAGES field type with pageNumberFormat', () => {
+        const textContent = {
+          parts: [{ text: '', fieldType: 'NUMPAGES', pageNumberFormat: 'upperRoman', formatting: {} }],
+        };
+        const result = createTextElement(textContent, 'left', 100, 50, {
+          totalPages: 9,
+        });
+
+        const span = result.querySelector('span');
+        expect(span.textContent).toBe('IX');
+      });
+
       it('should default PAGE to "1" when pageNumber not provided', () => {
         const textContent = {
           parts: [{ text: '', fieldType: 'PAGE', formatting: {} }],

--- a/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
+++ b/packages/super-editor/src/editors/v1/extensions/types/node-attributes.ts
@@ -986,9 +986,11 @@ export interface TotalPageCountAttrs extends InlineNodeAttributes {
   /** @internal Original NUMPAGES field instruction when switched */
   instruction?: string | null;
   /** @internal Normalized field switch format */
-  pageNumberFormat?: string | null;
+  pageNumberFormat?: PageNumberFormat | null;
   /** @internal Zero-padding width from numeric picture switch */
   pageNumberZeroPadding?: number | null;
+  /** @internal Raw numeric picture switch */
+  pageNumberNumericPicture?: string | null;
 }
 
 /** Section page count node attributes */


### PR DESCRIPTION
## Summary

The `PAGE` field already honored Word formatting switches (`\* roman`, `\# 0000`, etc.), but `NUMPAGES` (total page count) fields rendered as a bare integer everywhere. This branch threads page-number field-switch formatting through every code path that resolves a total-page-count value, so a `NUMPAGES` field formatted as Roman numerals, zero-padded, ordinal, or with a numeric picture now renders consistently across pagination, the DOM painter, SVG shapes, headers/footers, F9 field refresh, and the Document API.

It also adds two new switch capabilities shared by all page-number fields:
- **`ordinal`** format (`\* Ordinal` → `1st`, `2nd`, `3rd`, `11th`…).
- **Numeric picture** literals (`\# "Page 0"`) preserved as `numericPicture` rather than being collapsed to plain zero-padding.

## Changes

### Formatting contract (`layout-engine/contracts`)
- `PageNumberFieldFormat` gains an `ordinal` format option and a `numericPicture` field.
- `formatPageNumber` adds ordinal suffix logic; `formatPageNumberFieldValue` routes through the numeric-picture formatter when one is present.

### Field-switch parsing (`super-converter/field-references`)
- `parsePageNumberFieldSwitches` now recognizes `Ordinal` and captures non-zero numeric-picture literals as `pageNumberNumericPicture` (instead of breaking out on the first `\#` match).
- New `normalizeInstructionWhitespace` collapses field-code whitespace **outside** quoted switch arguments while preserving significant spaces inside numeric-picture literals.
- `preProcessPageFieldsOnly` inserts a switch-boundary space when concatenating `instrText` fragments (e.g. `NUMPAGES` + `\* Ordinal` split across runs) so switches aren't glued to preceding tokens.

### Resolution paths
- **Layout engine** (`resolvePageTokens`): `totalPageCount` tokens now format via `formatPageNumberFieldValue` and clear their field-format metadata after resolution. `activeNumberFormat` retyped to the shared `PageNumberFormat`.
- **DOM painter** & **SVG utils**: `NUMPAGES` rendering applies `pageNumberFormat` when present.
- **HeaderFooterRegistry**: total-pages DOM nodes are formatted using the field format resolved from the backing PM node (`posAtDOM` → `nodeAt`).
- **Document API** (`field-wrappers`, `field-resolver`): `NUMPAGES` insert now parses and stores switches; rebuild formats the fresh value; the synthetic node resolves its preserved instruction.
- **Editor extensions** (`field-update` F9, `page-number` node view): total-page-number nodes format their value with the resolved field format.

### Types
- `TotalPageCountAttrs.pageNumberNumericPicture` added; `pageNumberFormat` narrowed to `PageNumberFormat`.
- `f20e00310` extracts a shared field-format attrs mapper to avoid duplicating the `attrs → format` projection.

## Testing

Adds/extends unit tests across all touched layers (`page-number-formatting`, `resolvePageTokens`, DOM painter, `HeaderFooterRegistry`, switch parsing, whitespace normalization, `totalPageNumber-translator`, `field-resolver`, `field-wrappers`, `field-update`, `page-number`, `svg-utils`) covering ordinal output, numeric pictures, split/quoted switch instructions, and edit-mode/F9 formatting.
