### PR TITLE
test: expand Pickled build dogfood coverage

### DIFF
--- a/fixtures/pickled/cli-mutation.solution.patch
+++ b/fixtures/pickled/cli-mutation.solution.patch
@@ -1,0 +1,23 @@
+diff --git a/scripts/update-contract.sh b/scripts/update-contract.sh
+new file mode 100755
+index 0000000..e9b4c1a
+--- /dev/null
++++ b/scripts/update-contract.sh
+@@ -0,0 +1,17 @@
++#!/usr/bin/env bash
++set -euo pipefail
++
++superdoc open ./contract.docx
++
++target_json="$(
++  superdoc query match \
++    --select-json '{"type":"text","pattern":"termination"}' \
++    --require exactlyOne
++)"
++
++superdoc replace \
++  --target-json "$target_json" \
++  --text "expiration"
++
++superdoc save --in-place
++superdoc close

--- a/fixtures/pickled/cli-mutation/README.md
+++ b/fixtures/pickled/cli-mutation/README.md
@@ -1,0 +1,18 @@
+# CLI mutation fixture
+
+Create `scripts/update-contract.sh`.
+
+Required:
+
+- Create the `scripts` directory if it does not exist.
+- Make `scripts/update-contract.sh` executable.
+- Use `set -euo pipefail`.
+- Open `./contract.docx` with `superdoc open`.
+- Use `superdoc query match --select-json ... --require exactlyOne` to get a mutation-grade target.
+- Mutate with `superdoc replace` using the query target.
+- Save in place with `superdoc save --in-place`.
+- Close the session with `superdoc close`.
+
+Do not use `superdoc find` as a mutation target.
+Do not use `replace-legacy`.
+Do not answer with instructions only. Modify the workspace.

--- a/fixtures/pickled/cli-mutation/package.json
+++ b/fixtures/pickled/cli-mutation/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pickled-cli-mutation-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/pickled/cli-mutation/tests/verify-cli-mutation.sh
+++ b/fixtures/pickled/cli-mutation/tests/verify-cli-mutation.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test -f scripts/update-contract.sh
+test -x scripts/update-contract.sh
+
+grep -Fq "set -euo pipefail" scripts/update-contract.sh
+grep -Fq "superdoc open ./contract.docx" scripts/update-contract.sh
+grep -Fq "superdoc query match" scripts/update-contract.sh
+grep -Fq -- "--select-json" scripts/update-contract.sh
+grep -Fq -- "--require exactlyOne" scripts/update-contract.sh
+grep -Eq "target|target-json|block-id|start|end" scripts/update-contract.sh
+grep -Fq "superdoc replace" scripts/update-contract.sh
+grep -Fq "superdoc save --in-place" scripts/update-contract.sh
+grep -Fq "superdoc close" scripts/update-contract.sh
+
+if grep -Eq "superdoc find.*(replace|target|mutation)|superdoc replace-legacy" scripts/update-contract.sh; then
+  echo "CLI mutation fixture must use query match, not find or replace-legacy" >&2
+  exit 1
+fi

--- a/fixtures/pickled/react-editor/README.md
+++ b/fixtures/pickled/react-editor/README.md
@@ -5,10 +5,28 @@ Create `src/ContractEditor.tsx`.
 Required:
 
 - Export `ContractEditor({ file }: { file: File })`.
+- Create the `src` directory if it does not exist.
 - Import `SuperDocEditor` from `@superdoc-dev/react`.
 - Import `@superdoc-dev/react/style.css`.
 - Render `<SuperDocEditor document={file} documentMode="editing" ... />`.
 - Include an `onReady` callback.
+
+Use this shape:
+
+```tsx
+import { SuperDocEditor } from '@superdoc-dev/react';
+import '@superdoc-dev/react/style.css';
+
+export function ContractEditor({ file }: { file: File }) {
+  return (
+    <SuperDocEditor
+      document={file}
+      documentMode="editing"
+      onReady={({ superdoc }) => console.log('Ready', superdoc)}
+    />
+  );
+}
+```
 
 Do not import from `superdoc`.
 Do not use unsupported document modes such as `edit`, `view`, or `suggest`.

--- a/fixtures/pickled/vanilla-editor.solution.patch
+++ b/fixtures/pickled/vanilla-editor.solution.patch
@@ -1,0 +1,22 @@
+diff --git a/src/embed-superdoc.js b/src/embed-superdoc.js
+new file mode 100644
+index 0000000..df163ce
+--- /dev/null
++++ b/src/embed-superdoc.js
+@@ -0,0 +1,16 @@
++import { SuperDoc } from 'superdoc';
++import 'superdoc/style.css';
++
++export function embedSuperDoc({ file }) {
++  return new SuperDoc({
++    selector: '#editor',
++    documentMode: 'editing',
++    documents: [
++      {
++        id: 'contract',
++        type: 'docx',
++        data: file,
++      },
++    ],
++  });
++}

--- a/fixtures/pickled/vanilla-editor/README.md
+++ b/fixtures/pickled/vanilla-editor/README.md
@@ -1,0 +1,15 @@
+# Vanilla editor fixture
+
+Create `src/embed-superdoc.js`.
+
+Required:
+
+- Create the `src` directory if it does not exist.
+- Import `SuperDoc` from `superdoc`.
+- Import `superdoc/style.css`.
+- Export an `embedSuperDoc({ file })` function.
+- Create `new SuperDoc({ selector: '#editor', documentMode: 'editing', documents: [...] })`.
+- Pass the incoming `file` as the DOCX document data.
+
+Use `documentMode: 'editing'`. Do not use unsupported modes such as `edit`, `view`, or `suggest`.
+Do not answer with instructions only. Modify the workspace.

