### PR TITLE
refactor(font-system): source substitution evidence from @docfonts/fallbacks

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3325,6 +3325,10 @@ importers:
         version: 3.5.32(typescript@5.9.3)
 
   shared/font-system:
+    dependencies:
+      '@docfonts/fallbacks':
+        specifier: 0.2.0
+        version: 0.2.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -4818,6 +4822,9 @@ packages:
   '@discoveryjs/json-ext@0.6.3':
     resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
     engines: {node: '>=14.17.0'}
+
+  '@docfonts/fallbacks@0.2.0':
+    resolution: {integrity: sha512-IwLMo3ETubHb69yYp9w0uTs+GR8VbEeL+ylFaHz8tv9vK84f7xZvIFgqwgdgoW89KpicNZr46qekflV7mCFD0g==}
 
   '@dxup/nuxt@0.4.0':
     resolution: {integrity: sha512-28LDotpr9G2knUse3cQYsOo6NJq5yhABv4ByRVRYJUmzf9Q31DI7rpRek4POlKy1aAcYyKgu5J2616pyqLohYg==}
@@ -25641,6 +25648,8 @@ snapshots:
   '@discoveryjs/json-ext@0.5.7': {}
 
   '@discoveryjs/json-ext@0.6.3': {}
+
+  '@docfonts/fallbacks@0.2.0': {}
 
   '@dxup/nuxt@0.4.0(magicast@0.5.2)(typescript@5.9.3)':
     dependencies:

--- a/shared/font-system/package.json
+++ b/shared/font-system/package.json
@@ -31,5 +31,8 @@
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "dependencies": {
+    "@docfonts/fallbacks": "0.2.0"
   }
 }

--- a/shared/font-system/src/resolver.ts
+++ b/shared/font-system/src/resolver.ts
@@ -23,6 +23,9 @@
  * default instance for callers that have no document context (and for backward compatibility).
  */
 
+import { getRenderableFallback } from '@docfonts/fallbacks';
+
+import { BUNDLED_MANIFEST } from './bundled-manifest';
 import { SUBSTITUTION_EVIDENCE } from './substitution-evidence';
 
 export type FontResolutionReason =
