### PR TITLE
fix: align column test fixtures

### DIFF
--- a/packages/layout-engine/layout-engine/src/index.test.ts
+++ b/packages/layout-engine/layout-engine/src/index.test.ts
@@ -4628,9 +4628,7 @@ describe('requirePageBoundary edge cases', () => {
 
       const layout = layoutDocument(blocks, measures, options);
       const page = layout.pages[0];
-      const contentWidth = options.pageSize!.w - options.margins!.left - options.margins!.right;
-      const totalGap = 48 * 2;
-      const expectedSecondColumnX = 50 + (100 * (contentWidth - totalGap)) / (100 + 100 + 300) + 48;
+      const expectedSecondColumnX = 50 + 100 + 48;
 
       const p2 = page.fragments.find((f) => f.blockId === 'p2') as ParaFragment;
       const p3 = page.fragments.find((f) => f.blockId === 'p3') as ParaFragment;


### PR DESCRIPTION
Fixes a stale SD-2629 layout-engine Bun test expectation left after the explicit-column no-scale geometry flip.

Root cause:
- Current column geometry preserves authored explicit widths. For the test case, the second column starts at `50 + 100 + 48 = 198`.
- The test still computed the old scaled-width position and expected `198.8`, so `unit-tests (other-packages)` failed in the Bun test step.

What changed:
- Updated the layout-engine test to expect the authored-width column position.

Context:
- The earlier `clickToPosition` and `columnRegions` fixture fixes are already present on current `main`, so this branch now only carries the remaining layout-engine expectation.

Checks:
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec prettier --check packages/layout-engine/layout-engine/src/index.test.ts`
- `git diff --check`
- Lefthook pre-commit: `check-dts-shadows`, format, lint

Local unit tests were not run because this repo forbids local unit test runs. CI should run the affected Bun path.