### PR TITLE
feat(font-system): category_fallback for non-metric substitutes (Calibri Light)

### DIFF
--- a/shared/font-system/src/report.test.ts
+++ b/shared/font-system/src/report.test.ts
@@ -85,6 +85,17 @@ describe('buildFontReport', () => {
     ]);
     expect(report.every((r) => r.reason === 'bundled_substitute' && !r.missing)).toBe(true);
   });
+
+  it('reports Calibri Light as a non-metric category_fallback and marks it missing even when loaded', () => {
+    const reg = new FakeRegistry();
+    reg.statuses.set('Carlito', 'loaded'); // the fallback family itself loads fine...
+    const [rec] = buildFontReport(['Calibri Light'], reg.asRegistry());
+    expect(rec.physicalFamily).toBe('Carlito');
+    expect(rec.reason).toBe('category_fallback');
+    // ...but it is NOT a metric clone (reflows + Regular weight), so it is reported missing.
+    expect(rec.missing).toBe(true);
+    expect(rec.exportFamily).toBe('Calibri Light');
+  });
 });
 
 /** A face-aware fake: tracks per-face load status + which faces are registered (hasFace). */
@@ -215,5 +226,18 @@ describe('buildFaceReport (face-level)', () => {
     expect(regular?.missing).toBe(false);
     expect(bold?.loadStatus).toBe('failed');
     expect(bold?.missing).toBe(true); // the bold face failed - reported missing, regular unaffected
+  });
+
+  it('Calibri Light face resolves to Carlito (category_fallback) and stays missing though the face loaded', () => {
+    const reg = new FaceRegistry();
+    reg.setFace('Carlito', '400', 'normal', 'loaded'); // Carlito Regular registered + loaded
+    const rows = buildFaceReport(
+      [{ logicalFamily: 'Calibri Light', weight: '400', style: 'normal' }],
+      reg.asRegistry(),
+    );
+    expect(rows[0]?.physicalFamily).toBe('Carlito');
+    expect(rows[0]?.reason).toBe('category_fallback');
+    // The face loaded, but it is a non-metric fallback (wrong weight), so it is still reported missing.
+    expect(rows[0]?.missing).toBe(true);
   });
 });