@@ -91,23 +94,33 @@ function sortPairs(pairs: Array<[string, string]>): Array<[string, string]> {
 }
 
 /**
- * Logical (normalized) -> physical family, DERIVED from the substitution evidence registry
- * ({@link ./substitution-evidence}): every row docfonts marks `policyAction: 'substitute'` with a
- * physical target. The evidence file is the single source of truth; this is its resolver projection
- * (lowercased, quote-stripped keys).
+ * Asset gate: a docfonts fallback activates only when SuperDoc actually ships its physical clone. The
+ * evidence registry carries more substitutes than the bundled pack covers (e.g. Georgia -> Gelasio), so
+ * `canRenderFamily` keeps an un-shipped candidate OUT of the resolver until its `.woff2` lands. The
+ * predicate checks the SUBSTITUTE (physical) family against `bundled-manifest`, matching the package's
+ * `getRenderableFallback` contract.
+ */
+const bundledFamilies: ReadonlySet<string> = new Set(BUNDLED_MANIFEST.map((f) => f.family));
+const canRenderFamily = (family: string): boolean => bundledFamilies.has(family);
+
+/**
+ * Logical (normalized) -> physical family, DERIVED from the docfonts substitution registry: every row
+ * whose ASSET-GATED fallback (`getRenderableFallback`) is a renderable `substitute`. docfonts owns the
+ * decision (evidence + policy + asset-safety); SuperDoc keeps key normalization (`normalizeFamilyKey`)
+ * authoritative so resolver lookups land on the same keys.
  *
  * The inclusion predicate is policyAction, NOT verdict: a QUALIFIED substitute - e.g. Cambria ->
  * Caladea, top-level `visual_only` because Bold Italic's U+0060 advance reflows - is still the
  * recommended substitute and stays mapped. Verdict drives how fidelity is REPORTED (a later pass),
  * never whether SuperDoc substitutes. Gate status (e.g. Helvetica's stale `ship: fail`) is diagnostic,
- * never an inclusion input. Each physical target MUST be a family the bundled pack supplies
- * (see `bundled-manifest.ts`); `substitution-evidence.test.ts` enforces that.
+ * never an inclusion input. The asset gate guarantees every mapped physical ships in the bundled pack.
  */
 function deriveBundledSubstitutes(): Readonly<Record<string, string>> {
   const substitutes: Record<string, string> = {};
   for (const row of SUBSTITUTION_EVIDENCE) {
-    if (row.policyAction === 'substitute' && row.physicalFamily) {
-      substitutes[normalizeFamilyKey(row.logicalFamily)] = row.physicalFamily;
+    const fallback = getRenderableFallback(row.logicalFamily, { canRenderFamily });
+    if (fallback?.policyAction === 'substitute') {
+      substitutes[normalizeFamilyKey(row.logicalFamily)] = fallback.substituteFamily;
     }
   }
   return Object.freeze(substitutes);
@@ -116,18 +129,20 @@ function deriveBundledSubstitutes(): Readonly<Record<string, string>> {
 const BUNDLED_SUBSTITUTES: Readonly<Record<string, string>> = deriveBundledSubstitutes();
 
 /**
- * Logical (normalized) -> non-metric family fallback, DERIVED from the evidence rows docfonts marks
- * `policyAction: 'category_fallback'`. These carry the right letterforms but are NOT metric clones
- * (they reflow and/or differ in weight, e.g. Calibri Light -> Carlito), so they resolve with reason
+ * Logical (normalized) -> non-metric family fallback, DERIVED from the docfonts rows whose asset-gated
+ * fallback is a `category_fallback`. These carry the right letterforms but are NOT metric clones (they
+ * reflow and/or differ in weight, e.g. Calibri Light -> Carlito), so they resolve with reason
  * `category_fallback`, never `bundled_substitute`. A SEPARATE map and reason keep a lower-fidelity
- * fallback from being mistaken for a clean clone. Same source of truth as
- * {@link deriveBundledSubstitutes}; the two partition the evidence by `policyAction`.
+ * fallback from being mistaken for a clean clone. Same asset gate as {@link deriveBundledSubstitutes};
+ * the two partition the renderable fallbacks by `policyAction` (an un-bundled category target, e.g.
+ * Consolas -> Inconsolata SemiExpanded, stays inert).
  */
 function deriveCategoryFallbacks(): Readonly<Record<string, string>> {
   const fallbacks: Record<string, string> = {};
   for (const row of SUBSTITUTION_EVIDENCE) {
-    if (row.policyAction === 'category_fallback' && row.physicalFamily) {
-      fallbacks[normalizeFamilyKey(row.logicalFamily)] = row.physicalFamily;
+    const fallback = getRenderableFallback(row.logicalFamily, { canRenderFamily });
+    if (fallback?.policyAction === 'category_fallback') {
+      fallbacks[normalizeFamilyKey(row.logicalFamily)] = fallback.substituteFamily;
     }
   }
   return Object.freeze(fallbacks);

--- a/shared/font-system/src/substitution-evidence.test.ts
+++ b/shared/font-system/src/substitution-evidence.test.ts
@@ -23,13 +23,17 @@ describe('substitution evidence -> resolver derivation', () => {
     for (const [logical, physical] of EXPECTED_SUBSTITUTES) {
       expect(resolver.resolvePrimaryPhysicalFamily(logical)).toBe(physical);
     }
-    // The derivation input is exactly six rows: policyAction 'substitute' with a physical target.
-    const substituteRows = SUBSTITUTION_EVIDENCE.filter((r) => r.policyAction === 'substitute' && r.physicalFamily);
-    expect(substituteRows).toHaveLength(EXPECTED_SUBSTITUTES.length);
+    // Asset-gated input: the registry carries more substitute rows than SuperDoc ships, so count only
+    // the ones whose clone is bundled (the resolver's actual input). That set is exactly the six pairs.
+    const bundled = new Set(BUNDLED_MANIFEST.map((f) => f.family));
+    const activeSubstitutes = SUBSTITUTION_EVIDENCE.filter(
+      (r) => r.policyAction === 'substitute' && r.physicalFamily && bundled.has(r.physicalFamily),
+    );
+    expect(activeSubstitutes).toHaveLength(EXPECTED_SUBSTITUTES.length);
   });
 
   it('does not substitute a family with no evidence row (the map did not grow)', () => {
-    // Aptos is not in the snapshot (no clean open substitute), so it must pass through unchanged.
+    // Aptos has a registry row but no open substitute (customer_supplied), so it passes through unchanged.
     expect(resolveFontFamily('Aptos')).toEqual({
       logicalFamily: 'Aptos',
       physicalFamily: 'Aptos',
@@ -50,12 +54,23 @@ describe('substitution evidence -> resolver derivation', () => {
     });
   });
 
-  it('every substitute target is a family the bundled pack ships (asset-availability invariant)', () => {
-    const bundledFamilies = new Set(BUNDLED_MANIFEST.map((f) => f.family));
-    for (const row of SUBSTITUTION_EVIDENCE) {
-      if (row.policyAction === 'substitute' && row.physicalFamily) {
-        expect(bundledFamilies.has(row.physicalFamily)).toBe(true);
-      }
+  it('every substitute the resolver activates ships in the bundled pack (asset-availability invariant)', () => {
+    const bundled = new Set(BUNDLED_MANIFEST.map((f) => f.family));
+    for (const [, physical] of EXPECTED_SUBSTITUTES) {
+      expect(bundled.has(physical)).toBe(true);
+    }
+  });
+
+  it('keeps an un-bundled substitute inert until its asset ships (the asset gate, not just the policy)', () => {
+    // The registry recommends substitutes SuperDoc has not shipped a clone for (e.g. Georgia -> Gelasio).
+    // canRenderFamily must keep every such row OUT of the resolver: it resolves as_requested, not mapped.
+    const bundled = new Set(BUNDLED_MANIFEST.map((f) => f.family));
+    const unbundled = SUBSTITUTION_EVIDENCE.filter(
+      (r) => r.policyAction === 'substitute' && r.physicalFamily && !bundled.has(r.physicalFamily),
+    );
+    expect(unbundled.length).toBeGreaterThan(0); // the registry really does carry some (e.g. Georgia)
+    for (const row of unbundled) {
+      expect(resolveFontFamily(row.logicalFamily).reason).toBe('as_requested');
     }
   });
 

--- a/shared/font-system/src/substitution-evidence.ts
+++ b/shared/font-system/src/substitution-evidence.ts
@@ -1,26 +1,18 @@
 /**
- * Substitution EVIDENCE: per logical font, the measured docfonts verdict behind SuperDoc's
- * logical -> physical substitution. Pure data, no imports. The resolver derives its substitute map
- * from this (see `resolver.ts`), so this file is the single source of truth for WHICH logical family
- * maps to WHICH physical substitute and HOW faithful that substitution is.
+ * Substitution EVIDENCE for SuperDoc's logical -> physical font substitution: the measured docfonts
+ * verdict behind each row. The DATA is sourced from `@docfonts/fallbacks` (one upstream, measured,
+ * PR-reviewed registry); the TYPE shapes are SuperDoc's own, kept LOCAL so the public facade stays
+ * self-contained - re-exporting the package's types would leave `@docfonts/fallbacks` in superdoc's
+ * emitted `.d.ts`, which a consumer (who does not install that package) cannot resolve.
  *
- * Distinct from {@link ./bundled-manifest} (the PHYSICAL pack: which `.woff2` files ship). That is the
- * asset layer; this is the EVIDENCE layer - which proprietary font each substitute stands in for, the
- * docfonts verdict, per-face verdicts, and the worst-case advance delta that gates layout fidelity.
- *
- * VENDORED SNAPSHOT. docfonts (`@docfonts/core` + `@docfonts/registry`) is the upstream source of
- * truth: a measured, reviewed registry kept in a separate repo, not yet a build dependency of
- * SuperDoc. These rows are a hand-reviewed copy of the docfonts EvidenceRecords for the families
- * SuperDoc currently substitutes; `evidenceId` + `measurementRefs` point back to the source record. A
- * generator/import is deferred until docfonts is a dependency CI can reproduce - until then this is
- * reviewed evidence (committed, PR-reviewed), never an unsupervised generated truth source.
- *
- * Scope note: this is the DATA plus the resolver derivation only. Reports do NOT yet branch on
- * `verdict` - Cambria still resolves to Caladea and reports `bundled_substitute`; verdict-aware
- * diagnostics are a later pass. The richer fields ride along as data so that pass needs no reshape.
+ * The const assignment at the bottom pins the package's rows to SuperDoc's {@link SubstitutionEvidence}
+ * contract: if the registry's shape stops matching, this file fails to compile - a build-time drift
+ * guard. docfonts owns the evidence; SuperDoc owns WHICH rows activate (asset-gated in `resolver.ts`
+ * against `bundled-manifest`) and how they load, render, and report.
  */
+import { SUBSTITUTION_EVIDENCE as DOCFONTS_EVIDENCE } from '@docfonts/fallbacks';
 
-/** docfonts fidelity verdict, best to worst. Vendored from `@docfonts/core` `Verdict`. */
+/** docfonts fidelity verdict, best to worst. */
 export type SubstituteVerdict =
   | 'metric_safe' // advances within the DIRECT threshold (weighted-mean <= 0.5%, worst-case <= 1%)
   | 'near_metric' // LIKELY band: weighted-mean <= 1%, worst-case <= 2.5% - near-exact, a few glyphs drift
@@ -30,7 +22,7 @@ export type SubstituteVerdict =
   | 'preserve_only' // keep the original name, do not substitute (e.g. math / symbol fonts)
   | 'no_substitute'; // no open candidate qualifies
 
-/** docfonts renderer-neutral resolution action. Vendored from `@docfonts/core` `PolicyAction`. */
+/** docfonts renderer-neutral resolution action. */
 export type SubstitutePolicyAction =
   | 'substitute' // render the named physical candidate in place of the logical font
   | 'category_fallback' // no clean candidate; fall back to a generic category (serif / sans / mono)
@@ -87,7 +79,8 @@ export interface GlyphException {
 /**
  * One logical font's substitution evidence. Mirrors the renderer-relevant fields of a docfonts
  * EvidenceRecord and omits its prose (`notes`, `confidence`, measured dates): SuperDoc decides from
- * structured data, not free text.
+ * structured data, not free text. The {@link SUBSTITUTION_EVIDENCE} assignment enforces that the
+ * package's rows conform to this shape.
  */
 export interface SubstitutionEvidence {
   /** docfonts EvidenceRecord id - the provenance pointer back to the source record, e.g. "cambria". */
@@ -120,127 +113,9 @@ export interface SubstitutionEvidence {
 }
 
 /**
- * The substitution evidence for every family SuperDoc currently substitutes - six rows, vendored from
- * docfonts. The resolver maps the rows whose `policyAction` is `substitute`; the verdict / per-face /
- * glyph-exception fields are carried for the later verdict-aware reporting pass and are not yet read.
+ * The reviewed substitution evidence, sourced from `@docfonts/fallbacks` and pinned to SuperDoc's
+ * {@link SubstitutionEvidence} contract (the assignment is the drift guard - see the file header). The
+ * resolver activates the rows it can render (asset-gated); the verdict / per-face / glyph-exception
+ * fields ride along for the later verdict-aware reporting pass and are not read for inclusion.
  */
-export const SUBSTITUTION_EVIDENCE: readonly SubstitutionEvidence[] = Object.freeze([
-  {
-    evidenceId: 'calibri',
-    logicalFamily: 'Calibri',
-    physicalFamily: 'Carlito',
-    verdict: 'metric_safe',
-    faces: { regular: true, bold: true, italic: true, boldItalic: true },
-    advance: { meanDelta: 0, maxDelta: 0 },
-    gates: { static: 'pass', metric: 'pass', layout: 'pass', ship: 'pass' },
-    policyAction: 'substitute',
-    measurementRefs: ['calibri__carlito#analytic_advance#2026-06-03', 'calibri__carlito#face_aggregate#2026-06-03'],
-    candidateLicense: 'OFL-1.1',
-    exportRule: 'preserve_original_name',
-  },
-  {
-    // The QUALIFIED case. Regular/bold/italic are metric_safe, but Caladea's Bold Italic grave accent
-    // (U+0060) advance diverges ~23%, so a line containing it reflows. The worst face rolls the
-    // top-level verdict to `visual_only`; policyAction stays `substitute` (Caladea IS the recommended
-    // substitute), which is why the resolver still maps Cambria. faceVerdicts is authoritative.
-    evidenceId: 'cambria',
-    logicalFamily: 'Cambria',
-    physicalFamily: 'Caladea',
-    verdict: 'visual_only',
-    faceVerdicts: { regular: 'metric_safe', bold: 'metric_safe', italic: 'metric_safe', boldItalic: 'visual_only' },
-    glyphExceptions: [
-      {
-        slot: 'boldItalic',
-        codepoint: 0x60,
-        advanceDelta: 0.231,
-        note: 'Caladea Bold Italic grave accent (U+0060) advance diverges ~23% from Cambria; lines containing it reflow.',
-      },
-    ],
-    faces: { regular: true, bold: true, italic: true, boldItalic: true },
-    advance: { meanDelta: 0.0002378, maxDelta: 0.2310758 },
-    gates: { static: 'pass', metric: 'pass', layout: 'not_run', ship: 'pass' },
-    policyAction: 'substitute',
-    measurementRefs: [
-      'cambria_regular__caladea#regular#w400#d2f6cad3#analytic_advance#2026-06-04',
-      'cambria_bold__caladea#bold#w700#74eda4fc#analytic_advance#2026-06-04',
-      'cambria_italic__caladea#italic#w400#9c968bf6#analytic_advance#2026-06-04',
-      'cambria_boldItalic__caladea#boldItalic#w700#f47a35ad#analytic_advance#2026-06-04',
-    ],
-    candidateLicense: 'Apache-2.0',
-    exportRule: 'preserve_original_name',
-  },
-  {
-    evidenceId: 'arial',
-    logicalFamily: 'Arial',
-    physicalFamily: 'Liberation Sans',
-    verdict: 'metric_safe',
-    faces: { regular: true, bold: true, italic: true, boldItalic: true },
-    advance: { meanDelta: 0, maxDelta: 0 },
-    gates: { static: 'pass', metric: 'pass', layout: 'not_run', ship: 'pass' },
-    policyAction: 'substitute',
-    measurementRefs: ['arial__liberation-sans#analytic_advance#2026-06-03'],
-    candidateLicense: 'OFL-1.1',
-    exportRule: 'preserve_original_name',
-  },
-  {
-    evidenceId: 'times-new-roman',
-    logicalFamily: 'Times New Roman',
-    physicalFamily: 'Liberation Serif',
-    verdict: 'metric_safe',
-    faces: { regular: true, bold: true, italic: true, boldItalic: true },
-    advance: { meanDelta: 0, maxDelta: 0 },
-    gates: { static: 'pass', metric: 'pass', layout: 'not_run', ship: 'pass' },
-    policyAction: 'substitute',
-    measurementRefs: ['times-new-roman__liberation-serif#analytic_advance#2026-06-03'],
-    candidateLicense: 'OFL-1.1',
-    exportRule: 'preserve_original_name',
-  },
-  {
-    evidenceId: 'courier-new',
-    logicalFamily: 'Courier New',
-    physicalFamily: 'Liberation Mono',
-    verdict: 'metric_safe',
-    faces: { regular: true, bold: true, italic: true, boldItalic: true },
-    advance: { meanDelta: 0, maxDelta: 0 },
-    gates: { static: 'pass', metric: 'pass', layout: 'not_run', ship: 'pass' },
-    policyAction: 'substitute',
-    measurementRefs: ['courier-new__liberation-mono#analytic_advance#2026-06-03'],
-    candidateLicense: 'OFL-1.1',
-    exportRule: 'preserve_original_name',
-  },
-  {
-    // Same candidate and metric verdict as Arial. metric_safe from one Apple/macOS Helvetica
-    // analytic-advance measurement (0.000% delta). Its static + layout gates are `not_run`, and ship
-    // was `fail` in docfonts only because SuperDoc had not consumed the alias yet - a stale-until-
-    // shipped gate, NOT a fidelity signal, so it never gates inclusion here (policyAction does).
-    evidenceId: 'helvetica',
-    logicalFamily: 'Helvetica',
-    physicalFamily: 'Liberation Sans',
-    verdict: 'metric_safe',
-    faces: { regular: true, bold: true, italic: true, boldItalic: true },
-    advance: { meanDelta: 0, maxDelta: 0 },
-    gates: { static: 'not_run', metric: 'pass', layout: 'not_run', ship: 'fail' },
-    policyAction: 'substitute',
-    measurementRefs: ['helvetica__liberation-sans#analytic_advance#2026-06-03'],
-    candidateLicense: 'OFL-1.1',
-    exportRule: 'preserve_original_name',
-  },
-  {
-    // No open Calibri Light clone: Carlito carries the Calibri letterforms but has no Light face, so it
-    // renders at Regular (weight 400 vs Light 300) and reflows up to 6.6%. `category_fallback` (a family
-    // fallback, NOT a metric clone), verdict `visual_only`, metric gate fails. `faces` are all false:
-    // Carlito faithfully supplies none of Calibri Light's own faces - the runtime still renders Carlito
-    // Regular where it is loadable, but reports it non-metric.
-    evidenceId: 'calibri-light',
-    logicalFamily: 'Calibri Light',
-    physicalFamily: 'Carlito',
-    verdict: 'visual_only',
-    faces: { regular: false, bold: false, italic: false, boldItalic: false },
-    advance: { meanDelta: 0.0148, maxDelta: 0.066 },
-    gates: { static: 'not_run', metric: 'fail', layout: 'not_run', ship: 'fail' },
-    policyAction: 'category_fallback',
-    measurementRefs: ['calibri-light__carlito#analytic_advance#2026-06-05'],
-    candidateLicense: 'OFL-1.1',
-    exportRule: 'preserve_original_name',
-  },
-]);
+export const SUBSTITUTION_EVIDENCE: readonly SubstitutionEvidence[] = DOCFONTS_EVIDENCE;


### PR DESCRIPTION
SuperDoc's font-fallback evidence was a hand-copied snapshot of the docfonts registry. This sources the measured data from the published `@docfonts/fallbacks` package (pinned 0.2.0) instead, so there's one upstream source of truth and no drift.

- Type shapes stay local; the package's rows are pinned to them by a const assignment (a build-time drift guard), which also keeps the public facade free of any `@docfonts/fallbacks` reference consumers can't resolve.
- The resolver derives its maps through the package's asset-safe decision (`getRenderableFallback`), gated by `BUNDLED_MANIFEST`, so substitutes we haven't shipped assets for (Georgia, Arial Narrow, Baskerville) stay inert. Key normalization unchanged.
- Behavior-preserving: the same seven rows activate and the default toolbar is identical. The offering layer now classifies the whole registry, setting up the document-specific dropdown without changing what ships.

**Verified**: check:types pass; check:public:superdoc pass (14 stages); frozen-lockfile pass; `@docfonts/fallbacks` bundled away (no import/dep in the published package). Unit tests in CI.
