### PR TITLE
feat(font-system): attach docfonts verdict evidence to font reports

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3327,8 +3327,8 @@ importers:
   shared/font-system:
     dependencies:
       '@docfonts/fallbacks':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.4.0
+        version: 0.4.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -4823,8 +4823,8 @@ packages:
     resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
     engines: {node: '>=14.17.0'}
 
-  '@docfonts/fallbacks@0.3.0':
-    resolution: {integrity: sha512-IgbshubvIRCIfkevcWREyuvHKBF1u6yMwpivFHdbeTFKhSwQg4VgwcE7mGU5tZ/oqJKOjrckNIhzwUpHRd2xuA==}
+  '@docfonts/fallbacks@0.4.0':
+    resolution: {integrity: sha512-445WsZfyAe7ENv2R0z7SIl6pYCSCDSmjSPSfgB3m/L4Cfsm5eLJkgp3+IivcEJmF+HopIVOBQR6VdJt6fyYo/g==}
 
   '@dxup/nuxt@0.4.0':
     resolution: {integrity: sha512-28LDotpr9G2knUse3cQYsOo6NJq5yhABv4ByRVRYJUmzf9Q31DI7rpRek4POlKy1aAcYyKgu5J2616pyqLohYg==}
@@ -25649,7 +25649,7 @@ snapshots:
 
   '@discoveryjs/json-ext@0.6.3': {}
 
-  '@docfonts/fallbacks@0.3.0': {}
+  '@docfonts/fallbacks@0.4.0': {}
 
   '@dxup/nuxt@0.4.0(magicast@0.5.2)(typescript@5.9.3)':
     dependencies:

--- a/shared/font-system/package.json
+++ b/shared/font-system/package.json
@@ -33,6 +33,6 @@
     "vitest": "catalog:"
   },
   "dependencies": {
-    "@docfonts/fallbacks": "0.3.0"
+    "@docfonts/fallbacks": "0.4.0"
   }
 }

--- a/shared/font-system/src/report.test.ts
+++ b/shared/font-system/src/report.test.ts
@@ -30,6 +30,12 @@ describe('buildFontReport', () => {
         loadStatus: 'loaded',
         exportFamily: 'Calibri',
         missing: false,
+        evidence: {
+          evidenceId: 'calibri',
+          policyAction: 'substitute',
+          verdict: 'metric_safe',
+          lineBreakSafe: true,
+        },
       },
     ]);
   });