--- a/shared/font-system/src/report.ts
+++ b/shared/font-system/src/report.ts
@@ -22,13 +22,16 @@ export interface FontResolutionRecord {
   /** The family export writes back - always the logical name, so intent is preserved. */
   exportFamily: string;
   /**
-   * True when the physical face reached a SETTLED state that is not `loaded` - the user
-   * sees a generic fallback, not the intended font. This covers BOTH a font with no known
-   * substitute (`reason: 'as_requested'`, e.g. Aptos) AND a substitute whose asset failed
-   * to load (`reason: 'bundled_substitute'`, `loadStatus: 'failed'`, e.g. a misconfigured
-   * `assetBaseUrl` that 404s). Transient states (`unloaded` / `loading`) are NOT missing,
-   * so an early `getReport()` pull before the gate settles does not over-report. The
-   * `reason` and `loadStatus` fields distinguish the cause (unsupported vs failed vs timed out).
+   * True when SuperDoc did NOT faithfully render the requested font with a metric-compatible face.
+   * Two ways this happens:
+   *   - a non-metric substitute rendered but is not faithful, so it is missing EVEN WHEN `loaded`:
+   *     `reason: 'category_fallback'` (wrong weight / reflows, e.g. Calibri Light -> Carlito), and on
+   *     face-level rows `reason: 'fallback_face_absent'` (the substitute lacks this weight/style).
+   *   - the physical face settled to a state other than `loaded`: a font with no known substitute
+   *     (`reason: 'as_requested'`, e.g. Aptos), or a substitute whose asset failed
+   *     (`reason: 'bundled_substitute'`, `loadStatus: 'failed'`, e.g. a 404ing `assetBaseUrl`).
+   * Transient states (`unloaded` / `loading`) are NOT missing, so an early `getReport()` pull before
+   * the gate settles does not over-report. `reason` and `loadStatus` distinguish the cause.
    */
   missing: boolean;
   /**
@@ -70,7 +73,9 @@ export function buildFontReport(
       reason,
       loadStatus,
       exportFamily: logical,
-      missing: isSettled(loadStatus) && loadStatus !== 'loaded',
+      // `category_fallback` is a non-metric substitute (reflows / wrong weight), so it lacks a faithful
+      // render the same way `fallback_face_absent` does, regardless of whether the family loaded.
+      missing: reason === 'category_fallback' || (isSettled(loadStatus) && loadStatus !== 'loaded'),
     });
   }
   return report;
@@ -120,9 +125,14 @@ export function buildFaceReport(
     //   report `loaded` (document.fonts.load resolves only registered faces, not system fonts - it is
     //   always `fallback_used` here), which is why this is reason-based and deterministic rather than
     //   keyed on a probe.
+    // - `category_fallback` is ALWAYS missing too: a non-metric family fallback (reflows / wrong weight,
+    //   e.g. Calibri Light -> Carlito at Regular) renders something, but not a faithful metric match.
     // - Otherwise: missing once the load settles to anything but `loaded` (failed/timed_out/
     //   fallback_used); `loading`/`unloaded` are not yet settled, so not yet missing.
-    const missing = reason === 'fallback_face_absent' || (isSettled(loadStatus) && loadStatus !== 'loaded');
+    const missing =
+      reason === 'fallback_face_absent' ||
+      reason === 'category_fallback' ||
+      (isSettled(loadStatus) && loadStatus !== 'loaded');
     report.push({
       logicalFamily,
       physicalFamily,

--- a/shared/font-system/src/resolver.test.ts
+++ b/shared/font-system/src/resolver.test.ts
@@ -417,3 +417,61 @@ describe('face-aware resolution (resolveFace / resolvePhysicalFamilyForFace)', (
     });
   });
 });
+
+describe('category_fallback (non-metric family fallback: Calibri Light -> Carlito)', () => {
+  const norm = (f: string) => f.replace(/^["']|["']$/g, '').toLowerCase();
+  const carlito = (f: string) => norm(f) === 'carlito'; // bundled Carlito is registered; Calibri Light is not
+  const noFaces = () => false;
+  const R400 = { weight: '400', style: 'normal' } as const;
+
+  it('family-level: Calibri Light -> Carlito with reason category_fallback (NOT bundled_substitute)', () => {
+    expect(resolveFontFamily('Calibri Light')).toEqual({
+      logicalFamily: 'Calibri Light',
+      physicalFamily: 'Carlito',
+      reason: 'category_fallback',
+    });
+    // Calibri (Regular) stays a metric clone, unaffected.
+    expect(resolveFontFamily('Calibri').reason).toBe('bundled_substitute');
+    // CSS stack keeps fallbacks; case/quote-insensitive.
+    expect(resolvePhysicalFamily('Calibri Light, sans-serif')).toBe('Carlito, sans-serif');
+    expect(resolvePhysicalFamily('"calibri light"')).toBe('Carlito');
+    expect(resolvePrimaryPhysicalFamily('Calibri Light, sans-serif')).toBe('Carlito');
+  });
+
+  it('face-aware: resolveFace maps Calibri Light -> Carlito (category_fallback) when Carlito has the face', () => {
+    const r = createFontResolver();
+    expect(r.resolveFace('Calibri Light', R400, carlito)).toEqual({
+      logicalFamily: 'Calibri Light',
+      physicalFamily: 'Carlito',
+      reason: 'category_fallback',
+    });
+  });
+
+  it('paint/measure: resolvePhysicalFamilyForFace swaps the stack to Carlito (incl. a quoted primary)', () => {
+    const r = createFontResolver();
+    expect(r.resolvePhysicalFamilyForFace('Calibri Light, sans-serif', R400, carlito)).toBe('Carlito, sans-serif');
+    // The normalized swap guard swaps a quoted/cased primary too (not a raw physical !== parts[0]).
+    expect(r.resolvePhysicalFamilyForFace('"Calibri Light"', R400, carlito)).toBe('Carlito');
+  });
+
+  it('category target lacking the face falls through to as_requested (no swap, NOT fallback_face_absent)', () => {
+    const r = createFontResolver();
+    // Carlito provides no faces here: there is no metric substitute that could be "absent".
+    expect(r.resolveFace('Calibri Light', R400, noFaces)).toEqual({
+      logicalFamily: 'Calibri Light',
+      physicalFamily: 'Calibri Light',
+      reason: 'as_requested',
+    });
+    expect(r.resolvePhysicalFamilyForFace('Calibri Light, sans-serif', R400, noFaces)).toBe('Calibri Light, sans-serif');
+  });
+
+  it('a customer fonts.map still overrides the category fallback (custom_mapping wins)', () => {
+    const r = createFontResolver();
+    r.map('Calibri Light', 'Customer Light');
+    expect(r.resolveFontFamily('Calibri Light')).toEqual({
+      logicalFamily: 'Calibri Light',
+      physicalFamily: 'Customer Light',
+      reason: 'custom_mapping',
+    });
+  });
+});

--- a/shared/font-system/src/resolver.ts
+++ b/shared/font-system/src/resolver.ts
@@ -40,6 +40,13 @@ export type FontResolutionReason =
   /** Replaced by a runtime mapping set on this document's resolver (customer `fonts.map`). */
   | 'custom_mapping'
   /**
+   * Replaced by the closest bundled FAMILY, but NOT a metric-compatible clone: advances reflow and/or
+   * the weight differs (e.g. Calibri Light -> Carlito, which has no Light face, so it renders at Regular
+   * and reflows ~6.6%). A useful family fallback, never reported as metric-safe. Lower precedence than
+   * `bundled_substitute`; sourced from docfonts rows with `policyAction: 'category_fallback'`.
+   */
+  | 'category_fallback'
+  /**
    * A substitute is known for the family but does NOT provide the requested face (weight/style),
    * so the family passes through UNsubstituted rather than faux-styling the substitute's Regular
    * onto a face it lacks. Reported non-metric. Only the face-aware path (`resolveFace` /
@@ -101,6 +108,26 @@ function deriveBundledSubstitutes(): Readonly<Record<string, string>> {
 }
 
 const BUNDLED_SUBSTITUTES: Readonly<Record<string, string>> = deriveBundledSubstitutes();
+
+/**
+ * Logical (normalized) -> non-metric family fallback, DERIVED from the evidence rows docfonts marks
+ * `policyAction: 'category_fallback'`. These carry the right letterforms but are NOT metric clones
+ * (they reflow and/or differ in weight, e.g. Calibri Light -> Carlito), so they resolve with reason
+ * `category_fallback`, never `bundled_substitute`. A SEPARATE map and reason keep a lower-fidelity
+ * fallback from being mistaken for a clean clone. Same source of truth as
+ * {@link deriveBundledSubstitutes}; the two partition the evidence by `policyAction`.
+ */
+function deriveCategoryFallbacks(): Readonly<Record<string, string>> {
+  const fallbacks: Record<string, string> = {};
+  for (const row of SUBSTITUTION_EVIDENCE) {
+    if (row.policyAction === 'category_fallback' && row.physicalFamily) {
+      fallbacks[normalizeFamilyKey(row.logicalFamily)] = row.physicalFamily;
+    }
+  }
+  return Object.freeze(fallbacks);
+}
+
+const CATEGORY_FALLBACKS: Readonly<Record<string, string>> = deriveCategoryFallbacks();
 
 /**
  * Strip surrounding quotes from a family name, PRESERVING case, so a STRUCTURED resolution returns a
@@ -233,6 +260,8 @@ export class FontResolver {
     if (override) return { physical: override, reason: 'custom_mapping' };
     const bundled = BUNDLED_SUBSTITUTES[key];
     if (bundled) return { physical: bundled, reason: 'bundled_substitute' };
+    const category = CATEGORY_FALLBACKS[key];
+    if (category) return { physical: category, reason: 'category_fallback' };
     return { physical: bareFamily, reason: 'as_requested' };
   }
 
@@ -243,8 +272,11 @@ export class FontResolver {
    *   2. a registered real face for the logical family itself (customer `fonts.add` / embedded)
    *      -> registered_face  (so SuperDoc renders the real family instead of the bundled clone)
    *   3. bundled metric-compatible substitute -> bundled_substitute  (if it provides the face)
-   *   4. otherwise as_requested (no provider) - or fallback_face_absent when an override/substitute
-   *      WAS known but lacked the face, so a single-face clone is never faux-styled.
+   *   4. non-metric category fallback -> category_fallback  (if it provides the face; a lower-fidelity
+   *      family fallback like Calibri Light -> Carlito, never reported metric-safe)
+   *   5. otherwise as_requested (no provider, including a category fallback that lacked the face) - or
+   *      fallback_face_absent when an override/bundled substitute WAS known but lacked the face, so a
+   *      single-face clone is never faux-styled.
    * `physical === primary` (no swap) for registered_face / as_requested / fallback_face_absent.
    */
   #resolveFaceLadder(
@@ -270,12 +302,19 @@ export class FontResolver {
     if (bundled && hasFace(bundled, face.weight, face.style)) {
       return { physical: bundled, reason: 'bundled_substitute' };
     }
-    // 4. a configured provider (an override or a bundled clone) was known but none could supply this
+    // 4. non-metric category fallback (e.g. Calibri Light -> Carlito): a family fallback, lower
+    //    fidelity. Apply only when it actually supplies the face. On a miss it falls through to
+    //    as_requested below (there was no metric substitute to be "absent"), never fallback_face_absent.
+    const category = CATEGORY_FALLBACKS[key];
+    if (category && hasFace(category, face.weight, face.style)) {
+      return { physical: category, reason: 'category_fallback' };
+    }
+    // 5. a configured provider (an override or a bundled clone) was known but none could supply this
     //    face: pass the logical family through, reported non-metric, never faux-styled.
     if (override || bundled) {
       return { physical: primary, reason: 'fallback_face_absent' };
     }
-    // 5. no provider at all: render the requested family as-is (browser/system fallback).
+    // 6. no provider at all: render the requested family as-is (browser/system fallback).
     return { physical: primary, reason: 'as_requested' };
   }
 
@@ -336,11 +375,14 @@ export class FontResolver {
     if (!cssFontFamily) return cssFontFamily;
     const parts = splitStack(cssFontFamily);
     if (parts.length === 0) return cssFontFamily;
-    const { physical, reason } = this.#resolveFaceLadder(parts[0], face, hasFace);
-    // Swap the primary to the physical ONLY when a substitute/override actually applies. For
-    // registered_face / as_requested / fallback_face_absent the physical IS the logical family, so
-    // keep the original stack (the registered real face or the browser fallback renders it).
-    if (reason === 'custom_mapping' || reason === 'bundled_substitute') {
+    const { physical } = this.#resolveFaceLadder(parts[0], face, hasFace);
+    // Swap the primary to the physical whenever resolution actually CHANGED the family - any provider
+    // tier (custom_mapping / bundled_substitute / category_fallback). Comparing the family instead of
+    // enumerating reasons is deliberate: enumerating is exactly how category_fallback was missed, and a
+    // future tier would repeat it. Compare NORMALIZED (quote-stripped + lowercased) because
+    // registered_face / as_requested / fallback_face_absent return the logical primary itself, so they
+    // must NOT swap even when the primary was quoted or cased.
+    if (normalizeFamilyKey(physical) !== normalizeFamilyKey(parts[0])) {
       return [physical, ...parts.slice(1)].join(', ');
     }
     return cssFontFamily;

--- a/shared/font-system/src/substitution-evidence.test.ts
+++ b/shared/font-system/src/substitution-evidence.test.ts
@@ -72,4 +72,16 @@ describe('substitution evidence -> resolver derivation', () => {
     });
     expect(cambria?.glyphExceptions?.[0]).toMatchObject({ slot: 'boldItalic', codepoint: 0x60 });
   });
+
+  it('Calibri Light is a category_fallback (visual_only), not a metric substitute', () => {
+    const cl = SUBSTITUTION_EVIDENCE.find((r) => r.evidenceId === 'calibri-light');
+    expect(cl).toMatchObject({ policyAction: 'category_fallback', verdict: 'visual_only', physicalFamily: 'Carlito' });
+    // NOT among the metric substitutes, so the six-pair guard above is unaffected; the resolver maps it
+    // with reason category_fallback, never bundled_substitute.
+    const substituteRows = SUBSTITUTION_EVIDENCE.filter((r) => r.policyAction === 'substitute' && r.physicalFamily);
+    expect(substituteRows.some((r) => r.evidenceId === 'calibri-light')).toBe(false);
+    expect(resolveFontFamily('Calibri Light').reason).toBe('category_fallback');
+    // Its Carlito target still ships in the bundled pack, so the runtime can render the fallback.
+    expect(new Set(BUNDLED_MANIFEST.map((f) => f.family)).has('Carlito')).toBe(true);
+  });
 });

