### PR TITLE
fix(mcp): resolve word-layout from source

### DIFF
--- a/packages/word-layout/package.json
+++ b/packages/word-layout/package.json
@@ -4,13 +4,13 @@
   "description": "Shared Word paragraph and list layout math for SuperDoc",
   "type": "module",
   "private": true,
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "source": "./src/index.ts",
-      "default": "./dist/index.js"
+      "default": "./src/index.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
apps/mcp bundles super-editor from source, which imports `@superdoc/word-layout`. word-layout is private and its dist output is gitignored, so resolving its default export through `./dist/index.js` fails when the package has not been built first. Match the internal package pattern used by `contracts` and point word-layout `main`/`types`/`default` at `src/index.ts`.

**Verified**: `pnpm --prefix apps/mcp run build` → builds; `pnpm check:types` → passes
