### PR TITLE
feat(font-system): alias Helvetica to the bundled Liberation Sans

### DIFF
--- a/shared/font-system/src/resolver.test.ts
+++ b/shared/font-system/src/resolver.test.ts
@@ -50,9 +50,10 @@ describe('font resolver', () => {
     expect(resolveFontFamily('Calibri, sans-serif').logicalFamily).toBe('Calibri, sans-serif');
   });
 
-  it('aliases Helvetica to the already-bundled Liberation Sans (metric-identical, no new asset)', () => {
-    // Helvetica/Arial/Liberation share metrics; Helvetica->Liberation Sans measures 0.000% advance
-    // delta, so it is a clean clone alias - same bucket as Arial, not a visual fallback.
+  it('aliases Helvetica to the already-bundled Liberation Sans (metric_safe alias, no new asset)', () => {
+    // docfonts records Helvetica -> Liberation Sans as metric_safe (0.000% analytic advance, all four
+    // faces; resolver-alias only, no layout proof). Resolves like a bundled substitute, not a visual
+    // fallback.
     expect(resolveFontFamily('Helvetica')).toEqual({
       logicalFamily: 'Helvetica',
       physicalFamily: 'Liberation Sans',

--- a/shared/font-system/src/resolver.test.ts
+++ b/shared/font-system/src/resolver.test.ts
@@ -8,12 +8,13 @@ import {
 } from './index';
 
 describe('font resolver', () => {
-  it('maps the five verified clean clones (bare names)', () => {
+  it('maps the verified clean clones (bare names)', () => {
     expect(resolvePhysicalFamily('Calibri')).toBe('Carlito');
     expect(resolvePhysicalFamily('Cambria')).toBe('Caladea');
     expect(resolvePhysicalFamily('Arial')).toBe('Liberation Sans');
     expect(resolvePhysicalFamily('Times New Roman')).toBe('Liberation Serif');
     expect(resolvePhysicalFamily('Courier New')).toBe('Liberation Mono');
+    expect(resolvePhysicalFamily('Helvetica')).toBe('Liberation Sans');
   });
 
   it('resolves the PRIMARY family of a CSS stack and keeps the fallbacks', () => {
@@ -47,6 +48,20 @@ describe('font resolver', () => {
       reason: 'bundled_substitute',
     });
     expect(resolveFontFamily('Calibri, sans-serif').logicalFamily).toBe('Calibri, sans-serif');
+  });
+
+  it('aliases Helvetica to the already-bundled Liberation Sans (metric-identical, no new asset)', () => {
+    // Helvetica/Arial/Liberation share metrics; Helvetica->Liberation Sans measures 0.000% advance
+    // delta, so it is a clean clone alias - same bucket as Arial, not a visual fallback.
+    expect(resolveFontFamily('Helvetica')).toEqual({
+      logicalFamily: 'Helvetica',
+      physicalFamily: 'Liberation Sans',
+      reason: 'bundled_substitute',
+    });
+    // Resolves like the other clones: CSS stack keeps fallbacks, case/quote-insensitive.
+    expect(resolvePhysicalFamily('Helvetica, Arial, sans-serif')).toBe('Liberation Sans, Arial, sans-serif');
+    expect(resolvePhysicalFamily('"helvetica"')).toBe('Liberation Sans');
+    expect(resolvePrimaryPhysicalFamily('Helvetica, sans-serif')).toBe('Liberation Sans');
   });
 
   it('extracts the bare physical face the gate must await', () => {

--- a/shared/font-system/src/resolver.ts
+++ b/shared/font-system/src/resolver.ts
@@ -80,8 +80,10 @@ const BUNDLED_SUBSTITUTES: Readonly<Record<string, string>> = Object.freeze({
   arial: 'Liberation Sans',
   'times new roman': 'Liberation Serif',
   'courier new': 'Liberation Mono',
-  // Helvetica is metric-identical to the already-bundled Liberation Sans (0.000% advance delta, same
-  // 2048 upem, all four faces - Helvetica/Arial/Liberation share metrics). An alias only: no new asset.
+  // Helvetica -> the already-bundled Liberation Sans: same candidate and metric verdict as Arial
+  // above. docfonts records it `metric_safe` from one Apple/macOS Helvetica analytic-advance
+  // measurement (0.000% delta, all four faces; evidenceId "helvetica"). Resolver alias ONLY: no new
+  // asset, no new license; its layout gate is not_run and its ship gate fails until this alias lands.
   helvetica: 'Liberation Sans',
 });
 

--- a/shared/font-system/src/resolver.ts
+++ b/shared/font-system/src/resolver.ts
@@ -17,10 +17,10 @@
  * own so two editors on one page can map the same logical family differently (a
  * customer `fonts.map`) without leaking across documents - the same per-document
  * isolation the registry already has per `FontFaceSet`. Every instance is seeded with
- * the five verified clean clones (Calibri->Carlito, Cambria->Caladea, Arial->Liberation
- * Sans, Times New Roman->Liberation Serif, Courier New->Liberation Mono). The
- * module-level `resolve*` functions delegate to a shared default instance for callers
- * that have no document context (and for backward compatibility).
+ * the verified clean clones (Calibri->Carlito, Cambria->Caladea, Arial->Liberation Sans,
+ * Times New Roman->Liberation Serif, Courier New->Liberation Mono, plus Helvetica aliased
+ * to the same Liberation Sans). The module-level `resolve*` functions delegate to a shared
+ * default instance for callers that have no document context (and for backward compatibility).
  */
 
 export type FontResolutionReason =
@@ -73,6 +73,9 @@ const BUNDLED_SUBSTITUTES: Readonly<Record<string, string>> = Object.freeze({
   arial: 'Liberation Sans',
   'times new roman': 'Liberation Serif',
   'courier new': 'Liberation Mono',
+  // Helvetica is metric-identical to the already-bundled Liberation Sans (0.000% advance delta, same
+  // 2048 upem, all four faces - Helvetica/Arial/Liberation share metrics). An alias only: no new asset.
+  helvetica: 'Liberation Sans',
 });
 
 /** Normalize a family name for lookup: trim, strip surrounding quotes, lowercase. */


### PR DESCRIPTION
Documents that request Helvetica - common from Mac-authored files - currently fall through to a system font because Helvetica is not in the substitute map. This adds it as a resolver alias to the already-bundled Liberation Sans.

docfonts records Helvetica to Liberation Sans as `metric_safe` from one Apple/macOS Helvetica analytic-advance measurement (0.000% advance delta at the same 2048 upem; evidenceId `helvetica`), with the record covering the canonical four-face row. That is the same candidate and metric verdict as the existing Arial row. Its metric gate passes; its layout gate is `not_run` and its ship gate fails until this alias lands - so this is a resolver alias only: no new asset (Liberation Sans already ships), no new license, no new resolver reason. It lands in the same `bundled_substitute` bucket as Arial and resolves the same way (CSS-stack and case-insensitive).

This is the first row taken from the docfonts measured registry, chosen because it is the lowest-risk class: a `metric_safe` verdict whose target already ships. I have kept the code comment honest about its proof depth rather than calling it a fully proven clone - only Calibri->Carlito carries a passing layout gate today; the Arial/Times/Courier rows (and now Helvetica) are metric-verified with layout `not_run`. Non-metric fallbacks (e.g. Calibri Light, which has no open Light clone) are deliberately left out: they need a separate, non-metric resolver reason so they are never reported as clean clones.

**Review**: the only behavior change is Helvetica now resolving to Liberation Sans with reason `bundled_substitute`. Tests cover the mapping, the reason, and CSS-stack/case handling.