--- a/shared/font-system/src/substitution-evidence.ts
+++ b/shared/font-system/src/substitution-evidence.ts
@@ -228,4 +228,22 @@ export const SUBSTITUTION_EVIDENCE: readonly SubstitutionEvidence[] = Object.fre
     candidateLicense: 'OFL-1.1',
     exportRule: 'preserve_original_name',
   },
+  {
+    // No open Calibri Light clone: Carlito carries the Calibri letterforms but has no Light face, so it
+    // renders at Regular (weight 400 vs Light 300) and reflows up to 6.6%. `category_fallback` (a family
+    // fallback, NOT a metric clone), verdict `visual_only`, metric gate fails. `faces` are all false:
+    // Carlito faithfully supplies none of Calibri Light's own faces - the runtime still renders Carlito
+    // Regular where it is loadable, but reports it non-metric.
+    evidenceId: 'calibri-light',
+    logicalFamily: 'Calibri Light',
+    physicalFamily: 'Carlito',
+    verdict: 'visual_only',
+    faces: { regular: false, bold: false, italic: false, boldItalic: false },
+    advance: { meanDelta: 0.0148, maxDelta: 0.066 },
+    gates: { static: 'not_run', metric: 'fail', layout: 'not_run', ship: 'fail' },
+    policyAction: 'category_fallback',
+    measurementRefs: ['calibri-light__carlito#analytic_advance#2026-06-05'],
+    candidateLicense: 'OFL-1.1',
+    exportRule: 'preserve_original_name',
+  },
 ]);