@@ -261,5 +267,101 @@ describe('buildFaceReport (face-level)', () => {
     expect(rows[0]?.reason).toBe('category_fallback');
     // The face loaded, but it is a non-metric fallback (wrong weight), so it is still reported missing.
     expect(rows[0]?.missing).toBe(true);
+  });
+});
+
+describe('verdict-aware evidence (rendered substitutes only)', () => {
+  it('Calibri: metric_safe substitute, line-break safe', () => {
+    const reg = new FakeRegistry();
+    reg.statuses.set('Carlito', 'loaded');
+    expect(buildFontReport(['Calibri'], reg.asRegistry())[0].evidence).toEqual({
+      evidenceId: 'calibri',
+      policyAction: 'substitute',
+      verdict: 'metric_safe',
+      lineBreakSafe: true,
+    });
+  });
+
+  it('Calibri Light: category_fallback, visual_only, NOT line-break safe', () => {
+    const reg = new FakeRegistry();
+    reg.statuses.set('Carlito', 'loaded');
+    expect(buildFontReport(['Calibri Light'], reg.asRegistry())[0].evidence).toEqual({
+      evidenceId: 'calibri-light',
+      policyAction: 'category_fallback',
+      verdict: 'visual_only',
+      lineBreakSafe: false,
+    });
+  });
+
+  it('Cambria family: top-level worst-face verdict (visual_only), all glyph exceptions', () => {
+    const reg = new FakeRegistry();
+    reg.statuses.set('Caladea', 'loaded');
+    const ev = buildFontReport(['Cambria'], reg.asRegistry())[0].evidence;
+    expect(ev?.verdict).toBe('visual_only'); // NOT a clean clone, despite reason bundled_substitute
+    expect(ev?.lineBreakSafe).toBe(false);
+    expect(ev?.glyphExceptions).toMatchObject([{ slot: 'boldItalic', codepoint: 0x60 }]);
+  });
+
+  it('Cambria Regular face: per-face metric_safe, and NO unrelated (Bold Italic) glyph exception', () => {
+    const reg = new FaceRegistry();
+    reg.setFace('Caladea', '400', 'normal', 'loaded');
+    const [row] = buildFaceReport(
+      [{ logicalFamily: 'Cambria', weight: '400', style: 'normal' }],
+      reg.asRegistry(),
+    );
+    expect(row.reason).toBe('bundled_substitute');
+    expect(row.evidence).toEqual({
+      evidenceId: 'cambria',
+      policyAction: 'substitute',
+      verdict: 'metric_safe',
+      lineBreakSafe: true,
+    });
+  });
+
+  it('Cambria Bold Italic face: per-face visual_only, includes its grave-accent exception', () => {
+    const reg = new FaceRegistry();
+    reg.setFace('Caladea', '700', 'italic', 'loaded');
+    const [row] = buildFaceReport(
+      [{ logicalFamily: 'Cambria', weight: '700', style: 'italic' }],
+      reg.asRegistry(),
+    );
+    expect(row.reason).toBe('bundled_substitute');
+    expect(row.evidence?.verdict).toBe('visual_only');
+    expect(row.evidence?.lineBreakSafe).toBe(false);
+    expect(row.evidence?.glyphExceptions).toMatchObject([{ slot: 'boldItalic', codepoint: 0x60 }]);
+  });
+
+  it('attaches NO evidence for as_requested / custom_mapping / registered_face / fallback_face_absent', () => {
+    // as_requested: Aptos has no substitute.
+    const fam = new FakeRegistry();
+    fam.statuses.set('Aptos', 'loaded');
+    expect(buildFontReport(['Aptos'], fam.asRegistry())[0].evidence).toBeUndefined();
+
+    // custom_mapping (Regular) + fallback_face_absent (Bold) via a single-face custom map.
+    const face = new FaceRegistry();
+    face.setFace('Gelasio', '400', 'normal', 'loaded');
+    face.setAwaitedFaceStatus('Georgia', '700', 'normal', 'fallback_used');
+    const resolver = createFontResolver();
+    resolver.map('Georgia', 'Gelasio');
+    const rows = buildFaceReport(
+      [
+        { logicalFamily: 'Georgia', weight: '400', style: 'normal' },
+        { logicalFamily: 'Georgia', weight: '700', style: 'normal' },
+      ],
+      face.asRegistry(),
+      resolver,
+    );
+    expect(rows.find((r) => r.reason === 'custom_mapping')?.evidence).toBeUndefined();
+    expect(rows.find((r) => r.reason === 'fallback_face_absent')?.evidence).toBeUndefined();
+
+    // registered_face: a real Calibri face registered for the logical family.
+    const reg2 = new FaceRegistry();
+    reg2.setFace('Calibri', '400', 'normal', 'loaded');
+    const [calRow] = buildFaceReport(
+      [{ logicalFamily: 'Calibri', weight: '400', style: 'normal' }],
+      reg2.asRegistry(),
+    );
+    expect(calRow.reason).toBe('registered_face');
+    expect(calRow.evidence).toBeUndefined();
   });
 });

--- a/shared/font-system/src/report.ts
+++ b/shared/font-system/src/report.ts
@@ -1,6 +1,72 @@
 import { resolveFontFamily, resolveFace, type FaceKey, type FontResolutionReason, type FontResolver } from './resolver';
 import type { FontRegistry } from './registry';
+import { getRenderableFallback, getRenderableFallbackForFace } from '@docfonts/fallbacks';
+import type {
+  FaceSlot,
+  GlyphException,
+  SubstituteVerdict,
+  SubstitutePolicyAction,
+} from './substitution-evidence';
 import { isSettled, type FontLoadStatus } from './types';
