### PR TITLE
ci(pickled): prove build verifiers in the deterministic job

### DIFF
--- a/.github/workflows/pickled.yml
+++ b/.github/workflows/pickled.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Plan build cells
         run: bunx @pickled-dev/cli build . --plan
 
+      - name: Prove build verifiers
+        run: bunx @pickled-dev/cli build . --verify-only
+
   real-agent:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest


### PR DESCRIPTION
The deterministic Pickled job planned build cells but did not prove the build harness. This adds a step running `pickled build --verify-only`, which runs each build's preflight and reference control with no agent: per build it checks that the untouched fixture fails its `failToPass`, passes its `passToPass`, and that the declared `referenceSolution` patch applies and clears the verifier.

- Catches a broken reference patch, a failing verify script, a starter that already passes, or a red regression guard before the paid real-agent run.
- Deterministic and per-build (no tokens); it supplements `build --plan`, which still validates cell expansion.
- Verified against this repo's config: all three builds report proven.
