### PR TITLE
feat: check for intent in URL detection and normalization paste handler

### DIFF
--- a/packages/super-editor/src/editors/v1/core/inputRules/paste-link-normalizer.js
+++ b/packages/super-editor/src/editors/v1/core/inputRules/paste-link-normalizer.js
@@ -17,6 +17,19 @@ export function maybeAddProtocol(text) {
 }
 
 /**
+ * Detect explicit intent to paste a URL and checks for common URL patterns:
+ * - Starts with `www.`
+ * - Starts with `http://` or `https://`
+ * - Starts with `mailto:`, `tel:`, or `sms:`
+ */
+function hasExplicitUrlIntent(text) {
+  if (/^www\./i.test(text)) return true;
+  if (/^(mailto|tel|sms):/i.test(text)) return true;
+
+  return /^https?:\/\//i.test(text);
+}
+
+/**
  * Detect whether a pasted plain-text string is a single URL.
  *
  * Rejects strings with internal whitespace (not a bare URL).
@@ -33,8 +46,10 @@ export function detectPasteUrl(text, protocols = []) {
   // A bare URL has no internal whitespace
   if (/\s/.test(trimmed)) return null;
 
-  const withProtocol = maybeAddProtocol(trimmed);
   const allowedProtocols = buildAllowedProtocols(protocols);
+  if (!hasExplicitUrlIntent(trimmed)) return null;
+
+  const withProtocol = maybeAddProtocol(trimmed);
   const result = sanitizeHref(withProtocol, { allowedProtocols });
 
   return result ? { href: result.href } : null;

--- a/packages/super-editor/src/editors/v1/core/inputRules/paste-link-normalizer.test.js
+++ b/packages/super-editor/src/editors/v1/core/inputRules/paste-link-normalizer.test.js
@@ -32,7 +32,10 @@ vi.mock('@superdoc/url-validation', () => {
 
       // Must have a known protocol
       const match = trimmed.match(/^([a-z]+):/i);
-      if (!match) return null;
+      if (!match) {
+        if (/^\/\//.test(trimmed) || /\s/.test(trimmed)) return null;
+        return { href: new URL(trimmed, 'http://localhost:9094/').href, protocol: null, isExternal: false };
+      }
 
       const protocol = match[1].toLowerCase();
       const allowed = config?.allowedProtocols ?? DEFAULT_ALLOWED_PROTOCOLS;
@@ -197,8 +200,27 @@ describe('detectPasteUrl', () => {
     expect(result).toEqual({ href: 'mailto:user@example.com' });
   });
 
+  it('detects tel and sms links', () => {
+    expect(detectPasteUrl('tel:5551234567')).toEqual({ href: 'tel:5551234567' });
+    expect(detectPasteUrl('sms:5551234567')).toEqual({ href: 'sms:5551234567' });
+  });
+
   it('returns null for plain text', () => {
     expect(detectPasteUrl('just some text')).toBeNull();
+  });
+
+  it('returns null for single-word plain text even when sanitizeHref accepts relative paths', () => {
+    expect(detectPasteUrl('dog')).toBeNull();
+  });
+
+  it('returns null for template tokens even when sanitizeHref accepts relative paths', () => {
+    expect(detectPasteUrl('{project_number}')).toBeNull();
+  });
+
+  it('returns null for relative paths in plain text', () => {
+    expect(detectPasteUrl('/docs/page')).toBeNull();
+    expect(detectPasteUrl('./docs/page')).toBeNull();
+    expect(detectPasteUrl('docs/page')).toBeNull();
   });
 
   it('returns null for URL with trailing text', () => {
@@ -223,8 +245,7 @@ describe('detectPasteUrl', () => {
     expect(detectPasteUrl(undefined)).toBeNull();
   });
 
-  it('normalizes protocol config entries (case and {scheme} objects)', () => {
-    // Mock sanitizeHref to accept FTP protocol when configured
+  it('does not allow configured protocols to expand plain-text auto-link detection', () => {
     sanitizeHref.mockImplementationOnce((raw, config) => {
       if (raw === 'ftp://files.example.com' && config?.allowedProtocols?.includes('ftp')) {
         return { href: 'ftp://files.example.com', protocol: 'ftp', isExternal: true };
@@ -233,7 +254,8 @@ describe('detectPasteUrl', () => {
     });
 
     const result = detectPasteUrl('ftp://files.example.com', [{ scheme: 'FTP' }]);
-    expect(result).toEqual({ href: 'ftp://files.example.com' });
+    expect(result).toBeNull();
+    expect(sanitizeHref).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/super-editor/src/editors/v1/core/inputRules/paste-link-normalizer.test.js
+++ b/packages/super-editor/src/editors/v1/core/inputRules/paste-link-normalizer.test.js
@@ -246,13 +246,6 @@ describe('detectPasteUrl', () => {
   });
 
   it('does not allow configured protocols to expand plain-text auto-link detection', () => {
-    sanitizeHref.mockImplementationOnce((raw, config) => {
-      if (raw === 'ftp://files.example.com' && config?.allowedProtocols?.includes('ftp')) {
-        return { href: 'ftp://files.example.com', protocol: 'ftp', isExternal: true };
-      }
-      return null;
-    });
-
     const result = detectPasteUrl('ftp://files.example.com', [{ scheme: 'FTP' }]);
     expect(result).toBeNull();
     expect(sanitizeHref).not.toHaveBeenCalled();


### PR DESCRIPTION
This pull request improves the detection logic for automatically converting pasted text into links, making it more precise. The main focus is to ensure that only text with an explicit URL intent (such as starting with `www.`, `http(s)://`, `mailto:`, `tel:`, or `sms:`) is auto-linked, and to prevent plain text or relative paths from being mistakenly treated as URLs. Tests have been updated to reflect these changes and to prevent protocol configuration from expanding what is auto-linked.