+
+/**
+ * docfonts fidelity evidence for a row where SuperDoc rendered the recommended substitute. Local types
+ * only (no `@docfonts/fallbacks` in the emitted `.d.ts`). `verdict` describes THIS row: the worst-face
+ * top-level verdict on family rows, the per-face verdict on face rows - so a consumer never reads
+ * `reason: 'bundled_substitute'` as a clean clone (Cambria -> Caladea is `visual_only` overall but
+ * `metric_safe` at Regular).
+ */
+export interface ResolvedFontEvidence {
+  /** docfonts evidence id, e.g. "cambria". */
+  evidenceId: string;
+  /** renderer-neutral action behind the substitution. */
+  policyAction: SubstitutePolicyAction;
+  /** fidelity verdict for this row (per-face on face rows; worst-face top-level on family rows). */
+  verdict: SubstituteVerdict;
+  /** advances preserve line breaks: metric_safe, near_metric, or monospace cell_width_only. */
+  lineBreakSafe: boolean;
+  /** named glyph-level divergences qualifying this row's face(s); omitted when none apply. */
+  glyphExceptions?: readonly GlyphException[];
+}
+
+/** Map a runtime weight/style face to its RIBBI slot, for the face-aware docfonts lookup. */
+const faceSlotFor = ({ weight, style }: FaceKey): FaceSlot => {
+  const bold = weight === '700';
+  const italic = style === 'italic';
+  if (bold && italic) return 'boldItalic';
+  if (bold) return 'bold';
+  if (italic) return 'italic';
+  return 'regular';
+};
+
+/** Whether a resolution reason means SuperDoc rendered the docfonts-recommended substitute. */
+const isRenderedSubstitute = (reason: FontResolutionReason): boolean =>
+  reason === 'bundled_substitute' || reason === 'category_fallback';
+
+/**
+ * The resolver already asset-gated against the bundle, so the report only needs docfonts' verdict
+ * projection for what rendered - query with everything renderable.
+ */
+const RENDER_ALL = { canRenderFamily: (): boolean => true };
+
+/**
+ * Project a docfonts fallback - already verdict-/exception-scoped by `@docfonts/fallbacks` (top-level
+ * for a family lookup, per-face for {@link getRenderableFallbackForFace}) - onto SuperDoc's LOCAL
+ * {@link ResolvedFontEvidence}. Copies only the report-safe fields, so the package's types never enter
+ * the emitted `.d.ts`. A null fallback (none renderable) becomes undefined.
+ */
+function toEvidence(
+  fallback: ReturnType<typeof getRenderableFallback>,
+): ResolvedFontEvidence | undefined {
+  if (!fallback) return undefined;
+  return {
+    evidenceId: fallback.evidenceId,
+    policyAction: fallback.policyAction,
+    verdict: fallback.verdict,
+    lineBreakSafe: fallback.lineBreakSafe,
+    ...(fallback.glyphExceptions ? { glyphExceptions: fallback.glyphExceptions } : {}),
+  };
+}
 
 /**
  * One row of the font report: what the document asked for, what SuperDoc actually
@@ -42,6 +108,13 @@ export interface FontResolutionRecord {
    * same family may substitute. Optional + additive, so existing consumers are unaffected.
    */
   face?: { weight: '400' | '700'; style: 'normal' | 'italic' };
