### PR TITLE
fix: raise Pickled build execution cap

### DIFF
--- a/.github/workflows/pickled.yml
+++ b/.github/workflows/pickled.yml
@@ -20,9 +20,13 @@ on:
   workflow_dispatch:
     inputs:
       max_cells:
-        description: Max Pickled cells for real-agent jobs
+        description: Max Pickled question cells for real-agent jobs
         required: false
         default: '20'
+      build_max_cells:
+        description: Max Pickled build executions for real-agent jobs
+        required: false
+        default: '6'
 
 concurrency:
   group: pickled-${{ github.event.pull_request.number || github.run_id }}
@@ -71,7 +75,7 @@ jobs:
         run: |
           bunx @pickled-dev/cli ci . \
             --questions-max-cells "${{ github.event.inputs.max_cells || '20' }}" \
-            --builds-max-cells 4 \
+            --builds-max-cells "${{ github.event.inputs.build_max_cells || '6' }}" \
             --report-dir pickled-reports
 
       - name: Upload Pickled reports


### PR DESCRIPTION
Raises the manual Pickled build cap to match the current build dogfood.

Why:
- PR #3650 expanded build dogfood to 3 build cells with 2 trials each.
- The manual real-agent workflow still used `--builds-max-cells 4`, so builds stopped at planning with 6 executions.
- This adds a `build_max_cells` workflow input and defaults it to 6.

Validation:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pickled.yml")'`
- `git diff --check`
- `bunx @pickled-dev/cli build . --plan`

I did not run local SuperDoc unit tests. This is a workflow-only change, and this repo asks agents not to run unit tests locally.