--- a/fixtures/pickled/vanilla-editor/package.json
+++ b/fixtures/pickled/vanilla-editor/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pickled-vanilla-editor-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/pickled/vanilla-editor/tests/verify-vanilla-editor.sh
+++ b/fixtures/pickled/vanilla-editor/tests/verify-vanilla-editor.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test -f src/embed-superdoc.js
+
+grep -Fq "SuperDoc" src/embed-superdoc.js
+grep -Fq "superdoc/style.css" src/embed-superdoc.js
+grep -Eq "from ['\"]superdoc['\"]" src/embed-superdoc.js
+grep -Fq "embedSuperDoc" src/embed-superdoc.js
+grep -Fq "new SuperDoc" src/embed-superdoc.js
+grep -Fq "selector" src/embed-superdoc.js
+grep -Fq "#editor" src/embed-superdoc.js
+grep -Fq "documents" src/embed-superdoc.js
+grep -Eq "type:[[:space:]]*['\"]docx['\"]" src/embed-superdoc.js
+grep -Eq "data:[[:space:]]*file" src/embed-superdoc.js
+grep -Eq "documentMode:[[:space:]]*['\"]editing['\"]" src/embed-superdoc.js
+
+if grep -Eq "documentMode:[[:space:]]*['\"](edit|view|suggest)['\"]" src/embed-superdoc.js; then
+  echo "unsupported documentMode name" >&2
+  exit 1
+fi

--- a/pickled.yml
+++ b/pickled.yml
@@ -266,8 +266,9 @@ builds:
   - id: build_react_editor_component
     goal: >-
       Edit the workspace by creating `src/ContractEditor.tsx`. Do not answer
-      with instructions only. The file must export a React component that
-      embeds SuperDoc for a `file: File` prop. It must import
+      with instructions only. Create the `src` directory if needed. The file
+      must export a React component that embeds SuperDoc for a `file: File`
+      prop. It must import
       `SuperDocEditor` from `@superdoc-dev/react`, import
       `@superdoc-dev/react/style.css`, render `<SuperDocEditor document={file}
       documentMode="editing" ... />`, and include an `onReady` callback. Do
@@ -285,6 +286,51 @@ builds:
         - { name: fixture readme remains, run: test -f README.md }
     referenceSolution:
       patch: ./fixtures/pickled/react-editor.solution.patch
+
+  - id: build_vanilla_editor_embed
+    goal: >-
+      Edit the workspace by creating `src/embed-superdoc.js`. Do not answer
+      with instructions only. Create the `src` directory if needed. The file
+      must import `SuperDoc` from `superdoc`, import `superdoc/style.css`,
+      export an `embedSuperDoc({ file })` function, and return `new SuperDoc`
+      configured with `selector: '#editor'`, `documentMode: 'editing'`, and a
+      DOCX document entry whose `data` is the incoming `file`. Do not use
+      unsupported document modes such as "edit".
+    agents: [builder]
+    contexts: [given_superdoc_readme]
+    trials: 2
+    workspace:
+      path: ./fixtures/pickled/vanilla-editor
+    verifier:
+      failToPass:
+        - { name: vanilla editor embed, run: ./tests/verify-vanilla-editor.sh }
+      passToPass:
+        - { name: fixture readme remains, run: test -f README.md }
+    referenceSolution:
+      patch: ./fixtures/pickled/vanilla-editor.solution.patch
+
+  - id: build_cli_mutation_script
+    goal: >-
+      Edit the workspace by creating `scripts/update-contract.sh`. Do not
+      answer with instructions only. Create the `scripts` directory if needed.
+      Make the script executable. The script must use `set -euo pipefail`,
+      open `./contract.docx` with `superdoc open`, use `superdoc query match
+      --select-json ... --require exactlyOne` to get a mutation-grade target,
+      mutate with `superdoc replace`, save with `superdoc save --in-place`,
+      and close with `superdoc close`. Do not use `superdoc find` as a
+      mutation target and do not use `replace-legacy`.
+    agents: [builder]
+    contexts: [given_cli]
+    trials: 2
+    workspace:
+      path: ./fixtures/pickled/cli-mutation
+    verifier:
+      failToPass:
+        - { name: cli mutation script, run: ./tests/verify-cli-mutation.sh }
+      passToPass:
+        - { name: fixture readme remains, run: test -f README.md }
+    referenceSolution:
+      patch: ./fixtures/pickled/cli-mutation.solution.patch
 
 thresholds:
   questions: 80


### PR DESCRIPTION
Expands the Pickled build dogfood so the build gate measures more than one React fixture.

Why:
- The latest real-agent run showed questions passing, but builds failing because the only build cell passed 1/2 trials.
- A single build cell made the threshold too binary. This adds two more public developer workflows with the same fail-to-pass, pass-to-pass, and reference-solution bracket.

Changes:
- Tighten the React fixture instructions with `src` creation guidance and a full `ContractEditor` shape.
- Add a vanilla SuperDoc embed fixture.
- Add a CLI mutation script fixture using `query match`, `replace`, `save`, and `close`.

Validation:
- `git diff --check`
- YAML parse for `pickled.yml`
- `bunx @pickled-dev/cli test .`
- `bunx @pickled-dev/cli check . --plan`
- `bunx @pickled-dev/cli build . --plan`
- Manually verified each reference patch applies and passes its verifier.

I did not run local SuperDoc unit tests. This repo asks agents not to run unit tests locally for this project.
