### PR TITLE
test: add contract collaboration custom XML story

### DIFF
--- a/.github/workflows/ci-superdoc.yml
+++ b/.github/workflows/ci-superdoc.yml
@@ -258,6 +258,45 @@ jobs:
       - name: Run CLI tests
         run: pnpm run test:cli
 
+  doc-api-stories:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build doc-api story runtime
+        run: |
+          pnpm --silent --prefix packages/sdk run generate
+          pnpm --silent --prefix packages/superdoc run build:es
+          pnpm --silent --prefix apps/cli run build
+          pnpm --silent --prefix packages/sdk/langs/node run build
+
+      - name: Run contract collaboration doc-api story
+        working-directory: tests/doc-api-stories
+        run: pnpm exec vitest run --config ./vitest.config.ts tests/contract-collaboration/customxml-cache-roundtrip.ts
+
+      - name: Upload contract collaboration story output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-collaboration-doc-api-story-results
+          path: tests/doc-api-stories/results/contract-collaboration/customxml-cache-roundtrip/*.docx
+          if-no-files-found: ignore
+
   coverage:
     needs: build
     runs-on: ubuntu-latest
@@ -286,7 +325,7 @@ jobs:
   validate:
     name: CI SuperDoc / validate
     if: always()
-    needs: [detect, build, unit-tests, cli-tests, coverage]
+    needs: [detect, build, unit-tests, cli-tests, doc-api-stories, coverage]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
@@ -303,6 +342,7 @@ jobs:
             "build:${{ needs.build.result }}" \
             "unit-tests:${{ needs.unit-tests.result }}" \
             "cli-tests:${{ needs.cli-tests.result }}" \
+            "doc-api-stories:${{ needs.doc-api-stories.result }}" \
             "coverage:${{ needs.coverage.result }}"; do
             name="${job_result%%:*}"
             result="${job_result##*:}"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3371,6 +3371,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sdk/langs/node
     devDependencies:
+      jszip:
+        specifier: 'catalog:'
+        version: 3.10.1
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)

--- a/tests/doc-api-stories/package.json
+++ b/tests/doc-api-stories/package.json
@@ -10,6 +10,7 @@
     "@superdoc-dev/sdk": "workspace:*"
   },
   "devDependencies": {
+    "jszip": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/tests/doc-api-stories/tests/contract-collaboration/customxml-cache-roundtrip.ts
+++ b/tests/doc-api-stories/tests/contract-collaboration/customxml-cache-roundtrip.ts
@@ -1,0 +1,329 @@
+/**
+ * doc-api story: contract collaboration cache round-trip.
+ *
+ * This validates the runtime path the contract-collaboration prototype depends
+ * on: a disposable cache written through `customXml.parts.create`, saved to a
+ * real DOCX, reopened through SuperDoc, patched for the next turn, saved again,
+ * and reopened again. The cache remains non-authoritative. Server-side ledger
+ * state is still the source of truth.
+ */
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import JSZip from 'jszip';
+import type { SuperDocDocument } from '@superdoc-dev/sdk';
+import { useStoryHarness } from '../harness';
+
+const BASE_DOC = path.resolve(import.meta.dirname, '../../../../shared/common/data/blank.docx');
+const CACHE_NAMESPACE = 'urn:superdoc:contract-collaboration:cache:1';
+const CACHE_SCHEMA_REF = 'urn:superdoc:contract-collaboration:schema:1';
+const SESSION_ID = 'cc-session-runtime-001';
+const SERVER_REF = 'https://contracts.example.test/sessions/cc-session-runtime-001';
+const HEAD_1 = 'sha256:1111111111111111111111111111111111111111111111111111111111111111';
+const HEAD_2 = 'sha256:2222222222222222222222222222222222222222222222222222222222222222';
+
+type UnknownRecord = Record<string, unknown>;
+
+type CacheSummary = {
+  id?: string;
+  partName: string;
+  propsPartName?: string;
+  rootNamespace?: string;
+  schemaRefs: string[];
+};
+
+type CacheInfo = CacheSummary & {
+  content: string;
+};
+
+type CreatedCachePart = {
+  id: string;
+  partName: string;
+  propsPartName: string;
+};
+
+function xmlAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
+
+function xmlText(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;');
+}
+
+function cacheXml(headHash: string, turnCount: number): string {
+  const payload = JSON.stringify({
+    headHash,
+    sessionId: SESSION_ID,
+    turnCount,
+  });
+
+  return [
+    `<cc:contractSessionCache xmlns:cc="${xmlAttr(CACHE_NAMESPACE)}" version="0.1">`,
+    `<cc:sessionId>${xmlText(SESSION_ID)}</cc:sessionId>`,
+    `<cc:serverRef href="${xmlAttr(SERVER_REF)}" autoCall="false"/>`,
+    `<cc:freshness headHash="${xmlAttr(headHash)}" turnCount="${turnCount}"/>`,
+    `<cc:payload encoding="application/json">${xmlText(payload)}</cc:payload>`,
+    '</cc:contractSessionCache>',
+  ].join('');
+}
+
+function makeSessionId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function asRecord(value: unknown, label: string): UnknownRecord {
+  expect(value, `${label} should be an object`).not.toBeNull();
+  expect(typeof value, `${label} should be an object`).toBe('object');
+  return value as UnknownRecord;
+}
+
+function asString(value: unknown, label: string): string {
+  expect(typeof value, `${label} should be a string`).toBe('string');
+  return value as string;
+}
+
+function asStringArray(value: unknown, label: string): string[] {
+  expect(Array.isArray(value), `${label} should be an array`).toBe(true);
+  const strings = value as unknown[];
+  for (const [index, item] of strings.entries()) {
+    expect(typeof item, `${label}[${index}] should be a string`).toBe('string');
+  }
+  return strings as string[];
+}
+
+function toCacheSummary(value: unknown, label: string): CacheSummary {
+  const record = asRecord(value, label);
+  const summary: CacheSummary = {
+    partName: asString(record.partName, `${label}.partName`),
+    schemaRefs: asStringArray(record.schemaRefs, `${label}.schemaRefs`),
+  };
+
+  if (record.id !== undefined) summary.id = asString(record.id, `${label}.id`);
+  if (record.propsPartName !== undefined) {
+    summary.propsPartName = asString(record.propsPartName, `${label}.propsPartName`);
+  }
+  if (record.rootNamespace !== undefined) {
+    summary.rootNamespace = asString(record.rootNamespace, `${label}.rootNamespace`);
+  }
+
+  return summary;
+}
+
+function toCacheInfo(value: unknown): CacheInfo {
+  const summary = toCacheSummary(value, 'customXml.parts.get result');
+  const record = value as UnknownRecord;
+  return {
+    ...summary,
+    content: asString(record.content, 'customXml.parts.get result.content'),
+  };
+}
+
+function listedCacheSummaries(value: unknown): CacheSummary[] {
+  const record = asRecord(value, 'customXml.parts.list result');
+  expect(typeof record.total, 'customXml.parts.list result.total should be a number').toBe('number');
+  expect(Array.isArray(record.items), 'customXml.parts.list result.items should be an array').toBe(true);
+  return (record.items as unknown[]).map((item, index) => toCacheSummary(item, `customXml.parts.list item ${index}`));
+}
+
+function formatDiagnostic(value: unknown): string {
+  return JSON.stringify(
+    value,
+    (_key, nested) => {
+      if (typeof nested === 'string' && nested.length > 500) return `${nested.slice(0, 500)}...`;
+      return nested;
+    },
+    2,
+  );
+}
+
+async function readZipEntry(docPath: string, zipPath: string): Promise<string | null> {
+  const buffer = await readFile(docPath);
+  const zip = await JSZip.loadAsync(buffer);
+  const file = zip.file(zipPath);
+  return file ? file.async('string') : null;
+}
+
+async function requireZipEntry(docPath: string, zipPath: string): Promise<string> {
+  const content = await readZipEntry(docPath, zipPath);
+  if (content == null) {
+    throw new Error(`Missing zip entry "${zipPath}" in ${docPath}`);
+  }
+  return content;
+}
+
+function itemIndexFromPartName(partName: string): string {
+  const match = partName.match(/^customXml\/item(\d+)\.xml$/);
+  if (!match?.[1]) {
+    throw new Error(`Expected customXml item part name, got ${partName}`);
+  }
+  return match[1];
+}
+
+function requireCreatedPart(part: CreatedCachePart | null): CreatedCachePart {
+  if (!part) {
+    throw new Error('Expected custom XML part creation to complete before save assertions.');
+  }
+  return part;
+}
+
+async function assertCachePackageShape(
+  docPath: string,
+  createdPart: CreatedCachePart,
+  expectedHeadHash: string,
+): Promise<void> {
+  const itemIndex = itemIndexFromPartName(createdPart.partName);
+  const itemRelsPath = `customXml/_rels/item${itemIndex}.xml.rels`;
+
+  const storageXml = await requireZipEntry(docPath, createdPart.partName);
+  expect(storageXml).toContain(`<cc:sessionId>${SESSION_ID}</cc:sessionId>`);
+  expect(storageXml).toContain(expectedHeadHash);
+
+  const propsXml = await requireZipEntry(docPath, createdPart.propsPartName);
+  expect(propsXml).toContain(createdPart.id);
+  expect(propsXml).toContain(CACHE_SCHEMA_REF);
+  expect(propsXml).toContain('officeDocument/2006/customXml');
+
+  const itemRelsXml = await requireZipEntry(docPath, itemRelsPath);
+  expect(itemRelsXml).toContain('customXmlProps');
+  expect(itemRelsXml).toContain(`Target="itemProps${itemIndex}.xml"`);
+
+  const contentTypesXml = await requireZipEntry(docPath, '[Content_Types].xml');
+  expect(contentTypesXml).toContain(`/${createdPart.propsPartName}`);
+  expect(contentTypesXml).toContain('customXmlProperties+xml');
+
+  const documentRelsXml = await requireZipEntry(docPath, 'word/_rels/document.xml.rels');
+  expect(documentRelsXml).toContain('officeDocument/2006/relationships/customXml');
+  expect(documentRelsXml).toContain(`Target="../${createdPart.partName}"`);
+}
+
+describe('document-api story: contract collaboration customXml cache', () => {
+  const { createHandleClient, outPath } = useStoryHarness('contract-collaboration/customxml-cache-roundtrip', {
+    preserveResults: true,
+  });
+
+  async function openSession(doc: string, prefix: string): Promise<SuperDocDocument> {
+    const client = await createHandleClient();
+    const sessionId = makeSessionId(prefix);
+    return client.open({ sessionId, doc });
+  }
+
+  async function closeSession(doc: SuperDocDocument | null): Promise<void> {
+    await doc?.close({ discard: true }).catch(() => {});
+  }
+
+  async function readSingleCache(doc: SuperDocDocument, expectedId: string, stage: string): Promise<CacheInfo> {
+    const list = await doc.customXml.parts.list({
+      rootNamespace: CACHE_NAMESPACE,
+    });
+
+    const summaries = listedCacheSummaries(list).filter(
+      (summary) => summary.rootNamespace === CACHE_NAMESPACE && summary.schemaRefs.includes(CACHE_SCHEMA_REF),
+    );
+    if (summaries.length !== 1) {
+      const unfiltered = await doc.customXml.parts.list();
+      const direct = await doc.customXml.parts.get({
+        target: { id: expectedId },
+      });
+      throw new Error(
+        [
+          `Expected one contract cache part during ${stage}, got ${summaries.length}.`,
+          `Filtered list: ${formatDiagnostic(list)}`,
+          `Unfiltered list: ${formatDiagnostic(unfiltered)}`,
+          `Direct get by id: ${formatDiagnostic(direct)}`,
+        ].join('\n'),
+      );
+    }
+
+    const [summary] = summaries;
+    expect(summary.partName).toMatch(/^customXml\/item\d+\.xml$/);
+    expect(summary.propsPartName).toMatch(/^customXml\/itemProps\d+\.xml$/);
+
+    const info = await doc.customXml.parts.get({
+      target: { id: expectedId },
+    });
+    expect(info).not.toBeNull();
+
+    const cacheInfo = toCacheInfo(info);
+    expect(cacheInfo.id).toBe(expectedId);
+    expect(cacheInfo.content).toContain(`<cc:sessionId>${SESSION_ID}</cc:sessionId>`);
+    expect(cacheInfo.content).toContain(`href="${SERVER_REF}"`);
+    expect(cacheInfo.content).toContain('autoCall="false"');
+    return cacheInfo;
+  }
+
+  it('creates, saves, reopens, patches, and reopens a disposable cache part', async () => {
+    let authorDoc: SuperDocDocument | null = await openSession(BASE_DOC, 'cc-author');
+    let createdId = '';
+    let createdPart: CreatedCachePart | null = null;
+
+    try {
+      const created = await authorDoc.customXml.parts.create({
+        content: cacheXml(HEAD_1, 1),
+        schemaRefs: [CACHE_SCHEMA_REF],
+      });
+      expect(created.success).toBe(true);
+      expect(created.id).toMatch(/^\{[0-9A-F-]+\}$/);
+      expect(created.partName).toMatch(/^customXml\/item\d+\.xml$/);
+      expect(created.propsPartName).toMatch(/^customXml\/itemProps\d+\.xml$/);
+      createdId = created.id;
+      createdPart = {
+        id: created.id,
+        partName: created.partName,
+        propsPartName: created.propsPartName,
+      };
+
+      const written = await readSingleCache(authorDoc, createdId, 'author session after create');
+      expect(written.id).toBe(created.id);
+      expect(written.content).toContain(HEAD_1);
+
+      const createdDocPath = outPath('contract-cache-created.docx');
+      await authorDoc.save({
+        out: createdDocPath,
+        force: true,
+      });
+      await assertCachePackageShape(createdDocPath, requireCreatedPart(createdPart), HEAD_1);
+    } finally {
+      await closeSession(authorDoc);
+      authorDoc = null;
+    }
+
+    let reviewerDoc: SuperDocDocument | null = await openSession(outPath('contract-cache-created.docx'), 'cc-reviewer');
+    try {
+      const reopened = await readSingleCache(reviewerDoc, createdId, 'reviewer session after reopen');
+      expect(reopened.id).toBe(createdId);
+      expect(reopened.content).toContain(HEAD_1);
+
+      const patched = await reviewerDoc.customXml.parts.patch({
+        target: { id: createdId },
+        content: cacheXml(HEAD_2, 2),
+      });
+      expect(patched.success).toBe(true);
+      expect(patched.id).toBe(createdId);
+
+      const afterPatch = await readSingleCache(reviewerDoc, createdId, 'reviewer session after patch');
+      expect(afterPatch.content).toContain(HEAD_2);
+      expect(afterPatch.content).not.toContain(HEAD_1);
+
+      const patchedDocPath = outPath('contract-cache-patched.docx');
+      await reviewerDoc.save({
+        out: patchedDocPath,
+        force: true,
+      });
+      await assertCachePackageShape(patchedDocPath, requireCreatedPart(createdPart), HEAD_2);
+    } finally {
+      await closeSession(reviewerDoc);
+      reviewerDoc = null;
+    }
+
+    let finalDoc: SuperDocDocument | null = await openSession(outPath('contract-cache-patched.docx'), 'cc-final');
+    try {
+      const finalCache = await readSingleCache(finalDoc, createdId, 'final session after reopen');
+      expect(finalCache.id).toBe(createdId);
+      expect(finalCache.content).toContain(HEAD_2);
+      expect(finalCache.content).not.toContain(HEAD_1);
+    } finally {
+      await closeSession(finalDoc);
+      finalDoc = null;
+    }
+  });
+});

