### PR TITLE
fix(export): sanitize DOCX relationships and numbering namespaces (SD-3399)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/opc/reconcile-document-relationships.js
+++ b/packages/super-editor/src/editors/v1/core/opc/reconcile-document-relationships.js
@@ -66,11 +66,38 @@ function findMaxRId(elements) {
 }
 
 /**
- * Ensure document-level relationships exist for all managed parts that are
- * present in the package.
+ * Resolve a relationship target to a zip path.
+ * Targets in word/_rels/document.xml.rels are relative to word/.
  *
- * Adds missing relationships with collision-free rId allocation. Does not
- * remove or modify existing relationships.
+ * @param {string} target - The Target attribute value (e.g., "styles.xml", "./header1.xml", "../customXml/item1.xml")
+ * @returns {string} The normalized zip path (e.g., "word/styles.xml", "customXml/item1.xml")
+ */
+function resolveRelTarget(target) {
+  if (!target) return '';
+
+  // Strip leading ./
+  let normalized = target.startsWith('./') ? target.slice(2) : target;
+
+  // Handle parent directory references (e.g., ../customXml/item1.xml)
+  if (normalized.startsWith('../')) {
+    // Target is outside word/ directory, return as-is without word/ prefix
+    return normalized.slice(3);
+  }
+
+  // Target is relative to word/
+  return normalized.startsWith('word/') ? normalized : `word/${normalized}`;
+}
+
+/**
+ * Ensure document-level relationships exist for all managed parts that are
+ * present in the package, and prune dangling relationships that point to
+ * non-existent files.
+ *
+ * - Adds missing relationships with collision-free rId allocation.
+ * - Removes relationships whose target file does not exist in the package
+ *   (e.g., stylesWithEffects.xml references from legacy documents).
+ * - External relationships (TargetMode="External") are preserved regardless
+ *   of file existence since they point to URLs, not package parts.
  *
  * @param {string} relsXml - Current word/_rels/document.xml.rels XML string
  * @param {(zipPath: string) => boolean} fileExists - Predicate: does this file exist in the package?
@@ -93,6 +120,26 @@ export function reconcileDocumentRelationships(relsXml, fileExists) {
   let changed = false;
   let maxId = findMaxRId(relsTag.elements);
 
+  // Prune dangling relationships (target file doesn't exist)
+  const originalCount = relsTag.elements.length;
+  relsTag.elements = relsTag.elements.filter((el) => {
+    if (el.name !== 'Relationship') return true;
+
+    // Keep external relationships (they point to URLs, not files)
+    if (el.attributes?.TargetMode === 'External') return true;
+
+    const target = el.attributes?.Target;
+    if (!target) return true;
+
+    const zipPath = resolveRelTarget(target);
+    return fileExists(zipPath);
+  });
+
+  if (relsTag.elements.length !== originalCount) {
+    changed = true;
+  }
+
+  // Add missing relationships for managed parts
   for (const entry of MANAGED_DOCUMENT_PARTS) {
     if (!fileExists(entry.zipPath)) continue;
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/SuperConverter.js
@@ -1467,6 +1467,25 @@ class SuperConverter {
       currentNumberingXml.elements = [];
     }
 
+    // Ensure required namespaces are declared on the <w:numbering> element.
+    // Some source documents lack xmlns:w15 but content uses w15:restartNumberingAfterBreak,
+    // causing Word to report namespace errors and require repair.
+    if (currentNumberingXml.attributes) {
+      // Add xmlns:mc if missing (required for mc:Ignorable)
+      if (!currentNumberingXml.attributes['xmlns:mc']) {
+        currentNumberingXml.attributes['xmlns:mc'] = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+      }
+      // Add xmlns:w15 if missing (used by w15:restartNumberingAfterBreak)
+      if (!currentNumberingXml.attributes['xmlns:w15']) {
+        currentNumberingXml.attributes['xmlns:w15'] = 'http://schemas.microsoft.com/office/word/2012/wordml';
+      }
+      // Ensure mc:Ignorable includes w15
+      const ignorable = currentNumberingXml.attributes['mc:Ignorable'] || '';
+      if (!ignorable.includes('w15')) {
+        currentNumberingXml.attributes['mc:Ignorable'] = ignorable ? `${ignorable} w15` : 'w15';
+      }
+    }
+
     this.convertedXml[numberingPath] = numberingXml;
   }
 


### PR DESCRIPTION
## Summary
- Prune dangling relationships in `word/_rels/document.xml.rels` that reference non-existent parts (e.g., `stylesWithEffects.xml` from legacy Word 2010 documents)
- Ensure `xmlns:w15` namespace is declared in `numbering.xml` when `w15:restartNumberingAfterBreak` attributes are present
- Fixes exported DOCX files requiring Word repair before opening