### PR TITLE
fix(painter): render double table borders as two rules (SD-3308)

### DIFF
--- a/packages/layout-engine/painters/dom/src/table/border-utils.test.ts
+++ b/packages/layout-engine/painters/dom/src/table/border-utils.test.ts
@@ -39,10 +39,19 @@ describe('applyBorder', () => {
     expect(element.style.borderTop).toMatch(/2px solid (#FF0000|rgb\(255,\s*0,\s*0\))/i);
   });
 
-  it('should apply border with double style', () => {
+  // SD-3308: CSS `double` only renders two distinct rules at >= 3px (1px rule + 1px gap +
+  // 1px rule); below that it collapses to a single solid-looking line, while Word always
+  // shows two rules for w:val="double". The painter clamps the width up, never down.
+  it('clamps a double border below 3px up so both rules render', () => {
     const border: BorderSpec = { style: 'double', width: 2, color: '#FF0000' };
     applyBorder(element, 'Top', border);
-    expect(element.style.borderTop).toMatch(/2px double (#FF0000|rgb\(255,\s*0,\s*0\))/i);
+    expect(element.style.borderTop).toMatch(/3px double (#FF0000|rgb\(255,\s*0,\s*0\))/i);
+  });
+
+  it('keeps an authored double width that is already >= 3px', () => {
+    const border: BorderSpec = { style: 'double', width: 4, color: '#FF0000' };
+    applyBorder(element, 'Top', border);
+    expect(element.style.borderTop).toMatch(/4px double (#FF0000|rgb\(255,\s*0,\s*0\))/i);
   });
 
   it('should apply border with dashed style', () => {

--- a/packages/layout-engine/painters/dom/src/table/border-utils.ts
+++ b/packages/layout-engine/painters/dom/src/table/border-utils.ts
@@ -83,7 +83,11 @@ export const applyBorder = (
   const width = border.width ?? 1;
   const color = border.color ?? '#000000';
   const safeColor = isValidHexColor(color) ? color : '#000000';
-  const actualWidth = border.style === 'thick' ? Math.max(width * 2, 3) : width;
+  // CSS `double` only renders two distinct rules at >= 3px (1px rule + 1px gap + 1px rule);
+  // below that it collapses to a single solid-looking line. Word always shows two rules for
+  // w:val="double", so clamp the rendered width up (never shrink an authored width). (SD-3308)
+  const minStyleWidth = style === 'double' ? 3 : 0;
+  const actualWidth = border.style === 'thick' ? Math.max(width * 2, 3) : Math.max(width, minStyleWidth);
   element.style[`border${side}`] = `${actualWidth}px ${style} ${safeColor}`;
 };
 


### PR DESCRIPTION
## Summary

Word renders w:val="double" table borders as two parallel rules. SuperDoc emitted the authored width verbatim, and CSS double collapses to a single solid-looking line below 3px (1px rule + 1px gap + 1px rule), so a typical sz12 double border (~2px) rendered as one thin line.

The fix clamps the rendered width up to 3px when the resolved CSS style is double, without shrinking authored widths that are already 3px or wider. All border paint paths (cell borders, outer table edges, continuation rows) funnel through applyBorder, so the one change covers them all.

Linear: [SD-3308](https://linear.app/superdocworkspace/issue/SD-3308/feature-table-borders)

## Verification

- Mutation fixture double_or_dotted_borders.docx: the double table now shows two rules on every outer and interior edge; dotted and dashed tables render unchanged (2px dotted/dashed before and after).
- The prior unit test asserted the collapsed 2px double output and locked in the bug; the expectation flip to 3px is deliberate and documented in the test.
- painter-dom suite: 1243 passed.

## Notes

One step of the SD-3308 plan. Border precedence, nil/none suppression, inside gridlines, and cell-spacing borders were verified at Word parity against the SD-3308 fixture set and are untouched here.