+  /**
+   * docfonts fidelity evidence, present ONLY when SuperDoc rendered the recommended substitute
+   * (`reason` `bundled_substitute` or `category_fallback`). Lets a consumer distinguish a clean clone
+   * (Calibri -> Carlito, `metric_safe`) from a qualified one (Cambria -> Caladea, `visual_only`)
+   * instead of treating every `bundled_substitute` alike. Optional + additive. See {@link ResolvedFontEvidence}.
+   */
+  evidence?: ResolvedFontEvidence;
 }
 
 /**
@@ -67,6 +140,9 @@ export function buildFontReport(
     // `fonts.map`; fall back to the shared bundled map for callers without a context.
     const { physicalFamily, reason } = resolver ? resolver.resolveFontFamily(logical) : resolveFontFamily(logical);
     const loadStatus = registry.getStatus(physicalFamily);
+    const evidence = isRenderedSubstitute(reason)
+      ? toEvidence(getRenderableFallback(logical, RENDER_ALL))
+      : undefined;
     report.push({
       logicalFamily: logical,
       physicalFamily,
@@ -76,6 +152,8 @@ export function buildFontReport(
       // `category_fallback` is a non-metric substitute (reflows / wrong weight), so it lacks a faithful
       // render the same way `fallback_face_absent` does, regardless of whether the family loaded.
       missing: reason === 'category_fallback' || (isSettled(loadStatus) && loadStatus !== 'loaded'),
+      // docfonts verdict for the rendered substitute (family-level: top-level worst-face verdict).
+      ...(evidence ? { evidence } : {}),
     });
   }
   return report;
@@ -133,6 +211,9 @@ export function buildFaceReport(
       reason === 'fallback_face_absent' ||
       reason === 'category_fallback' ||
       (isSettled(loadStatus) && loadStatus !== 'loaded');
+    const evidence = isRenderedSubstitute(reason)
+      ? toEvidence(getRenderableFallbackForFace(logicalFamily, faceSlotFor(face), RENDER_ALL))
+      : undefined;
     report.push({
       logicalFamily,
       // For an embedded font, the resolved physical is a document-unique INTERNAL alias
@@ -146,6 +227,9 @@ export function buildFaceReport(
       exportFamily: logicalFamily,
       missing,
       face,
+      // docfonts verdict for the rendered substitute, scoped to THIS face (per-face verdict + only this
+      // slot's glyph exceptions, so Cambria Regular never shows the Bold Italic exception).
+      ...(evidence ? { evidence } : {}),
     });
   }
   return report;


### PR DESCRIPTION
A font report row's `reason` (`bundled_substitute` / `category_fallback`) tells you SuperDoc substituted, not how faithful the substitute is - so a consumer can't tell Calibri -> Carlito (`metric_safe`, a clean clone) from Cambria -> Caladea (`visual_only`, qualified by the Bold Italic grave accent). This adds the docfonts verdict to the report so that distinction is visible.

New optional `evidence` field on `FontResolutionRecord`, populated ONLY when SuperDoc actually rendered the recommended substitute (`bundled_substitute` / `category_fallback`):

- `evidenceId`, `policyAction`, `verdict`, `lineBreakSafe`, and `glyphExceptions`.
- **Family report** (`buildFontReport`): the row's top-level worst-face verdict and all glyph exceptions.
- **Face report** (`buildFaceReport`): the **per-face** verdict (`faceVerdicts[slot] ?? verdict`) and only that slot's glyph exceptions - Cambria Regular reads `metric_safe` with no Bold-Italic exception; Bold Italic reads `visual_only` and carries it.
- Sourced from the local `SUBSTITUTION_EVIDENCE`; **local types only**, so `@docfonts/fallbacks` never leaks into the emitted `.d.ts` (the discipline `substitution-evidence.ts` already documents).

Additive and behavior-preserving: `reason` / `missing` / `loadStatus` are unchanged. Per the agreed scope, only rendered substitutes get evidence - `as_requested` / `custom_mapping` / `registered_face` / `fallback_face_absent` carry none (an advisory/recommendation surface is a separate future field, since this one can't say "docfonts recommends X but it didn't render").

**Review**: check `report.ts` evidence sourcing + the face-slot filtering; the new tests in `report.test.ts` pin Calibri (metric_safe), Calibri Light (category_fallback/visual_only), Cambria family (visual_only + exceptions), Cambria Regular (metric_safe, no stray exception), Cambria Bold Italic (visual_only + its exception), and no-evidence for the four non-substitute reasons. Per repo rule I did not run the suite locally - CI is the gate; I checked that no other test asserts full substitute report rows (resolver tests assert resolver output, the integration tests assert names/config).
