### PR TITLE
refactor(font-system): derive substitutes from a vendored docfonts evidence registry

### DIFF
--- a/shared/font-system/src/resolver.ts
+++ b/shared/font-system/src/resolver.ts
@@ -23,6 +23,8 @@
  * default instance for callers that have no document context (and for backward compatibility).
  */
 
+import { SUBSTITUTION_EVIDENCE } from './substitution-evidence';
+
 export type FontResolutionReason =
   /** No substitute is known; the requested family is used as-is. */
   | 'as_requested'
@@ -67,26 +69,6 @@ export interface FaceKey {
  */
 export type HasFace = (physicalFamily: string, weight: '400' | '700', style: 'normal' | 'italic') => boolean;
 
-/**
- * Logical (normalized) -> physical family. Lowercased, quote-stripped keys.
- *
- * Only metric-verified clean clones (advance widths + OS/2 line metrics match the Word
- * original) belong here. Each target MUST be a family the bundled pack supplies
- * (see `bundled.ts`). Aptos/Georgia are intentionally absent - no clean clone yet.
- */
-const BUNDLED_SUBSTITUTES: Readonly<Record<string, string>> = Object.freeze({
-  calibri: 'Carlito',
-  cambria: 'Caladea',
-  arial: 'Liberation Sans',
-  'times new roman': 'Liberation Serif',
-  'courier new': 'Liberation Mono',
-  // Helvetica -> the already-bundled Liberation Sans: same candidate and metric verdict as Arial
-  // above. docfonts records it `metric_safe` from one Apple/macOS Helvetica analytic-advance
-  // measurement (0.000% delta, all four faces; evidenceId "helvetica"). Resolver alias ONLY: no new
-  // asset, no new license; its layout gate is not_run and its ship gate fails until this alias lands.
-  helvetica: 'Liberation Sans',
-});
-
 /** Normalize a family name for lookup: trim, strip surrounding quotes, lowercase. */
 function normalizeFamilyKey(family: string): string {
   return family
@@ -94,6 +76,31 @@ function normalizeFamilyKey(family: string): string {
     .replace(/^["']|["']$/g, '')
     .toLowerCase();
 }
+
+/**
+ * Logical (normalized) -> physical family, DERIVED from the substitution evidence registry
+ * ({@link ./substitution-evidence}): every row docfonts marks `policyAction: 'substitute'` with a
+ * physical target. The evidence file is the single source of truth; this is its resolver projection
+ * (lowercased, quote-stripped keys).
+ *
+ * The inclusion predicate is policyAction, NOT verdict: a QUALIFIED substitute - e.g. Cambria ->
+ * Caladea, top-level `visual_only` because Bold Italic's U+0060 advance reflows - is still the
+ * recommended substitute and stays mapped. Verdict drives how fidelity is REPORTED (a later pass),
+ * never whether SuperDoc substitutes. Gate status (e.g. Helvetica's stale `ship: fail`) is diagnostic,
+ * never an inclusion input. Each physical target MUST be a family the bundled pack supplies
+ * (see `bundled-manifest.ts`); `substitution-evidence.test.ts` enforces that.
+ */
+function deriveBundledSubstitutes(): Readonly<Record<string, string>> {
+  const substitutes: Record<string, string> = {};
+  for (const row of SUBSTITUTION_EVIDENCE) {
+    if (row.policyAction === 'substitute' && row.physicalFamily) {
+      substitutes[normalizeFamilyKey(row.logicalFamily)] = row.physicalFamily;
+    }
+  }
+  return Object.freeze(substitutes);
+}
+
+const BUNDLED_SUBSTITUTES: Readonly<Record<string, string>> = deriveBundledSubstitutes();
 
 /**
  * Strip surrounding quotes from a family name, PRESERVING case, so a STRUCTURED resolution returns a

--- a/shared/font-system/src/substitution-evidence.test.ts
+++ b/shared/font-system/src/substitution-evidence.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { createFontResolver, resolveFontFamily } from './resolver';
+import { SUBSTITUTION_EVIDENCE } from './substitution-evidence';
+import { BUNDLED_MANIFEST } from './bundled-manifest';
+
+/**
+ * The six logical -> physical substitutions the resolver shipped before the evidence registry
+ * existed. The registry must derive EXACTLY these - introducing the manifest is a no-behavior-change
+ * refactor, not an expansion. Adding a substitute is a deliberate, reviewed edit to this list.
+ */
+const EXPECTED_SUBSTITUTES: ReadonlyArray<readonly [logical: string, physical: string]> = [
+  ['Calibri', 'Carlito'],
+  ['Cambria', 'Caladea'],
+  ['Arial', 'Liberation Sans'],
+  ['Times New Roman', 'Liberation Serif'],
+  ['Courier New', 'Liberation Mono'],
+  ['Helvetica', 'Liberation Sans'],
+];
+
+describe('substitution evidence -> resolver derivation', () => {
+  it("derives exactly today's six substitutions (no behavior change)", () => {
+    const resolver = createFontResolver();
+    for (const [logical, physical] of EXPECTED_SUBSTITUTES) {
+      expect(resolver.resolvePrimaryPhysicalFamily(logical)).toBe(physical);
+    }
+    // The derivation input is exactly six rows: policyAction 'substitute' with a physical target.
+    const substituteRows = SUBSTITUTION_EVIDENCE.filter(
+      (r) => r.policyAction === 'substitute' && r.physicalFamily,
+    );
+    expect(substituteRows).toHaveLength(EXPECTED_SUBSTITUTES.length);
+  });
+
+  it('does not substitute a family with no evidence row (the map did not grow)', () => {
+    // Aptos is not in the snapshot (no clean open substitute), so it must pass through unchanged.
+    expect(resolveFontFamily('Aptos')).toEqual({
+      logicalFamily: 'Aptos',
+      physicalFamily: 'Aptos',
+      reason: 'as_requested',
+    });
+  });
+
+  it('keeps a QUALIFIED substitute mapped: Cambria -> Caladea (verdict does not gate inclusion)', () => {
+    const cambria = SUBSTITUTION_EVIDENCE.find((r) => r.evidenceId === 'cambria');
+    expect(cambria?.verdict).toBe('visual_only'); // worst-face verdict (Bold Italic U+0060)
+    expect(cambria?.policyAction).toBe('substitute'); // ...but still the recommended substitute
+    // So the resolver maps it like any other bundled substitute; reporting stays bundled_substitute
+    // until the verdict-aware reporting pass.
+    expect(resolveFontFamily('Cambria')).toEqual({
+      logicalFamily: 'Cambria',
+      physicalFamily: 'Caladea',
+      reason: 'bundled_substitute',
+    });
+  });
+
+  it('every substitute target is a family the bundled pack ships (asset-availability invariant)', () => {
+    const bundledFamilies = new Set(BUNDLED_MANIFEST.map((f) => f.family));
+    for (const row of SUBSTITUTION_EVIDENCE) {
+      if (row.policyAction === 'substitute' && row.physicalFamily) {
+        expect(bundledFamilies.has(row.physicalFamily)).toBe(true);
+      }
+    }
+  });
+
+  it('a QUALIFIED row carries the authoritative per-face breakdown its top-level verdict hides', () => {
+    // The whole point of the evidence layer: visual_only at the top, but three faces are metric_safe.
+    const cambria = SUBSTITUTION_EVIDENCE.find((r) => r.evidenceId === 'cambria');
+    expect(cambria?.faceVerdicts).toEqual({
+      regular: 'metric_safe',
+      bold: 'metric_safe',
+      italic: 'metric_safe',
+      boldItalic: 'visual_only',
+    });
+    expect(cambria?.glyphExceptions?.[0]).toMatchObject({ slot: 'boldItalic', codepoint: 0x60 });
+  });
+});

--- a/shared/font-system/src/substitution-evidence.ts
+++ b/shared/font-system/src/substitution-evidence.ts
@@ -1,0 +1,231 @@
+/**
+ * Substitution EVIDENCE: per logical font, the measured docfonts verdict behind SuperDoc's
+ * logical -> physical substitution. Pure data, no imports. The resolver derives its substitute map
+ * from this (see `resolver.ts`), so this file is the single source of truth for WHICH logical family
+ * maps to WHICH physical substitute and HOW faithful that substitution is.
+ *
+ * Distinct from {@link ./bundled-manifest} (the PHYSICAL pack: which `.woff2` files ship). That is the
+ * asset layer; this is the EVIDENCE layer - which proprietary font each substitute stands in for, the
+ * docfonts verdict, per-face verdicts, and the worst-case advance delta that gates layout fidelity.
+ *
+ * VENDORED SNAPSHOT. docfonts (`@docfonts/core` + `@docfonts/registry`) is the upstream source of
+ * truth: a measured, reviewed registry kept in a separate repo, not yet a build dependency of
+ * SuperDoc. These rows are a hand-reviewed copy of the docfonts EvidenceRecords for the families
+ * SuperDoc currently substitutes; `evidenceId` + `measurementRefs` point back to the source record. A
+ * generator/import is deferred until docfonts is a dependency CI can reproduce - until then this is
+ * reviewed evidence (committed, PR-reviewed), never an unsupervised generated truth source.
+ *
+ * Scope note: this is the DATA plus the resolver derivation only. Reports do NOT yet branch on
+ * `verdict` - Cambria still resolves to Caladea and reports `bundled_substitute`; verdict-aware
+ * diagnostics are a later pass. The richer fields ride along as data so that pass needs no reshape.
+ */
+
+/** docfonts fidelity verdict, best to worst. Vendored from `@docfonts/core` `Verdict`. */
+export type SubstituteVerdict =
+  | 'metric_safe' // advances within the DIRECT threshold (weighted-mean <= 0.5%, worst-case <= 1%)
+  | 'near_metric' // LIKELY band: weighted-mean <= 1%, worst-case <= 2.5% - near-exact, a few glyphs drift
+  | 'cell_width_only' // monospace cell width matches; glyph shapes do not
+  | 'visual_only' // same visual category, but advances are NOT line-break safe
+  | 'customer_supplied' // the real font must come from the customer
+  | 'preserve_only' // keep the original name, do not substitute (e.g. math / symbol fonts)
+  | 'no_substitute'; // no open candidate qualifies
+
+/** docfonts renderer-neutral resolution action. Vendored from `@docfonts/core` `PolicyAction`. */
+export type SubstitutePolicyAction =
+  | 'substitute' // render the named physical candidate in place of the logical font
+  | 'category_fallback' // no clean candidate; fall back to a generic category (serif / sans / mono)
+  | 'preserve_only' // keep the logical name + a system fallback; claim no substitute
+  | 'customer_supplied'; // the customer must provide the real font
+
+/** Derived public gate status. Diagnostic only - NOT a runtime inclusion input. */
+export type SubstituteGateStatus = 'pass' | 'not_run' | 'fail';
+
+/**
+ * RIBBI face slot - the four canonical faces docfonts scores. Deliberately NOT named `StyleKey` (its
+ * docfonts name) or `FaceKey` (the runtime weight/style face in `resolver.ts`): an evidence slot is a
+ * coarse RIBBI bucket, not a runtime weight+style pair, and the two must not be confused.
+ */
+export type FaceSlot = 'regular' | 'bold' | 'italic' | 'boldItalic';
+
+/** Advance-width divergence vs the proprietary oracle, as fractions (0 = identical advances). */
+export interface AdvanceDelta {
+  meanDelta: number;
+  /** the worst-case delta, not the mean, is what gates line-break fidelity. */
+  maxDelta: number;
+}
+
+/** Which of the four RIBBI faces the physical candidate supplies. */
+export interface FaceCoverage {
+  regular: boolean;
+  bold: boolean;
+  italic: boolean;
+  boldItalic: boolean;
+}
+
+/** The four derived gate statuses behind a verdict; the proof is the referenced measurements. */
+export interface SubstituteGates {
+  static: SubstituteGateStatus;
+  metric: SubstituteGateStatus;
+  layout: SubstituteGateStatus;
+  ship: SubstituteGateStatus;
+}
+
+/**
+ * A named glyph-level advance divergence that qualifies one face: the honest exception behind a face
+ * whose advances match everywhere EXCEPT a specific codepoint (e.g. Caladea Bold Italic vs Cambria on
+ * U+0060). The full numbers live in the referenced measurement; this names the divergence publicly.
+ */
+export interface GlyphException {
+  slot: FaceSlot;
+  /** the diverging codepoint, e.g. 0x60 (grave accent). */
+  codepoint: number;
+  /** fractional advance divergence at this glyph (0.231 = 23.1%). */
+  advanceDelta: number;
+  note: string;
+}
+
+/**
+ * One logical font's substitution evidence. Mirrors the renderer-relevant fields of a docfonts
+ * EvidenceRecord and omits its prose (`notes`, `confidence`, measured dates): SuperDoc decides from
+ * structured data, not free text.
+ */
+export interface SubstitutionEvidence {
+  /** docfonts EvidenceRecord id - the provenance pointer back to the source record, e.g. "cambria". */
+  evidenceId: string;
+  /** the proprietary family the document asks for (docfonts `originalFont`), e.g. "Cambria". */
+  logicalFamily: string;
+  /** the physical substitute rendered in its place; null when no candidate is recommended. */
+  physicalFamily: string | null;
+  /** worst-face fidelity verdict (the public summary; see `faceVerdicts` when faces disagree). */
+  verdict: SubstituteVerdict;
+  /**
+   * Per-face verdicts, AUTHORITATIVE when present - set when the faces do not share one verdict (a
+   * QUALIFIED substitute). When present, the top-level `verdict` is the WORST face; a consumer showing
+   * fidelity must show this breakdown, not the rolled-up verdict alone.
+   */
+  faceVerdicts?: Partial<Record<FaceSlot, SubstituteVerdict>>;
+  /** named glyph-level divergences that qualify a face (e.g. one codepoint reflows). */
+  glyphExceptions?: readonly GlyphException[];
+  faces: FaceCoverage;
+  advance?: AdvanceDelta;
+  gates: SubstituteGates;
+  /** renderer-neutral action; `substitute` is what makes the resolver map the family. */
+  policyAction: SubstitutePolicyAction;
+  /** proof pointers back into docfonts, by MeasurementId. */
+  measurementRefs: readonly string[];
+  /** SPDX id of the substitute's license. */
+  candidateLicense?: string | null;
+  /** SuperDoc renders substitutes but always exports the original name. Always this for now. */
+  exportRule: 'preserve_original_name';
+}
+
+/**
+ * The substitution evidence for every family SuperDoc currently substitutes - six rows, vendored from
+ * docfonts. The resolver maps the rows whose `policyAction` is `substitute`; the verdict / per-face /
+ * glyph-exception fields are carried for the later verdict-aware reporting pass and are not yet read.
+ */
+export const SUBSTITUTION_EVIDENCE: readonly SubstitutionEvidence[] = Object.freeze([
+  {
+    evidenceId: 'calibri',
+    logicalFamily: 'Calibri',
+    physicalFamily: 'Carlito',
+    verdict: 'metric_safe',
+    faces: { regular: true, bold: true, italic: true, boldItalic: true },
+    advance: { meanDelta: 0, maxDelta: 0 },
+    gates: { static: 'pass', metric: 'pass', layout: 'pass', ship: 'pass' },
+    policyAction: 'substitute',
+    measurementRefs: [
+      'calibri__carlito#analytic_advance#2026-06-03',
+      'calibri__carlito#face_aggregate#2026-06-03',
+    ],
+    candidateLicense: 'OFL-1.1',
+    exportRule: 'preserve_original_name',
+  },
+  {
+    // The QUALIFIED case. Regular/bold/italic are metric_safe, but Caladea's Bold Italic grave accent
+    // (U+0060) advance diverges ~23%, so a line containing it reflows. The worst face rolls the
+    // top-level verdict to `visual_only`; policyAction stays `substitute` (Caladea IS the recommended
+    // substitute), which is why the resolver still maps Cambria. faceVerdicts is authoritative.
+    evidenceId: 'cambria',
+    logicalFamily: 'Cambria',
+    physicalFamily: 'Caladea',
+    verdict: 'visual_only',
+    faceVerdicts: { regular: 'metric_safe', bold: 'metric_safe', italic: 'metric_safe', boldItalic: 'visual_only' },
+    glyphExceptions: [
+      {
+        slot: 'boldItalic',
+        codepoint: 0x60,
+        advanceDelta: 0.231,
+        note: 'Caladea Bold Italic grave accent (U+0060) advance diverges ~23% from Cambria; lines containing it reflow.',
+      },
+    ],
+    faces: { regular: true, bold: true, italic: true, boldItalic: true },
+    advance: { meanDelta: 0.0002378, maxDelta: 0.2310758 },
+    gates: { static: 'pass', metric: 'pass', layout: 'not_run', ship: 'pass' },
+    policyAction: 'substitute',
+    measurementRefs: [
+      'cambria_regular__caladea#regular#w400#d2f6cad3#analytic_advance#2026-06-04',
+      'cambria_bold__caladea#bold#w700#74eda4fc#analytic_advance#2026-06-04',
+      'cambria_italic__caladea#italic#w400#9c968bf6#analytic_advance#2026-06-04',
+      'cambria_boldItalic__caladea#boldItalic#w700#f47a35ad#analytic_advance#2026-06-04',
+    ],
+    candidateLicense: 'Apache-2.0',
+    exportRule: 'preserve_original_name',
+  },
+  {
+    evidenceId: 'arial',
+    logicalFamily: 'Arial',
+    physicalFamily: 'Liberation Sans',
+    verdict: 'metric_safe',
+    faces: { regular: true, bold: true, italic: true, boldItalic: true },
+    advance: { meanDelta: 0, maxDelta: 0 },
+    gates: { static: 'pass', metric: 'pass', layout: 'not_run', ship: 'pass' },
+    policyAction: 'substitute',
+    measurementRefs: ['arial__liberation-sans#analytic_advance#2026-06-03'],
+    candidateLicense: 'OFL-1.1',
+    exportRule: 'preserve_original_name',
+  },
+  {
+    evidenceId: 'times-new-roman',
+    logicalFamily: 'Times New Roman',
+    physicalFamily: 'Liberation Serif',
+    verdict: 'metric_safe',
+    faces: { regular: true, bold: true, italic: true, boldItalic: true },
+    advance: { meanDelta: 0, maxDelta: 0 },
+    gates: { static: 'pass', metric: 'pass', layout: 'not_run', ship: 'pass' },
+    policyAction: 'substitute',
+    measurementRefs: ['times-new-roman__liberation-serif#analytic_advance#2026-06-03'],
+    candidateLicense: 'OFL-1.1',
+    exportRule: 'preserve_original_name',
+  },
+  {
+    evidenceId: 'courier-new',
+    logicalFamily: 'Courier New',
+    physicalFamily: 'Liberation Mono',
+    verdict: 'metric_safe',
+    faces: { regular: true, bold: true, italic: true, boldItalic: true },
+    advance: { meanDelta: 0, maxDelta: 0 },
+    gates: { static: 'pass', metric: 'pass', layout: 'not_run', ship: 'pass' },
+    policyAction: 'substitute',
+    measurementRefs: ['courier-new__liberation-mono#analytic_advance#2026-06-03'],
+    candidateLicense: 'OFL-1.1',
+    exportRule: 'preserve_original_name',
+  },
+  {
+    // Same candidate and metric verdict as Arial. metric_safe from one Apple/macOS Helvetica
+    // analytic-advance measurement (0.000% delta). Its static + layout gates are `not_run`, and ship
+    // was `fail` in docfonts only because SuperDoc had not consumed the alias yet - a stale-until-
+    // shipped gate, NOT a fidelity signal, so it never gates inclusion here (policyAction does).
+    evidenceId: 'helvetica',
+    logicalFamily: 'Helvetica',
+    physicalFamily: 'Liberation Sans',
+    verdict: 'metric_safe',
+    faces: { regular: true, bold: true, italic: true, boldItalic: true },
+    advance: { meanDelta: 0, maxDelta: 0 },
+    gates: { static: 'not_run', metric: 'pass', layout: 'not_run', ship: 'fail' },
+    policyAction: 'substitute',
+    measurementRefs: ['helvetica__liberation-sans#analytic_advance#2026-06-03'],
+    candidateLicense: 'OFL-1.1',
+    exportRule: 'preserve_original_name',
+  },
+]);


### PR DESCRIPTION
The resolver's logical-to-physical substitute table (Calibri, Cambria, Arial, Times New Roman, Courier New, Helvetica) was a hand-written literal. This moves it behind a typed evidence registry so the mapping and its measured fidelity come from one reviewed vendored snapshot.

`substitution-evidence.ts` is a vendored, reviewed snapshot of the docfonts evidence for those six families. The resolver derives its map from the rows docfonts marks `policyAction: substitute` - inclusion is the substitute recommendation, not the fidelity verdict - so Cambria stays mapped to Caladea even though its top-level verdict is `visual_only` (Bold Italic's grave accent reflows). No behavior change: the derived map is exactly today's six pairs, pinned by a guard test that also checks every target is bundled. docfonts is not a build dependency yet, so this is a snapshot, not an import; verdict-aware reporting is a later change.

**Review**: confirm the derived map equals the prior six substitutions and that nothing branches on `verdict` yet.