### PR DESCRIPTION
Builds on the substitution-evidence registry (#3653, merged). Calibri Light has no open Light clone: Carlito carries the Calibri letterforms but has no Light face, so it renders at Regular (weight 400 vs Light 300) and reflows up to ~6.6%. It is a real family fallback, not a metric-compatible clone, so it must not share the `bundled_substitute` bucket.

This adds Calibri Light as a `policyAction: category_fallback` row in the evidence registry and derives a category-fallback map beside the substitute map - one source of truth, partitioned by `policyAction`. The resolver gains a `category_fallback` rung in the face-aware ladder (the path the load planner and paint actually use, not just the family-level helper), after `bundled_substitute` and gated by `hasFace`; on a miss it falls through to `as_requested`, never `fallback_face_absent`.

The paint/measure swap guard now swaps whenever resolution changed the family, compared on a normalized (quote-stripped, lowercased) name, instead of enumerating `custom_mapping`/`bundled_substitute`. Enumerating reasons is exactly how the face path missed `category_fallback`; comparing the family means the next provider tier cannot repeat it.

`category_fallback` is reported `missing: true` for now, matching the documented "no faithful render font loaded" meaning of `missingFonts`. A clearer explicit `fidelity` field can replace that overload in a follow-up.

**Review**: Calibri (Regular) still resolves to Carlito as `bundled_substitute` (unchanged); only Calibri Light is new. Tests cover family + face-aware resolution, the paint CSS-stack swap (incl. a quoted primary), the missing-category-target fall-through, the custom-map override, and the report reason + missing flag.
