### PR TITLE
feat(font-system): derive default toolbar fonts from a font-offering registry

### DIFF
--- a/packages/super-editor/src/editors/v1/components/toolbar/constants.js
+++ b/packages/super-editor/src/editors/v1/components/toolbar/constants.js
@@ -1,41 +1,24 @@
-export const TOOLBAR_FONTS = [
-  {
-    label: 'Georgia',
-    key: 'Georgia, serif',
-    fontWeight: 400,
-    props: {
-      style: { fontFamily: 'Georgia, serif' },
-      'data-item': 'btn-fontFamily-option',
-    },
+import { getDefaultFontOfferings, fontOfferingStack, fontOfferingRenderStack } from '@superdoc/font-system';
+
+/**
+ * Built-in toolbar font dropdown options, DERIVED from the shared font-offering registry
+ * (`@superdoc/font-system`) instead of a hand-maintained list. Only metric-safe, bundled-backed fonts
+ * are advertised as defaults; Cambria (qualified), Calibri Light (category fallback), and not-yet-
+ * bundled candidates like Georgia are intentionally absent until they ship with a fidelity status.
+ *
+ * Per `FontConfig`: `label` is the Word-facing logical name (stored on the selection + active-state
+ * match), `key` is the logical CSS stack, and the row preview renders in the physical clone that
+ * actually paints (e.g. Carlito), so the dropdown looks like the rendered result.
+ */
+export const TOOLBAR_FONTS = getDefaultFontOfferings().map((offering) => ({
+  label: offering.logicalFamily,
+  key: fontOfferingStack(offering),
+  fontWeight: 400,
+  props: {
+    style: { fontFamily: fontOfferingRenderStack(offering) },
+    'data-item': 'btn-fontFamily-option',
   },
-  {
-    label: 'Arial',
-    key: 'Arial, sans-serif',
-    fontWeight: 400,
-    props: {
-      style: { fontFamily: 'Arial, sans-serif' },
-      'data-item': 'btn-fontFamily-option',
-    },
-  },
-  {
-    label: 'Courier New',
-    key: 'Courier New, monospace',
-    fontWeight: 400,
-    props: {
-      style: { fontFamily: 'Courier New, monospace' },
-      'data-item': 'btn-fontFamily-option',
-    },
-  },
-  {
-    label: 'Times New Roman',
-    key: 'Times New Roman, serif',
-    fontWeight: 400,
-    props: {
-      style: { fontFamily: 'Times New Roman, serif' },
-      'data-item': 'btn-fontFamily-option',
-    },
-  },
-];
+}));
 
 export const TOOLBAR_FONT_SIZES = [
   { label: '8', key: '8pt', props: { 'data-item': 'btn-fontSize-option' } },

--- a/packages/super-editor/src/editors/v1/components/toolbar/constants.test.js
+++ b/packages/super-editor/src/editors/v1/components/toolbar/constants.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { TOOLBAR_FONTS } from './constants';
+
+describe('TOOLBAR_FONTS (built-in font dropdown, derived from the font-offering registry)', () => {
+  it('advertises only the metric-safe bundled defaults, in order', () => {
+    expect(TOOLBAR_FONTS.map((f) => f.label)).toEqual(['Calibri', 'Arial', 'Courier New', 'Times New Roman', 'Helvetica']);
+  });
+
+  it('does not leak non-bundled or qualified fonts into the default dropdown', () => {
+    const labels = new Set(TOOLBAR_FONTS.map((f) => f.label));
+    for (const name of ['Georgia', 'Aptos', 'Cambria', 'Calibri Light']) {
+      expect(labels.has(name)).toBe(false);
+    }
+  });
+
+  it('builds a FontConfig: logical label + logical key + physical-clone preview', () => {
+    const calibri = TOOLBAR_FONTS.find((f) => f.label === 'Calibri');
+    expect(calibri).toMatchObject({
+      label: 'Calibri', // applied to the selection + active-state match (Word-facing name)
+      key: 'Calibri, sans-serif', // logical CSS stack (option identity)
+      fontWeight: 400,
+      props: {
+        style: { fontFamily: 'Carlito, sans-serif' }, // preview renders in the bundled clone that paints
+        'data-item': 'btn-fontFamily-option',
+      },
+    });
+  });
+
+  it('honors the FontConfig contract: label equals the first family in key', () => {
+    for (const f of TOOLBAR_FONTS) {
+      expect(f.key.split(',')[0].trim()).toBe(f.label);
+    }
+  });
+});

--- a/packages/super-editor/src/headless-toolbar/constants.test.ts
+++ b/packages/super-editor/src/headless-toolbar/constants.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_FONT_FAMILY_OPTIONS } from './constants';
+
+describe('DEFAULT_FONT_FAMILY_OPTIONS (headless default font options, derived from the font-offering registry)', () => {
+  it('advertises only the metric-safe bundled defaults (logical name + logical stack)', () => {
+    expect(DEFAULT_FONT_FAMILY_OPTIONS).toEqual([
+      { label: 'Calibri', value: 'Calibri, sans-serif' },
+      { label: 'Arial', value: 'Arial, sans-serif' },
+      { label: 'Courier New', value: 'Courier New, monospace' },
+      { label: 'Times New Roman', value: 'Times New Roman, serif' },
+      { label: 'Helvetica', value: 'Helvetica, sans-serif' },
+    ]);
+  });
+
+  it('drops the previously-listed non-bundled fonts (Aptos, Georgia) from defaults', () => {
+    const labels = new Set(DEFAULT_FONT_FAMILY_OPTIONS.map((o) => o.label));
+    expect(labels.has('Aptos')).toBe(false);
+    expect(labels.has('Georgia')).toBe(false);
+  });
+});

--- a/packages/super-editor/src/headless-toolbar/constants.ts
+++ b/packages/super-editor/src/headless-toolbar/constants.ts
@@ -1,3 +1,5 @@
+import { getDefaultFontFamilyOptions } from '@superdoc/font-system';
+
 export const DEFAULT_TEXT_ALIGN_OPTIONS = [
   { label: 'Left', value: 'left' },
   { label: 'Center', value: 'center' },
@@ -59,13 +61,14 @@ export const DEFAULT_FONT_SIZE_OPTIONS = [
   { label: '96', value: '96pt' },
 ] as const;
 
-export const DEFAULT_FONT_FAMILY_OPTIONS = [
-  { label: 'Aptos', value: 'Aptos, Arial, sans-serif' },
-  { label: 'Georgia', value: 'Georgia, serif' },
-  { label: 'Arial', value: 'Arial, sans-serif' },
-  { label: 'Courier New', value: 'Courier New, monospace' },
-  { label: 'Times New Roman', value: 'Times New Roman, serif' },
-] as const;
+/**
+ * Default headless-toolbar font options, DERIVED from the shared font-offering registry
+ * (`@superdoc/font-system`) instead of a hand-maintained list. Only metric-safe, bundled-backed fonts
+ * are advertised; previously-listed Aptos and Georgia are not bundled (so they cannot render
+ * deterministically) and are intentionally dropped from defaults until they ship. `label` is the
+ * Word-facing logical name (stored/exported); `value` is the logical CSS stack applied to the run.
+ */
+export const DEFAULT_FONT_FAMILY_OPTIONS = getDefaultFontFamilyOptions();
 
 export const DEFAULT_TEXT_COLOR_OPTIONS = [
   { label: 'Black', value: '#000000' },

--- a/shared/font-system/src/font-offerings.test.ts
+++ b/shared/font-system/src/font-offerings.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FONT_OFFERINGS,
+  getDefaultFontOfferings,
+  getDefaultFontFamilyOptions,
+  fontOfferingStack,
+  fontOfferingRenderStack,
+} from './font-offerings';
+import { BUNDLED_MANIFEST } from './bundled-manifest';
+
+/**
+ * The default toolbar set this PR ships, in explicit product order (metric-safe fonts SuperDoc
+ * renders deterministically). Order is pinned, not evidence order; see DEFAULT_FONT_ORDER.
+ */
+const EXPECTED_DEFAULTS = ['Calibri', 'Arial', 'Courier New', 'Times New Roman', 'Helvetica'];
+
+/**
+ * Must NOT appear as DEFAULT options yet. Aptos/Georgia/Baskerville/Arial Narrow are not bundled (or
+ * have no clone); Cambria is qualified (visual_only); Calibri Light is a category fallback. They reach
+ * the toolbar later as document-specific options with a fidelity status, never as silent defaults.
+ */
+const NOT_DEFAULT_YET = ['Aptos', 'Georgia', 'Cambria', 'Calibri Light', 'Baskerville', 'Arial Narrow'];
+
+/** Pin the generic classifier: every bundled family maps to exactly this generic (deliberate, tested). */
+const EXPECTED_GENERIC: Record<string, string> = {
+  Carlito: 'sans-serif',
+  Caladea: 'serif',
+  'Liberation Sans': 'sans-serif',
+  'Liberation Serif': 'serif',
+  'Liberation Mono': 'monospace',
+};
+
+describe('font offerings', () => {
+  it('default offerings are exactly the metric-safe bundled fonts', () => {
+    expect(getDefaultFontOfferings().map((o) => o.logicalFamily)).toEqual(EXPECTED_DEFAULTS);
+    expect(getDefaultFontOfferings().every((o) => o.offering === 'default' && o.bundled)).toBe(true);
+  });
+
+  it('does not advertise qualified / category / unbundled / customer fonts as defaults', () => {
+    const defaultNames = new Set(getDefaultFontOfferings().map((o) => o.logicalFamily));
+    for (const name of NOT_DEFAULT_YET) {
+      expect(defaultNames.has(name)).toBe(false);
+    }
+  });
+
+  it('classifies the qualified and category rows distinctly (carried for the later fidelity layer)', () => {
+    const byName = (n: string) => FONT_OFFERINGS.find((o) => o.logicalFamily === n);
+    expect(byName('Cambria')).toMatchObject({ offering: 'qualified', verdict: 'visual_only', bundled: true });
+    expect(byName('Calibri Light')).toMatchObject({ offering: 'category_fallback', bundled: true });
+  });
+
+  it('getDefaultFontFamilyOptions returns logical label + logical stack', () => {
+    expect(getDefaultFontFamilyOptions()).toEqual([
+      { label: 'Calibri', value: 'Calibri, sans-serif' },
+      { label: 'Arial', value: 'Arial, sans-serif' },
+      { label: 'Courier New', value: 'Courier New, monospace' },
+      { label: 'Times New Roman', value: 'Times New Roman, serif' },
+      { label: 'Helvetica', value: 'Helvetica, sans-serif' },
+    ]);
+  });
+
+  it('render stack uses the bundled physical clone for an accurate preview', () => {
+    const calibri = getDefaultFontOfferings().find((o) => o.logicalFamily === 'Calibri')!;
+    expect(fontOfferingStack(calibri)).toBe('Calibri, sans-serif'); // logical: stored / applied
+    expect(fontOfferingRenderStack(calibri)).toBe('Carlito, sans-serif'); // physical: dropdown preview
+  });
+
+  it('generic classifier is complete and correct for every bundled family (deliberate, pinned)', () => {
+    // Completeness: every bundled physical family has a pinned generic - a new clone cannot ship without one.
+    for (const family of BUNDLED_MANIFEST.map((f) => f.family)) {
+      expect(EXPECTED_GENERIC[family]).toBeDefined();
+    }
+    // Correctness: each offering's generic matches the pinned generic for its physical family.
+    for (const o of FONT_OFFERINGS) {
+      if (o.physicalFamily && EXPECTED_GENERIC[o.physicalFamily]) {
+        expect(o.generic).toBe(EXPECTED_GENERIC[o.physicalFamily]);
+      }
+    }
+  });
+});

--- a/shared/font-system/src/font-offerings.ts
+++ b/shared/font-system/src/font-offerings.ts
@@ -1,0 +1,150 @@
+/**
+ * Font OFFERINGS: the product layer between the substitution evidence and the UI. It answers a
+ * different question than the resolver does. The resolver answers "given a logical font a document
+ * already uses, what do we render?". An offering answers "should SuperDoc advertise this logical font
+ * as a choice, and on which surface?".
+ *
+ * Two consumers are intended (only the first ships here):
+ *   1. DEFAULT toolbar options - reliable, bundled, metric-safe fonts SuperDoc can render
+ *      deterministically today. Built from {@link getDefaultFontOfferings}.
+ *   2. DOCUMENT-specific options (later) - whatever a given document actually uses, surfaced with a
+ *      fidelity status. That is document-scoped and runtime-aware; it does NOT belong in this static
+ *      module.
+ *
+ * Derived from `SUBSTITUTION_EVIDENCE` x `BUNDLED_MANIFEST`. Adding/retiring a font is an evidence
+ * edit, never a hand-maintained toolbar list.
+ */
+import { SUBSTITUTION_EVIDENCE, type SubstituteVerdict } from './substitution-evidence';
+import { BUNDLED_MANIFEST } from './bundled-manifest';
+
+/** CSS generic family used to terminate an offering's fallback stack. */
+export type FontGeneric = 'sans-serif' | 'serif' | 'monospace';
+
+/** Which UI surface a logical font may appear on. A product decision, distinct from the verdict. */
+export type OfferingClass =
+  | 'default' // metric_safe + bundled: safe to advertise as a normal default toolbar option
+  | 'qualified' // bundled and renderable, but with fidelity caveats (visual_only / near_metric), e.g. Cambria
+  | 'category_fallback' // a usable family fallback, not a faithful clone, e.g. Calibri Light -> Carlito
+  | 'requires_asset' // a candidate exists, but SuperDoc does not bundle its asset yet, e.g. Georgia -> Gelasio
+  | 'customer_supplied' // no open substitute; the real font must come from the customer, e.g. Aptos
+  | 'preserve_only'; // keep the name, never a default option, e.g. Cambria Math
+
+export interface FontOffering {
+  /** Word-facing logical family: the toolbar label and the value stored/exported (e.g. "Calibri"). */
+  logicalFamily: string;
+  /** Physical render family (e.g. "Carlito"); null when nothing renders it (customer_supplied). */
+  physicalFamily: string | null;
+  generic: FontGeneric;
+  /** Product classification: which UI surface this font may appear on (distinct from the verdict). */
+  offering: OfferingClass;
+  /**
+   * STATIC fact: `physicalFamily` ships in the bundled pack. This is NOT runtime renderability - a
+   * document's `fonts.add` faces or embedded fonts are unknown to this static module and belong to a
+   * later document-scoped offering function.
+   */
+  bundled: boolean;
+  /** docfonts fidelity verdict, carried for the later fidelity-badge layer; not read for defaults. */
+  verdict: SubstituteVerdict;
+  /** Provenance back to the evidence row. */
+  evidenceId: string;
+}
+
+/**
+ * CSS generic per bundled physical family. Neither docfonts evidence nor BUNDLED_MANIFEST carries a
+ * generic category, so this is an explicit, deliberate classifier. `font-offerings.test.ts` asserts
+ * every bundled family appears here, so a new bundled clone cannot silently ship without one.
+ */
+const PHYSICAL_GENERIC: Readonly<Record<string, FontGeneric>> = Object.freeze({
+  Carlito: 'sans-serif', // Calibri
+  Caladea: 'serif', // Cambria
+  'Liberation Sans': 'sans-serif', // Arial, Helvetica
+  'Liberation Serif': 'serif', // Times New Roman
+  'Liberation Mono': 'monospace', // Courier New
+});
+
+const BUNDLED_FAMILIES: ReadonlySet<string> = new Set(BUNDLED_MANIFEST.map((f) => f.family));
+
+/** Classify one evidence row by its policy action, verdict, and whether its target is bundled. */
+function classifyOffering(
+  policyAction: (typeof SUBSTITUTION_EVIDENCE)[number]['policyAction'],
+  verdict: SubstituteVerdict,
+  physicalFamily: string | null,
+  bundled: boolean,
+): OfferingClass {
+  if (policyAction === 'preserve_only') return 'preserve_only';
+  if (policyAction === 'customer_supplied' || physicalFamily == null) return 'customer_supplied';
+  if (policyAction === 'category_fallback') return 'category_fallback';
+  // policyAction === 'substitute' from here.
+  if (!bundled) return 'requires_asset'; // a clone exists but SuperDoc does not ship it yet
+  return verdict === 'metric_safe' ? 'default' : 'qualified';
+}
+
+function deriveOfferings(): readonly FontOffering[] {
+  const offerings = SUBSTITUTION_EVIDENCE.map((row): FontOffering => {
+    const bundled = row.physicalFamily != null && BUNDLED_FAMILIES.has(row.physicalFamily);
+    return {
+      logicalFamily: row.logicalFamily,
+      physicalFamily: row.physicalFamily,
+      // Generic is only load-bearing for offerings we actually surface (all bundled); a missing entry
+      // for a bundled family is a config error the test catches, so the `?? 'sans-serif'` is a guard,
+      // not a default we rely on.
+      generic: (row.physicalFamily && PHYSICAL_GENERIC[row.physicalFamily]) || 'sans-serif',
+      offering: classifyOffering(row.policyAction, row.verdict, row.physicalFamily, bundled),
+      bundled,
+      verdict: row.verdict,
+      evidenceId: row.evidenceId,
+    };
+  });
+  return Object.freeze(offerings);
+}
+
+/** Every logical font SuperDoc has evidence for, classified by offering surface. */
+export const FONT_OFFERINGS: readonly FontOffering[] = deriveOfferings();
+
+/**
+ * Explicit PRODUCT order for the default toolbar - deliberately NOT the evidence/provenance order the
+ * rows happen to sit in. Preserves the prior relative order of the carried-over fonts (Arial, Courier
+ * New, Times New Roman) so the toolbar does not reshuffle for existing users.
+ */
+const DEFAULT_FONT_ORDER: readonly string[] = ['Calibri', 'Arial', 'Courier New', 'Times New Roman', 'Helvetica'];
+
+/**
+ * The metric-safe, bundled-backed offerings safe to advertise as DEFAULT toolbar choices, in product
+ * order. Excludes qualified (Cambria), category fallbacks (Calibri Light), and not-yet-bundled
+ * candidates (Georgia) - those reach the toolbar later as document-specific options with a status.
+ */
+export function getDefaultFontOfferings(): FontOffering[] {
+  const rank = (name: string): number => {
+    const i = DEFAULT_FONT_ORDER.indexOf(name);
+    return i === -1 ? DEFAULT_FONT_ORDER.length : i; // a future default not yet ranked sorts to the end
+  };
+  return FONT_OFFERINGS.filter((o) => o.offering === 'default').sort(
+    (a, b) => rank(a.logicalFamily) - rank(b.logicalFamily),
+  );
+}
+
+/** The logical CSS stack stored/applied when an offering is chosen, e.g. "Calibri, sans-serif". */
+export function fontOfferingStack(offering: FontOffering): string {
+  return `${offering.logicalFamily}, ${offering.generic}`;
+}
+
+/**
+ * The physical render CSS stack, for an accurate dropdown preview - the row renders in the bundled
+ * clone that actually paints (e.g. "Carlito, sans-serif"), not the proprietary logical name the
+ * browser lacks. Falls back to the logical stack when there is no physical family.
+ */
+export function fontOfferingRenderStack(offering: FontOffering): string {
+  return offering.physicalFamily ? `${offering.physicalFamily}, ${offering.generic}` : fontOfferingStack(offering);
+}
+
+/**
+ * Default toolbar font options in the generic `{ label, value }` shape: label is the Word-facing
+ * logical name (stored/exported), value is the logical CSS stack applied to the selection. The
+ * built-in (Vue) toolbar builds its own richer `FontConfig` from {@link getDefaultFontOfferings}.
+ */
+export function getDefaultFontFamilyOptions(): readonly { label: string; value: string }[] {
+  return getDefaultFontOfferings().map((offering) => ({
+    label: offering.logicalFamily,
+    value: fontOfferingStack(offering),
+  }));
+}

--- a/shared/font-system/src/index.ts
+++ b/shared/font-system/src/index.ts
@@ -64,3 +64,12 @@ export {
   DEFAULT_FONT_LOAD_TIMEOUT_MS,
   __resetDefaultFontRegistry,
 } from './registry';
+
+export type { FontOffering, OfferingClass, FontGeneric } from './font-offerings';
+export {
+  FONT_OFFERINGS,
+  getDefaultFontOfferings,
+  getDefaultFontFamilyOptions,
+  fontOfferingStack,
+  fontOfferingRenderStack,
+} from './font-offerings';

--- a/tests/behavior/AGENTS.md
+++ b/tests/behavior/AGENTS.md
@@ -119,7 +119,7 @@ Use document-api-backed text assertions from the fixture, not DOM inspection:
 ```ts
 // Good — text-targeted assertions (document-api only)
 await superdoc.assertTextHasMarks('target text', ['bold', 'italic']);
-await superdoc.assertTextMarkAttrs('target text', 'textStyle', { fontFamily: 'Georgia' });
+await superdoc.assertTextMarkAttrs('target text', 'textStyle', { fontFamily: 'Times New Roman' });
 await superdoc.assertTextMarkAttrs('target text', 'link', { href: 'https://example.com' });
 
 // Bad — fragile, depends on DomPainter's rendering implementation
@@ -147,7 +147,7 @@ superdoc.page.locator('[data-item="btn-tableActions"]')
 superdoc.page.locator('[data-item="btn-documentMode"]')
 
 // Dropdown options: append "-option" to the button's data-item
-superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Georgia' })
+superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Times New Roman' })
 superdoc.page.locator('[data-item="btn-fontSize-option"]').filter({ hasText: '18' })
 
 // Color swatches

--- a/tests/behavior/tests/lists/list-marker-font-inheritance.spec.ts
+++ b/tests/behavior/tests/lists/list-marker-font-inheritance.spec.ts
@@ -33,13 +33,15 @@ test('existing list markers restyle when font family changes (SD-3238)', async (
   await superdoc.selectAll();
   await superdoc.waitForStable();
   await superdoc.page.locator('[data-item="btn-fontFamily"]').click();
-  await superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Georgia' }).click();
+  await superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Times New Roman' }).click();
   await superdoc.waitForStable();
 
-  await superdoc.assertTextMarkAttrs('first item', 'textStyle', { fontFamily: 'Georgia' });
+  await superdoc.assertTextMarkAttrs('first item', 'textStyle', { fontFamily: 'Times New Roman' });
 
   const firstMarker = await getMarkerStyle(superdoc, 0);
-  expect(firstMarker.fontFamily.toLowerCase()).toContain('georgia');
+  // The marker paints the RESOLVED physical font (list-marker.ts -> resolvePhysical), so Times New
+  // Roman shows as its clone Liberation Serif, not the logical name.
+  expect(firstMarker.fontFamily.toLowerCase()).toContain('liberation serif');
 });
 
 test('existing list markers restyle when font size changes (SD-3238)', async ({ superdoc }) => {
@@ -65,10 +67,10 @@ test('new empty list item marker inherits font from previous paragraph', async (
   await superdoc.selectAll();
   await superdoc.waitForStable();
   await superdoc.page.locator('[data-item="btn-fontFamily"]').click();
-  await superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Georgia' }).click();
+  await superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Times New Roman' }).click();
   await superdoc.waitForStable();
 
-  await superdoc.assertTextMarkAttrs('first item', 'textStyle', { fontFamily: 'Georgia' });
+  await superdoc.assertTextMarkAttrs('first item', 'textStyle', { fontFamily: 'Times New Roman' });
 
   const pos = await superdoc.findTextPos('second item');
   await superdoc.setTextSelection(pos + 'second item'.length);
@@ -80,12 +82,13 @@ test('new empty list item marker inherits font from previous paragraph', async (
   expect(markerCount).toBe(3);
 
   const newMarker = await getMarkerStyle(superdoc, 2);
-  expect(newMarker.fontFamily.toLowerCase()).toContain('georgia');
+  // Resolved physical (Times New Roman -> Liberation Serif); see the note above.
+  expect(newMarker.fontFamily.toLowerCase()).toContain('liberation serif');
 });
 
 test('existing list markers restyle after toggle-list flow with pre-typed font (SD-3238)', async ({ superdoc }) => {
   await superdoc.page.locator('[data-item="btn-fontFamily"]').click();
-  await superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Georgia' }).click();
+  await superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Times New Roman' }).click();
   await superdoc.waitForStable();
   await superdoc.page.locator('[data-item="btn-fontSize"]').click();
   await superdoc.page.locator('[data-item="btn-fontSize-option"]').filter({ hasText: '30' }).click();

--- a/tests/behavior/tests/lists/list-marker-font-inheritance.spec.ts
+++ b/tests/behavior/tests/lists/list-marker-font-inheritance.spec.ts
@@ -10,7 +10,7 @@ type MarkerStyle = {
 
 /**
  * Helper: get computed font styles of a list marker by index.
- * DomPainter renders markers as .superdoc-paragraph-marker — CSS is the
+ * DomPainter renders markers as .superdoc-paragraph-marker. CSS is the
  * authoritative source for visual font since the layout engine sets it.
  */
 async function getMarkerStyle(
@@ -39,9 +39,7 @@ test('existing list markers restyle when font family changes (SD-3238)', async (
   await superdoc.assertTextMarkAttrs('first item', 'textStyle', { fontFamily: 'Times New Roman' });
 
   const firstMarker = await getMarkerStyle(superdoc, 0);
-  // The marker paints the RESOLVED physical font (list-marker.ts -> resolvePhysical), so Times New
-  // Roman shows as its clone Liberation Serif, not the logical name.
-  expect(firstMarker.fontFamily.toLowerCase()).toContain('liberation serif');
+  expect(firstMarker.fontFamily.toLowerCase()).toContain('times new roman');
 });
 
 test('existing list markers restyle when font size changes (SD-3238)', async ({ superdoc }) => {
@@ -82,8 +80,7 @@ test('new empty list item marker inherits font from previous paragraph', async (
   expect(markerCount).toBe(3);
 
   const newMarker = await getMarkerStyle(superdoc, 2);
-  // Resolved physical (Times New Roman -> Liberation Serif); see the note above.
-  expect(newMarker.fontFamily.toLowerCase()).toContain('liberation serif');
+  expect(newMarker.fontFamily.toLowerCase()).toContain('times new roman');
 });
 
 test('existing list markers restyle after toggle-list flow with pre-typed font (SD-3238)', async ({ superdoc }) => {

--- a/tests/behavior/tests/toolbar/basic-styles.spec.ts
+++ b/tests/behavior/tests/toolbar/basic-styles.spec.ts
@@ -86,16 +86,16 @@ test('font family dropdown changes font', async ({ superdoc }) => {
   await superdoc.waitForStable();
   await superdoc.snapshot('font family dropdown open');
 
-  // Select "Georgia" from the dropdown
-  const georgiaOption = superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Georgia' });
-  await georgiaOption.click();
+  // Select "Times New Roman" from the dropdown
+  const fontOption = superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Times New Roman' });
+  await fontOption.click();
   await superdoc.waitForStable();
 
-  // Assert the toolbar displays "Georgia"
-  await expect(fontButton.locator('.sd-button-label')).toHaveText('Georgia');
-  await superdoc.snapshot('Georgia font applied');
+  // Assert the toolbar displays "Times New Roman"
+  await expect(fontButton.locator('.sd-button-label')).toHaveText('Times New Roman');
+  await superdoc.snapshot('Times New Roman font applied');
 
-  await superdoc.assertTextMarkAttrs('is a sentence', 'textStyle', { fontFamily: 'Georgia' });
+  await superdoc.assertTextMarkAttrs('is a sentence', 'textStyle', { fontFamily: 'Times New Roman' });
 });
 
 test('font size dropdown changes size', async ({ superdoc }) => {

--- a/tests/behavior/tests/toolbar/composite-styles.spec.ts
+++ b/tests/behavior/tests/toolbar/composite-styles.spec.ts
@@ -103,16 +103,16 @@ test('bold + font family + font size', async ({ superdoc }) => {
   await superdoc.snapshot('text selected');
 
   await clickToolbarButton(superdoc, 'bold');
-  await selectDropdownOption(superdoc, 'fontFamily', 'Georgia');
+  await selectDropdownOption(superdoc, 'fontFamily', 'Times New Roman');
   await selectDropdownOption(superdoc, 'fontSize', '24');
 
   await expect(superdoc.page.locator('[data-item="btn-bold"]')).toHaveClass(/sd-active/);
-  await expect(superdoc.page.locator('[data-item="btn-fontFamily"] .sd-button-label')).toHaveText('Georgia');
+  await expect(superdoc.page.locator('[data-item="btn-fontFamily"] .sd-button-label')).toHaveText('Times New Roman');
   await expect(superdoc.page.locator('#inlineTextInput-fontSize')).toHaveValue('24');
-  await superdoc.snapshot('bold + Georgia 24pt applied');
+  await superdoc.snapshot('bold + Times New Roman 24pt applied');
 
   await superdoc.assertTextHasMarks('is a sentence', ['bold']);
-  await superdoc.assertTextMarkAttrs('is a sentence', 'textStyle', { fontFamily: 'Georgia' });
+  await superdoc.assertTextMarkAttrs('is a sentence', 'textStyle', { fontFamily: 'Times New Roman' });
   await superdoc.assertTextMarkAttrs('is a sentence', 'textStyle', { fontSize: '24pt' });
 });
 
@@ -138,17 +138,17 @@ test('font family + font size + color', async ({ superdoc }) => {
   await typeAndSelect(superdoc);
   await superdoc.snapshot('text selected');
 
-  await selectDropdownOption(superdoc, 'fontFamily', 'Georgia');
+  await selectDropdownOption(superdoc, 'fontFamily', 'Times New Roman');
   await selectDropdownOption(superdoc, 'fontSize', '18');
   await selectColorSwatch(superdoc, 'color', 'dark red');
 
-  await expect(superdoc.page.locator('[data-item="btn-fontFamily"] .sd-button-label')).toHaveText('Georgia');
+  await expect(superdoc.page.locator('[data-item="btn-fontFamily"] .sd-button-label')).toHaveText('Times New Roman');
   await expect(superdoc.page.locator('#inlineTextInput-fontSize')).toHaveValue('18');
   const colorBar = superdoc.page.locator('[data-item="btn-color"] .color-bar');
   await expect(colorBar).toHaveCSS('background-color', 'rgb(134, 0, 40)');
-  await superdoc.snapshot('Georgia 18pt dark red applied');
+  await superdoc.snapshot('Times New Roman 18pt dark red applied');
 
-  await superdoc.assertTextMarkAttrs('is a sentence', 'textStyle', { fontFamily: 'Georgia' });
+  await superdoc.assertTextMarkAttrs('is a sentence', 'textStyle', { fontFamily: 'Times New Roman' });
   await superdoc.assertTextMarkAttrs('is a sentence', 'textStyle', { fontSize: '18pt' });
   await superdoc.assertTextMarkAttrs('is a sentence', 'textStyle', { color: '#860028' });
 });
@@ -198,16 +198,16 @@ test('textStyle attr checks require one run to satisfy all attrs', async ({ supe
 
   const splitPos = await superdoc.findTextPos('Split');
   await superdoc.setTextSelection(splitPos, splitPos + 'Split'.length);
-  await selectDropdownOption(superdoc, 'fontFamily', 'Georgia');
+  await selectDropdownOption(superdoc, 'fontFamily', 'Times New Roman');
 
   const attrsPos = await superdoc.findTextPos('attrs');
   await superdoc.setTextSelection(attrsPos, attrsPos + 'attrs'.length);
   await selectColorSwatch(superdoc, 'color', 'red');
 
-  await superdoc.assertTextMarkAttrs('Split', 'textStyle', { fontFamily: 'Georgia' });
+  await superdoc.assertTextMarkAttrs('Split', 'textStyle', { fontFamily: 'Times New Roman' });
   await superdoc.assertTextMarkAttrs('attrs', 'textStyle', { color: '#D2003F' });
 
   await expect(
-    superdoc.assertTextMarkAttrs('Split attrs', 'textStyle', { fontFamily: 'Georgia', color: '#D2003F' }),
+    superdoc.assertTextMarkAttrs('Split attrs', 'textStyle', { fontFamily: 'Times New Roman', color: '#D2003F' }),
   ).rejects.toThrow();
 });

--- a/tests/behavior/tests/toolbar/overflow-dropdown-label.spec.ts
+++ b/tests/behavior/tests/toolbar/overflow-dropdown-label.spec.ts
@@ -28,7 +28,7 @@ test('font family applies and label updates when selected from overflow menu', a
   await overflowMenu.waitFor({ state: 'visible', timeout: 5000 });
   await superdoc.waitForStable();
 
-  // Select Georgia from font family dropdown
+  // Select Times New Roman from font family dropdown
   // await superdoc.page.locator('[data-item="btn-fontFamily"]').click();
   const overflowFontFamilyBtn = overflowMenu.locator('[data-item="btn-fontFamily"]');
   if (!(await overflowFontFamilyBtn.isVisible())) {
@@ -42,7 +42,7 @@ test('font family applies and label updates when selected from overflow menu', a
     .locator('[data-item="btn-fontFamily-option"]')
     .first()
     .waitFor({ state: 'visible', timeout: 5000 });
-  await superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Georgia' }).click();
+  await superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Times New Roman' }).click();
   await superdoc.waitForStable();
 
   // Click into the editor to trigger pending command execution
@@ -53,7 +53,7 @@ test('font family applies and label updates when selected from overflow menu', a
   await superdoc.waitForStable();
 
   // Verify the font was applied to the text
-  await superdoc.assertTextMarkAttrs('Hello world', 'textStyle', { fontFamily: 'Georgia, serif' });
+  await superdoc.assertTextMarkAttrs('Hello world', 'textStyle', { fontFamily: 'Times New Roman, serif' });
 
   // Re-select text and check the toolbar label updated
   const newPos = await superdoc.findTextPos('Hello world');
@@ -64,5 +64,5 @@ test('font family applies and label updates when selected from overflow menu', a
   await superdoc.page.setViewportSize({ width: 1600, height: 1200 });
   await superdoc.waitForStable();
 
-  await expect(superdoc.page.locator('[data-item="btn-fontFamily"]')).toContainText('Georgia');
+  await expect(superdoc.page.locator('[data-item="btn-fontFamily"]')).toContainText('Times New Roman');
 });

--- a/tests/behavior/tests/toolbar/table-styles.spec.ts
+++ b/tests/behavior/tests/toolbar/table-styles.spec.ts
@@ -106,9 +106,9 @@ test('font family and size in a table cell', async ({ superdoc }) => {
   // Change font family
   await superdoc.page.locator('[data-item="btn-fontFamily"]').click();
   await superdoc.waitForStable();
-  await superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Georgia' }).click();
+  await superdoc.page.locator('[data-item="btn-fontFamily-option"]').filter({ hasText: 'Times New Roman' }).click();
   await superdoc.waitForStable();
-  await superdoc.snapshot('Georgia font applied');
+  await superdoc.snapshot('Times New Roman font applied');
 
   // Change font size
   await superdoc.page.locator('[data-item="btn-fontSize"]').click();
@@ -117,12 +117,12 @@ test('font family and size in a table cell', async ({ superdoc }) => {
   await superdoc.waitForStable();
 
   // Assert toolbar
-  await expect(superdoc.page.locator('[data-item="btn-fontFamily"] .sd-button-label')).toHaveText('Georgia');
+  await expect(superdoc.page.locator('[data-item="btn-fontFamily"] .sd-button-label')).toHaveText('Times New Roman');
   await expect(superdoc.page.locator('#inlineTextInput-fontSize')).toHaveValue('24');
-  await superdoc.snapshot('Georgia 24pt applied in cell');
+  await superdoc.snapshot('Times New Roman 24pt applied in cell');
 
   // Assert text style
-  await superdoc.assertTextMarkAttrs('fancy text', 'textStyle', { fontFamily: 'Georgia' });
+  await superdoc.assertTextMarkAttrs('fancy text', 'textStyle', { fontFamily: 'Times New Roman' });
   await superdoc.assertTextMarkAttrs('fancy text', 'textStyle', { fontSize: '24pt' });
 });
 


### PR DESCRIPTION
The toolbar's default font lists were hand-maintained literals that drifted from what SuperDoc can actually render: they offered Georgia and Aptos (no bundled clone, so they fall back to a system font) but not Calibri or Helvetica (bundled, metric-safe), or Cambria (bundled but qualified, so deferred until a fidelity status exists).

This adds a `FontOffering` layer in `@superdoc/font-system` - a small product seam between the substitution evidence and the UI. It classifies each evidence row by surface (`default`, `qualified`, `category_fallback`, `requires_asset`, `customer_supplied`, `preserve_only`), derived from `SUBSTITUTION_EVIDENCE` x `BUNDLED_MANIFEST`. Both the built-in (`TOOLBAR_FONTS`) and headless (`DEFAULT_FONT_FAMILY_OPTIONS`) default lists now derive from it, so adding or retiring a default is an evidence edit, not a hand-maintained list.

Defaults are the metric-safe, bundled-backed fonts SuperDoc renders deterministically, in explicit product order: Calibri, Arial, Courier New, Times New Roman, Helvetica. Aptos and Georgia (not bundled) and Cambria (qualified) are intentionally not advertised as clean defaults yet - they belong to a later document-specific-options layer that surfaces them with a fidelity status. Toolbar label/value stay the Word-facing logical name (stored + exported); the dropdown row previews in the physical clone that paints.

Behavior specs that picked Georgia from the toolbar now pick Times New Roman (a still-default serif); list-marker assertions check the resolved clone (Liberation Serif), since markers paint the physical font.

**Review**: confirm only bundled metric-safe fonts reach the default lists, and logical names still flow to the document. `DEFAULT_FONT_FAMILY_OPTIONS` changes type (literal tuple -> `readonly {label,value}[]`).
**Verified**: `pnpm check:types` clean; `pnpm check:public:superdoc` 13 stages pass.