--- a/tests/doc-api-stories/tests/harness.ts
+++ b/tests/doc-api-stories/tests/harness.ts
@@ -3,7 +3,12 @@ import { execFile } from 'node:child_process';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { afterEach, beforeEach } from 'vitest';
-import { createSuperDocClient, type SuperDocClient, type SuperDocClientOptions } from '@superdoc-dev/sdk';
+import {
+  createSuperDocClient,
+  type DocDescribeCommandParams,
+  type SuperDocClient,
+  type SuperDocClientOptions,
+} from '@superdoc-dev/sdk';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '../../..');
 const STORIES_ROOT = path.resolve(import.meta.dirname, '..');
@@ -23,7 +28,7 @@ export interface LegacyStoryClient {
   connect(): Promise<void>;
   dispose(): Promise<void>;
   describe(params?: Record<string, unknown>): Promise<unknown>;
-  describeCommand(params: Record<string, unknown>): Promise<unknown>;
+  describeCommand(params: DocDescribeCommandParams): Promise<unknown>;
 }
 
 function resolveInvocation(cliBin: string): CliInvocation {
@@ -232,21 +237,20 @@ export function useStoryHarness(storyName: string, options: StoryHarnessOptions 
     return ctx;
   };
 
-  const clientProxy = new Proxy({} as SuperDocClient, {
+  const clientProxy = new Proxy({} as LegacyStoryClient, {
     get: (_target, prop) => (requireCtx().client as any)[prop],
   });
 
-  const api = {
+  const api: StoryContext = {
     client: clientProxy,
+    get resultsDir() {
+      return requireCtx().resultsDir;
+    },
     copyDoc: (source: string, name?: string) => requireCtx().copyDoc(source, name),
     outPath: (name: string) => requireCtx().outPath(name),
     runCli: (args: string[], options?: { allowError?: boolean }) => requireCtx().runCli(args, options),
     createHandleClient: (clientOptions?: SuperDocClientOptions) => requireCtx().createHandleClient(clientOptions),
-  } as StoryContext;
-
-  Object.defineProperty(api, 'resultsDir', {
-    get: () => requireCtx().resultsDir,
-  });
+  };
 
   return api;
 }


### PR DESCRIPTION
Adds a doc-api story that validates contract-collaboration custom XML cache round-tripping through the generated SDK.

Why:
- Proves the SuperDoc runtime can create, save, reopen, patch, and reopen a disposable custom XML cache part for the contract-collaboration protocol.
- Adds ZIP-level assertions for the storage part, item properties part, item rels, content-type override, and document relationship.
- Declares jszip in doc-api-stories instead of borrowing a private package dependency.
- Adds a focused CI SuperDoc job that builds the story runtime and runs this contract-collaboration story in GitHub Actions.

Validated locally without running local unit or story tests:
- pnpm exec tsc --noEmit --module ESNext --moduleResolution Bundler --target ES2022 --types vitest --skipLibCheck tests/doc-api-stories/tests/contract-collaboration/customxml-cache-roundtrip.ts tests/doc-api-stories/tests/harness.ts
- pnpm check:types
- git diff --check
- Ruby YAML parse check for .github/workflows/ci-superdoc.yml
- en/em dash scan

Local unit and story tests were not run per repo instruction. The new CI job provides the runtime verdict for the DOCX create, save, reopen, patch, and ZIP assertions.