### PR TITLE
fix(style-engine): table style base shading as wholeTable layer (SD-3035)

### DIFF
--- a/packages/layout-engine/style-engine/src/ooxml/index.test.ts
+++ b/packages/layout-engine/style-engine/src/ooxml/index.test.ts
@@ -887,6 +887,92 @@ describe('ooxml - resolveTableCellProperties basedOn tblStylePr inheritance', ()
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
+// Style base-level tcPr as the wholeTable layer (ECMA-376 17.7.6, SD-3035)
+// A table style's base-level <w:tcPr><w:shd/></w:tcPr> is stored on the style
+// def's own tableCellProperties (sibling of tableStyleProperties) and IS the
+// wholeTable conditional layer. Word paints it on every cell.
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ooxml - style base-level tcPr surfaces as wholeTable (SD-3035)', () => {
+  const interiorCell = (styleId: string) => ({
+    tableProperties: { tableStyleId: styleId, tblLook: { noHBand: true, noVBand: true } },
+    rowIndex: 1,
+    cellIndex: 1,
+    numRows: 3,
+    numCells: 3,
+  });
+
+  it('resolves a base-level shading with no explicit wholeTable region', () => {
+    const styles = {
+      ...emptyStyles,
+      styles: {
+        CondStyle: {
+          type: 'table',
+          tableProperties: {},
+          tableCellProperties: { shading: { val: 'clear', color: 'auto', fill: 'F2F2F2' } },
+        },
+      },
+    };
+    const result = resolveTableCellProperties(null, interiorCell('CondStyle'), styles);
+    expect(result.shading).toEqual({ val: 'clear', color: 'auto', fill: 'F2F2F2' });
+  });
+
+  it('leaf base-level shading beats an ancestor base-level shading via basedOn', () => {
+    const styles = {
+      ...emptyStyles,
+      styles: {
+        BaseStyle: {
+          type: 'table',
+          tableProperties: {},
+          tableCellProperties: { shading: { fill: 'AAAAAA' } },
+        },
+        LeafStyle: {
+          type: 'table',
+          basedOn: 'BaseStyle',
+          tableProperties: {},
+          tableCellProperties: { shading: { fill: 'F2F2F2' } },
+        },
+      },
+    };
+    const result = resolveTableCellProperties(null, interiorCell('LeafStyle'), styles);
+    expect(result.shading).toEqual({ fill: 'F2F2F2' });
+  });
+
+  it('an explicit tableStyleProperties.wholeTable entry beats the base-level tcPr', () => {
+    const styles = {
+      ...emptyStyles,
+      styles: {
+        CondStyle: {
+          type: 'table',
+          tableProperties: {},
+          tableCellProperties: { shading: { fill: 'BASE99' } },
+          tableStyleProperties: {
+            wholeTable: { tableCellProperties: { shading: { fill: 'EXPL77' } } },
+          },
+        },
+      },
+    };
+    const result = resolveTableCellProperties(null, interiorCell('CondStyle'), styles);
+    expect(result.shading).toEqual({ fill: 'EXPL77' });
+  });
+
+  it('inline cell shading still wins over the base-level wholeTable fill', () => {
+    const styles = {
+      ...emptyStyles,
+      styles: {
+        CondStyle: {
+          type: 'table',
+          tableProperties: {},
+          tableCellProperties: { shading: { fill: 'F2F2F2' } },
+        },
+      },
+    };
+    const result = resolveTableCellProperties({ shading: { fill: '4472C4' } }, interiorCell('CondStyle'), styles);
+    expect(result.shading).toEqual({ fill: '4472C4' });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
 // cnfStyle supplementing index-based conditional type detection
 // ──────────────────────────────────────────────────────────────────────────────
 

--- a/packages/layout-engine/style-engine/src/ooxml/index.ts
+++ b/packages/layout-engine/style-engine/src/ooxml/index.ts
@@ -483,6 +483,15 @@ function resolveConditionalProps<T extends PropertyObject>(
     const def: StyleDefinition | undefined = translatedLinkedStyles.styles?.[currentId];
     const props = def?.tableStyleProperties?.[styleType]?.[propertyType] as T | undefined;
     if (props) chain.push(props);
+    // ECMA-376 17.7.6: a table style's BASE-LEVEL <w:tcPr> (stored on the def's own
+    // tableCellProperties, a sibling of tableStyleProperties) IS the wholeTable
+    // conditional layer; Word paints e.g. its w:shd on every cell. Pushed after the
+    // explicit wholeTable entry so, post-reverse, the explicit entry still wins within
+    // one def while a leaf's base props beat any ancestor's. (SD-3035)
+    if (styleType === 'wholeTable' && propertyType === 'tableCellProperties') {
+      const baseProps = def?.tableCellProperties as T | undefined;
+      if (baseProps) chain.push(baseProps);
+    }
     currentId = def?.basedOn;
   }
   if (chain.length === 0) return undefined;


### PR DESCRIPTION
## Summary

A table style's base-level w:tcPr shading (e.g. fill F2F2F2) is the wholeTable conditional layer per ECMA-376 17.7.6: Word paints it on every cell of a table that references the style. SuperDoc's cascade only read tableStyleProperties[region] and never the style definition's base-level tableCellProperties, so style-only cell fills were dropped and such tables rendered with no background.

The fix collects the base-level tableCellProperties into the wholeTable chain while walking the basedOn hierarchy. Ordering preserved: explicit wholeTable region entries beat the base level within one definition, leaf styles beat ancestors, bands and conditional regions sit above wholeTable, inline cell shading wins over everything.

Linear: [SD-3035](https://linear.app/superdocworkspace/issue/SD-3035/feature-table-styles)

## Verification

- Fixture gates (SD-3035 mutation set): tblStyle_applied, style_plus_direct_border_overrides, style_plus_width_interactions now paint F2F2F2 on all six cells each, matching Word render pixel values exactly.
- Regression locks: first_row_styling and banded_rows_or_columns render byte-identical fills before and after (bands mask wholeTable, as in Word).
- 4 new unit tests (base-level resolution, basedOn precedence, explicit-region precedence, inline wins).
- Suites: style-engine 146, painter-dom 1242, super-editor 16136 passing.
- Layout corpus compare: 476 docs, zero changes.

## Notes

Part of the SD-3035 plan. The plan's banding-gate step was dropped after pixel-probing Word's renders proved the four "spurious band" verdicts were misreads: Word paints the same band fills SuperDoc does, so the existing banding behavior is correct and untouched.