### PR TITLE
chore(font-system): upgrade @docfonts/fallbacks to 0.3.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3327,8 +3327,8 @@ importers:
   shared/font-system:
     dependencies:
       '@docfonts/fallbacks':
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.3.0
+        version: 0.3.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -4823,8 +4823,8 @@ packages:
     resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
     engines: {node: '>=14.17.0'}
 
-  '@docfonts/fallbacks@0.2.0':
-    resolution: {integrity: sha512-IwLMo3ETubHb69yYp9w0uTs+GR8VbEeL+ylFaHz8tv9vK84f7xZvIFgqwgdgoW89KpicNZr46qekflV7mCFD0g==}
+  '@docfonts/fallbacks@0.3.0':
+    resolution: {integrity: sha512-IgbshubvIRCIfkevcWREyuvHKBF1u6yMwpivFHdbeTFKhSwQg4VgwcE7mGU5tZ/oqJKOjrckNIhzwUpHRd2xuA==}
 
   '@dxup/nuxt@0.4.0':
     resolution: {integrity: sha512-28LDotpr9G2knUse3cQYsOo6NJq5yhABv4ByRVRYJUmzf9Q31DI7rpRek4POlKy1aAcYyKgu5J2616pyqLohYg==}
@@ -25649,7 +25649,7 @@ snapshots:
 
   '@discoveryjs/json-ext@0.6.3': {}
 
-  '@docfonts/fallbacks@0.2.0': {}
+  '@docfonts/fallbacks@0.3.0': {}
 
   '@dxup/nuxt@0.4.0(magicast@0.5.2)(typescript@5.9.3)':
     dependencies:

--- a/shared/font-system/package.json
+++ b/shared/font-system/package.json
@@ -33,6 +33,6 @@
     "vitest": "catalog:"
   },
   "dependencies": {
-    "@docfonts/fallbacks": "0.2.0"
+    "@docfonts/fallbacks": "0.3.0"
   }
 }


### PR DESCRIPTION
Pins `@superdoc/font-system` to the face-scope-safe docfonts release. The integration itself already happened (the vendored evidence is a wrapper over `@docfonts/fallbacks`, the resolver derives asset-gated maps from it); this is just the version bump to 0.3.0.

0.3.0 is additive for SuperDoc: it adds the face-aware lookups, a `faces` field on every result, and the category-fallback face fix. SuperDoc reads only `policyAction`/`substituteFamily` off `getRenderableFallback` (unchanged at 0.3.0), and the `SUBSTITUTION_EVIDENCE` data-row shape is unchanged, so the drift-guard `const` in `substitution-evidence.ts` still compiles. No behavior change.

One deliberate call worth flagging: I did **not** switch `resolveFace` to `getFallbackDecisionForFace`, even though that helper now exists. `#resolveFaceLadder` is already face-safe via runtime `hasFace` - a bundled substitute applies only when `hasFace(bundled, weight, style)`, so a Regular-only substitute asked for bold already falls through to `fallback_face_absent`. The live FontFaceSet is more accurate than the package's static `faces` data, so delegating to the package helper would be a step back. The 0.3.0 helper stays available for the later verdict-aware reporting pass (per-face verdicts), which is out of scope here.

Net effect: makes 0.3.0 the baseline so a future Regular-only bundled substitute (e.g. Caprasimo for Cooper Black) is handled correctly with no further resolver change.

Lockfile diff is scoped to the one dependency (integrity verified against npm); no other versions churned.
