### PR TITLE
chore: add Pickled coverage

### DIFF
--- a/.github/workflows/pickled.yml
+++ b/.github/workflows/pickled.yml
@@ -1,0 +1,74 @@
+name: Pickled
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - pickled.yml
+      - fixtures/pickled/**
+      - .github/workflows/pickled.yml
+      - AGENTS.md
+      - apps/docs/llms.txt
+      - apps/docs/llms-full.txt
+      - packages/react/README.md
+      - packages/document-api/README.md
+      - apps/mcp/README.md
+      - apps/cli/README.md
+      - packages/superdoc/scripts/README.md
+  workflow_dispatch:
+    inputs:
+      max_cells:
+        description: Max Pickled cells for real-agent jobs
+        required: false
+        default: "12"
+
+concurrency:
+  group: pickled-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  deterministic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Calibrate answer examples
+        run: bunx @pickled-dev/cli test .
+
+      - name: Plan question cells
+        run: bunx @pickled-dev/cli check . --plan
+
+      - name: Plan build cells
+        run: bunx @pickled-dev/cli build . --plan
+
+  real-agent:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY_PICKLED: ${{ secrets.ANTHROPIC_API_KEY_PICKLED }}
+      ANTHROPIC_API_KEY_DEFAULT: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Check secret availability
+        run: |
+          if [ -n "${ANTHROPIC_API_KEY_PICKLED:-}" ]; then
+            echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY_PICKLED}" >> "$GITHUB_ENV"
+          elif [ -n "${ANTHROPIC_API_KEY_DEFAULT:-}" ]; then
+            echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY_DEFAULT}" >> "$GITHUB_ENV"
+          else
+            echo "::error::ANTHROPIC_API_KEY_PICKLED or ANTHROPIC_API_KEY is required for real-agent Pickled runs"
+            exit 1
+          fi
+
+      - name: Run real-agent questions
+        run: bunx @pickled-dev/cli check . --max-cells "${{ github.event.inputs.max_cells || '12' }}"
+
+      - name: Run real-agent builds
+        run: bunx @pickled-dev/cli build . --max-cells 4

--- a/fixtures/pickled/public-check-script.solution.patch
+++ b/fixtures/pickled/public-check-script.solution.patch
@@ -1,0 +1,11 @@
+diff --git a/scripts/check-public-surface.sh b/scripts/check-public-surface.sh
+new file mode 100755
+index 0000000..d6c3a11
+--- /dev/null
++++ b/scripts/check-public-surface.sh
+@@ -0,0 +1,5 @@
++#!/usr/bin/env bash
++set -euo pipefail
++
++pnpm check:public
++pnpm check:types

--- a/fixtures/pickled/public-check-script/README.md
+++ b/fixtures/pickled/public-check-script/README.md
@@ -1,0 +1,9 @@
+# Public check script fixture
+
+Create `scripts/check-public-surface.sh`.
+
+The script should run the non-mutating public-surface checks used before
+reviewing API or package export changes.
+
+This fixture is incomplete on purpose. Do not answer with instructions only.
+Edit the workspace by creating `scripts/check-public-surface.sh`.

--- a/fixtures/pickled/public-check-script/package.json
+++ b/fixtures/pickled/public-check-script/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pickled-public-check-script-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/pickled/public-check-script/tests/verify-public-check-script.sh
+++ b/fixtures/pickled/public-check-script/tests/verify-public-check-script.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test -f scripts/check-public-surface.sh
+test -x scripts/check-public-surface.sh
+
+grep -Fq "set -euo pipefail" scripts/check-public-surface.sh
+grep -Fq "pnpm check:public" scripts/check-public-surface.sh
+grep -Fq "pnpm check:types" scripts/check-public-surface.sh
+
+if grep -Eq "pnpm (run )?test|generate:|generate:all" scripts/check-public-surface.sh; then
+  echo "public-surface helper must not run unit tests or mutating generate commands" >&2
+  exit 1
+fi

--- a/fixtures/pickled/react-editor.solution.patch
+++ b/fixtures/pickled/react-editor.solution.patch
@@ -1,0 +1,22 @@
+diff --git a/src/ContractEditor.tsx b/src/ContractEditor.tsx
+new file mode 100644
+index 0000000..35c895d
+--- /dev/null
++++ b/src/ContractEditor.tsx
+@@ -0,0 +1,16 @@
++import { SuperDocEditor } from '@superdoc-dev/react';
++import '@superdoc-dev/react/style.css';
++
++export interface ContractEditorProps {
++  file: File;
++}
++
++export function ContractEditor({ file }: ContractEditorProps) {
++  return (
++    <SuperDocEditor
++      document={file}
++      documentMode="editing"
++      onReady={({ superdoc }) => console.log('Ready', superdoc)}
++    />
++  );
++}

--- a/fixtures/pickled/react-editor/README.md
+++ b/fixtures/pickled/react-editor/README.md
@@ -1,0 +1,11 @@
+# React editor fixture
+
+Create `src/ContractEditor.tsx`.
+
+The file should export a React component that accepts a `file: File` prop and
+renders SuperDoc with the React wrapper.
+
+Use `@superdoc-dev/react`, not the core `superdoc` package.
+
+This fixture is incomplete on purpose. Do not answer with instructions only.
+Edit the workspace by creating `src/ContractEditor.tsx`.

--- a/fixtures/pickled/react-editor/package.json
+++ b/fixtures/pickled/react-editor/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pickled-react-editor-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/pickled/react-editor/tests/verify-react-editor.sh
+++ b/fixtures/pickled/react-editor/tests/verify-react-editor.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test -f src/ContractEditor.tsx
+
+grep -Fq "SuperDocEditor" src/ContractEditor.tsx
+grep -Fq "@superdoc-dev/react" src/ContractEditor.tsx
+grep -Fq "@superdoc-dev/react/style.css" src/ContractEditor.tsx
+grep -Fq "document={file}" src/ContractEditor.tsx
+grep -Eq "documentMode=['\"]editing['\"]" src/ContractEditor.tsx
+grep -Fq "onReady" src/ContractEditor.tsx
+
+if grep -Eq "from ['\"]superdoc['\"]" src/ContractEditor.tsx; then
+  echo "React wrapper fixture must not import from core superdoc directly" >&2
+  exit 1
+fi
+
+if grep -Eq "documentMode=['\"](edit|view|suggest)['\"]" src/ContractEditor.tsx; then
+  echo "unsupported documentMode name" >&2
+  exit 1
+fi

--- a/pickled.yml
+++ b/pickled.yml
@@ -1,0 +1,334 @@
+# yaml-language-server: $schema=https://pickled.dev/schema/pickled.schema.json
+
+schemaVersion: 2
+
+product:
+  name: SuperDoc
+  description: Document engine for rendering, editing, and automating DOCX files.
+
+sources:
+  public_llms: { path: ./apps/docs/llms.txt }
+  public_full: { path: ./apps/docs/llms-full.txt }
+  root_agents: { path: ./AGENTS.md }
+  superdoc_readme: { path: ./packages/superdoc/README.md }
+  react_readme: { path: ./packages/react/README.md }
+  document_api_readme: { path: ./packages/document-api/README.md }
+  mcp_readme: { path: ./apps/mcp/README.md }
+  cli_readme: { path: ./apps/cli/README.md }
+  public_checks: { path: ./packages/superdoc/scripts/README.md }
+
+agents:
+  quick:
+    provider: claude-code
+    model: claude-haiku-4-5
+    maxTurns: 5
+  builder:
+    provider: claude-code
+    model: claude-sonnet-4-5
+    maxTurns: 30
+
+contexts:
+  memory: { mode: memory }
+  given_public: { mode: inject, source: public_llms }
+  given_public_full: { mode: inject, source: public_full }
+  given_agents: { mode: inject, source: root_agents }
+  given_superdoc_readme: { mode: inject, source: superdoc_readme }
+  given_react: { mode: inject, source: react_readme }
+  given_document_api: { mode: inject, source: document_api_readme }
+  given_mcp: { mode: inject, source: mcp_readme }
+  given_cli: { mode: inject, source: cli_readme }
+  given_public_checks: { mode: inject, source: public_checks }
+
+facts:
+  react_install:
+    statement: React apps install @superdoc-dev/react, which includes superdoc.
+    match:
+      allOf: ["@superdoc-dev/react"]
+      anyOf: ["included as a dependency", "includes superdoc", "includes `superdoc`", "no need to install it separately"]
+  react_embed:
+    statement: React embedding uses SuperDocEditor, the React stylesheet, document, and documentMode.
+    match:
+      allOf: ["SuperDocEditor", "@superdoc-dev/react/style.css", "document", "documentMode"]
+  vanilla_embed:
+    statement: Vanilla embedding uses superdoc, SuperDoc, the core stylesheet, selector, and document.
+    match:
+      allOf: ["superdoc", "SuperDoc", "superdoc/style.css", "selector", "document"]
+  document_modes:
+    statement: Names the supported document modes.
+    match:
+      allOf: ["editing", "viewing", "suggesting"]
+  create_agents:
+    statement: The create package writes app-specific AGENTS.md.
+    match:
+      allOf: ["npx @superdoc-dev/create", "AGENTS.md"]
+  mcp_setup:
+    statement: Claude Code MCP setup uses the SuperDoc MCP package.
+    match:
+      allOf: ["claude mcp add superdoc -- npx @superdoc-dev/mcp"]
+  mcp_workflow:
+    statement: MCP work opens a session, reads or searches, applies intent tools, saves, and closes.
+    match:
+      allOf: ["superdoc_open", "superdoc_save", "superdoc_close"]
+      anyOf: ["superdoc_get_content", "superdoc_search"]
+  mcp_local:
+    statement: MCP runs locally over stdio.
+    match:
+      allOf: ["stdio"]
+      anyOf: ["local", "subprocess"]
+  docapi_four_files:
+    statement: Adding a Document API operation touches the contract definition, registry, invoke table, and implementation.
+    match:
+      allOf: ["operation-definitions.ts", "operation-registry.ts", "invoke.ts"]
+      anyOf: ["src/index.ts", "DocumentApi", "implementation"]
+  docapi_generate:
+    statement: Document API contract changes require generated outputs.
+    match:
+      anyOf: ["pnpm run generate:all", "pnpm run docapi:sync", "pnpm run docapi:sync:check"]
+  docapi_generated:
+    statement: Derived maps and reference docs must not be hand-edited.
+    match:
+      allOf: ["COMMAND_CATALOG", "OPERATION_MEMBER_PATH_MAP", "OPERATION_REFERENCE_DOC_PATH_MAP"]
+      anyOf: ["do not edit", "Do not hand-edit", "derived"]
+  rendering_pipeline:
+    statement: Describes the SuperDoc rendering pipeline.
+    match:
+      allOf: ["super-converter", "layout-adapter", "FlowBlock", "layout-engine", "ResolvedLayout", "DomPainter"]
+  style_boundary:
+    statement: Converter stores raw OOXML and style-engine resolves formatting at render time.
+    match:
+      allOf: ["raw OOXML", "style-engine"]
+      anyOf: ["render time", "resolves"]
+  painter_boundary:
+    statement: DomPainter owns final DOM rendering and static visuals should not use PM decorations.
+    match:
+      allOf: ["DomPainter"]
+      anyOf: ["Do not style static document content with ProseMirror decorations", "PM decorations"]
+  public_check:
+    statement: Public surface work should use pnpm check:public and narrower public checks.
+    match:
+      allOf: ["pnpm check:public", "pnpm check:public:superdoc", "pnpm check:public:docapi"]
+  command_vocabulary:
+    statement: check commands do not mutate, generate commands mutate, report commands are read-only.
+    match:
+      allOf: ["check:*", "generate:*", "report:*"]
+      anyOf: ["non-mutating", "mutate", "read-only"]
+  type_check:
+    statement: pnpm check:types is the raw TypeScript project build.
+    match:
+      allOf: ["pnpm check:types"]
+      anyOf: ["TypeScript", "tsc"]
+  document_api_layer:
+    statement: Programmatic document mutations use the Document API.
+    match:
+      allOf: ["Document API", "editor.doc"]
+      anyOf: ["programmatic", "mutations", "document mutation"]
+  custom_ui_layer:
+    statement: Custom React UI uses superdoc/ui/react hooks.
+    match:
+      allOf: ["superdoc/ui/react"]
+      anyOf: ["custom React UI", "useSuperDocCommand", "useSuperDocComments", "useSuperDocTrackChanges", "useSuperDocSelection"]
+  built_in_modules:
+    statement: Built-in modules are for SuperDoc-rendered UI.
+    match:
+      allOf: ["modules"]
+      anyOf: ["built-in", "SuperDoc renders the UI", "built-in UI"]
+  cli_open_save_close:
+    statement: CLI document workflows open a file, save changes, and close the session.
+    match:
+      allOf: ["superdoc open", "superdoc save", "superdoc close"]
+  cli_query_match:
+    statement: CLI mutations should use query match with JSON selectors and explicit match requirements.
+    match:
+      allOf: ["superdoc query match", "--select-json", "--require exactlyOne"]
+  cli_find_discovery:
+    statement: CLI find is discovery-grade and query match returns mutation-grade addresses.
+    match:
+      allOf: ["find", "discovery", "query match"]
+      anyOf: ["mutation-grade", "target"]
+
+misstatements:
+  wrong_modes:
+    statement: Uses unsupported document mode names.
+    match:
+      anyOf: ["documentMode: 'edit'", "documentMode: 'view'", "documentMode: 'suggest'"]
+  mcp_cloud:
+    statement: Claims MCP uploads documents to a SuperDoc cloud service.
+    match:
+      anyOf: ["uploads documents to SuperDoc cloud before editing", "upload the document to SuperDoc cloud before editing"]
+  edit_generated_docapi:
+    statement: Tells agents to hand-edit generated Document API maps or docs.
+    match:
+      anyOf: ["edit COMMAND_CATALOG", "hand-edit COMMAND_CATALOG", "hand-editing COMMAND_CATALOG", "edit OPERATION_MEMBER_PATH_MAP", "edit OPERATION_REFERENCE_DOC_PATH_MAP"]
+  pm_visuals:
+    statement: Tells agents to render static document visuals with ProseMirror decorations.
+    match:
+      anyOf: ["use ProseMirror decorations for static document visuals", "render static document content with PM decorations"]
+  active_editor_commands:
+    statement: Recommends activeEditor.commands for new programmatic mutations.
+    match:
+      anyOf: ["use superdoc.activeEditor.commands instead of editor.doc", "use activeEditor.commands for new programmatic mutations"]
+  generate_as_check:
+    statement: Treats generate commands as read-only checks.
+    match:
+      anyOf: ["generate:* commands are non-mutating", "pnpm run generate:all is read-only", "generate:all does not mutate"]
+  find_for_mutation:
+    statement: Uses find output directly as a mutation target.
+    match:
+      anyOf: ["use find output for mutations", "pass find results to replace", "find returns mutation targets"]
+
+questions:
+  - id: react_embed
+    question: How should I embed SuperDoc in a React app, and what package and CSS imports matter?
+    agents: [quick]
+    contexts: [given_react]
+    expects: [react_install, react_embed, document_modes]
+    rejects: [wrong_modes]
+    examples:
+      pass:
+        - "For React, install `@superdoc-dev/react`; `superdoc` is included as a dependency. Import `SuperDocEditor` and `@superdoc-dev/react/style.css`, then pass `document` and `documentMode`. Modes are editing, viewing, and suggesting."
+      fail:
+        - "Use `documentMode: 'edit'` and skip the stylesheet."
+
+  - id: vanilla_embed
+    question: How should I embed SuperDoc in a vanilla JavaScript app?
+    agents: [quick]
+    contexts: [given_public_full, given_superdoc_readme]
+    expects: [vanilla_embed, document_modes]
+    rejects: [wrong_modes]
+    examples:
+      pass:
+        - "Install `superdoc`, import `SuperDoc` from `superdoc`, import `superdoc/style.css`, then create `new SuperDoc({ selector: '#editor', document: file, documentMode: 'editing' })`. Modes are editing, viewing, and suggesting."
+      fail:
+        - "Use `documentMode: 'view'` and leave out the CSS import."
+
+  - id: mcp_session_workflow
+    question: How do I set up SuperDoc MCP for an AI coding agent, and what is the session workflow?
+    agents: [quick]
+    contexts: [given_mcp]
+    expects: [mcp_setup, mcp_workflow, mcp_local]
+    rejects: [mcp_cloud]
+    examples:
+      pass:
+        - "For Claude Code, run `claude mcp add superdoc -- npx @superdoc-dev/mcp`. The MCP server runs locally over stdio as a subprocess. Workflows open with `superdoc_open`, read with `superdoc_get_content` or `superdoc_search`, then save with `superdoc_save` and close with `superdoc_close`."
+      fail:
+        - "The MCP server uploads documents to SuperDoc cloud before editing."
+
+  - id: agent_instructions_setup
+    question: How should I prepare a consuming app so AI coding agents have SuperDoc-specific instructions?
+    agents: [quick]
+    contexts: [given_superdoc_readme]
+    expects: [create_agents, mcp_setup]
+    rejects: [mcp_cloud]
+    examples:
+      pass:
+        - "Run `npx @superdoc-dev/create` to generate app-specific AGENTS.md, then add the Claude Code MCP server with `claude mcp add superdoc -- npx @superdoc-dev/mcp`."
+      fail:
+        - "Generate instructions by uploading files elsewhere, then upload the document to SuperDoc cloud before editing."
+
+  - id: cli_mutation_workflow
+    question: How should an agent safely mutate a DOCX file with the SuperDoc CLI?
+    agents: [quick]
+    contexts: [given_cli]
+    expects: [cli_open_save_close, cli_query_match, cli_find_discovery]
+    rejects: [find_for_mutation]
+    examples:
+      pass:
+        - "Open the document with `superdoc open ./contract.docx`, use `superdoc query match --select-json ... --require exactlyOne` to get a mutation-grade target, apply the edit, then run `superdoc save --in-place` and `superdoc close`. Treat `find` as discovery, not as a mutation target."
+      fail:
+        - "Use find output for mutations and pass find results to replace."
+
+  - id: document_api_operation
+    question: If I add a Document API operation, which files change, what should I regenerate, and what must not be hand-edited?
+    agents: [quick]
+    contexts: [given_agents, given_document_api]
+    expects: [docapi_four_files, docapi_generate, docapi_generated]
+    rejects: [edit_generated_docapi]
+    examples:
+      pass:
+        - "Add the operation in `operation-definitions.ts`, add the registry entry in `operation-registry.ts`, wire `invoke.ts`, and implement it on `DocumentApi` in `src/index.ts` plus the adapter. Run `pnpm run generate:all` and `pnpm check:public:docapi`. Do not hand-edit derived outputs such as COMMAND_CATALOG, OPERATION_MEMBER_PATH_MAP, or OPERATION_REFERENCE_DOC_PATH_MAP."
+      fail:
+        - "Add a command by hand-editing COMMAND_CATALOG and OPERATION_REFERENCE_DOC_PATH_MAP."
+
+  - id: rendering_boundaries
+    question: Where should DOCX import, style resolution, layout projection, and final rendering changes live?
+    agents: [quick]
+    contexts: [given_agents]
+    expects: [rendering_pipeline, style_boundary, painter_boundary]
+    rejects: [pm_visuals]
+    examples:
+      pass:
+        - "The pipeline is super-converter to layout-adapter to FlowBlock to layout-engine to ResolvedLayout to DomPainter. The converter stores raw OOXML, while style-engine resolves formatting at render time. DomPainter owns final DOM rendering. Do not style static document content with ProseMirror decorations."
+      fail:
+        - "Use ProseMirror decorations for static document visuals."
+
+  - id: public_surface_checks
+    question: Which commands should I run for public API or package-surface changes, and which command families mutate files?
+    agents: [quick]
+    contexts: [given_agents, given_public_checks]
+    expects: [public_check, command_vocabulary, type_check]
+    rejects: [generate_as_check]
+    examples:
+      pass:
+        - "Use `pnpm check:public` for the umbrella gate, `pnpm check:public:superdoc` for the SuperDoc package, `pnpm check:public:docapi` for Document API, and `pnpm check:types` for raw TypeScript. `check:*` is non-mutating, `generate:*` mutates files, and `report:*` is read-only."
+      fail:
+        - "pnpm run generate:all is read-only, so use it as the normal non-mutating public check."
+
+  - id: layer_choice
+    question: When should I use Document API, superdoc/ui/react, or built-in modules?
+    agents: [quick]
+    contexts: [given_public, given_public_full]
+    expects: [document_api_layer, custom_ui_layer, built_in_modules]
+    rejects: [active_editor_commands]
+    examples:
+      pass:
+        - "Use the Document API (`editor.doc.*`) for programmatic document mutations. Use `superdoc/ui/react` hooks such as `useSuperDocCommand`, `useSuperDocComments`, `useSuperDocTrackChanges`, and `useSuperDocSelection` for custom React UI. Use `modules.*` when the built-in SuperDoc-rendered UI is enough."
+      fail:
+        - "For new programmatic mutations, use superdoc.activeEditor.commands instead of editor.doc."
+
+builds:
+  - id: build_react_editor_component
+    goal: >-
+      Edit the workspace by creating `src/ContractEditor.tsx`. Do not answer
+      with instructions only. The file must export a React component that
+      embeds SuperDoc for a `file: File` prop. It must import
+      `SuperDocEditor` from `@superdoc-dev/react`, import
+      `@superdoc-dev/react/style.css`, render `<SuperDocEditor document={file}
+      documentMode="editing" ... />`, and include an `onReady` callback. Do
+      not import from `superdoc` directly and do not use unsupported document
+      modes such as "edit".
+    agents: [builder]
+    contexts: [given_react]
+    trials: 2
+    workspace:
+      path: ./fixtures/pickled/react-editor
+    verifier:
+      failToPass:
+        - { name: react editor component, run: ./tests/verify-react-editor.sh }
+      passToPass:
+        - { name: fixture readme remains, run: test -f README.md }
+    referenceSolution:
+      patch: ./fixtures/pickled/react-editor.solution.patch
+
+  - id: build_public_surface_check_script
+    goal: >-
+      Edit the workspace by creating `scripts/check-public-surface.sh`. Do not
+      answer with instructions only. The file must be an executable helper for
+      public API changes. It must use `set -euo pipefail`, run
+      `pnpm check:public`, then run `pnpm check:types`. It must not run
+      `pnpm test`, `pnpm run generate:all`, or any `generate:*` command.
+    agents: [builder]
+    contexts: [given_public_checks]
+    trials: 2
+    workspace:
+      path: ./fixtures/pickled/public-check-script
+    verifier:
+      failToPass:
+        - { name: public surface script, run: ./tests/verify-public-check-script.sh }
+      passToPass:
+        - { name: fixture readme remains, run: test -f README.md }
+    referenceSolution:
+      patch: ./fixtures/pickled/public-check-script.solution.patch
+
+thresholds:
+  questions: 80
+  builds: 80


### PR DESCRIPTION
Adds the first Pickled coverage batch for SuperDoc developer workflows.

Why:
- Dogfood whether agents can answer and build with SuperDoc context.
- Cover real developer workflows instead of product identity.
- Add build fixtures with failToPass, passToPass, and reference-solution proof.

What changed:
- Adds pickled.yml with question and build tasks.
- Uses existing SuperDoc context sources, including apps/docs/llms.txt, apps/docs/llms-full.txt, AGENTS.md, package READMEs, and script docs.
- Adds a Pickled GitHub Actions workflow.
- Adds two build fixtures: React editor component and public-surface check script.

Verified:
- bunx @pickled-dev/cli test .
- bunx @pickled-dev/cli check . --plan
- bunx @pickled-dev/cli build . --plan
- Reference patches apply and pass both fixture verifiers.
- Real-agent questions passed after using existing docs sources: 13 cells, 7 YES, 6 PARTIAL, 0 NO, score 83.
- Real-agent builds passed with Sonnet builder: both build cells Built 2/2, verifierProof passed, score 100.
- git diff --check clean.
- No em dashes in added Pickled files.

Not run:
- SuperDoc local unit tests, per repo policy.
