### PR TITLE
fix: keep CLI JSON output parseable

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -3,7 +3,7 @@
   "version": "0.16.0",
   "type": "module",
   "bin": {
-    "superdoc": "./dist/index.js"
+    "superdoc": "./dist/main.js"
   },
   "files": [
     "dist",
@@ -11,11 +11,11 @@
   ],
   "scripts": {
     "predev": "node scripts/ensure-superdoc-build.js",
-    "dev": "bun run src/index.ts",
+    "dev": "bun run src/main.ts",
     "prebuild": "node scripts/ensure-superdoc-build.js",
-    "build": "bun build src/index.ts --outdir dist --target node --format esm",
+    "build": "bun build src/main.ts --outdir dist --target node --format esm",
     "prebuild:native": "node scripts/ensure-superdoc-build.js",
-    "build:native": "bun build src/index.ts --compile --outfile dist/superdoc",
+    "build:native": "bun build src/main.ts --compile --outfile dist/superdoc",
     "build:native:all": "node scripts/build-native-cli.js --all",
     "build:native:host": "node scripts/build-native-cli.js",
     "build:stage": "node scripts/stage-artifacts.js",

--- a/apps/cli/scripts/build-native-cli.js
+++ b/apps/cli/scripts/build-native-cli.js
@@ -6,7 +6,7 @@ import { spawnSync } from 'node:child_process';
 import { cliRoot, ensureNoUnknownFlags, getOptionalFlagValue, isDirectExecution, repoRoot } from './utils.js';
 import { ensureSuperdocBuild } from './ensure-superdoc-build.js';
 
-const cliEntry = path.join(cliRoot, 'src/index.ts');
+const cliEntry = path.join(cliRoot, 'src/main.ts');
 const cliPackagePath = path.join(cliRoot, 'package.json');
 const artifactsRoot = path.join(cliRoot, 'artifacts');
 const manifestPath = path.join(artifactsRoot, 'manifest.json');

--- a/apps/cli/src/__tests__/host.test.ts
+++ b/apps/cli/src/__tests__/host.test.ts
@@ -8,7 +8,7 @@ import { validateOperationResponseData } from '../lib/operation-args';
 import { resolveSourceDocFixture } from './fixtures';
 
 const REPO_ROOT = path.resolve(import.meta.dir, '../../../..');
-const CLI_BIN = path.join(REPO_ROOT, 'apps/cli/src/index.ts');
+const CLI_BIN = path.join(REPO_ROOT, 'apps/cli/src/main.ts');
 const CLI_PACKAGE_JSON = path.join(REPO_ROOT, 'apps/cli/package.json');
 const HOST_TEST_TIMEOUT_MS = 20_000;
 

--- a/apps/cli/src/__tests__/lib/version.test.ts
+++ b/apps/cli/src/__tests__/lib/version.test.ts
@@ -33,7 +33,7 @@ describe('resolveCliPackageVersion', () => {
 
   test('resolves the CLI package version from the published dist layout', async () => {
     const expectedVersion = await readCliPackageVersion();
-    const moduleUrl = pathToFileURL(join(CLI_ROOT, 'dist/index.js')).href;
+    const moduleUrl = pathToFileURL(join(CLI_ROOT, 'dist/main.js')).href;
 
     expect(resolveCliPackageVersionFromModuleUrl(moduleUrl)).toBe(expectedVersion);
   });
@@ -53,7 +53,7 @@ describe('resolveCliPackageVersion', () => {
         }),
       );
 
-      const moduleUrl = pathToFileURL(join(platformPackageDir, 'dist/index.js')).href;
+      const moduleUrl = pathToFileURL(join(platformPackageDir, 'dist/main.js')).href;
       expect(resolveCliPackageVersionFromModuleUrl(moduleUrl)).toBe(expectedVersion);
     } finally {
       await rm(tempDir, { recursive: true, force: true });

--- a/apps/cli/src/__tests__/oneshot-subprocess.test.ts
+++ b/apps/cli/src/__tests__/oneshot-subprocess.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Subprocess tests for the one-shot JSON protocol boundary.
+ *
+ * These spawn the real CLI executable (`src/main.ts`) rather than calling
+ * `run()` in-process, because the process console policy that keeps the JSON
+ * protocol channels clean lives in the executable bootstrap, not in `run()`.
+ * The env deliberately unsets NODE_ENV so the super-editor telemetry-enabled
+ * path runs (the path that previously logged to the console on document open).
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { spawn } from 'node:child_process';
+import { copyFile, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { resolveSourceDocFixture } from './fixtures';
+
+const REPO_ROOT = path.resolve(import.meta.dir, '../../../..');
+const CLI_BIN = path.join(REPO_ROOT, 'apps/cli/src/main.ts');
+const ENCRYPTED_FIXTURE_SOURCE = path.join(
+  REPO_ROOT,
+  'packages/super-editor/src/editors/v1/core/ooxml-encryption/fixtures/encrypted-advanced-text.docx',
+);
+const SUBPROCESS_TIMEOUT_MS = 30_000;
+
+type SpawnResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+function runCliBinary(args: string[], stateDir: string): Promise<SpawnResult> {
+  return new Promise<SpawnResult>((resolve, reject) => {
+    const env = { ...process.env, SUPERDOC_CLI_STATE_DIR: stateDir };
+    // Exercise the telemetry-enabled path the way a real user run would.
+    delete env.NODE_ENV;
+
+    const child = spawn('bun', [CLI_BIN, ...args], {
+      cwd: REPO_ROOT,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+describe('one-shot JSON subprocess boundary', () => {
+  let stateDir = '';
+  let sourceDoc = '';
+  let encryptedDoc = '';
+
+  beforeAll(async () => {
+    stateDir = await mkdtemp(path.join(tmpdir(), 'superdoc-cli-oneshot-'));
+    sourceDoc = await resolveSourceDocFixture();
+    encryptedDoc = path.join(stateDir, 'encrypted.docx');
+    await mkdir(stateDir, { recursive: true });
+    await copyFile(ENCRYPTED_FIXTURE_SOURCE, encryptedDoc);
+  });
+
+  afterAll(async () => {
+    if (stateDir) await rm(stateDir, { recursive: true, force: true });
+  });
+
+  test(
+    'info --json emits parseable JSON on stdout with no telemetry leakage',
+    async () => {
+      const result = await runCliBinary(['info', sourceDoc, '--json'], stateDir);
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).not.toContain('Telemetry: enabled');
+      expect(result.stderr).not.toContain('Telemetry: enabled');
+
+      const envelope = JSON.parse(result.stdout.trim()) as { ok?: boolean; command?: string };
+      expect(envelope.ok).toBe(true);
+      expect(envelope.command).toBe('info');
+    },
+    SUBPROCESS_TIMEOUT_MS,
+  );
+
+  test(
+    'info --json on an encrypted doc emits structured failure on stderr only',
+    async () => {
+      const result = await runCliBinary(['info', encryptedDoc, '--json'], stateDir);
+
+      expect(result.code).not.toBe(0);
+      // stdout is the success-envelope channel; a failed one-shot must not emit
+      // diagnostic text there.
+      expect(result.stdout.trim()).toBe('');
+
+      const envelope = JSON.parse(result.stderr.trim()) as {
+        ok?: boolean;
+        error?: { code?: string };
+      };
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error?.code).toBe('DOCX_PASSWORD_REQUIRED');
+    },
+    SUBPROCESS_TIMEOUT_MS,
+  );
+});

--- a/apps/cli/src/__tests__/warm-sessions.test.ts
+++ b/apps/cli/src/__tests__/warm-sessions.test.ts
@@ -12,7 +12,7 @@ import path from 'node:path';
 import { resolveSourceDocFixture } from './fixtures';
 
 const REPO_ROOT = path.resolve(import.meta.dir, '../../../..');
-const CLI_BIN = path.join(REPO_ROOT, 'apps/cli/src/index.ts');
+const CLI_BIN = path.join(REPO_ROOT, 'apps/cli/src/main.ts');
 const TIMEOUT_MS = 15_000;
 const TEST_TIMEOUT_MS = 20_000;
 

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -9,7 +9,7 @@ const __dirname = dirname(__filename);
 
 function resolveSkillSource(): string {
   // In compiled dist: __dirname is dist/, skill/ is at dist/../skill/
-  // In dev (bun run src/index.ts): __dirname is src/commands/, skill/ is at src/commands/../../skill/
+  // In dev (bun run src/main.ts): __dirname is src/commands/, skill/ is at src/commands/../../skill/
   const fromDist = join(__dirname, '..', 'skill');
   if (existsSync(fromDist)) return fromDist;
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { parseGlobalArgs } from './lib/args';
 import { createFailureEnvelope, createSuccessEnvelope } from './lib/envelope';
 import { CliError, toCliError } from './lib/errors';
@@ -413,9 +411,4 @@ export async function run(
       return cliError.exitCode;
     }
   });
-}
-
-if (import.meta.main) {
-  const exitCode = await run(process.argv.slice(2));
-  process.exit(exitCode);
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import { parseGlobalArgs } from './lib/args';
+import type { OutputMode } from './lib/types';
+
+// AIDEV-NOTE: This is the CLI executable bootstrap, kept separate from the
+// importable module in `./index`. `run()` / `invokeCommand()` promise no
+// process-level I/O side effects, so the process console policy below MUST NOT
+// move into them. The policy is installed here, before any dynamic import of
+// `./index`, so transitive module-load logs (e.g. super-editor telemetry) are
+// already guarded when they fire.
+
+type ConsoleMethod = 'debug' | 'info' | 'log' | 'warn' | 'error';
+const CONSOLE_METHODS: ConsoleMethod[] = ['debug', 'info', 'log', 'warn', 'error'];
+
+function noop(): void {}
+
+function writeToStderr(...args: unknown[]): void {
+  // Reuse console's own formatting but force the stderr stream.
+  console.error(...args);
+}
+
+/**
+ * Installs the process-level console policy for one-shot and host runs.
+ *
+ * @param argv - Process arguments after the binary path (`process.argv.slice(2)`)
+ */
+function installConsolePolicy(argv: string[]): void {
+  let output: OutputMode = 'json';
+  let quiet = false;
+  let isHost = false;
+
+  try {
+    const { globals, rest } = parseGlobalArgs(argv);
+    output = globals.output;
+    quiet = globals.quiet;
+    isHost = rest[0] === 'host';
+  } catch {
+    // Argument parsing will fail again inside `run()`, which emits a structured
+    // JSON failure on stderr (default output mode is json). Fall through to the
+    // one-shot JSON policy so that failure stays the only protocol output.
+  }
+
+  if (quiet) {
+    // Quiet mode promises a silent diagnostic surface across one-shot and host
+    // execution, while envelopes/JSON-RPC frames still use direct stream I/O.
+    for (const method of CONSOLE_METHODS) {
+      console[method] = noop;
+    }
+    return;
+  }
+
+  if (isHost) {
+    // AIDEV-NOTE: Host stdout is the JSON-RPC channel; stderr is diagnostic.
+    // Redirect stdout-bound console methods to stderr so stray logs never
+    // corrupt a JSON-RPC frame. warn/error already write to stderr.
+    console.log = writeToStderr;
+    console.info = writeToStderr;
+    console.debug = writeToStderr;
+    return;
+  }
+
+  if (output === 'json') {
+    // One-shot JSON mode writes the success envelope to stdout and the failure
+    // envelope to stderr (see writeSuccess/writeFailure in ./index), so BOTH
+    // streams are structured protocol channels. Suppress all console output on
+    // both streams. The envelope itself is written via io.stdout/io.stderr, not
+    // console, so it is unaffected.
+    for (const method of CONSOLE_METHODS) {
+      console[method] = noop;
+    }
+    return;
+  }
+
+  // Pretty mode without --quiet: stdout is human-facing and diagnostics are
+  // expected, so console is left untouched.
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  installConsolePolicy(argv);
+  const { run } = await import('./index');
+  const exitCode = await run(argv);
+  process.exit(exitCode);
+}
+
+await main();

--- a/evals/AGENTS.md
+++ b/evals/AGENTS.md
@@ -57,7 +57,7 @@ pnpm --filter @superdoc-testing/evals run eval:benchmark:codex     # Codex-* pro
 pnpm --filter @superdoc-testing/evals run eval:benchmark:report    # markdown + CSV report
 ```
 
-Prerequisites for Level 3: MCP server built (`pnpm --filter @superdoc-dev/mcp run build`) and CLI built (`apps/cli/dist/index.js`). The `prebuild:benchmark-deps` script handles both.
+Prerequisites for Level 3: MCP server built (`pnpm --filter @superdoc-dev/mcp run build`) and CLI built. The `prebuild:benchmark-deps` script handles both.
 
 ## Baselines
 

--- a/evals/scripts/prepare-local-sdk.mjs
+++ b/evals/scripts/prepare-local-sdk.mjs
@@ -45,7 +45,7 @@ const SDK_TOOLS_DIR = resolve(REPO_ROOT, 'packages/sdk/tools');
 const OUTPUTS = {
   docApiContract: resolve(REPO_ROOT, 'packages/document-api/generated/schemas/document-api-contract.json'),
   sdkDist:      resolve(SDK_NODE_PKG, 'dist/index.js'),
-  cliDist:      resolve(REPO_ROOT, 'apps/cli/dist/index.js'),
+  cliDist:      resolve(REPO_ROOT, 'apps/cli/dist/main.js'),
   toolsVercel:  resolve(SDK_TOOLS_DIR, 'tools.vercel.json'),
   toolsOpenai:  resolve(SDK_TOOLS_DIR, 'tools.openai.json'),
   systemPrompt: resolve(SDK_TOOLS_DIR, 'system-prompt.md'),

--- a/evals/shared/agent-harness.mjs
+++ b/evals/shared/agent-harness.mjs
@@ -24,7 +24,7 @@ const EVALS_ROOT = resolve(__dirname, '..');
 export const PATHS = {
   mcpServer: resolve(EVALS_ROOT, '../apps/mcp/dist/index.js'),
   mcpSystemPrompt: resolve(EVALS_ROOT, '../packages/sdk/tools/system-prompt-mcp.md'),
-  cli: resolve(EVALS_ROOT, '../apps/cli/dist/index.js'),
+  cli: resolve(EVALS_ROOT, '../apps/cli/dist/main.js'),
   vendorSkill: resolve(EVALS_ROOT, 'fixtures/vendor/vendor-docx-skill.md'),
   mcpWrapper: resolve(EVALS_ROOT, 'providers/mcp-stdio-wrapper.mjs'),
 };

--- a/evals/shared/provider-utils.mjs
+++ b/evals/shared/provider-utils.mjs
@@ -28,7 +28,7 @@ export const PATHS = {
   output: resolve(EVALS_ROOT, 'results/output'),
   cache: resolve(EVALS_ROOT, 'results/.cache'),
   prompt: resolve(EVALS_ROOT, '..', 'packages/sdk/tools/system-prompt.md'),
-  cliBin: resolve(EVALS_ROOT, '../apps/cli/dist/index.js'),
+  cliBin: resolve(EVALS_ROOT, '../apps/cli/dist/main.js'),
 };
 
 // --- SDK ---

--- a/evals/shared/provider-utils.test.mjs
+++ b/evals/shared/provider-utils.test.mjs
@@ -28,7 +28,7 @@ test('computeSdkFingerprint changes when a nested SDK dist file changes', () => 
   withTempDir((root) => {
     const sdkDistDir = resolve(root, 'sdk/dist');
     const promptFile = resolve(root, 'packages/sdk/tools/system-prompt.md');
-    const cliFile = resolve(root, 'apps/cli/dist/index.js');
+    const cliFile = resolve(root, 'apps/cli/dist/main.js');
 
     writeFile(resolve(sdkDistDir, 'index.js'), "export { run } from './runtime/process.js';\n");
     writeFile(resolve(sdkDistDir, 'runtime/process.js'), 'export const run = () => "v1";\n');
@@ -55,7 +55,7 @@ test('computeSdkFingerprint changes when a new SDK dist file is added', () => {
   withTempDir((root) => {
     const sdkDistDir = resolve(root, 'sdk/dist');
     const promptFile = resolve(root, 'packages/sdk/tools/system-prompt.md');
-    const cliFile = resolve(root, 'apps/cli/dist/index.js');
+    const cliFile = resolve(root, 'apps/cli/dist/main.js');
 
     writeFile(resolve(sdkDistDir, 'index.js'), "export { run } from './runtime/process.js';\n");
     writeFile(resolve(sdkDistDir, 'runtime/process.js'), 'export const run = () => "ready";\n');

--- a/packages/sdk/langs/node/src/__tests__/request-timeout-ms.e2e.test.ts
+++ b/packages/sdk/langs/node/src/__tests__/request-timeout-ms.e2e.test.ts
@@ -7,7 +7,7 @@ import { SuperDocCliError } from '../runtime/errors.js';
 
 // Repo root: packages/sdk/langs/node/src/__tests__ → ../../../../../../
 const REPO_ROOT = path.resolve(import.meta.dir, '../../../../../..');
-const CLI_BIN = path.join(REPO_ROOT, 'apps/cli/src/index.ts');
+const CLI_BIN = path.join(REPO_ROOT, 'apps/cli/src/main.ts');
 const FIXTURE_DOC = path.join(REPO_ROOT, 'packages/super-editor/src/editors/v1/tests/data/advanced-text.docx');
 
 const E2E_TIMEOUT_MS = 30_000;
@@ -18,7 +18,7 @@ describe('SDK requestTimeoutMs propagation (e2e)', () => {
   beforeAll(() => {
     // Sanity-check the workspace layout once so test failures are clear when
     // the fixture moves or the CLI source is renamed.
-    expect(CLI_BIN.endsWith('apps/cli/src/index.ts')).toBe(true);
+    expect(CLI_BIN.endsWith('apps/cli/src/main.ts')).toBe(true);
   });
 
   afterEach(async () => {

--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -955,7 +955,6 @@ export class Editor extends EventEmitter<EditorEventMap> {
         licenseKey: resolvedLicenseKey,
         metadata: telemetryConfig.metadata,
       });
-      console.debug('[super-editor] Telemetry: enabled');
     } catch {
       // Fail silently - telemetry should never break the app
     }

--- a/tests/doc-api-stories/tests/harness.ts
+++ b/tests/doc-api-stories/tests/harness.ts
@@ -7,8 +7,8 @@ import { createSuperDocClient, type SuperDocClient, type SuperDocClientOptions }
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '../../..');
 const STORIES_ROOT = path.resolve(import.meta.dirname, '..');
-const CLI_DIST_BIN = path.join(REPO_ROOT, 'apps/cli/dist/index.js');
-const CLI_SRC_BIN = path.join(REPO_ROOT, 'apps/cli/src/index.ts');
+const CLI_DIST_BIN = path.join(REPO_ROOT, 'apps/cli/dist/main.js');
+const CLI_SRC_BIN = path.join(REPO_ROOT, 'apps/cli/src/main.ts');
 const execFileAsync = promisify(execFile);
 
 interface CliInvocation {

--- a/tests/doc-api-stories/tests/lists/missing-paraid-address-stability.ts
+++ b/tests/doc-api-stories/tests/lists/missing-paraid-address-stability.ts
@@ -41,7 +41,7 @@ type ListsGetEnvelope = {
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '../../../..');
 const RESULTS_DIR = path.resolve(import.meta.dirname, '../../results/lists/missing-paraid-address-stability');
-const CLI_SRC_BIN = path.join(REPO_ROOT, 'apps/cli/src/index.ts');
+const CLI_SRC_BIN = path.join(REPO_ROOT, 'apps/cli/src/main.ts');
 const LIST_FIXTURE_CANDIDATES = [
   path.join(REPO_ROOT, 'packages/super-editor/src/editors/v1/tests/data/basic-list.docx'),
   path.join(REPO_ROOT, 'packages/super-editor/src/editors/v1/tests/data/list_with_indents.docx'),

--- a/tests/doc-api-stories/tests/lists/numbering-metadata-regression.ts
+++ b/tests/doc-api-stories/tests/lists/numbering-metadata-regression.ts
@@ -8,7 +8,7 @@ const execFileAsync = promisify(execFile);
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '../../../..');
 const STORIES_ROOT = path.resolve(import.meta.dirname, '../..');
-const CLI_SRC_BIN = path.join(REPO_ROOT, 'apps/cli/src/index.ts');
+const CLI_SRC_BIN = path.join(REPO_ROOT, 'apps/cli/src/main.ts');
 const BASIC_PARAGRAPH_FIXTURE = path.join(
   REPO_ROOT,
   'packages/super-editor/src/editors/v1/tests/data/basic-paragraph.docx',

--- a/tests/document-api-smoke/src/sdk-smoke.test.ts
+++ b/tests/document-api-smoke/src/sdk-smoke.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, test } from 'vitest';
 import { createSuperDocClient, type SuperDocClient, type SuperDocDocument } from '@superdoc-dev/sdk';
 
 const REPO_ROOT = path.resolve(fileURLToPath(new URL('../../..', import.meta.url)));
-const CLI_BIN = path.join(REPO_ROOT, 'apps/cli/dist/index.js');
+const CLI_BIN = path.join(REPO_ROOT, 'apps/cli/dist/main.js');
 
 function createSessionId(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;


### PR DESCRIPTION
Supersedes #3257 with a CLI-boundary fix.

`superdoc info --json` could emit library diagnostics on stdout when `NODE_ENV` was unset, which made the JSON envelope unparseable. The fix keeps protocol ownership at the executable boundary instead of mutating `console` inside importable APIs.

What changed:
- split the executable bootstrap into `apps/cli/src/main.ts`; `apps/cli/src/index.ts` remains importable
- install the process console policy before importing CLI internals
- suppress all `console.*` for one-shot JSON mode, because success uses stdout and failures use stderr
- redirect `console.log` / `console.info` / `console.debug` to stderr only for `host`, where stdout is JSON-RPC
- suppress all console methods for `--quiet`
- remove the telemetry `console.debug`
- update CLI executable references from `dist/index.js` to `dist/main.js`
- add subprocess coverage for success JSON stdout and failure JSON stderr

Validation:
- `git diff --check HEAD~1..HEAD`
- stale CLI path guard with `rg`
- `bun build apps/cli/src/main.ts --packages external --outfile /tmp/superdoc-cli-main-final-review.js`
- `node .github/scripts/agent-docs-l1.mjs --target .` confirms the new `evals/AGENTS.md` broken path finding is gone
- local unit tests were not run per repo policy; CI is the verification path