### PR TITLE
feat(fonts): prefer a registered real face over the bundled substitute (provider precedence)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/DocumentFontController.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/DocumentFontController.test.ts
@@ -30,6 +30,10 @@ class FakeRegistry {
     return [];
   }
 
+  hasFace(family: string, weight: '400' | '700', style: 'normal' | 'italic'): boolean {
+    return this.#sources.has(`${family.toLowerCase()}|${weight}|${style}`);
+  }
+
   asRegistry(): FontRegistry {
     return this as unknown as FontRegistry;
   }
@@ -206,10 +210,26 @@ describe('DocumentFontController', () => {
   it('preload resolves logical families through the document resolver', async () => {
     const { controller, registry } = makeController();
 
-    controller.applyInitialConfig({ map: { Georgia: 'Gelasio' } });
+    // Register Gelasio (so the map target is loadable), then map Georgia -> Gelasio.
+    controller.applyInitialConfig({
+      families: [{ family: 'Gelasio', faces: [{ source: '/fonts/Gelasio-Regular.woff2' }] }],
+      map: { Georgia: 'Gelasio' },
+    });
     await controller.preload(['Georgia']);
 
     expect(registry.awaited).toEqual([[{ family: 'Gelasio', weight: '400', style: 'normal' }]]);
+  });
+
+  it('preload prefers a registered real face over the bundled substitute (provider precedence)', async () => {
+    const { controller, registry } = makeController();
+
+    // The document registered real Calibri faces; preload must load Calibri, NOT the bundled Carlito.
+    controller.applyInitialConfig({
+      families: [{ family: 'Calibri', faces: [{ source: '/fonts/Calibri.woff2' }] }],
+    });
+    await controller.preload(['Calibri']);
+
+    expect(registry.awaited).toEqual([[{ family: 'Calibri', weight: '400', style: 'normal' }]]);
   });
 
   it('still reflows for faces committed before a later conflicting face throws', () => {

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/DocumentFontController.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/DocumentFontController.test.ts
@@ -274,33 +274,48 @@ describe('DocumentFontController', () => {
     await expect(controller.preload('Georgia' as never)).rejects.toThrow(/expects an array/);
   });
 
-  it('does not reflow when mapping a family to the substitute it already resolves to', () => {
+  it('does not reflow on a redundant identity map (a true no-op stays cache-shareable)', () => {
     const { controller, resolver, notifyDocumentFontConfigChanged, flushMicrotasks } = makeController();
 
-    // Calibri already resolves to Carlito via the bundled map, so this map is a true no-op:
-    // it must not record an override (which would move the signature and de-opt cache sharing).
-    controller.map({ Calibri: 'Carlito' });
+    // Mapping a family to its OWN name is the absence of an override: no reflow, signature stays ''.
+    controller.map({ Georgia: 'Georgia' });
     flushMicrotasks();
 
-    expect(resolver.resolvePrimaryPhysicalFamily('Calibri')).toBe('Carlito');
     expect(resolver.signature).toBe('');
     expect(notifyDocumentFontConfigChanged).not.toHaveBeenCalled();
   });
 
-  it('mapping a previously-mapped family back to its default reflows once and restores shared cache', () => {
+  it('mapping a family to the bundled clone now stores an explicit pin (reflows; not a silent no-op)', () => {
+    const { controller, resolver, notifyDocumentFontConfigChanged, flushMicrotasks } = makeController();
+
+    // After provider precedence, map({ Calibri: 'Carlito' }) is an explicit pin to the clone, not a
+    // no-op: it stores a custom_mapping override (so it beats a registered real Calibri) and reflows.
+    controller.map({ Calibri: 'Carlito' });
+    flushMicrotasks();
+
+    expect(resolver.resolvePrimaryPhysicalFamily('Calibri')).toBe('Carlito');
+    expect(resolver.signature).not.toBe('');
+    expect(notifyDocumentFontConfigChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('unmap reverts a pin (mapping to the clone re-pins rather than reverting)', () => {
     const { controller, resolver, notifyDocumentFontConfigChanged, flushMicrotasks } = makeController();
 
     controller.map({ Calibri: 'Tinos' });
     flushMicrotasks();
-    expect(resolver.signature).not.toBe('');
     expect(notifyDocumentFontConfigChanged).toHaveBeenCalledTimes(1);
 
-    // Mapping back to the bundled default removes the override (resolution changes Tinos -> Carlito),
-    // so it reflows once more AND returns the signature to '' so this document re-shares caches.
+    // Mapping to the clone now RE-PINS (stores Calibri -> Carlito), it does not revert.
     controller.map({ Calibri: 'Carlito' });
     flushMicrotasks();
     expect(resolver.resolvePrimaryPhysicalFamily('Calibri')).toBe('Carlito');
-    expect(resolver.signature).toBe('');
+    expect(resolver.signature).not.toBe(''); // still pinned
     expect(notifyDocumentFontConfigChanged).toHaveBeenCalledTimes(2);
+
+    // unmap is the revert: back to the shared default.
+    controller.unmap('Calibri');
+    flushMicrotasks();
+    expect(resolver.signature).toBe('');
+    expect(notifyDocumentFontConfigChanged).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/DocumentFontController.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/DocumentFontController.ts
@@ -190,8 +190,13 @@ export class DocumentFontController {
     }
     const registry = this.#getGate()?.resolveRegistry();
     if (!registry) throw new Error('[superdoc] fonts.preload: the font registry is not ready yet');
+    // Resolve the regular face through the provider-precedence ladder, not the family-level bundled
+    // map: if the document registered a real face for this family, preload THAT, not the clone.
+    const hasFace = (family: string, weight: '400' | '700', style: 'normal' | 'italic'): boolean =>
+      registry.hasFace(family, weight, style);
+    const face = { weight: '400', style: 'normal' } as const;
     const requests: FontFaceRequest[] = families.map((logical) => ({
-      family: this.#resolver.resolvePrimaryPhysicalFamily(logical),
+      family: this.#resolver.resolveFace(logical, face, hasFace).physicalFamily,
       weight: '400',
       style: 'normal',
     }));

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/FontReadinessGate.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/FontReadinessGate.test.ts
@@ -400,6 +400,26 @@ describe('FontReadinessGate', () => {
       expect(summary.results).toEqual([{ family: 'Carlito', status: 'failed' }]);
     });
 
+    it('replans once when a required face terminally FAILS, so it can demote to the clone (Fix 2b)', async () => {
+      registry.faceStatuses.set(faceKey(BOLD), 'failed');
+      const gate = makeFaceGate(() => [BOLD]);
+
+      await gate.ensureReadyForMeasure();
+      // The failed required face triggers a demotion replan: caches invalidated synchronously, the
+      // (batched) reflow flushes after the scheduler window. The next render re-resolves to the clone.
+      expect(invalidateCaches).toHaveBeenCalledTimes(1);
+      expect(requestReflow).not.toHaveBeenCalled();
+      clock.advance(300);
+      expect(requestReflow).toHaveBeenCalledTimes(1);
+
+      // A second measure pass with the SAME face still failed must NOT replan again - fire-once, so it
+      // cannot loop when the bundled clone it steps down to also fails. Drain the full cooldown.
+      await gate.ensureReadyForMeasure();
+      clock.advance(2500);
+      expect(invalidateCaches).toHaveBeenCalledTimes(1);
+      expect(requestReflow).toHaveBeenCalledTimes(1);
+    });
+
     it('reflows once when the required bold face loads after a timed-out first paint', async () => {
       registry.faceStatuses.set(faceKey(BOLD), 'timed_out');
       const gate = makeFaceGate(() => [BOLD]);

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/FontReadinessGate.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/FontReadinessGate.ts
@@ -135,6 +135,9 @@ export class FontReadinessGate {
   readonly #seenAvailable = new Set<string>();
   /** Face keys observed available, so the face-path late-load handler fires once per face. */
   readonly #seenAvailableFaces = new Set<string>();
+  /** Face keys observed terminally FAILED, so the failure-demotion replan fires at most once per face
+   *  (and cannot loop when the bundled clone it steps down to also fails). */
+  readonly #seenFailedFaces = new Set<string>();
   #lastSummary: FontLoadSummary | null = null;
   #loadingDoneHandler: ((event: FontFaceSetLoadEvent) => void) | null = null;
   /** Batches late-load reflows so many font arrivals coalesce into bounded re-measures. */
@@ -256,11 +259,22 @@ export class FontReadinessGate {
       results = [];
     }
 
+    const failedKeys: string[] = [];
     for (const result of results) {
+      const key = faceKeyOf(result.request.family, result.request.weight, result.request.style);
       if (result.status === 'loaded') {
-        this.#seenAvailableFaces.add(faceKeyOf(result.request.family, result.request.weight, result.request.style));
+        this.#seenAvailableFaces.add(key);
+      } else if (result.status === 'failed' && !this.#seenFailedFaces.has(key)) {
+        // A registered provider face whose asset terminally FAILED to load. `registry.hasFace` now
+        // demotes it, so a replan re-resolves these runs to the bundled metric clone instead of leaving
+        // the document on a broken registered face for the session. Fire once per face (seenFailed) so
+        // it cannot loop if the clone it steps down to also fails. NOT done for `timed_out` - a slow
+        // face is recovered by the late-load reflow, and demoting it would strand the real font.
+        this.#seenFailedFaces.add(key);
+        failedKeys.push(key);
       }
     }
+    if (failedKeys.length > 0) this.#scheduleAvailabilityReflow(failedKeys);
     this.#lastSummary = summarizeFaces(results);
     return this.#lastSummary;
   }
@@ -377,6 +391,7 @@ export class FontReadinessGate {
     this.#requiredFamilies = new Set();
     this.#seenAvailable.clear();
     this.#seenAvailableFaces.clear();
+    this.#seenFailedFaces.clear();
     this.#lastSummary = null;
   }
 
@@ -469,11 +484,18 @@ export class FontReadinessGate {
     }
 
     if (changedKeys.length === 0) return;
-    // The available-font picture changed NOW, so bump the epoch and clear the measurement
-    // caches immediately - measure caches are keyed without the epoch (fontMetricsCache is
-    // `family|size|bold|italic`), so this explicit clear is the only thing that busts them,
-    // and any re-measure/paint before the batched reflow must already see the loaded font.
-    // Only the expensive full reflow is deferred to the scheduler so arrival waves coalesce.
+    this.#scheduleAvailabilityReflow(changedKeys);
+  }
+
+  /**
+   * The available-font picture changed (a required face loaded LATE, or a registered face terminally
+   * FAILED so it must demote to the bundled clone). Bump the epoch and clear the measurement caches
+   * immediately - measure caches are keyed without the epoch (`family|size|bold|italic`), so this
+   * explicit clear is the only thing that busts them, and any re-measure/paint before the batched
+   * reflow must already see the corrected resolution. Only the expensive full reflow is deferred to the
+   * scheduler so arrival/failure waves coalesce.
+   */
+  #scheduleAvailabilityReflow(changedKeys: string[]): void {
     this.#fontConfigVersion += 1;
     bumpFontConfigVersion(); // bump the global epoch so paint reuse signatures bust
     this.#invalidateCaches();

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/font-load-planner.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/font-load-planner.test.ts
@@ -180,7 +180,10 @@ describe('planFontFaces (face-aware single plan)', () => {
 
   it('four-face clone: all faces resolve to the substitute (requiredFaces unchanged vs family-level)', () => {
     const resolver = createFontResolver();
-    const allFaces = () => true;
+    // Only the bundled CLONE (Carlito) is registered - the normal substitute case. An all-true oracle
+    // would mark Calibri itself registered, so provider precedence would (correctly) resolve it to
+    // `registered_face` (Calibri) instead of the clone - which is a different scenario.
+    const cloneFaces = (f: string) => f.replace(/^["']|["']$/g, '').toLowerCase() === 'carlito';
     const blocks = [
       para('p', [
         text('Calibri'),
@@ -189,7 +192,7 @@ describe('planFontFaces (face-aware single plan)', () => {
         text('Calibri', { bold: true, italic: true }),
       ]),
     ];
-    expect(keyset(planFontFaces(blocks, resolver, allFaces).requiredFaces)).toEqual(
+    expect(keyset(planFontFaces(blocks, resolver, cloneFaces).requiredFaces)).toEqual(
       new Set(['Carlito|400|normal', 'Carlito|700|normal', 'Carlito|400|italic', 'Carlito|700|italic']),
     );
   });

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/font-load-planner.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/fonts/font-load-planner.test.ts
@@ -196,4 +196,14 @@ describe('planFontFaces (face-aware single plan)', () => {
       new Set(['Carlito|400|normal', 'Carlito|700|normal', 'Carlito|400|italic', 'Carlito|700|italic']),
     );
   });
+
+  it('a quoted registered family produces a BARE required face (Calibri|..., not "Calibri"|...)', () => {
+    const resolver = createFontResolver();
+    // A run whose CSS family is quoted (`"Calibri"`) and whose real face is registered. The required
+    // face the gate awaits must be the bare `Calibri|400|normal`; a quoted `"Calibri"|400|normal` would
+    // re-quote in the probe and never match the registered face.
+    const registeredCalibri = (f: string) => f.replace(/^["']|["']$/g, '').toLowerCase() === 'calibri';
+    const reqs = planFontFaces([para('p', [text('"Calibri"')])], resolver, registeredCalibri).requiredFaces;
+    expect(keyset(reqs)).toEqual(new Set(['Calibri|400|normal']));
+  });
 });

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -116,8 +116,8 @@ export interface SuperDocFontsApi {
   /**
    * Map logical families to physical render families for the ACTIVE document, overriding bundled
    * defaults: `map({ Georgia: 'Gelasio', Arial: 'Liberation Sans' })`. Applies all entries, then
-   * re-measures and repaints once (a redundant map - a family mapped to itself, or to the target it
-   * already has - does neither); observe via {@link onReport} / `fonts-changed` (`source:
+   * re-measures and repaints once (a redundant map - a self-map, or a mapping identical to an
+   * already-stored override - does neither); observe via {@link onReport} / `fonts-changed` (`source:
    * 'config-change'`). Mapping a family to its bundled clone (`map({ Calibri: 'Carlito' })`) is honored
    * as an explicit PIN - stored so it outranks a registered real face for that family - not treated as
    * a no-op. Each physical family must be loadable - a bundled substitute, or a face added via `add`.

--- a/packages/superdoc/src/core/types/index.ts
+++ b/packages/superdoc/src/core/types/index.ts
@@ -116,10 +116,13 @@ export interface SuperDocFontsApi {
   /**
    * Map logical families to physical render families for the ACTIVE document, overriding bundled
    * defaults: `map({ Georgia: 'Gelasio', Arial: 'Liberation Sans' })`. Applies all entries, then
-   * re-measures and repaints once (a no-op map does neither); observe via {@link onReport} /
-   * `fonts-changed` (`source: 'config-change'`). Each physical family must be loadable - a bundled
-   * substitute, or a face added via `add`. Per document: other editors on the page are unaffected.
-   * Render-only - export keeps the logical family name.
+   * re-measures and repaints once (a redundant map - a family mapped to itself, or to the target it
+   * already has - does neither); observe via {@link onReport} / `fonts-changed` (`source:
+   * 'config-change'`). Mapping a family to its bundled clone (`map({ Calibri: 'Carlito' })`) is honored
+   * as an explicit PIN - stored so it outranks a registered real face for that family - not treated as
+   * a no-op. Each physical family must be loadable - a bundled substitute, or a face added via `add`.
+   * Per document: other editors on the page are unaffected. Render-only - export keeps the logical
+   * family name.
    * @throws Error if no editor is active (a write needs a document; this fails loudly, not silently).
    */
   map(mappings: Record<string, string>): void;

--- a/shared/font-system/src/registry.test.ts
+++ b/shared/font-system/src/registry.test.ts
@@ -307,3 +307,48 @@ describe('FontRegistry face-aware APIs', () => {
     expect(registry.getStatus('Broken')).toBe('failed');
   });
 });
+
+describe('hasFace oracle (provider-only, failure-aware, weight-bucketed)', () => {
+  it('a REGISTERED face answers hasFace; a merely-AWAITED unregistered family does NOT (Fix A)', async () => {
+    const fontSet = new FakeFontSet();
+    const { registry } = makeRegistry(fontSet);
+    registry.register({ family: 'Real', source: 'url(real.woff2)' });
+    expect(registry.hasFace('Real', '400', 'normal')).toBe(true);
+
+    // Awaiting an unregistered family tracks it for the status rollup, but it must NOT become a
+    // provider face - else an as_requested family would flip to registered_face after the first await.
+    await registry.awaitFaceRequest({ family: 'Ghost', weight: '400', style: 'normal' }, 1000);
+    expect(registry.hasFace('Ghost', '400', 'normal')).toBe(false);
+  });
+
+  it('a terminally FAILED registered face drops out of hasFace; a TIMED_OUT one does not (Fix 2a)', async () => {
+    const fontSet = new FakeFontSet();
+    const { registry, timer } = makeRegistry(fontSet);
+    registry.register({ family: 'Broken', source: 'url(broken.woff2)' });
+    registry.register({ family: 'Slow', source: 'url(slow.woff2)' });
+    expect(registry.hasFace('Broken', '400', 'normal')).toBe(true); // unloaded != failed
+    expect(registry.hasFace('Slow', '400', 'normal')).toBe(true);
+
+    fontSet.behaviors.set('Broken', 'reject');
+    await registry.awaitFaceRequest({ family: 'Broken', weight: '400', style: 'normal' }, 1000);
+    expect(registry.hasFace('Broken', '400', 'normal')).toBe(false); // failed -> ladder steps down to the clone
+
+    fontSet.behaviors.set('Slow', 'never');
+    const slow = registry.awaitFaceRequest({ family: 'Slow', weight: '400', style: 'normal' }, 1000);
+    timer.fire(); // -> timed_out
+    await slow;
+    expect(registry.hasFace('Slow', '400', 'normal')).toBe(true); // timed_out stays available (late-load recovers)
+  });
+
+  it('an off-bucket registered weight answers the bucket key AND builds the FontFace at that weight (Fix 4)', () => {
+    const fontSet = new FakeFontSet();
+    const { registry } = makeRegistry(fontSet);
+    registry.register({ family: 'Heavy', source: 'url(heavy.woff2)', descriptors: { weight: '500' } });
+    // 500 buckets to 400: it answers the 400 query, not 700.
+    expect(registry.hasFace('Heavy', '400', 'normal')).toBe(true);
+    expect(registry.hasFace('Heavy', '700', 'normal')).toBe(false);
+    // ...and the FontFace is built at the bucketed weight, so it renders 400 (not its true 500).
+    const face = fontSet.added.find((f) => f.family === 'Heavy') as unknown as { descriptors?: { weight?: string } };
+    expect(face?.descriptors?.weight).toBe('400');
+  });
+});

--- a/shared/font-system/src/registry.ts
+++ b/shared/font-system/src/registry.ts
@@ -160,8 +160,17 @@ export class FontRegistry {
   readonly #faceInflight = new Map<string, Promise<FontFaceLoadResult>>();
   /** Registered `url(...)` source per face key, to name the failing URL on a face load error. */
   readonly #faceSources = new Map<string, string>();
-  /** Face keys seen per normalized family, for the family-level status rollup. */
+  /** Face keys seen per normalized family, for the family-level status rollup. Populated by BOTH
+   *  registration AND awaiting (so getStatus rolls up the status of an awaited pass-through face). */
   readonly #facesByFamily = new Map<string, Set<string>>();
+  /**
+   * Face keys this registry actually REGISTERED as a provider (a bundled clone or a `fonts.add`/
+   * embedded face) - NOT faces that were merely awaited. This is the oracle {@link hasFace} consults:
+   * the resolver's provider-precedence ladder must answer "is there a registered face for this
+   * family|weight|style?", which is distinct from `#facesByFamily`'s "have we ever seen/awaited it?".
+   * Mixing the two would let a once-awaited `as_requested` family masquerade as a registered face.
+   */
+  readonly #providerFaceKeys = new Set<string>();
   /** Faces already warned about a load failure, so the warning fires at most once each. */
   readonly #warnedFaceFailures = new Set<string>();
 
@@ -207,7 +216,11 @@ export class FontRegistry {
       }
     }
     if (this.#FontFaceCtor && this.#fontSet) {
-      const face = new this.#FontFaceCtor(family, source, descriptors);
+      // Build the FontFace with the BUCKETED weight/style the key uses, not the raw descriptor. The
+      // face key is family|<400|700>|<normal|italic>, so an off-bucket descriptor (e.g. weight 500)
+      // would answer hasFace for the 400 key yet render at 500 - the run model is binary, so clamp the
+      // rendered face to the same bucket. Other descriptors (stretch, unicodeRange, display) pass through.
+      const face = new this.#FontFaceCtor(family, source, { ...descriptors, weight, style });
       this.#fontSet.add(face);
       this.#managed.set(family, face);
     }
@@ -217,6 +230,8 @@ export class FontRegistry {
       this.#sources.set(family, list);
     }
     if (!this.#status.has(family)) this.#status.set(family, 'unloaded');
+    // Record this as a PROVIDER face (the hasFace oracle), distinct from the await-tracking below.
+    this.#providerFaceKeys.add(key);
     // Seed face-level status so the gate can await this exact weight/style.
     this.#trackFace(family, key);
     if (!this.#faceStatus.has(key)) this.#faceStatus.set(key, 'unloaded');
@@ -263,16 +278,27 @@ export class FontRegistry {
   }
 
   /**
-   * Is a face (family + weight + style) REGISTERED/known in this registry, regardless of load
-   * state? The face-availability oracle the face-aware resolver consults to answer "does the
-   * physical family actually provide this face?" - so a single-face substitute is never mapped
-   * onto a weight/style it lacks (which the painter would faux-synthesize). Covers bundled faces
-   * (registered by `installBundledSubstitutes`) and customer `fonts.add()` faces alike, because
-   * both register through {@link register}. Distinct from {@link isAvailable}, which asks whether a
-   * face is LOADED right now; this asks only whether it EXISTS to be loaded.
+   * Is a face (family + weight + style) provided by a REGISTERED face that has not terminally failed
+   * to load? The face-availability oracle the face-aware resolver consults to answer "does the
+   * physical family actually provide this face?" - so a single-face substitute is never mapped onto a
+   * weight/style it lacks (which the painter would faux-synthesize). Covers bundled faces (registered
+   * by `installBundledSubstitutes`) and customer `fonts.add()` faces alike, because both register
+   * through {@link register}.
+   *
+   * Two deliberate exclusions:
+   *  - A merely-AWAITED face is not a provider. The oracle reads {@link #providerFaceKeys} (registration
+   *    only), NOT `#facesByFamily` (which the await path also populates for the status rollup), so an
+   *    `as_requested` family the gate once awaited does not masquerade as a registered face on the next
+   *    resolve.
+   *  - A face whose asset terminally FAILED to load is dropped, so the ladder steps down to the bundled
+   *    clone instead of committing forever to a broken registered face. `timed_out` is NOT excluded -
+   *    the late-load reflow still recovers a slow face, and demoting it would strand the real font.
+   *
+   * Distinct from {@link isAvailable}, which asks whether a face is LOADED right now.
    */
   hasFace(family: string, weight: '400' | '700', style: 'normal' | 'italic'): boolean {
-    return this.#facesByFamily.get(normalizeFamilyKey(family))?.has(faceKeyOf(family, weight, style)) ?? false;
+    const key = faceKeyOf(family, weight, style);
+    return this.#providerFaceKeys.has(key) && this.#faceStatus.get(key) !== 'failed';
   }
 
   /**

--- a/shared/font-system/src/report.test.ts
+++ b/shared/font-system/src/report.test.ts
@@ -155,6 +155,40 @@ describe('buildFaceReport (face-level)', () => {
     ]);
   });
 
+  it('a registered real face for the logical family reports registered_face, not the bundled substitute', () => {
+    const reg = new FaceRegistry();
+    // A document/customer registered real Calibri faces (vs the bundled Carlito clone).
+    reg.setFace('Calibri', '400', 'normal', 'loaded');
+    reg.setFace('Calibri', '700', 'normal', 'loaded');
+    const rows = buildFaceReport(
+      [
+        { logicalFamily: 'Calibri', weight: '400', style: 'normal' },
+        { logicalFamily: 'Calibri', weight: '700', style: 'normal' },
+      ],
+      reg.asRegistry(),
+    );
+    expect(rows).toEqual([
+      {
+        logicalFamily: 'Calibri',
+        physicalFamily: 'Calibri', // the real family, not Carlito
+        reason: 'registered_face',
+        loadStatus: 'loaded',
+        exportFamily: 'Calibri',
+        missing: false,
+        face: { weight: '400', style: 'normal' },
+      },
+      {
+        logicalFamily: 'Calibri',
+        physicalFamily: 'Calibri',
+        reason: 'registered_face',
+        loadStatus: 'loaded',
+        exportFamily: 'Calibri',
+        missing: false,
+        face: { weight: '700', style: 'normal' },
+      },
+    ]);
+  });
+
   it('uses per-FACE status: a failed Bold face does not make the loaded Regular row missing', () => {
     const reg = new FaceRegistry();
     reg.setFace('Carlito', '400', 'normal', 'loaded');

--- a/shared/font-system/src/report.test.ts
+++ b/shared/font-system/src/report.test.ts
@@ -107,6 +107,14 @@ class FaceRegistry {
     this.registered.add(this.#key(family, weight, style));
     this.faceStatuses.set(this.#key(family, weight, style), status);
   }
+  setAwaitedFaceStatus(
+    family: string,
+    weight: '400' | '700',
+    style: 'normal' | 'italic',
+    status: FontLoadStatus,
+  ): void {
+    this.faceStatuses.set(this.#key(family, weight, style), status);
+  }
   asRegistry(): FontRegistry {
     return this as unknown as FontRegistry;
   }
@@ -120,7 +128,7 @@ describe('buildFaceReport (face-level)', () => {
     // unregistered family can never report `loaded` (document.fonts.load resolves only registered
     // faces, not system fonts), so in production it settles to `fallback_used` - model that, not the
     // prior unrealistic `unloaded`.
-    reg.setFace('Georgia', '700', 'normal', 'fallback_used');
+    reg.setAwaitedFaceStatus('Georgia', '700', 'normal', 'fallback_used');
     const resolver = createFontResolver();
     resolver.map('Georgia', 'Gelasio');
     const rows = buildFaceReport(

--- a/shared/font-system/src/resolver.test.ts
+++ b/shared/font-system/src/resolver.test.ts
@@ -226,7 +226,14 @@ describe('FontResolver (per-document context)', () => {
 });
 
 describe('face-aware resolution (resolveFace / resolvePhysicalFamilyForFace)', () => {
-  const allFaces = () => true;
+  const norm = (f: string) => f.replace(/^["']|["']$/g, '').toLowerCase();
+  // Realistic registries: the bundled CLONE (Carlito) is registered but the logical Calibri is NOT -
+  // the normal bundled-substitute case. `registered` lets a test say a logical family has a real face.
+  const cloneFaces = (f: string) => norm(f) === 'carlito';
+  const registered = (...families: string[]) => {
+    const set = new Set(families.map(norm));
+    return (f: string) => set.has(norm(f));
+  };
   const regularOnly = (_f: string, w: '400' | '700', s: 'normal' | 'italic') => w === '400' && s === 'normal';
   const noFaces = () => false;
   const FACES = [
@@ -236,16 +243,70 @@ describe('face-aware resolution (resolveFace / resolvePhysicalFamilyForFace)', (
     { weight: '700', style: 'italic' },
   ] as const;
 
-  it('four-face clones substitute on EVERY face (unchanged vs family-level)', () => {
+  it('four-face clones substitute on EVERY face when the logical family is NOT registered', () => {
     const r = createFontResolver();
     for (const face of FACES) {
-      expect(r.resolveFace('Calibri', face, allFaces)).toEqual({
+      // Calibri has no registered real face; the bundled Carlito clone does -> bundled_substitute.
+      expect(r.resolveFace('Calibri', face, cloneFaces)).toEqual({
         logicalFamily: 'Calibri',
         physicalFamily: 'Carlito',
         reason: 'bundled_substitute',
       });
-      expect(r.resolvePhysicalFamilyForFace('Calibri, sans-serif', face, allFaces)).toBe('Carlito, sans-serif');
+      expect(r.resolvePhysicalFamilyForFace('Calibri, sans-serif', face, cloneFaces)).toBe('Carlito, sans-serif');
     }
+  });
+
+  it('a REGISTERED real face for the logical family wins over the bundled substitute (registered_face)', () => {
+    const r = createFontResolver();
+    // A customer fonts.add (later: an embedded document font) registered real Calibri faces.
+    for (const face of FACES) {
+      expect(r.resolveFace('Calibri', face, registered('Calibri'))).toEqual({
+        logicalFamily: 'Calibri',
+        physicalFamily: 'Calibri', // the real family, NOT Carlito
+        reason: 'registered_face',
+      });
+      // CSS stack is unchanged (the registered Calibri face renders), no swap to the clone.
+      expect(r.resolvePhysicalFamilyForFace('Calibri, sans-serif', face, registered('Calibri'))).toBe(
+        'Calibri, sans-serif',
+      );
+    }
+    // Per face: a registered Bold but Regular-only-clone family still prefers the real Bold.
+    expect(r.resolveFace('Calibri', { weight: '700', style: 'normal' }, registered('Calibri')).reason).toBe(
+      'registered_face',
+    );
+  });
+
+  it('an explicit fonts.map override wins over a registered real face', () => {
+    const r = createFontResolver();
+    r.map('Calibri', 'Tinos');
+    // Even though Calibri is registered, the explicit map to Tinos takes precedence (still face-aware).
+    expect(r.resolveFace('Calibri', { weight: '400', style: 'normal' }, registered('Calibri', 'Tinos'))).toEqual({
+      logicalFamily: 'Calibri',
+      physicalFamily: 'Tinos',
+      reason: 'custom_mapping',
+    });
+  });
+
+  it('when the mapped target lacks the face but the logical family is registered, use the real face (not missing)', () => {
+    const r = createFontResolver();
+    r.map('Calibri', 'Tinos'); // Tinos is Regular-only; real Calibri is registered for every face.
+    const hasFace = (f: string, w: '400' | '700', s: 'normal' | 'italic') => {
+      if (norm(f) === 'calibri') return true; // real Calibri: all faces
+      if (norm(f) === 'tinos') return w === '400' && s === 'normal'; // Tinos: Regular only
+      return false;
+    };
+    // Regular: the explicit map to Tinos applies (Tinos has Regular).
+    expect(r.resolveFace('Calibri', { weight: '400', style: 'normal' }, hasFace)).toMatchObject({
+      physicalFamily: 'Tinos',
+      reason: 'custom_mapping',
+    });
+    // Bold: Tinos lacks it, but real Calibri Bold is registered -> render the real face, NOT a
+    // fallback_face_absent that would be reported missing.
+    expect(r.resolveFace('Calibri', { weight: '700', style: 'normal' }, hasFace)).toEqual({
+      logicalFamily: 'Calibri',
+      physicalFamily: 'Calibri',
+      reason: 'registered_face',
+    });
   });
 
   it('single-face substitute: maps the provided face, passes other faces through (fallback_face_absent)', () => {

--- a/shared/font-system/src/resolver.test.ts
+++ b/shared/font-system/src/resolver.test.ts
@@ -355,4 +355,39 @@ describe('face-aware resolution (resolveFace / resolvePhysicalFamilyForFace)', (
       reason: 'as_requested',
     });
   });
+
+  it('strips surrounding quotes from a quoted registered family (registered_face returns the bare family)', () => {
+    const r = createFontResolver();
+    // A quoted CSS primary for a registered real Calibri: physicalFamily MUST be the bare 'Calibri'
+    // (case preserved), not '"Calibri"'. Otherwise the load/preload probe (faceProbe -> quoteFamily)
+    // quotes it again and the browser probes a literal "Calibri" that never matches the registered face.
+    expect(r.resolveFace('"Calibri", sans-serif', { weight: '400', style: 'normal' }, registered('Calibri'))).toEqual({
+      logicalFamily: '"Calibri", sans-serif',
+      physicalFamily: 'Calibri',
+      reason: 'registered_face',
+    });
+    // The CSS paint variant KEEPS the quoted stack (valid CSS); measure awaits the bare family above.
+    expect(
+      r.resolvePhysicalFamilyForFace(
+        '"Calibri", sans-serif',
+        { weight: '400', style: 'normal' },
+        registered('Calibri'),
+      ),
+    ).toBe('"Calibri", sans-serif');
+  });
+
+  it('strips quotes for as_requested and fallback_face_absent structured returns (case preserved)', () => {
+    const r = createFontResolver();
+    // as_requested: no provider; the bare, case-preserved family passes through.
+    expect(r.resolveFace('"Aptos"', { weight: '400', style: 'normal' }, noFaces)).toMatchObject({
+      physicalFamily: 'Aptos',
+      reason: 'as_requested',
+    });
+    // fallback_face_absent: a mapped substitute that cannot supply the face -> the bare logical family.
+    r.map('Georgia', 'Some System Font'); // unregistered target (noFaces) -> override known but no face
+    expect(r.resolveFace('"Georgia"', { weight: '400', style: 'normal' }, noFaces)).toMatchObject({
+      physicalFamily: 'Georgia',
+      reason: 'fallback_face_absent',
+    });
+  });
 });

--- a/shared/font-system/src/resolver.test.ts
+++ b/shared/font-system/src/resolver.test.ts
@@ -98,27 +98,37 @@ describe('FontResolver (per-document context)', () => {
     expect(resolver.resolvePrimaryPhysicalFamily('Georgia')).toBe('Georgia'); // reverted to identity
   });
 
-  it('mapping a family to its DEFAULT physical drops any override instead of recording a redundant one', () => {
+  it('identity self-map is a no-op, but an explicit pin to the bundled clone is a STORED override', () => {
+    const norm = (f: string) => f.replace(/^["']|["']$/g, '').toLowerCase();
+    const registeredBoth = (f: string) => norm(f) === 'calibri' || norm(f) === 'carlito';
     const resolver = createFontResolver();
 
-    // Override away from the bundled default, then map back TO the bundled default.
-    resolver.map('Calibri', 'Tinos');
-    expect(resolver.version).toBe(1);
-    expect(resolver.signature).not.toBe('');
-    resolver.map('Calibri', 'Carlito'); // Carlito IS Calibri's bundled default
-    expect(resolver.resolvePrimaryPhysicalFamily('Calibri')).toBe('Carlito');
-    expect(resolver.version).toBe(2); // removing the override is a real change
-    expect(resolver.signature).toBe(''); // back to the shared default, not '[["calibri","Carlito"]]'
-
-    // Mapping to the default with no existing override is a pure no-op (no bump, no signature).
-    resolver.map('Cambria', 'Caladea'); // Caladea IS Cambria's bundled default
-    expect(resolver.version).toBe(2);
-    expect(resolver.signature).toBe('');
-
-    // Identity: mapping a non-substituted family to its own name is also a no-op.
+    // Identity self-map (and a quoted/cased variant of it) is the ABSENCE of an override: dropped, so
+    // the document keeps the shareable empty signature.
     resolver.map('Georgia', 'Georgia');
-    expect(resolver.version).toBe(2);
+    resolver.map('"Georgia"', 'Georgia');
+    expect(resolver.version).toBe(0);
     expect(resolver.signature).toBe('');
+
+    // Mapping to the bundled CLONE is an explicit PIN, not a no-op (after provider precedence a
+    // registered real Calibri would otherwise outrank the clone). It is stored as a custom_mapping.
+    resolver.map('Calibri', 'Carlito');
+    expect(resolver.signature).not.toBe('');
+    expect(resolver.resolveFontFamily('Calibri')).toEqual({
+      logicalFamily: 'Calibri',
+      physicalFamily: 'Carlito',
+      reason: 'custom_mapping',
+    });
+    // The pin wins even when a real Calibri face is registered (custom_mapping > registered_face).
+    expect(resolver.resolveFace('Calibri', { weight: '400', style: 'normal' }, registeredBoth)).toMatchObject({
+      physicalFamily: 'Carlito',
+      reason: 'custom_mapping',
+    });
+
+    // unmap reverts to normal provider precedence (back to the shareable empty signature).
+    resolver.unmap('Calibri');
+    expect(resolver.signature).toBe('');
+    expect(resolver.resolvePrimaryPhysicalFamily('Calibri')).toBe('Carlito');
   });
 
   it('isolates mappings per instance: two documents map the same logical family differently', () => {

--- a/shared/font-system/src/resolver.ts
+++ b/shared/font-system/src/resolver.ts
@@ -26,6 +26,13 @@
 export type FontResolutionReason =
   /** No substitute is known; the requested family is used as-is. */
   | 'as_requested'
+  /**
+   * The logical family ITSELF has a registered real face for this weight/style (a customer
+   * `fonts.add`, or - later - an embedded document font), so SuperDoc intentionally rendered the
+   * real family and bypassed the bundled substitute. Higher precedence than `bundled_substitute`,
+   * lower than an explicit `custom_mapping`. Only the face-aware path yields this.
+   */
+  | 'registered_face'
   /** Replaced by a bundled metric-compatible clone. */
   | 'bundled_substitute'
   /** Replaced by a runtime mapping set on this document's resolver (customer `fonts.map`). */
@@ -194,6 +201,49 @@ export class FontResolver {
   }
 
   /**
+   * The provider-precedence ladder for a bare PRIMARY family + face, consulting `hasFace` (the
+   * registry's registered-face oracle):
+   *   1. explicit `fonts.map` override  -> custom_mapping  (if the override provides the face)
+   *   2. a registered real face for the logical family itself (customer `fonts.add` / embedded)
+   *      -> registered_face  (so SuperDoc renders the real family instead of the bundled clone)
+   *   3. bundled metric-compatible substitute -> bundled_substitute  (if it provides the face)
+   *   4. otherwise as_requested (no provider) - or fallback_face_absent when an override/substitute
+   *      WAS known but lacked the face, so a single-face clone is never faux-styled.
+   * `physical === primary` (no swap) for registered_face / as_requested / fallback_face_absent.
+   */
+  #resolveFaceLadder(
+    primary: string,
+    face: FaceKey,
+    hasFace: HasFace,
+  ): { physical: string; reason: FontResolutionReason } {
+    const key = normalizeFamilyKey(primary);
+    const override = this.#overrides.get(key);
+    // 1. explicit `fonts.map` override - but only when the mapped family can actually supply this
+    //    face. An override that lacks the face does NOT short-circuit: a registered real face for the
+    //    logical family (or the bundled clone) can still render it faithfully, and reporting it
+    //    fallback_face_absent/missing when a loadable face exists would be a false diagnostic.
+    if (override && hasFace(override, face.weight, face.style)) {
+      return { physical: override, reason: 'custom_mapping' };
+    }
+    // 2. a registered real face for the logical family itself (customer `fonts.add` / embedded).
+    if (hasFace(primary, face.weight, face.style)) {
+      return { physical: primary, reason: 'registered_face' };
+    }
+    // 3. bundled metric-compatible substitute.
+    const bundled = BUNDLED_SUBSTITUTES[key];
+    if (bundled && hasFace(bundled, face.weight, face.style)) {
+      return { physical: bundled, reason: 'bundled_substitute' };
+    }
+    // 4. a configured provider (an override or a bundled clone) was known but none could supply this
+    //    face: pass the logical family through, reported non-metric, never faux-styled.
+    if (override || bundled) {
+      return { physical: primary, reason: 'fallback_face_absent' };
+    }
+    // 5. no provider at all: render the requested family as-is (browser/system fallback).
+    return { physical: primary, reason: 'as_requested' };
+  }
+
+  /**
    * Structured resolution of a logical family (or CSS stack) to its bare physical render
    * family. The primary (first) family drives the result; this is what the load gate
    * awaits and what diagnostics report.
@@ -229,13 +279,8 @@ export class FontResolver {
   resolveFace(logicalFamily: string, face: FaceKey, hasFace: HasFace): FontResolution {
     const parts = splitStack(logicalFamily);
     const primary = parts[0] ?? logicalFamily;
-    const { physical, reason } = this.#physicalFor(primary);
-    if (reason === 'as_requested') return { logicalFamily, physicalFamily: physical, reason };
-    if (hasFace(physical, face.weight, face.style)) return { logicalFamily, physicalFamily: physical, reason };
-    // The substitute lacks this face: do NOT map it (the painter would faux-style it). Pass the
-    // logical family through so the normal fallback chain (customer/embedded/system -> generic)
-    // applies, and report it non-metric.
-    return { logicalFamily, physicalFamily: primary, reason: 'fallback_face_absent' };
+    const { physical, reason } = this.#resolveFaceLadder(primary, face, hasFace);
+    return { logicalFamily, physicalFamily: physical, reason };
   }
 
   /**
@@ -249,10 +294,14 @@ export class FontResolver {
     if (!cssFontFamily) return cssFontFamily;
     const parts = splitStack(cssFontFamily);
     if (parts.length === 0) return cssFontFamily;
-    const { physical, reason } = this.#physicalFor(parts[0]);
-    if (reason === 'as_requested') return cssFontFamily;
-    if (!hasFace(physical, face.weight, face.style)) return cssFontFamily;
-    return [physical, ...parts.slice(1)].join(', ');
+    const { physical, reason } = this.#resolveFaceLadder(parts[0], face, hasFace);
+    // Swap the primary to the physical ONLY when a substitute/override actually applies. For
+    // registered_face / as_requested / fallback_face_absent the physical IS the logical family, so
+    // keep the original stack (the registered real face or the browser fallback renders it).
+    if (reason === 'custom_mapping' || reason === 'bundled_substitute') {
+      return [physical, ...parts.slice(1)].join(', ');
+    }
+    return cssFontFamily;
   }
 
   /**

--- a/shared/font-system/src/resolver.ts
+++ b/shared/font-system/src/resolver.ts
@@ -130,6 +130,10 @@ export class FontResolver {
    * Map a logical family to a physical render family for this document, overriding the
    * bundled default (e.g. "Georgia" -> "Gelasio", or a customer family -> their font).
    * The physical family must be one the registry can load.
+   *
+   * A self-map (`map('Georgia', 'Georgia')`, normalized) is the absence of an override and is dropped.
+   * Mapping to the bundled clone (`map('Calibri', 'Carlito')`) is NOT a no-op: it is stored as an
+   * explicit pin so it outranks a registered real face for that family (`custom_mapping` > `registered_face`).
    */
   map(logicalFamily: string, physicalFamily: string): void {
     const key = normalizeFamilyKey(logicalFamily);

--- a/shared/font-system/src/resolver.ts
+++ b/shared/font-system/src/resolver.ts
@@ -90,6 +90,19 @@ function normalizeFamilyKey(family: string): string {
     .toLowerCase();
 }
 
+/**
+ * Strip surrounding quotes from a family name, PRESERVING case, so a STRUCTURED resolution returns a
+ * bare load/report family - a quoted CSS primary like `"Calibri"` becomes `Calibri`. Without this, a
+ * quoted family that resolves to `registered_face` returns `"Calibri"`, which the load/preload probe
+ * (`faceProbe` -> `quoteFamily`) quotes AGAIN, so the browser probes a literal `"Calibri"` and never
+ * matches the registered face (a false fallback + reflow). Distinct from {@link normalizeFamilyKey},
+ * which lowercases for KEYING; here the rendered/reported family must keep its case. The CSS paint
+ * paths intentionally keep the quotes (a quoted stack is valid CSS).
+ */
+function stripFamilyQuotes(family: string): string {
+  return family.trim().replace(/^["']|["']$/g, '');
+}
+
 /** Split a CSS font-family value into trimmed, non-empty families (primary first). */
 function splitStack(cssFontFamily: string): string[] {
   return cssFontFamily
@@ -252,7 +265,9 @@ export class FontResolver {
     const parts = splitStack(logicalFamily);
     const primary = parts[0] ?? logicalFamily;
     const { physical, reason } = this.#physicalFor(primary);
-    return { logicalFamily, physicalFamily: physical, reason };
+    // physicalFamily is a bare load/report family, never a CSS token: strip quotes a quoted primary
+    // carried through (as_requested). No-op for the already-bare substitute/override names.
+    return { logicalFamily, physicalFamily: stripFamilyQuotes(physical), reason };
   }
 
   /**
@@ -280,7 +295,11 @@ export class FontResolver {
     const parts = splitStack(logicalFamily);
     const primary = parts[0] ?? logicalFamily;
     const { physical, reason } = this.#resolveFaceLadder(primary, face, hasFace);
-    return { logicalFamily, physicalFamily: physical, reason };
+    // physicalFamily is a bare load/report family (the gate awaits it via faceProbe, which re-quotes):
+    // strip quotes off a quoted primary carried through for registered_face / fallback_face_absent /
+    // as_requested, so the probe matches the registered face instead of a literal "Calibri". The CSS
+    // paint variant (resolvePhysicalFamilyForFace) keeps the quoted stack. No-op for substitute names.
+    return { logicalFamily, physicalFamily: stripFamilyQuotes(physical), reason };
   }
 
   /**

--- a/shared/font-system/src/resolver.ts
+++ b/shared/font-system/src/resolver.ts
@@ -138,14 +138,21 @@ export class FontResolver {
     const physical = physicalFamily?.trim();
     if (!key || !physical) return;
     if (this.#overrides.get(key) === physical) return;
-    // Mapping a family to the physical it resolves to by DEFAULT - its bundled substitute, or its
-    // own name when there is none - is the ABSENCE of an override, not an override to record.
-    // Storing it would leave a non-empty signature that permanently de-opts this document's cache
-    // sharing (a non-empty signature never re-shares with default documents). So treat it as an
-    // unmap: drop any existing override (reverting to the default) and bump only if that removed
-    // one. This makes `map({ Calibri: 'Carlito' })` a true no-op whether Calibri was unmapped or
-    // previously pointed elsewhere (e.g. ->Tinos), restoring shared-cache eligibility either way.
-    if ((BUNDLED_SUBSTITUTES[key] ?? logicalFamily.trim()) === physical) {
+    // Mapping a family to its OWN name (identity, e.g. `map({ Georgia: 'Georgia' })`) is the ABSENCE
+    // of an override, not one to record: drop any existing override and revert to the default. Use
+    // `unmap()` to revert other mappings.
+    //
+    // Mapping to the bundled CLONE (e.g. `map({ Calibri: 'Carlito' })`) is NOT treated as a no-op,
+    // unlike before provider precedence. A registered real Calibri now outranks the clone via
+    // `registered_face`, so an explicit pin to the clone is semantically distinct from the default and
+    // must be STORED as a real override - else `custom_mapping` could never beat a registered face and
+    // the pin would be silently ignored. The cost is a non-empty signature (this document stops sharing
+    // the measure cache with default documents), accepted for an explicit pin.
+    //
+    // Identity is compared with the resolver's family normalization (quote-strip + lowercase), so a
+    // quoted/cased self-map (`map('"Georgia"', 'Georgia')`) is still recognized as identity and dropped,
+    // not stored as a spurious override.
+    if (key === normalizeFamilyKey(physical)) {
       if (this.#overrides.delete(key)) {
         this.#version += 1;
         this.#cachedSignature = null;

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -16,6 +16,7 @@ export default defineConfig({
     projects: [
       './packages/super-editor',
       './packages/superdoc',
+      './shared/font-system',
       './packages/ai',
       './packages/collaboration-yjs',
       './packages/layout-engine/contracts',


### PR DESCRIPTION
Makes the per-document font resolver prefer a real registered face for a logical family over the bundled metric-compatible clone. Before this, a document that registered a real Calibri via `fonts.add` still rendered Carlito unless the user explicitly mapped around it.

The face-aware resolution now follows one precedence ladder, applied per face:

- explicit `fonts.map` override — when the mapped family actually provides the face
- a registered real face for the logical family (`registered_face`)
- bundled metric-compatible substitute
- pass through (`fallback_face_absent`) when a provider was configured but none could supply the face
- otherwise as requested

A subtle case the ladder fixes: if you map `Calibri -> Tinos`, Tinos lacks Bold, and a real Calibri Bold is registered, the resolver now renders the real Calibri Bold (`registered_face`) instead of reporting it missing. The override only consumes a face it can supply; otherwise the rest of the ladder still applies.

Adds the public `FontResolutionReason` value `registered_face` so the report distinguishes "rendered the real registered font" from a bundled substitute or a browser fallback. `preload` follows the same precedence, so it loads the real family rather than the clone.

Embedded DOCX fonts are **not** registered with the font system yet — the converter still injects them as `@font-face` CSS — so this PR changes precedence only for already-registered faces (`fonts.add`). Making embedded fonts first-class registry entries (with object-URL lifecycle and licensing handling) is a separate follow-up that will then flow through this same ladder.
