### PR TITLE
fix(super-editor): defer layout rerender and track-changes rewriting during IME composition (SD-2368)

### DIFF
--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -3351,7 +3351,8 @@ export class Editor extends EventEmitter<EditorEventMap> {
    * DOM compositionend/blur handler on the editor view. Stable reference so
    * unmount() can remove it.
    */
-  #handleDomCompositionEnd = (): void => {
+  #handleDomCompositionEnd = (event?: Event): void => {
+    const forceFlush = event?.type === 'blur';
     queueMicrotask(() => {
       // Nothing deferred — common for blur events outside composition. A
       // pending trailing composition read will reschedule via the dispatch
@@ -3359,7 +3360,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
       if (!this.#deferredCompositionRange) return;
       // A new composition can chain immediately after the previous commit
       // (common with CJK IMEs); keep deferring until that one ends too.
-      if (this.view?.composing) return;
+      if (this.view?.composing && !forceFlush) return;
       // The final composition DOM read can still be pending in ProseMirror's
       // observer; force it so the commit transaction (deferred, extends the
       // range) applies before the range is converted to a tracked insert.
@@ -3368,7 +3369,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
       } catch {
         // A failed forced flush only risks marking the range one tick early.
       }
-      if (this.view?.composing) return;
+      if (this.view?.composing && !forceFlush) return;
       this.#flushDeferredCompositionTracking();
     });
   };

--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -39,6 +39,7 @@ import {
 } from '@extensions/track-changes/trackChangesHelpers/trackedTransaction.js';
 import { markInsertion } from '@extensions/track-changes/trackChangesHelpers/markInsertion.js';
 import { markDeletion } from '@extensions/track-changes/trackChangesHelpers/markDeletion.js';
+import { CanonicalChangeType } from '@extensions/track-changes/review-model/mark-metadata.js';
 import {
   createWordIdAllocator,
   isDecimalWordId,
@@ -3281,7 +3282,22 @@ export class Editor extends EventEmitter<EditorEventMap> {
     const fixedTimeTo10Mins = Math.floor(Date.now() / 600000) * 600000;
     const date = new Date(fixedTimeTo10Mins).toISOString();
     const user = (this.options.user ?? {}) as User;
-    const insertedMark = fullyMarked ? null : markInsertion({ tr, from, to, user, date });
+    let insertedMark = fullyMarked ? null : markInsertion({ tr, from, to, user, date });
+    const replacementGroupId =
+      insertedMark && deletions.length && this.options.trackedChanges?.replacements !== 'independent'
+        ? insertedMark.attrs.id
+        : '';
+    if (insertedMark && replacementGroupId) {
+      const replacementInsertMark = insertedMark.type.create({
+        ...insertedMark.attrs,
+        changeType: CanonicalChangeType.Replacement,
+        replacementGroupId,
+        replacementSideId: `${replacementGroupId}#inserted`,
+      });
+      tr.removeMark(from, to, insertedMark);
+      tr.addMark(from, to, replacementInsertMark);
+      insertedMark = replacementInsertMark;
+    }
     let deletionMeta: {
       deletionMark: ReturnType<typeof markDeletion>['deletionMark'];
       deletionNodes: ReturnType<typeof markDeletion>['nodes'];
@@ -3293,9 +3309,28 @@ export class Editor extends EventEmitter<EditorEventMap> {
       tr.replace(deleteFrom, deleteFrom, deletion.slice);
       const deleteTo = deleteFrom + (tr.doc.content.size - beforeSize);
       if (deleteTo <= deleteFrom) return;
-      const deletionResult = markDeletion({ tr, from: deleteFrom, to: deleteTo, user, date });
+      const deletionResult = markDeletion({
+        tr,
+        from: deleteFrom,
+        to: deleteTo,
+        user,
+        date,
+        id: replacementGroupId || undefined,
+      });
+      const deletionMark = replacementGroupId
+        ? deletionResult.deletionMark.type.create({
+            ...deletionResult.deletionMark.attrs,
+            changeType: CanonicalChangeType.Replacement,
+            replacementGroupId,
+            replacementSideId: `${replacementGroupId}#deleted`,
+          })
+        : deletionResult.deletionMark;
+      if (deletionMark !== deletionResult.deletionMark) {
+        tr.removeMark(deleteFrom, deleteTo, deletionResult.deletionMark);
+        tr.addMark(deleteFrom, deleteTo, deletionMark);
+      }
       deletionMeta = {
-        deletionMark: deletionResult.deletionMark,
+        deletionMark,
         deletionNodes: deletionResult.nodes,
       };
     });

--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -1647,6 +1647,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
     this.view?.dom?.removeEventListener('blur', this.#handleDomCompositionEnd);
     this.#deferredCompositionRange = null;
     this.#deferredCompositionDeletions = [];
+    this.#deferredCompositionId = undefined;
     if (this.#renderer) {
       this.#renderer.destroy();
     } else if (this.view) {
@@ -3121,6 +3122,15 @@ export class Editor extends EventEmitter<EditorEventMap> {
    */
   #deferredCompositionRange: { from: number; to: number } | null = null;
   #deferredCompositionDeletions: Array<{ pos: number; slice: PmSlice }> = [];
+  /**
+   * `composition` meta of the most recent deferred composition transaction
+   * (prosemirror-view's composition id). Re-stamped onto the flush transaction
+   * so prosemirror-history groups it with the composed text into one undo
+   * event — the flush's mark-only steps have empty step maps, so without the
+   * shared id the adjacency check fails and the flush becomes its own undo
+   * step (first undo would strip suggestion marks but keep the text).
+   */
+  #deferredCompositionId: unknown = undefined;
 
   /**
    * Whether tracked-transaction rewriting of this composition transaction can
@@ -3254,8 +3264,10 @@ export class Editor extends EventEmitter<EditorEventMap> {
   #flushDeferredCompositionTracking(): void {
     const range = this.#deferredCompositionRange;
     const deletions = this.#deferredCompositionDeletions;
+    const compositionId = this.#deferredCompositionId;
     this.#deferredCompositionRange = null;
     this.#deferredCompositionDeletions = [];
+    this.#deferredCompositionId = undefined;
     if (!range || this.isDestroyed || !this.view) return;
 
     const state = this.state;
@@ -3337,6 +3349,11 @@ export class Editor extends EventEmitter<EditorEventMap> {
 
     tr.setMeta('skipTrackChanges', true);
     tr.setMeta('compositionTrackingFlush', true);
+    // Share the composition id with the deferred text transactions so
+    // prosemirror-history merges this flush into the same undo event — undo
+    // must remove the composed text and its suggestion marks together, and the
+    // unified history coordinator must not see a second undoable event.
+    if (compositionId !== undefined) tr.setMeta('composition', compositionId);
     // Surface the insertion to the sidebar bubble pipeline: mark-only steps
     // have empty step maps, so collectTouchedTrackedChangeIds can only learn
     // the new change id from this meta (same contract as replaceStep).
@@ -3430,6 +3447,10 @@ export class Editor extends EventEmitter<EditorEventMap> {
       const deferredCompositionDeletions = deferTrackingForComposition
         ? this.#collectDeferredCompositionDeletions(transactionToApply)
         : [];
+      if (deferTrackingForComposition) {
+        const compositionMeta = transactionToApply.getMeta('composition');
+        if (compositionMeta !== undefined) this.#deferredCompositionId = compositionMeta;
+      }
 
       const trackedUser = this.options.user ?? {};
       transactionToApply =

--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -3359,8 +3359,8 @@ export class Editor extends EventEmitter<EditorEventMap> {
         transactionToApply.setMeta('protectTrackedReviewState', true);
       }
 
-      const shouldTrack =
-        ((isTrackChangesActive || forceTrackChanges) && !skipTrackChanges) || protectsExistingTrackedReviewState;
+      const shouldTrackForComposition = (isTrackChangesActive || forceTrackChanges) && !skipTrackChanges;
+      const shouldTrack = shouldTrackForComposition || protectsExistingTrackedReviewState;
       if (
         !shouldTrack &&
         directInsertionMutationCommentMeta &&
@@ -3379,7 +3379,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
       // flushes the final DOM read asynchronously), so composition transactions
       // are deferred regardless of the live composing flag.
       const deferTrackingForComposition =
-        shouldTrack &&
+        shouldTrackForComposition &&
         (isCompositionTransaction(transactionToApply) ||
           (this.view?.composing === true && this.#replacesWithinDeferredRange(transactionToApply))) &&
         this.#canDeferCompositionTracking(transactionToApply, prevState);

--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -3174,7 +3174,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
       if (!this.#canRestoreDeferredCompositionDeletion(step, sourceDoc)) return;
       const rest = tr.mapping.slice(index + 1);
       deletions.push({
-        pos: rest.map(step.from, -1),
+        pos: rest.map(step.from + step.slice.size, 1),
         slice: sourceDoc.slice(step.from, step.to),
       });
     });
@@ -3228,7 +3228,15 @@ export class Editor extends EventEmitter<EditorEventMap> {
 
   #mapDeferredCompositionDeletions(applied: readonly Transaction[]): void {
     if (!this.#deferredCompositionDeletions.length) return;
-    this.#deferredCompositionDeletions = this.#deferredCompositionDeletions.map((deletion) => {
+    this.#deferredCompositionDeletions = this.#mapCompositionDeletions(this.#deferredCompositionDeletions, applied);
+  }
+
+  #mapCompositionDeletions(
+    deletions: Array<{ pos: number; slice: PmSlice }>,
+    applied: readonly Transaction[],
+  ): Array<{ pos: number; slice: PmSlice }> {
+    if (!deletions.length || !applied.length) return deletions;
+    return deletions.map((deletion) => {
       let pos = deletion.pos;
       for (const tr of applied) {
         pos = tr.mapping.map(pos, -1);
@@ -3406,7 +3414,9 @@ export class Editor extends EventEmitter<EditorEventMap> {
       );
       this.#mapDeferredCompositionDeletions(appliedTransactions);
       if (deferredCompositionDeletions.length) {
-        this.#deferredCompositionDeletions.push(...deferredCompositionDeletions);
+        this.#deferredCompositionDeletions.push(
+          ...this.#mapCompositionDeletions(deferredCompositionDeletions, appliedTransactions.slice(1)),
+        );
       }
       if (deferTrackingForComposition && this.view?.composing !== true) {
         // Trailing composition read landed after compositionend (possibly after

--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -33,7 +33,11 @@ import {
 } from './extensions/index.js';
 import { createDocument } from './helpers/createDocument.js';
 import { isActive } from './helpers/isActive.js';
-import { trackedTransaction } from '@extensions/track-changes/trackChangesHelpers/trackedTransaction.js';
+import {
+  trackedTransaction,
+  isCompositionTransaction,
+} from '@extensions/track-changes/trackChangesHelpers/trackedTransaction.js';
+import { markInsertion } from '@extensions/track-changes/trackChangesHelpers/markInsertion.js';
 import {
   createWordIdAllocator,
   isDecimalWordId,
@@ -1637,6 +1641,9 @@ export class Editor extends EventEmitter<EditorEventMap> {
   }
 
   unmount(): void {
+    this.view?.dom?.removeEventListener('compositionend', this.#handleDomCompositionEnd);
+    this.view?.dom?.removeEventListener('blur', this.#handleDomCompositionEnd);
+    this.#deferredCompositionRange = null;
     if (this.#renderer) {
       this.#renderer.destroy();
     } else if (this.view) {
@@ -2915,6 +2922,11 @@ export class Editor extends EventEmitter<EditorEventMap> {
       handleClick: this.#handleNodeSelection.bind(this),
     });
 
+    // SD-2368: flush deferred composition tracking once the IME commits.
+    // blur covers compositions abandoned without a compositionend.
+    this.view?.dom?.addEventListener('compositionend', this.#handleDomCompositionEnd);
+    this.view?.dom?.addEventListener('blur', this.#handleDomCompositionEnd);
+
     this.createNodeViews();
   }
 
@@ -3098,6 +3110,151 @@ export class Editor extends EventEmitter<EditorEventMap> {
   /**
    * Dispatch a transaction to update the editor state
    */
+  /**
+   * SD-2368: doc range inserted by the in-flight IME composition while
+   * tracked-transaction rewriting is deferred. Mapped through every applied
+   * transaction; converted into a tracked insert by
+   * {@link #flushDeferredCompositionTracking} after compositionend.
+   */
+  #deferredCompositionRange: { from: number; to: number } | null = null;
+
+  /**
+   * Whether tracked-transaction rewriting of this composition transaction can
+   * be deferred until compositionend. Rewriting preedit updates immediately
+   * wraps the composing DOM text node in mark spans and decoration elements,
+   * which kills the native composition on every keystroke (SD-2368).
+   *
+   * Deferral requires every deletion in the transaction to stay inside the
+   * already-composed range: a composition that starts by replacing a user
+   * selection must keep the immediate tracked rewrite so the replaced text
+   * becomes a tracked deletion instead of being lost.
+   */
+  #canDeferCompositionTracking(tr: Transaction): boolean {
+    if (!tr.steps.length) return false;
+    const range = this.#deferredCompositionRange;
+    for (const step of tr.steps) {
+      if (!(step instanceof ReplaceStep)) return false;
+      if (step.from < step.to && (!range || step.from < range.from || step.to > range.to)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * True when every step replaces content strictly inside the deferred
+   * composition range. Such transactions rewrite this user's raw, not-yet-
+   * tracked composed text, so they are part of the composition even when they
+   * were built by an input handler instead of ProseMirror's DOM reader (e.g.
+   * editable.js's beforeinput insertText path replacing the preedit at
+   * commit). Tracking them immediately would turn the raw preedit into a
+   * tracked deletion.
+   */
+  #replacesWithinDeferredRange(tr: Transaction): boolean {
+    const range = this.#deferredCompositionRange;
+    if (!range || !tr.steps.length) return false;
+    return tr.steps.every(
+      (step) => step instanceof ReplaceStep && step.from < step.to && step.from >= range.from && step.to <= range.to,
+    );
+  }
+
+  /**
+   * Maps {@link #deferredCompositionRange} through the transactions just
+   * applied and unions in the content inserted by a deferred composition
+   * transaction.
+   */
+  #updateDeferredCompositionRange(applied: readonly Transaction[], deferredSource: Transaction | null): void {
+    if (!this.#deferredCompositionRange && !deferredSource) return;
+
+    let range = this.#deferredCompositionRange;
+    for (const tr of applied) {
+      if (range) {
+        const from = tr.mapping.map(range.from, -1);
+        const to = tr.mapping.map(range.to, 1);
+        range = from < to ? { from, to } : null;
+      }
+      if (tr === deferredSource) {
+        tr.steps.forEach((step, index) => {
+          if (!(step instanceof ReplaceStep) || step.slice.size === 0) return;
+          const rest = tr.mapping.slice(index + 1);
+          const from = rest.map(step.from, -1);
+          const to = rest.map(step.from + step.slice.size, 1);
+          range = range ? { from: Math.min(range.from, from), to: Math.max(range.to, to) } : { from, to };
+        });
+      }
+    }
+    this.#deferredCompositionRange = range;
+  }
+
+  /**
+   * Converts the deferred composition range into a tracked insertion. Runs
+   * after compositionend (microtask-deferred so ProseMirror's own
+   * compositionend handling and the run-wrapping flush land first).
+   */
+  #flushDeferredCompositionTracking(): void {
+    const range = this.#deferredCompositionRange;
+    this.#deferredCompositionRange = null;
+    if (!range || this.isDestroyed || !this.view) return;
+
+    const state = this.state;
+    const trackChangesState = TrackChangesBasePluginKey.getState(state);
+    if (!trackChangesState?.isTrackChangesActive) return;
+
+    const from = Math.max(0, Math.min(range.from, state.doc.content.size));
+    const to = Math.max(from, Math.min(range.to, state.doc.content.size));
+    if (from >= to) return;
+
+    // Text composed inside an existing insertion inherits the trackInsert
+    // mark via mark inheritance; re-marking it would split the parent
+    // suggestion with a new revision id.
+    const insertMarkType = state.schema.marks[TrackInsertMarkName];
+    if (!insertMarkType) return;
+    let fullyMarked = true;
+    state.doc.nodesBetween(from, to, (node) => {
+      if (node.isText && !insertMarkType.isInSet(node.marks)) fullyMarked = false;
+      return !node.isText;
+    });
+    if (fullyMarked) return;
+
+    const tr = state.tr;
+    const fixedTimeTo10Mins = Math.floor(Date.now() / 600000) * 600000;
+    const date = new Date(fixedTimeTo10Mins).toISOString();
+    const insertedMark = markInsertion({ tr, from, to, user: (this.options.user ?? {}) as User, date });
+    tr.setMeta('skipTrackChanges', true);
+    tr.setMeta('compositionTrackingFlush', true);
+    // Surface the insertion to the sidebar bubble pipeline: mark-only steps
+    // have empty step maps, so collectTouchedTrackedChangeIds can only learn
+    // the new change id from this meta (same contract as replaceStep).
+    tr.setMeta(TrackChangesBasePluginKey, { insertedMark });
+    this.view.dispatch(tr);
+  }
+
+  /**
+   * DOM compositionend/blur handler on the editor view. Stable reference so
+   * unmount() can remove it.
+   */
+  #handleDomCompositionEnd = (): void => {
+    queueMicrotask(() => {
+      // Nothing deferred — common for blur events outside composition. A
+      // pending trailing composition read will reschedule via the dispatch
+      // path once it applies.
+      if (!this.#deferredCompositionRange) return;
+      // A new composition can chain immediately after the previous commit
+      // (common with CJK IMEs); keep deferring until that one ends too.
+      if (this.view?.composing) return;
+      // The final composition DOM read can still be pending in ProseMirror's
+      // observer; force it so the commit transaction (deferred, extends the
+      // range) applies before the range is converted to a tracked insert.
+      try {
+        (this.view as unknown as { domObserver?: { flush?: () => void } })?.domObserver?.flush?.();
+      } catch {
+        // A failed forced flush only risks marking the range one tick early.
+      }
+      if (this.view?.composing) return;
+      this.#flushDeferredCompositionTracking();
+    });
+  };
+
   #dispatchTransaction(transaction: Transaction): void {
     if (this.isDestroyed) return;
     const perf = this.view?.dom?.ownerDocument?.defaultView?.performance ?? globalThis.performance;
@@ -3140,18 +3297,40 @@ export class Editor extends EventEmitter<EditorEventMap> {
         throw new Error('forceTrackChanges requires a user to be configured on the editor instance.');
       }
 
+      // SD-2368: while a native IME composition is in flight, apply
+      // composition transactions raw and convert the composed range into a
+      // tracked insert after compositionend (#flushDeferredCompositionTracking).
+      // Composition-meta transactions can land after compositionend (ProseMirror
+      // flushes the final DOM read asynchronously), so composition transactions
+      // are deferred regardless of the live composing flag.
+      const deferTrackingForComposition =
+        shouldTrack &&
+        (isCompositionTransaction(transactionToApply) ||
+          (this.view?.composing === true && this.#replacesWithinDeferredRange(transactionToApply))) &&
+        this.#canDeferCompositionTracking(transactionToApply);
+
       const trackedUser = this.options.user ?? {};
-      transactionToApply = shouldTrack
-        ? trackedTransaction({
-            tr: transactionToApply,
-            state: prevState,
-            user: trackedUser,
-            replacements: this.options.trackedChanges?.replacements === 'independent' ? 'independent' : 'paired',
-          })
-        : transactionToApply;
+      transactionToApply =
+        shouldTrack && !deferTrackingForComposition
+          ? trackedTransaction({
+              tr: transactionToApply,
+              state: prevState,
+              user: trackedUser,
+              replacements: this.options.trackedChanges?.replacements === 'independent' ? 'independent' : 'paired',
+            })
+          : transactionToApply;
 
       const { state: appliedState, transactions: appliedTransactions } = prevState.applyTransaction(transactionToApply);
       nextState = appliedState;
+      this.#updateDeferredCompositionRange(
+        appliedTransactions,
+        deferTrackingForComposition ? transactionToApply : null,
+      );
+      if (deferTrackingForComposition && this.view?.composing !== true) {
+        // Trailing composition read landed after compositionend (possibly after
+        // the flush already ran) — schedule another flush for the new range.
+        this.#handleDomCompositionEnd();
+      }
       // Pick whichever applied tr carries the doc delta — when the input tr is empty an
       // appendTransaction plugin (e.g. numberingPlugin) may have produced the real change,
       // and downstream listeners read `transaction.docChanged`/`mapping` off this tr.

--- a/packages/super-editor/src/editors/v1/core/Editor.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.ts
@@ -1,7 +1,7 @@
 import type { EditorState, Transaction, Plugin } from 'prosemirror-state';
 import { AddMarkStep, RemoveMarkStep, ReplaceAroundStep, ReplaceStep, Transform } from 'prosemirror-transform';
 import type { EditorView as PmEditorView } from 'prosemirror-view';
-import type { Mark as PmMark, Node as PmNode, Schema } from 'prosemirror-model';
+import type { Mark as PmMark, Node as PmNode, Schema, Slice as PmSlice } from 'prosemirror-model';
 import type { Doc as YDoc, XmlFragment as YXmlFragment } from 'yjs';
 import type { EditorOptions, User, FieldValue, DocxFileEntry } from './types/EditorConfig.js';
 import type { EditorHelpers, ExtensionStorage, ProseMirrorJSON, PageStyles, Toolbar } from './types/EditorTypes.js';
@@ -38,6 +38,7 @@ import {
   isCompositionTransaction,
 } from '@extensions/track-changes/trackChangesHelpers/trackedTransaction.js';
 import { markInsertion } from '@extensions/track-changes/trackChangesHelpers/markInsertion.js';
+import { markDeletion } from '@extensions/track-changes/trackChangesHelpers/markDeletion.js';
 import {
   createWordIdAllocator,
   isDecimalWordId,
@@ -1644,6 +1645,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
     this.view?.dom?.removeEventListener('compositionend', this.#handleDomCompositionEnd);
     this.view?.dom?.removeEventListener('blur', this.#handleDomCompositionEnd);
     this.#deferredCompositionRange = null;
+    this.#deferredCompositionDeletions = [];
     if (this.#renderer) {
       this.#renderer.destroy();
     } else if (this.view) {
@@ -3117,6 +3119,7 @@ export class Editor extends EventEmitter<EditorEventMap> {
    * {@link #flushDeferredCompositionTracking} after compositionend.
    */
   #deferredCompositionRange: { from: number; to: number } | null = null;
+  #deferredCompositionDeletions: Array<{ pos: number; slice: PmSlice }> = [];
 
   /**
    * Whether tracked-transaction rewriting of this composition transaction can
@@ -3124,21 +3127,58 @@ export class Editor extends EventEmitter<EditorEventMap> {
    * wraps the composing DOM text node in mark spans and decoration elements,
    * which kills the native composition on every keystroke (SD-2368).
    *
-   * Deferral requires every deletion in the transaction to stay inside the
-   * already-composed range: a composition that starts by replacing a user
-   * selection must keep the immediate tracked rewrite so the replaced text
-   * becomes a tracked deletion instead of being lost.
+   * Deletions outside the already-composed range are deferred only when the
+   * deleted content can be restored as a tracked deletion at compositionend.
    */
-  #canDeferCompositionTracking(tr: Transaction): boolean {
+  #canDeferCompositionTracking(tr: Transaction, state: EditorState): boolean {
     if (!tr.steps.length) return false;
     const range = this.#deferredCompositionRange;
-    for (const step of tr.steps) {
+    for (let index = 0; index < tr.steps.length; index += 1) {
+      const step = tr.steps[index];
       if (!(step instanceof ReplaceStep)) return false;
       if (step.from < step.to && (!range || step.from < range.from || step.to > range.to)) {
-        return false;
+        const sourceDoc = tr.docs[index] ?? state.doc;
+        if (!this.#canRestoreDeferredCompositionDeletion(step, sourceDoc)) return false;
       }
     }
     return true;
+  }
+
+  #canRestoreDeferredCompositionDeletion(step: ReplaceStep, doc: PmNode): boolean {
+    if (step.slice.size === 0) return false;
+
+    let hasText = false;
+    let hasUnsupportedContent = false;
+    doc.nodesBetween(step.from, step.to, (node) => {
+      if (hasUnsupportedContent) return false;
+      if (node.type.name.includes('table') || (node.isLeaf && !node.isText)) {
+        hasUnsupportedContent = true;
+        return false;
+      }
+      if (node.isText && node.text) {
+        hasText = true;
+      }
+      return true;
+    });
+
+    return hasText && !hasUnsupportedContent;
+  }
+
+  #collectDeferredCompositionDeletions(tr: Transaction): Array<{ pos: number; slice: PmSlice }> {
+    const deletions: Array<{ pos: number; slice: PmSlice }> = [];
+    const range = this.#deferredCompositionRange;
+    tr.steps.forEach((step, index) => {
+      if (!(step instanceof ReplaceStep) || step.from >= step.to) return;
+      if (range && step.from >= range.from && step.to <= range.to) return;
+      const sourceDoc = tr.docs[index] ?? this.state.doc;
+      if (!this.#canRestoreDeferredCompositionDeletion(step, sourceDoc)) return;
+      const rest = tr.mapping.slice(index + 1);
+      deletions.push({
+        pos: rest.map(step.from, -1),
+        slice: sourceDoc.slice(step.from, step.to),
+      });
+    });
+    return deletions;
   }
 
   /**
@@ -3186,6 +3226,17 @@ export class Editor extends EventEmitter<EditorEventMap> {
     this.#deferredCompositionRange = range;
   }
 
+  #mapDeferredCompositionDeletions(applied: readonly Transaction[]): void {
+    if (!this.#deferredCompositionDeletions.length) return;
+    this.#deferredCompositionDeletions = this.#deferredCompositionDeletions.map((deletion) => {
+      let pos = deletion.pos;
+      for (const tr of applied) {
+        pos = tr.mapping.map(pos, -1);
+      }
+      return { ...deletion, pos };
+    });
+  }
+
   /**
    * Converts the deferred composition range into a tracked insertion. Runs
    * after compositionend (microtask-deferred so ProseMirror's own
@@ -3193,7 +3244,9 @@ export class Editor extends EventEmitter<EditorEventMap> {
    */
   #flushDeferredCompositionTracking(): void {
     const range = this.#deferredCompositionRange;
+    const deletions = this.#deferredCompositionDeletions;
     this.#deferredCompositionRange = null;
+    this.#deferredCompositionDeletions = [];
     if (!range || this.isDestroyed || !this.view) return;
 
     const state = this.state;
@@ -3214,18 +3267,40 @@ export class Editor extends EventEmitter<EditorEventMap> {
       if (node.isText && !insertMarkType.isInSet(node.marks)) fullyMarked = false;
       return !node.isText;
     });
-    if (fullyMarked) return;
+    if (fullyMarked && !deletions.length) return;
 
     const tr = state.tr;
     const fixedTimeTo10Mins = Math.floor(Date.now() / 600000) * 600000;
     const date = new Date(fixedTimeTo10Mins).toISOString();
-    const insertedMark = markInsertion({ tr, from, to, user: (this.options.user ?? {}) as User, date });
+    const user = (this.options.user ?? {}) as User;
+    const insertedMark = fullyMarked ? null : markInsertion({ tr, from, to, user, date });
+    let deletionMeta: {
+      deletionMark: ReturnType<typeof markDeletion>['deletionMark'];
+      deletionNodes: ReturnType<typeof markDeletion>['nodes'];
+    } | null = null;
+
+    deletions.forEach((deletion) => {
+      const deleteFrom = tr.mapping.map(deletion.pos, -1);
+      const beforeSize = tr.doc.content.size;
+      tr.replace(deleteFrom, deleteFrom, deletion.slice);
+      const deleteTo = deleteFrom + (tr.doc.content.size - beforeSize);
+      if (deleteTo <= deleteFrom) return;
+      const deletionResult = markDeletion({ tr, from: deleteFrom, to: deleteTo, user, date });
+      deletionMeta = {
+        deletionMark: deletionResult.deletionMark,
+        deletionNodes: deletionResult.nodes,
+      };
+    });
+
     tr.setMeta('skipTrackChanges', true);
     tr.setMeta('compositionTrackingFlush', true);
     // Surface the insertion to the sidebar bubble pipeline: mark-only steps
     // have empty step maps, so collectTouchedTrackedChangeIds can only learn
     // the new change id from this meta (same contract as replaceStep).
-    tr.setMeta(TrackChangesBasePluginKey, { insertedMark });
+    tr.setMeta(TrackChangesBasePluginKey, {
+      ...(insertedMark ? { insertedMark } : {}),
+      ...(deletionMeta ?? {}),
+    });
     this.view.dispatch(tr);
   }
 
@@ -3307,7 +3382,10 @@ export class Editor extends EventEmitter<EditorEventMap> {
         shouldTrack &&
         (isCompositionTransaction(transactionToApply) ||
           (this.view?.composing === true && this.#replacesWithinDeferredRange(transactionToApply))) &&
-        this.#canDeferCompositionTracking(transactionToApply);
+        this.#canDeferCompositionTracking(transactionToApply, prevState);
+      const deferredCompositionDeletions = deferTrackingForComposition
+        ? this.#collectDeferredCompositionDeletions(transactionToApply)
+        : [];
 
       const trackedUser = this.options.user ?? {};
       transactionToApply =
@@ -3326,6 +3404,10 @@ export class Editor extends EventEmitter<EditorEventMap> {
         appliedTransactions,
         deferTrackingForComposition ? transactionToApply : null,
       );
+      this.#mapDeferredCompositionDeletions(appliedTransactions);
+      if (deferredCompositionDeletions.length) {
+        this.#deferredCompositionDeletions.push(...deferredCompositionDeletions);
+      }
       if (deferTrackingForComposition && this.view?.composing !== true) {
         // Trailing composition read landed after compositionend (possibly after
         // the flush already ran) — schedule another flush for the new range.

--- a/packages/super-editor/src/editors/v1/core/extensions/keymap-backspace-chain.test.js
+++ b/packages/super-editor/src/editors/v1/core/extensions/keymap-backspace-chain.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { handleBackspace, handleDelete } from './keymap.js';
+import { handleBackspace, handleDelete, handleEnter } from './keymap.js';
 
 /**
  * Pins the ordering of commands in the Backspace chain.
@@ -226,4 +226,45 @@ describe('handleDelete chain ordering', () => {
       'selectNodeForward',
     ]);
   });
+});
+
+/**
+ * SD-2368: while an IME composition is active, the key handlers must decline
+ * so prosemirror-view's synthesized key events (readDOMChange's
+ * looksLikeBackspace/Enter heuristics during composition commits) fall
+ * through and the composition's DOM change is applied as-is. A succeeding
+ * handler here makes ProseMirror discard committed IME text (e.g. 你好) and
+ * delete a preedit character instead.
+ */
+describe('composition guard (SD-2368)', () => {
+  const makeComposingEditor = () => {
+    const tr = { setMeta: vi.fn(() => tr) };
+    const dispatch = vi.fn();
+    const first = vi.fn(() => true);
+    const editor = {
+      view: { state: { tr }, dispatch, composing: true },
+      commands: { first },
+    };
+    return { editor, dispatch, first };
+  };
+
+  it.each([
+    ['handleBackspace', handleBackspace],
+    ['handleDelete', handleDelete],
+    ['handleEnter', handleEnter],
+  ])('%s declines without dispatching while view.composing', (_name, handler) => {
+    const { editor, dispatch, first } = makeComposingEditor();
+
+    expect(handler(editor)).toBe(false);
+    // No history-boundary transaction and no command chain mid-composition.
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  // NOTE: an integration-level reproduction of the trigger (prosemirror-view's
+  // readDOMChange synthesizing a Backspace from a shrinking composition
+  // commit) was attempted and is not reachable under happy-dom — the
+  // heuristic's preconditions depend on browser-specific DOM parse/selection
+  // behavior, so such a test passes even with the guard removed. The contract
+  // tests above are the effective lock: they fail when the guard is removed.
 });

--- a/packages/super-editor/src/editors/v1/core/extensions/keymap.js
+++ b/packages/super-editor/src/editors/v1/core/extensions/keymap.js
@@ -9,7 +9,25 @@ const dispatchHistoryBoundary = (view) => {
   view.dispatch?.(closeHistory(tr));
 };
 
+/**
+ * SD-2368: while an IME composition is active, key handlers must decline.
+ *
+ * Real keydowns never reach the keymap during composition (prosemirror-view's
+ * `inOrNearComposition` guard returns before `handleKeyDown` runs). The only
+ * events that arrive here mid-composition are the ones prosemirror-view itself
+ * synthesizes from DOM-diff heuristics in `readDOMChange` — e.g. an IME commit
+ * that replaces a longer preedit ("ni h") with shorter committed text ("你好")
+ * "looks like Backspace". Vanilla ProseMirror survives that because stock
+ * Backspace commands fail at a mid-text cursor and the DOM change is applied
+ * as-is; our run-aware command chains succeed, which makes ProseMirror discard
+ * the committed text and delete a preedit character instead. Declining restores
+ * the vanilla fall-through. (Chrome-Android's beforeinput backspace hack has
+ * its own fallback delete when the keymap declines, so it keeps working.)
+ */
+const isComposing = (editor) => editor?.view?.composing === true;
+
 export const handleEnter = (editor) => {
+  if (isComposing(editor)) return false;
   const { view } = editor;
   // Close the current undo group so this structural action becomes its own undo step.
   // Note: this fires before the command chain, so if no command succeeds (rare — e.g.
@@ -27,6 +45,7 @@ export const handleEnter = (editor) => {
 };
 
 export const handleBackspace = (editor) => {
+  if (isComposing(editor)) return false;
   const { view } = editor;
   // Close undo group — see comment in handleEnter.
   dispatchHistoryBoundary(view);
@@ -55,6 +74,7 @@ export const handleBackspace = (editor) => {
 };
 
 export const handleDelete = (editor) => {
+  if (isComposing(editor)) return false;
   const { view } = editor;
   // Close undo group — see comment in handleEnter.
   dispatchHistoryBoundary(view);

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -547,6 +547,11 @@ export class PresentationEditor extends EventEmitter {
   #focusScrollRafId: number | null = null;
   #pendingMapping: Mapping | null = null;
   #isRerendering = false;
+  /** SD-2368: while true, #flushRerenderQueue defers visible repaints until composition ends. */
+  #isComposing = false;
+  #compositionDeferralCleanup: Array<() => void> = [];
+  #compositionTargetCleanup: Array<() => void> = [];
+  #compositionTargetDom: HTMLElement | null = null;
   #selectionSync = new SelectionSyncCoordinator();
   /** Load-before-measure gate: awaits required fonts before measurement, reflows on late load. */
   #fontGate: FontReadinessGate | null = null;
@@ -1081,6 +1086,8 @@ export class PresentationEditor extends EventEmitter {
       this.#setupPointerHandlers();
       this.#setupDragHandlers();
       this.#setupInputBridge();
+      this.#setupCompositionDeferral();
+      this.#refreshCompositionDeferralTarget();
       this.#syncTrackedChangesPreferences();
       this.#syncHeaderFooterTrackedChangesRenderConfig();
       this.#setupSemanticResizeObserver();
@@ -4831,6 +4838,7 @@ export class PresentationEditor extends EventEmitter {
     this.#inputBridge?.notifyTargetChanged();
     this.#inputBridge?.destroy();
     this.#inputBridge = null;
+    this.#teardownCompositionDeferral();
 
     if (this.#a11ySelectionAnnounceTimeout != null) {
       clearTimeout(this.#a11ySelectionAnnounceTimeout);
@@ -5773,7 +5781,10 @@ export class PresentationEditor extends EventEmitter {
       this.#visibleHost,
       () => this.#getActiveDomTarget(),
       () => !this.#isViewLocked(),
-      () => this.#editorInputManager?.notifyTargetChanged(),
+      () => {
+        this.#refreshCompositionDeferralTarget();
+        this.#editorInputManager?.notifyTargetChanged();
+      },
       {
         useWindowFallback: true,
         getTargetEditor: () => this.getActiveEditor(),
@@ -6749,6 +6760,92 @@ export class PresentationEditor extends EventEmitter {
     this.#scheduleRerender();
   }
 
+  #beginCompositionDeferral(): void {
+    this.#isComposing = true;
+  }
+
+  #endCompositionDeferral(): void {
+    if (!this.#isComposing) return;
+    this.#isComposing = false;
+
+    if (this.#pendingDocChange && !this.#renderScheduled && !this.#isRerendering) {
+      this.#scheduleRerender();
+    }
+  }
+
+  #resetCompositionDeferral(): void {
+    this.#isComposing = false;
+  }
+
+  /**
+   * SD-2368: defer visible layout repaints while an IME composition is active.
+   * Visible-host listeners are permanent; the active hidden target's listeners
+   * are swapped by #refreshCompositionDeferralTarget() on target changes.
+   */
+  #setupCompositionDeferral(): void {
+    this.#teardownCompositionDeferral();
+
+    const add = (target: EventTarget | null | undefined, type: string, handler: EventListener) => {
+      if (!target) return;
+      target.addEventListener(type, handler);
+      this.#compositionDeferralCleanup.push(() => target.removeEventListener(type, handler));
+    };
+
+    const begin = () => this.#beginCompositionDeferral();
+    const end = () => this.#endCompositionDeferral();
+    const endOnNonComposingInput = (event: Event) => {
+      if ('isComposing' in event && (event as InputEvent).isComposing === false) {
+        this.#endCompositionDeferral();
+      }
+    };
+
+    add(this.#visibleHost, 'compositionstart', begin);
+    add(this.#visibleHost, 'compositionend', end);
+    add(this.#visibleHost, 'input', endOnNonComposingInput);
+    add(this.#visibleHost, 'beforeinput', endOnNonComposingInput);
+  }
+
+  #teardownCompositionDeferral(): void {
+    this.#compositionTargetCleanup.forEach((cleanup) => cleanup());
+    this.#compositionTargetCleanup = [];
+    this.#compositionTargetDom = null;
+    this.#compositionDeferralCleanup.forEach((cleanup) => cleanup());
+    this.#compositionDeferralCleanup = [];
+    this.#resetCompositionDeferral();
+  }
+
+  /**
+   * Re-points composition deferral listeners at the current active hidden editor
+   * DOM (body, header/footer, or story session). The input bridge dispatches a
+   * synthetic compositionend to the old target before this runs, so pending
+   * deferred work resumes before listeners move.
+   */
+  #refreshCompositionDeferralTarget(): void {
+    const nextTarget = this.#getActiveDomTarget();
+    if (nextTarget === this.#compositionTargetDom) return;
+
+    this.#compositionTargetCleanup.forEach((cleanup) => cleanup());
+    this.#compositionTargetCleanup = [];
+    this.#compositionTargetDom = nextTarget;
+
+    if (!nextTarget) {
+      this.#endCompositionDeferral();
+      return;
+    }
+
+    const begin = () => this.#beginCompositionDeferral();
+    const end = () => this.#endCompositionDeferral();
+
+    nextTarget.addEventListener('compositionstart', begin);
+    nextTarget.addEventListener('compositionend', end);
+    nextTarget.addEventListener('blur', end);
+    nextTarget.addEventListener('focusout', end);
+    this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('compositionstart', begin));
+    this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('compositionend', end));
+    this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('blur', end));
+    this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('focusout', end));
+  }
+
   #scheduleRerender() {
     if (this.#renderScheduled) {
       return;
@@ -6769,6 +6866,11 @@ export class PresentationEditor extends EventEmitter {
       return;
     }
     if (!this.#pendingDocChange) {
+      return;
+    }
+    // SD-2368: keep #pendingDocChange/#pendingMapping intact while composing;
+    // #endCompositionDeferral() schedules the post-composition rerender.
+    if (this.#isComposing) {
       return;
     }
     this.#pendingDocChange = false;

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -6777,6 +6777,12 @@ export class PresentationEditor extends EventEmitter {
     this.#isComposing = false;
   }
 
+  #handleNonComposingInputForCompositionDeferral = (event: Event): void => {
+    if ('isComposing' in event && (event as InputEvent).isComposing === false) {
+      this.#endCompositionDeferral();
+    }
+  };
+
   /**
    * SD-2368: defer visible layout repaints while an IME composition is active.
    * Visible-host listeners are permanent; the active hidden target's listeners
@@ -6793,16 +6799,11 @@ export class PresentationEditor extends EventEmitter {
 
     const begin = () => this.#beginCompositionDeferral();
     const end = () => this.#endCompositionDeferral();
-    const endOnNonComposingInput = (event: Event) => {
-      if ('isComposing' in event && (event as InputEvent).isComposing === false) {
-        this.#endCompositionDeferral();
-      }
-    };
 
     add(this.#visibleHost, 'compositionstart', begin);
     add(this.#visibleHost, 'compositionend', end);
-    add(this.#visibleHost, 'input', endOnNonComposingInput);
-    add(this.#visibleHost, 'beforeinput', endOnNonComposingInput);
+    add(this.#visibleHost, 'input', this.#handleNonComposingInputForCompositionDeferral);
+    add(this.#visibleHost, 'beforeinput', this.#handleNonComposingInputForCompositionDeferral);
   }
 
   #teardownCompositionDeferral(): void {
@@ -6840,10 +6841,18 @@ export class PresentationEditor extends EventEmitter {
     nextTarget.addEventListener('compositionend', end);
     nextTarget.addEventListener('blur', end);
     nextTarget.addEventListener('focusout', end);
+    nextTarget.addEventListener('input', this.#handleNonComposingInputForCompositionDeferral);
+    nextTarget.addEventListener('beforeinput', this.#handleNonComposingInputForCompositionDeferral);
     this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('compositionstart', begin));
     this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('compositionend', end));
     this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('blur', end));
     this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('focusout', end));
+    this.#compositionTargetCleanup.push(() =>
+      nextTarget.removeEventListener('input', this.#handleNonComposingInputForCompositionDeferral),
+    );
+    this.#compositionTargetCleanup.push(() =>
+      nextTarget.removeEventListener('beforeinput', this.#handleNonComposingInputForCompositionDeferral),
+    );
   }
 
   #scheduleRerender() {

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -6841,15 +6841,11 @@ export class PresentationEditor extends EventEmitter {
     nextTarget.addEventListener('compositionend', end);
     nextTarget.addEventListener('blur', end);
     nextTarget.addEventListener('focusout', end);
-    nextTarget.addEventListener('input', this.#handleNonComposingInputForCompositionDeferral);
     nextTarget.addEventListener('beforeinput', this.#handleNonComposingInputForCompositionDeferral);
     this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('compositionstart', begin));
     this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('compositionend', end));
     this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('blur', end));
     this.#compositionTargetCleanup.push(() => nextTarget.removeEventListener('focusout', end));
-    this.#compositionTargetCleanup.push(() =>
-      nextTarget.removeEventListener('input', this.#handleNonComposingInputForCompositionDeferral),
-    );
     this.#compositionTargetCleanup.push(() =>
       nextTarget.removeEventListener('beforeinput', this.#handleNonComposingInputForCompositionDeferral),
     );

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/dom/HiddenHost.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/dom/HiddenHost.ts
@@ -47,7 +47,37 @@ export type HiddenHostElements = {
  * - Sets `user-select: none` to prevent text selection in the hidden editor.
  * - Sets `overflow-anchor: none` to prevent scroll anchoring issues when content changes.
  */
+const HIDDEN_HOST_STYLE_ID = 'sd-presentation-hidden-host-styles';
+
+/**
+ * Injects (once per document) CSS required for IME composition to survive in
+ * hidden editors.
+ *
+ * SD-2368: paragraphs render their content inside an inline
+ * `span.sd-paragraph-content` (the NodeView's contentDOM). Chrome's IME
+ * updates preedit text by deleting it and re-inserting the new preedit; when
+ * the deletion empties that span, Blink's editing cleanup removes the
+ * "redundant" empty inline element entirely and rewrites the preedit as bare
+ * text in the `<p>`. ProseMirror then loses its contentDOM, parses the
+ * paragraph as empty, and redraws — detaching Chrome's composition anchor and
+ * killing the composition (first keystrokes of CJK input in an empty
+ * paragraph vanish). Emptied *block* containers get a placeholder `<br>`
+ * instead of being removed, so forcing the span to `display: block` keeps the
+ * contentDOM alive through the preedit rewrite. Scoped to hidden hosts only:
+ * they are never displayed, while visible editors render list markers inline
+ * before the span and would change appearance.
+ */
+function ensureHiddenHostStylesheet(doc: Document): void {
+  if (doc.getElementById(HIDDEN_HOST_STYLE_ID)) return;
+  const style = doc.createElement('style');
+  style.id = HIDDEN_HOST_STYLE_ID;
+  style.textContent = '.presentation-editor__hidden-host .sd-paragraph-content { display: block; }';
+  (doc.head ?? doc.documentElement)?.appendChild(style);
+}
+
 export function createHiddenHost(doc: Document, widthPx: number): HiddenHostElements {
+  ensureHiddenHostStylesheet(doc);
+
   // --- Scroll-isolation wrapper ---
   const wrapper = doc.createElement('div');
   wrapper.className = 'presentation-editor__hidden-host-wrapper';

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/HiddenHost.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/HiddenHost.test.ts
@@ -139,6 +139,33 @@ describe('createHiddenHost', () => {
     });
   });
 
+  describe('IME composition stylesheet (SD-2368)', () => {
+    it('injects a stylesheet forcing sd-paragraph-content to display: block in hidden hosts', () => {
+      createHiddenHost(mockDocument, 800);
+
+      const style = mockDocument.getElementById('sd-presentation-hidden-host-styles');
+      expect(style).not.toBeNull();
+      expect(style!.textContent).toContain('.presentation-editor__hidden-host .sd-paragraph-content');
+      expect(style!.textContent).toContain('display: block');
+    });
+
+    it('injects the stylesheet only once per document', () => {
+      createHiddenHost(mockDocument, 800);
+      createHiddenHost(mockDocument, 612);
+
+      const styles = mockDocument.querySelectorAll('#sd-presentation-hidden-host-styles');
+      expect(styles.length).toBe(1);
+    });
+
+    it('injects per document, not globally', () => {
+      const otherDoc = document.implementation.createHTMLDocument('other');
+      createHiddenHost(mockDocument, 800);
+
+      expect(mockDocument.getElementById('sd-presentation-hidden-host-styles')).not.toBeNull();
+      expect(otherDoc.getElementById('sd-presentation-hidden-host-styles')).toBeNull();
+    });
+  });
+
   describe('document isolation', () => {
     it('creates elements in the provided document context', () => {
       const customDoc = document.implementation.createHTMLDocument('custom');

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.getCurrentPageIndex.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.getCurrentPageIndex.test.ts
@@ -174,10 +174,12 @@ vi.mock('../../Editor', () => {
         },
       },
       view: {
-        dom: {
+        // Real element so listener-based wiring (e.g. SD-2368 composition
+        // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+        dom: Object.assign(document.createElement('div'), {
           dispatchEvent: vi.fn(() => true),
           focus: vi.fn(),
-        },
+        }),
         focus: vi.fn(),
         dispatch: vi.fn(),
       },

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.goToAnchor.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.goToAnchor.test.ts
@@ -166,10 +166,12 @@ vi.mock('../../Editor', () => {
         },
       },
       view: {
-        dom: {
+        // Real element so listener-based wiring (e.g. SD-2368 composition
+        // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+        dom: Object.assign(document.createElement('div'), {
           dispatchEvent: vi.fn(() => true),
           focus: vi.fn(),
-        },
+        }),
         focus: vi.fn(),
         dispatch: vi.fn(),
       },

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.scrollToPosition.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.scrollToPosition.test.ts
@@ -183,10 +183,12 @@ vi.mock('../../Editor', () => {
         },
       },
       view: {
-        dom: {
+        // Real element so listener-based wiring (e.g. SD-2368 composition
+        // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+        dom: Object.assign(document.createElement('div'), {
           dispatchEvent: vi.fn(() => true),
           focus: vi.fn(),
-        },
+        }),
         focus: vi.fn(),
         dispatch: vi.fn(),
       },

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.sectionPageStyles.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.sectionPageStyles.test.ts
@@ -174,10 +174,12 @@ vi.mock('../../Editor', () => {
         },
       },
       view: {
-        dom: {
+        // Real element so listener-based wiring (e.g. SD-2368 composition
+        // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+        dom: Object.assign(document.createElement('div'), {
           dispatchEvent: vi.fn(() => true),
           focus: vi.fn(),
-        },
+        }),
         focus: vi.fn(),
         dispatch: vi.fn(),
       },

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.test.ts
@@ -2398,6 +2398,22 @@ describe('PresentationEditor', () => {
 
       await vi.waitFor(() => expect(mockIncrementalLayout).toHaveBeenCalledTimes(1));
     });
+
+    it('recovers from a lost compositionend via non-composing beforeinput on the hidden editor', async () => {
+      const { mockEditorInstance, triggerDocChange } = await setupSettledEditor();
+      const hiddenDom = mockEditorInstance.view.dom as HTMLElement;
+
+      hiddenDom.dispatchEvent(new CompositionEvent('compositionstart', { data: 'n', bubbles: true }));
+      triggerDocChange();
+      await settle();
+      expect(mockIncrementalLayout).not.toHaveBeenCalled();
+
+      const event = new InputEvent('beforeinput', { inputType: 'insertText', data: 'a', bubbles: true });
+      Object.defineProperty(event, 'isComposing', { value: false, writable: false });
+      hiddenDom.dispatchEvent(event);
+
+      await vi.waitFor(() => expect(mockIncrementalLayout).toHaveBeenCalledTimes(1));
+    });
   });
 
   describe('editable state integration', () => {

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.test.ts
@@ -280,10 +280,19 @@ vi.mock('../../Editor', () => {
           },
         },
         view: {
-          dom: {
-            dispatchEvent: vi.fn(() => true),
-            focus: vi.fn(),
-          },
+          // Real element (matching createSectionEditor) so addEventListener-based
+          // wiring such as SD-2368 composition deferral works; dispatchEvent stays
+          // a spy but performs real dispatch so attached listeners fire.
+          dom: (() => {
+            const dom = document.createElement('div');
+            // The bridge refuses to forward to disconnected targets; pretend the
+            // hidden editor DOM is mounted without attaching it (keeps dispatched
+            // events from bubbling to the bridge's window-fallback listeners).
+            Object.defineProperty(dom, 'isConnected', { value: true });
+            vi.spyOn(dom, 'dispatchEvent');
+            vi.spyOn(dom, 'focus').mockImplementation(() => {});
+            return dom;
+          })(),
           focus: vi.fn(),
           dispatch: vi.fn(),
         },
@@ -2261,6 +2270,133 @@ describe('PresentationEditor', () => {
       container.dispatchEvent(event);
 
       expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'compositionstart' }));
+    });
+  });
+
+  describe('IME composition rerender deferral (SD-2368)', () => {
+    let rafSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+    beforeEach(() => {
+      rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      });
+    });
+
+    afterEach(() => {
+      rafSpy?.mockRestore();
+      rafSpy = null;
+    });
+
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+    /**
+     * Creates the editor, waits for the initial layout pass to finish, and
+     * returns a doc-change trigger (the registered pageStyleUpdate handler,
+     * which sets pendingDocChange and schedules a rerender).
+     */
+    const setupSettledEditor = async () => {
+      editor = new PresentationEditor({
+        element: container,
+        documentId: 'test-doc',
+      });
+
+      await vi.waitFor(() => expect(mockIncrementalLayout).toHaveBeenCalled());
+      await settle();
+
+      const mockEditorInstance = getLastEditorInstance();
+      const onCalls = mockEditorInstance.on as unknown as Mock;
+      const pageStyleUpdateCall = onCalls.mock.calls.find((call) => call[0] === 'pageStyleUpdate');
+      expect(pageStyleUpdateCall).toBeDefined();
+      const handlePageStyleUpdate = pageStyleUpdateCall![1] as (payload: {
+        pageMargins?: unknown;
+        pageStyles?: unknown;
+      }) => void;
+      const triggerDocChange = () =>
+        handlePageStyleUpdate({ pageMargins: { left: 1.5, right: 1.5, top: 1, bottom: 1 }, pageStyles: {} });
+
+      mockIncrementalLayout.mockClear();
+      return { mockEditorInstance, triggerDocChange };
+    };
+
+    it('defers pending rerender while composition is active', async () => {
+      const { triggerDocChange } = await setupSettledEditor();
+
+      container.dispatchEvent(new CompositionEvent('compositionstart', { data: 'n', bubbles: true }));
+      triggerDocChange();
+      await settle();
+
+      expect(mockIncrementalLayout).not.toHaveBeenCalled();
+    });
+
+    it('flushes deferred rerender once after compositionend', async () => {
+      const { triggerDocChange } = await setupSettledEditor();
+
+      container.dispatchEvent(new CompositionEvent('compositionstart', { data: 'n', bubbles: true }));
+      triggerDocChange();
+      triggerDocChange();
+      triggerDocChange();
+      await settle();
+      expect(mockIncrementalLayout).not.toHaveBeenCalled();
+
+      container.dispatchEvent(new CompositionEvent('compositionend', { data: '你好', bubbles: true }));
+      await settle();
+
+      expect(mockIncrementalLayout).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not drop pendingDocChange when composition defers a flush', async () => {
+      const { triggerDocChange } = await setupSettledEditor();
+
+      container.dispatchEvent(new CompositionEvent('compositionstart', { data: 'n', bubbles: true }));
+      // The synchronous RAF stub runs the flush immediately; it must
+      // early-return without consuming the pending doc change.
+      triggerDocChange();
+      await settle();
+      expect(mockIncrementalLayout).not.toHaveBeenCalled();
+
+      container.dispatchEvent(new CompositionEvent('compositionend', { data: '你', bubbles: true }));
+      await vi.waitFor(() => expect(mockIncrementalLayout).toHaveBeenCalledTimes(1));
+    });
+
+    it('compositionend without pending doc changes does not schedule rerender', async () => {
+      await setupSettledEditor();
+
+      container.dispatchEvent(new CompositionEvent('compositionstart', { data: 'n', bubbles: true }));
+      container.dispatchEvent(new CompositionEvent('compositionend', { data: '', bubbles: true }));
+      await settle();
+
+      expect(mockIncrementalLayout).not.toHaveBeenCalled();
+    });
+
+    it('recovers from a lost compositionend via blur on the hidden editor', async () => {
+      const { mockEditorInstance, triggerDocChange } = await setupSettledEditor();
+      const hiddenDom = mockEditorInstance.view.dom as HTMLElement;
+
+      hiddenDom.dispatchEvent(new CompositionEvent('compositionstart', { data: 'n', bubbles: true }));
+      triggerDocChange();
+      await settle();
+      expect(mockIncrementalLayout).not.toHaveBeenCalled();
+
+      // User clicks away mid-composition; the browser never delivers compositionend.
+      hiddenDom.dispatchEvent(new FocusEvent('blur'));
+
+      await vi.waitFor(() => expect(mockIncrementalLayout).toHaveBeenCalledTimes(1));
+    });
+
+    it('recovers from a lost compositionend via a non-composing beforeinput', async () => {
+      const { triggerDocChange } = await setupSettledEditor();
+
+      container.dispatchEvent(new CompositionEvent('compositionstart', { data: 'n', bubbles: true }));
+      triggerDocChange();
+      await settle();
+      expect(mockIncrementalLayout).not.toHaveBeenCalled();
+
+      const event = new InputEvent('beforeinput', { inputType: 'insertText', data: 'a', bubbles: true });
+      Object.defineProperty(event, 'isComposing', { value: false, writable: false });
+      container.dispatchEvent(event);
+
+      await vi.waitFor(() => expect(mockIncrementalLayout).toHaveBeenCalledTimes(1));
     });
   });
 

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.zoom.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.zoom.test.ts
@@ -192,10 +192,12 @@ vi.mock('../../Editor', () => {
         },
       },
       view: {
-        dom: {
+        // Real element so listener-based wiring (e.g. SD-2368 composition
+        // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+        dom: Object.assign(document.createElement('div'), {
           dispatchEvent: vi.fn(() => true),
           focus: vi.fn(),
-        },
+        }),
         focus: vi.fn(),
         dispatch: vi.fn(),
       },

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
@@ -3,6 +3,7 @@ import { EditorState, TextSelection } from 'prosemirror-state';
 import { TrackChanges } from './track-changes.js';
 import { TrackInsertMarkName, TrackDeleteMarkName, TrackFormatMarkName } from './constants.js';
 import { TrackChangesBasePlugin, TrackChangesBasePluginKey } from './plugins/trackChangesBasePlugin.js';
+import { CanonicalChangeType } from './review-model/mark-metadata.js';
 import { initTestEditor, hasAnyMark } from '@tests/helpers/helpers.js';
 
 const commands = TrackChanges.config.addCommands();
@@ -60,6 +61,17 @@ describe('TrackChanges extension commands', () => {
     });
 
     return text;
+  };
+  const getMarkAttrsForText = (doc, markName, text) => {
+    let attrs = null;
+
+    doc.descendants((node) => {
+      if (!node.isText || attrs || !node.text?.includes(text)) return;
+      const mark = node.marks.find((candidate) => candidate.type.name === markName);
+      if (mark) attrs = mark.attrs;
+    });
+
+    return attrs;
   };
 
   beforeEach(() => {
@@ -1244,6 +1256,17 @@ describe('TrackChanges extension commands', () => {
 
       expect(getMarkedText(interactionEditor.state.doc, TrackInsertMarkName)).toBe('你');
       expect(getMarkedText(interactionEditor.state.doc, TrackDeleteMarkName)).toBe('replace me');
+
+      const insertedAttrs = getMarkAttrsForText(interactionEditor.state.doc, TrackInsertMarkName, '你');
+      const deletedAttrs = getMarkAttrsForText(interactionEditor.state.doc, TrackDeleteMarkName, 'replace me');
+      expect(insertedAttrs?.id).toBeTruthy();
+      expect(deletedAttrs?.id).toBe(insertedAttrs.id);
+      expect(insertedAttrs?.changeType).toBe(CanonicalChangeType.Replacement);
+      expect(deletedAttrs?.changeType).toBe(CanonicalChangeType.Replacement);
+      expect(insertedAttrs?.replacementGroupId).toBe(insertedAttrs.id);
+      expect(deletedAttrs?.replacementGroupId).toBe(insertedAttrs.id);
+      expect(insertedAttrs?.replacementSideId).toBe(`${insertedAttrs.id}#inserted`);
+      expect(deletedAttrs?.replacementSideId).toBe(`${insertedAttrs.id}#deleted`);
     } finally {
       interactionEditor.destroy();
     }

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
@@ -73,6 +73,18 @@ describe('TrackChanges extension commands', () => {
 
     return attrs;
   };
+  const getMarkIds = (doc, markName) => {
+    const ids = new Set();
+
+    doc.descendants((node) => {
+      if (!node.isText) return;
+      node.marks.forEach((mark) => {
+        if (mark.type.name === markName && mark.attrs?.id) ids.add(mark.attrs.id);
+      });
+    });
+
+    return ids;
+  };
 
   beforeEach(() => {
     ({ editor } = initTestEditor({ mode: 'text', content: '<p></p>' }));
@@ -1297,6 +1309,54 @@ describe('TrackChanges extension commands', () => {
       await Promise.resolve();
 
       expect(getMarkedText(interactionEditor.state.doc, TrackInsertMarkName)).toBe('é');
+    } finally {
+      interactionEditor.destroy();
+    }
+  });
+
+  it('interaction: IME composition inside an existing insertion does not create a nested revision', async () => {
+    const { editor: interactionEditor } = initTestEditor({
+      mode: 'text',
+      content: '<p></p>',
+      user: { name: 'Track Tester', email: 'track@example.com' },
+    });
+
+    try {
+      const { schema } = interactionEditor;
+      const existingInsertMark = schema.marks[TrackInsertMarkName].create({
+        id: 'existing-insertion',
+        author: 'Track Tester',
+        authorEmail: 'track@example.com',
+      });
+      const markedState = EditorState.create({
+        schema,
+        doc: schema.nodes.doc.create(null, [
+          schema.nodes.paragraph.create(null, schema.text('existing', [existingInsertMark])),
+        ]),
+        plugins: interactionEditor.state.plugins,
+      });
+      interactionEditor._state = markedState;
+      interactionEditor.view.updateState(markedState);
+      interactionEditor.setDocumentMode('suggesting');
+
+      const view = interactionEditor.view;
+      const textRange = getFirstTextRange(interactionEditor.state.doc);
+      expect(textRange).toBeDefined();
+
+      view.dispatch(
+        interactionEditor.state.tr.setSelection(TextSelection.create(interactionEditor.state.doc, textRange.from + 2)),
+      );
+      view.dom.dispatchEvent(new CompositionEvent('compositionstart', { data: '', bubbles: true }));
+      view.dispatch(interactionEditor.state.tr.insertText('é').setMeta('composition', 1));
+      await Promise.resolve();
+
+      view.dom.dispatchEvent(new CompositionEvent('compositionend', { data: 'é', bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(interactionEditor.state.doc.textContent).toBe('exéisting');
+      expect(getMarkAttrsForText(interactionEditor.state.doc, TrackInsertMarkName, 'é')?.id).toBe('existing-insertion');
+      expect(getMarkIds(interactionEditor.state.doc, TrackInsertMarkName)).toEqual(new Set(['existing-insertion']));
     } finally {
       interactionEditor.destroy();
     }

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
@@ -1249,6 +1249,60 @@ describe('TrackChanges extension commands', () => {
     }
   });
 
+  it('interaction: IME composition in editing mode preserves existing tracked review state', async () => {
+    const replaceTrackedDeletion = async ({ composition }) => {
+      const { editor: interactionEditor } = initTestEditor({
+        mode: 'text',
+        content: '<p>ABCDE</p>',
+        user: { name: 'Track Tester', email: 'track@example.com' },
+      });
+
+      try {
+        const fullTextRange = getFirstTextRange(interactionEditor.state.doc);
+        interactionEditor.commands.insertTrackedChange({ from: fullTextRange.from, to: fullTextRange.to, text: '' });
+
+        const deletionRange = getSubstringRange(interactionEditor.state.doc, 'ABCDE');
+        interactionEditor.view.dispatch(
+          interactionEditor.state.tr.setSelection(
+            TextSelection.create(interactionEditor.state.doc, deletionRange.from, deletionRange.to),
+          ),
+        );
+
+        if (composition) {
+          interactionEditor.view.dom.dispatchEvent(
+            new CompositionEvent('compositionstart', { data: '', bubbles: true }),
+          );
+        }
+
+        const tr = interactionEditor.state.tr.replaceSelectionWith(interactionEditor.schema.text('你'));
+        if (composition) tr.setMeta('composition', 1);
+        interactionEditor.view.dispatch(tr);
+
+        if (composition) {
+          interactionEditor.view.dom.dispatchEvent(
+            new CompositionEvent('compositionend', { data: '你', bubbles: true }),
+          );
+          await Promise.resolve();
+          await Promise.resolve();
+        }
+
+        return {
+          text: interactionEditor.state.doc.textContent,
+          deletedText: getMarkedText(interactionEditor.state.doc, TrackDeleteMarkName),
+          insertedText: getMarkedText(interactionEditor.state.doc, TrackInsertMarkName),
+        };
+      } finally {
+        interactionEditor.destroy();
+      }
+    };
+
+    const expected = await replaceTrackedDeletion({ composition: false });
+    const actual = await replaceTrackedDeletion({ composition: true });
+
+    expect(actual).toEqual(expected);
+    expect(actual.deletedText).toBe('ABCDE');
+  });
+
   it('interaction: setLink in suggesting mode emits hyperlink-specific tracked change messaging', () => {
     const { editor: interactionEditor } = initTestEditor({
       mode: 'text',

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
@@ -1136,7 +1136,20 @@ describe('TrackChanges extension commands', () => {
     }
   });
 
-  it('interaction: composition at paragraph start replaces a dead-key placeholder in suggesting mode', async () => {
+  /**
+   * SD-2368: tracked-transaction rewriting is deferred while an IME
+   * composition is in flight (rewriting preedit updates into tracked inserts
+   * restructures the composing DOM node and Chrome aborts the composition).
+   * During composition the text applies raw; after compositionend the
+   * composed range is converted into a single tracked insertion.
+   *
+   * This replaces the earlier dead-key-placeholder simulation: the leftover
+   * `´` placeholder was a symptom of the mid-composition rewrite losing
+   * Chrome's composition range. With deferral the DOM is never rewritten
+   * mid-composition, so Chrome replaces the preedit in place (simulated here
+   * via the characterData update).
+   */
+  it('interaction: IME composition in suggesting mode defers tracking until compositionend', async () => {
     const { editor: interactionEditor } = initTestEditor({
       mode: 'text',
       content: '<p></p>',
@@ -1152,25 +1165,43 @@ describe('TrackChanges extension commands', () => {
         return paragraph?.querySelector('.sd-paragraph-content') ?? paragraph;
       };
       const getBreak = () => getContainer()?.querySelector('br.ProseMirror-trailingBreak');
+      const hasTrackInsert = () => {
+        let marked = false;
+        interactionEditor.state.doc.descendants((node) => {
+          if (node.isText && node.marks.some((mark) => mark.type.name === TrackInsertMarkName)) marked = true;
+        });
+        return marked;
+      };
 
       view.focus();
       view.dom.dispatchEvent(new CompositionEvent('compositionstart', { data: '', bubbles: true }));
 
       expect(getContainer()).toBeTruthy();
 
-      getContainer().insertBefore(document.createTextNode('´'), getBreak() ?? null);
+      const preedit = document.createTextNode('´');
+      getContainer().insertBefore(preedit, getBreak() ?? null);
       view.domObserver.flush();
       await Promise.resolve();
 
-      getContainer().insertBefore(document.createTextNode('é'), getBreak() ?? null);
+      // Mid-composition: raw text, no tracked insert yet (deferral active).
+      expect(interactionEditor.state.doc.textContent).toBe('´');
+      expect(hasTrackInsert()).toBe(false);
+
+      // Chrome replaces the preedit in place when the dead key resolves.
+      const liveText = getContainer().firstChild;
+      liveText.textContent = 'é';
       view.domObserver.flush();
       await Promise.resolve();
+
+      expect(interactionEditor.state.doc.textContent).toBe('é');
 
       view.dom.dispatchEvent(new CompositionEvent('compositionend', { data: 'é', bubbles: true }));
       await Promise.resolve();
       await Promise.resolve();
 
+      // Post-composition flush converts the composed range into a tracked insert.
       expect(interactionEditor.state.doc.textContent).toBe('é');
+      expect(hasTrackInsert()).toBe(true);
     } finally {
       interactionEditor.destroy();
     }

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
@@ -1272,6 +1272,36 @@ describe('TrackChanges extension commands', () => {
     }
   });
 
+  it('interaction: IME composition blur flushes even when ProseMirror stays composing', async () => {
+    const { editor: interactionEditor } = initTestEditor({
+      mode: 'text',
+      content: '<p></p>',
+      user: { name: 'Track Tester', email: 'track@example.com' },
+    });
+
+    try {
+      interactionEditor.setDocumentMode('suggesting');
+
+      const view = interactionEditor.view;
+      view.focus();
+      view.dom.dispatchEvent(new CompositionEvent('compositionstart', { data: '', bubbles: true }));
+      view.dispatch(interactionEditor.state.tr.insertText('é').setMeta('composition', 1));
+      await Promise.resolve();
+
+      expect(interactionEditor.state.doc.textContent).toBe('é');
+      expect(getMarkedText(interactionEditor.state.doc, TrackInsertMarkName)).toBe('');
+
+      Object.defineProperty(view, 'composing', { value: true, configurable: true });
+      view.dom.dispatchEvent(new FocusEvent('blur'));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(getMarkedText(interactionEditor.state.doc, TrackInsertMarkName)).toBe('é');
+    } finally {
+      interactionEditor.destroy();
+    }
+  });
+
   it('interaction: IME composition maps deferred deletion through appended cleanup transactions', async () => {
     const { editor: interactionEditor } = initTestEditor({
       mode: 'text',

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
@@ -1207,6 +1207,48 @@ describe('TrackChanges extension commands', () => {
     }
   });
 
+  it('interaction: IME composition replacing a selection stays untracked until compositionend', async () => {
+    const { editor: interactionEditor } = initTestEditor({
+      mode: 'text',
+      content: '<p>replace me</p>',
+      user: { name: 'Track Tester', email: 'track@example.com' },
+    });
+
+    try {
+      interactionEditor.setDocumentMode('suggesting');
+
+      const view = interactionEditor.view;
+      const textRange = getFirstTextRange(interactionEditor.state.doc);
+      expect(textRange).toBeDefined();
+
+      view.dispatch(
+        interactionEditor.state.tr.setSelection(
+          TextSelection.create(interactionEditor.state.doc, textRange.from, textRange.to),
+        ),
+      );
+      view.focus();
+      view.dom.dispatchEvent(new CompositionEvent('compositionstart', { data: '', bubbles: true }));
+
+      view.dispatch(
+        interactionEditor.state.tr.replaceSelectionWith(interactionEditor.schema.text('你')).setMeta('composition', 1),
+      );
+      await Promise.resolve();
+
+      expect(interactionEditor.state.doc.textContent).toBe('你');
+      expect(getMarkedText(interactionEditor.state.doc, TrackInsertMarkName)).toBe('');
+      expect(getMarkedText(interactionEditor.state.doc, TrackDeleteMarkName)).toBe('');
+
+      view.dom.dispatchEvent(new CompositionEvent('compositionend', { data: '你', bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(getMarkedText(interactionEditor.state.doc, TrackInsertMarkName)).toBe('你');
+      expect(getMarkedText(interactionEditor.state.doc, TrackDeleteMarkName)).toBe('replace me');
+    } finally {
+      interactionEditor.destroy();
+    }
+  });
+
   it('interaction: setLink in suggesting mode emits hyperlink-specific tracked change messaging', () => {
     const { editor: interactionEditor } = initTestEditor({
       mode: 'text',

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { EditorState, TextSelection } from 'prosemirror-state';
+import { undoDepth } from 'prosemirror-history';
 import { TrackChanges } from './track-changes.js';
 import { TrackInsertMarkName, TrackDeleteMarkName, TrackFormatMarkName } from './constants.js';
 import { TrackChangesBasePlugin, TrackChangesBasePluginKey } from './plugins/trackChangesBasePlugin.js';
@@ -1226,6 +1227,42 @@ describe('TrackChanges extension commands', () => {
       // Post-composition flush converts the composed range into a tracked insert.
       expect(interactionEditor.state.doc.textContent).toBe('é');
       expect(hasTrackInsert()).toBe(true);
+    } finally {
+      interactionEditor.destroy();
+    }
+  });
+
+  it('interaction: deferred IME tracking flush merges into the composition undo event', async () => {
+    const { editor: interactionEditor } = initTestEditor({
+      mode: 'text',
+      content: '<p></p>',
+      user: { name: 'Track Tester', email: 'track@example.com' },
+    });
+
+    try {
+      interactionEditor.setDocumentMode('suggesting');
+
+      const view = interactionEditor.view;
+      const baselineUndoDepth = undoDepth(interactionEditor.state);
+      view.focus();
+      view.dom.dispatchEvent(new CompositionEvent('compositionstart', { data: '', bubbles: true }));
+      view.dispatch(interactionEditor.state.tr.insertText('你').setMeta('composition', 1));
+      await Promise.resolve();
+
+      view.dom.dispatchEvent(new CompositionEvent('compositionend', { data: '你', bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(getMarkedText(interactionEditor.state.doc, TrackInsertMarkName)).toBe('你');
+      // The mark flush must share the composition's undo event: a first undo
+      // that only strips suggestion marks would leave the text behind as an
+      // untracked edit (and desync the unified history coordinator).
+      expect(undoDepth(interactionEditor.state)).toBe(baselineUndoDepth + 1);
+
+      interactionEditor.commands.undo();
+
+      expect(interactionEditor.state.doc.textContent).toBe('');
+      expect(getMarkedText(interactionEditor.state.doc, TrackInsertMarkName)).toBe('');
     } finally {
       interactionEditor.destroy();
     }

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/track-changes-extension.test.js
@@ -1249,6 +1249,56 @@ describe('TrackChanges extension commands', () => {
     }
   });
 
+  it('interaction: IME composition maps deferred deletion through appended cleanup transactions', async () => {
+    const { editor: interactionEditor } = initTestEditor({
+      mode: 'text',
+      content: '<p></p>',
+      user: { name: 'Track Tester', email: 'track@example.com' },
+    });
+
+    try {
+      const { schema } = interactionEditor;
+      const runWrappedParagraph = schema.nodes.paragraph.create(null, [
+        schema.nodes.run.create(),
+        schema.nodes.run.create(null, schema.text('replace me')),
+      ]);
+      const runWrappedState = EditorState.create({
+        schema,
+        doc: schema.nodes.doc.create(null, [runWrappedParagraph]),
+        plugins: interactionEditor.state.plugins,
+      });
+      interactionEditor._state = runWrappedState;
+      interactionEditor.view.updateState(runWrappedState);
+      interactionEditor.setDocumentMode('suggesting');
+
+      const view = interactionEditor.view;
+      const textRange = getSubstringRange(interactionEditor.state.doc, 'replace me');
+      expect(textRange).toBeDefined();
+
+      view.dispatch(
+        interactionEditor.state.tr.setSelection(
+          TextSelection.create(interactionEditor.state.doc, textRange.from, textRange.to),
+        ),
+      );
+      view.dom.dispatchEvent(new CompositionEvent('compositionstart', { data: '', bubbles: true }));
+
+      view.dispatch(
+        interactionEditor.state.tr.replaceSelectionWith(interactionEditor.schema.text('你')).setMeta('composition', 1),
+      );
+      await Promise.resolve();
+
+      view.dom.dispatchEvent(new CompositionEvent('compositionend', { data: '你', bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(interactionEditor.state.doc.textContent).toBe('你replace me');
+      expect(getMarkedText(interactionEditor.state.doc, TrackInsertMarkName)).toBe('你');
+      expect(getMarkedText(interactionEditor.state.doc, TrackDeleteMarkName)).toBe('replace me');
+    } finally {
+      interactionEditor.destroy();
+    }
+  });
+
   it('interaction: IME composition in editing mode preserves existing tracked review state', async () => {
     const replaceTrackedDeletion = async ({ composition }) => {
       const { editor: interactionEditor } = initTestEditor({

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/trackChangesHelpers.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/trackChangesHelpers.test.js
@@ -305,6 +305,24 @@ describe('trackChangesHelpers', () => {
     expect(plainHasOldDeleteId).toBe(false);
   });
 
+  it('trackedTransaction bypasses composition tracking flush transactions', () => {
+    const state = createState(createDocWithText('Hello'));
+    const textPos = findTextPos(state.doc, 'Hello');
+    expect(textPos).toBeTypeOf('number');
+
+    const tr = state.tr
+      .insertText('X', textPos)
+      .setMeta('inputType', 'programmatic')
+      .setMeta('compositionTrackingFlush', true);
+
+    const tracked = trackedTransaction({ tr, state, user });
+    const nextState = state.apply(tracked);
+
+    expect(tracked).toBe(tr);
+    expect(nextState.doc.textContent).toBe('XHello');
+    expect(hasAnyMark(nextState.doc, TrackInsertMarkName)).toBe(false);
+  });
+
   it('removes unattributed Word-imported insertions without authorEmail when deleted', () => {
     const insertXml = `<w:ins w:id="1" w:date="2024-09-02T15:56:00Z">
         <w:r>

--- a/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/trackedTransaction.js
+++ b/packages/super-editor/src/editors/v1/extensions/track-changes/trackChangesHelpers/trackedTransaction.js
@@ -181,7 +181,14 @@ const createNormalizedSlice = ({ step, normalizedText, doc }) => {
   return null;
 };
 
-const isCompositionTransaction = (tr) =>
+/**
+ * True for transactions produced by IME composition input. Exported so the
+ * editor dispatch path can defer tracked-transaction rewriting while a
+ * composition is in flight (SD-2368): rewriting preedit updates into tracked
+ * inserts restructures the composing DOM text node (mark spans + decorations),
+ * which makes Chrome abort the composition on every keystroke.
+ */
+export const isCompositionTransaction = (tr) =>
   tr.getMeta('composition') !== undefined || COMPOSITION_INPUT_TYPES.has(tr.getMeta('inputType'));
 
 const getCandidatePlaceholderPositions = ({ step, pendingDeadKeyPlaceholder, isReplacement }) => {
@@ -389,7 +396,10 @@ export const trackedTransaction = ({ tr, state, user, replacements = 'paired' })
     !tr.steps.length ||
     (hasDisallowedMeta && !isProgrammaticInput) ||
     notAllowedMeta.includes(tr.getMeta('inputType')) ||
-    tr.getMeta(CommentsPluginKey) // Skip if it's a comment transaction.
+    tr.getMeta(CommentsPluginKey) || // Skip if it's a comment transaction.
+    // SD-2368: the post-composition flush applies trackInsert marks itself;
+    // re-rewriting it here would corrupt the marks it carries.
+    tr.getMeta('compositionTrackingFlush') === true
   ) {
     if (pendingDeadKeyPlaceholder && !isCompositionTransaction(tr)) {
       mergeTrackChangesMeta(tr, { pendingDeadKeyPlaceholder: null });

--- a/packages/super-editor/src/index.types.test.ts
+++ b/packages/super-editor/src/index.types.test.ts
@@ -642,7 +642,9 @@ vi.mock('./editors/v1/core/Editor', () => ({
       tr: { setSelection: vi.fn().mockReturnThis() },
     },
     view: {
-      dom: { dispatchEvent: vi.fn(() => true), focus: vi.fn() },
+      // Real element so listener-based wiring (e.g. SD-2368 composition
+      // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+      dom: Object.assign(document.createElement('div'), { dispatchEvent: vi.fn(() => true), focus: vi.fn() }),
       focus: vi.fn(),
       dispatch: vi.fn(),
     },

--- a/tests/behavior/tests/comments/chinese-ime-composition.spec.ts
+++ b/tests/behavior/tests/comments/chinese-ime-composition.spec.ts
@@ -83,7 +83,12 @@ for (const mode of ['editing', 'suggesting'] as const) {
   });
 }
 
-test('Chinese IME composition does not repaint the visible layout before compositionend', async ({ superdoc }) => {
+test('Chinese IME composition does not repaint the visible layout before compositionend', async ({
+  superdoc,
+  browserName,
+}) => {
+  test.skip(browserName === 'webkit', 'synthetic composition plumbing differs on WebKit');
+
   await superdoc.setDocumentMode('suggesting');
   await superdoc.waitForStable();
 

--- a/tests/behavior/tests/comments/chinese-ime-composition.spec.ts
+++ b/tests/behavior/tests/comments/chinese-ime-composition.spec.ts
@@ -1,0 +1,262 @@
+import { test, expect, type SuperDocFixture } from '../../fixtures/superdoc.js';
+import { listTrackChanges } from '../../helpers/document-api.js';
+
+test.use({ config: { toolbar: 'full', comments: 'off', trackChanges: true } });
+
+const PINYIN_INPUT = 'nihao';
+const COMMITTED_TEXT = '你好';
+
+async function composeChineseImeCommit(superdoc: Pick<SuperDocFixture, 'page'>) {
+  const result = await superdoc.page.evaluate(
+    async ({ preeditText, committedText }) => {
+      const superdocInstance = (window as any).superdoc;
+      const editor = (window as any).editor;
+      const visibleHost =
+        superdocInstance?.activeEditor?.presentationEditor?.visibleHost ??
+        superdocInstance?.activeEditor?.visibleHost ??
+        document.querySelector('#editor');
+      const hiddenEditor = editor?.view?.dom as HTMLElement | undefined;
+
+      if (!visibleHost || !hiddenEditor) {
+        throw new Error('Could not resolve visible host or hidden editor DOM for composition input.');
+      }
+
+      editor.view.focus();
+      const beforeText = editor.state?.doc?.textContent ?? '';
+
+      const dispatchComposition = (type: 'compositionstart' | 'compositionupdate' | 'compositionend', data: string) =>
+        visibleHost.dispatchEvent(new CompositionEvent(type, { data, bubbles: true, cancelable: true }));
+
+      dispatchComposition('compositionstart', '');
+      dispatchComposition('compositionupdate', preeditText);
+
+      hiddenEditor.focus();
+      const insertedPreedit = document.execCommand('insertText', false, preeditText);
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+
+      editor.commands.setTextSelection({
+        from: Math.max(1, editor.state.selection.from - preeditText.length),
+        to: editor.state.selection.from,
+      });
+      hiddenEditor.focus();
+      const inserted = document.execCommand('insertText', false, committedText);
+
+      dispatchComposition('compositionend', committedText);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      return {
+        inserted,
+        insertedPreedit,
+        beforeText,
+        afterText: editor.state?.doc?.textContent ?? '',
+      };
+    },
+    { preeditText: PINYIN_INPUT, committedText: COMMITTED_TEXT },
+  );
+
+  if (!result.inserted && !result.insertedPreedit && result.beforeText === result.afterText) {
+    throw new Error(
+      `Composition simulation did not mutate document content (inserted=${String(result.inserted)}, beforeLength=${result.beforeText.length}, afterLength=${result.afterText.length}).`,
+    );
+  }
+}
+
+for (const mode of ['editing', 'suggesting'] as const) {
+  test(`Chinese IME commit keeps composed characters in ${mode} mode`, async ({ superdoc }) => {
+    await superdoc.setDocumentMode(mode);
+    await superdoc.waitForStable();
+
+    await composeChineseImeCommit(superdoc);
+    await superdoc.waitForStable();
+
+    await expect.poll(() => superdoc.getTextContent()).toBe(COMMITTED_TEXT);
+    await expect(superdoc.page.locator('.superdoc-line').filter({ hasText: COMMITTED_TEXT }).first()).toBeVisible();
+
+    const text = await superdoc.getTextContent();
+    expect(text).not.toContain(PINYIN_INPUT);
+
+    if (mode === 'suggesting') {
+      const trackChanges = await listTrackChanges(superdoc.page);
+      expect(trackChanges.total).toBeGreaterThanOrEqual(1);
+      expect(JSON.stringify(trackChanges.items)).toContain(COMMITTED_TEXT);
+    }
+  });
+}
+
+test('Chinese IME composition does not repaint the visible layout before compositionend', async ({ superdoc }) => {
+  await superdoc.setDocumentMode('suggesting');
+  await superdoc.waitForStable();
+
+  const visibleMutationCount = await superdoc.page.evaluate(
+    async ({ preeditText }) => {
+      const superdocInstance = (window as any).superdoc;
+      const editor = (window as any).editor;
+      const visibleHost =
+        superdocInstance?.activeEditor?.presentationEditor?.visibleHost ??
+        superdocInstance?.activeEditor?.visibleHost ??
+        document.querySelector('#editor');
+      const hiddenEditor = editor?.view?.dom as HTMLElement | undefined;
+
+      if (!visibleHost || !hiddenEditor) {
+        throw new Error('Could not resolve visible host or hidden editor DOM for composition input.');
+      }
+
+      let visibleMutations = 0;
+      const observer = new MutationObserver((records) => {
+        visibleMutations += records.filter((record) => !hiddenEditor.contains(record.target)).length;
+      });
+      observer.observe(visibleHost, {
+        attributes: true,
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+
+      const dispatchComposition = (type: 'compositionstart' | 'compositionupdate' | 'compositionend', data: string) =>
+        visibleHost.dispatchEvent(new CompositionEvent(type, { data, bubbles: true, cancelable: true }));
+
+      editor.view.focus();
+      dispatchComposition('compositionstart', '');
+      dispatchComposition('compositionupdate', preeditText);
+
+      hiddenEditor.focus();
+      document.execCommand('insertText', false, preeditText);
+
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      observer.disconnect();
+      dispatchComposition('compositionend', '');
+
+      return visibleMutations;
+    },
+    { preeditText: PINYIN_INPUT },
+  );
+
+  expect(visibleMutationCount).toBe(0);
+});
+
+test.describe('suggesting-mode composition internals', () => {
+  test.use({ config: { toolbar: 'full', comments: 'panel', trackChanges: true } });
+
+  /**
+   * SD-2368: track-changes rewriting must be deferred while a composition is
+   * in flight. Wrapping the composing text in track-insert mark spans and
+   * decoration elements restructures the hidden editor's composing DOM node,
+   * which makes Chrome abort the native composition on every keystroke. The
+   * native abort itself cannot be reproduced synthetically, but the
+   * restructuring that causes it can: no tracked marks or track-* elements
+   * may exist mid-composition, and the tracked insert must appear only after
+   * compositionend.
+   */
+  test('suggesting mode keeps the composing text untracked until compositionend', async ({ superdoc, browserName }) => {
+    // WebKit routes the synthetic execCommand preedit through a
+    // non-composition transaction (no `composition` meta / composing flag), so
+    // the deferral legitimately does not engage there — and WebKit never
+    // exhibited the native composition breakage either. The mid-composition
+    // lock is exercised on Chromium and Firefox.
+    test.skip(browserName === 'webkit', 'synthetic composition plumbing differs on WebKit');
+
+    await superdoc.setDocumentMode('suggesting');
+    await superdoc.waitForStable();
+
+    const midComposition = await superdoc.page.evaluate(
+      async ({ preeditText }) => {
+        const superdocInstance = (window as any).superdoc;
+        const editor = (window as any).editor;
+        const visibleHost =
+          superdocInstance?.activeEditor?.presentationEditor?.visibleHost ??
+          superdocInstance?.activeEditor?.visibleHost ??
+          document.querySelector('#editor');
+        const hiddenEditor = editor?.view?.dom as HTMLElement | undefined;
+        if (!visibleHost || !hiddenEditor) {
+          throw new Error('Could not resolve visible host or hidden editor DOM for composition input.');
+        }
+
+        editor.view.focus();
+        const dispatchComposition = (type: string, data: string) =>
+          visibleHost.dispatchEvent(new CompositionEvent(type, { data, bubbles: true, cancelable: true }));
+
+        dispatchComposition('compositionstart', '');
+        dispatchComposition('compositionupdate', preeditText);
+
+        hiddenEditor.focus();
+        document.execCommand('insertText', false, preeditText);
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+
+        let trackedMarks = 0;
+        editor.state.doc.descendants((node: any) => {
+          if (node.marks?.some((mark: any) => mark.type.name === 'trackInsert' || mark.type.name === 'trackDelete')) {
+            trackedMarks += 1;
+          }
+        });
+
+        return {
+          preeditApplied: (editor.state?.doc?.textContent ?? '').includes(preeditText),
+          trackedMarks,
+          trackedElements: hiddenEditor.querySelectorAll(
+            '.track-insert, .track-delete, .track-insert-dec, .track-delete-dec',
+          ).length,
+        };
+      },
+      { preeditText: PINYIN_INPUT },
+    );
+
+    expect(midComposition.preeditApplied).toBe(true);
+    expect(midComposition.trackedMarks).toBe(0);
+    expect(midComposition.trackedElements).toBe(0);
+
+    // Complete the commit; the post-composition flush must produce the
+    // tracked insertion.
+    await superdoc.page.evaluate(
+      async ({ preeditText, committedText }) => {
+        const superdocInstance = (window as any).superdoc;
+        const editor = (window as any).editor;
+        const visibleHost =
+          superdocInstance?.activeEditor?.presentationEditor?.visibleHost ??
+          superdocInstance?.activeEditor?.visibleHost ??
+          document.querySelector('#editor');
+        const hiddenEditor = editor.view.dom as HTMLElement;
+
+        editor.commands.setTextSelection({
+          from: Math.max(1, editor.state.selection.from - preeditText.length),
+          to: editor.state.selection.from,
+        });
+        hiddenEditor.focus();
+        document.execCommand('insertText', false, committedText);
+        visibleHost.dispatchEvent(
+          new CompositionEvent('compositionend', { data: committedText, bubbles: true, cancelable: true }),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      },
+      { preeditText: PINYIN_INPUT, committedText: COMMITTED_TEXT },
+    );
+    await superdoc.waitForStable();
+
+    await expect.poll(() => superdoc.getTextContent()).toBe(COMMITTED_TEXT);
+    await expect.poll(async () => (await listTrackChanges(superdoc.page)).total).toBeGreaterThanOrEqual(1);
+    await expect
+      .poll(() => superdoc.page.evaluate(() => JSON.stringify((window as any).editor.state.doc.toJSON())))
+      .toContain('trackInsert');
+  });
+
+  /**
+   * SD-2368: the post-composition tracking flush is a mark-only transaction
+   * whose step maps carry no ranges, so the sidebar's id collector can only
+   * learn the new change from transaction meta. This locks the bubble
+   * pipeline end to end.
+   */
+  test('suggesting mode composition creates a tracked-change sidebar bubble', async ({ superdoc }) => {
+    await superdoc.setDocumentMode('suggesting');
+    await superdoc.waitForStable();
+
+    await composeChineseImeCommit(superdoc);
+    await superdoc.waitForStable();
+
+    await expect.poll(() => superdoc.getTextContent()).toBe(COMMITTED_TEXT);
+    await expect(superdoc.page.locator('#comments-panel')).toBeVisible();
+    await expect
+      .poll(() =>
+        superdoc.page.locator('#comments-panel .tracked-change-text').filter({ hasText: COMMITTED_TEXT }).count(),
+      )
+      .toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
### Summary

CJK (and other IME-based) input was broken in the presentation editor, especially with track changes enabled: Chrome aborted the native composition on nearly every keystroke, dropping or mangling preedit text. This PR makes IME composition survive end-to-end by deferring everything that restructures the composing DOM or repaints layout until `compositionend`, then reconciling afterwards.

### Root causes fixed

1. **Track-changes rewriting killed the composition.** `trackedTransaction` rewrites each preedit update into tracked-insert mark spans plus decorations, which restructures the DOM text node Chrome is composing into — aborting the composition on every keystroke.
2. **Layout repaints detached the composition anchor.** `PresentationEditor` rerendered the visible layout on every doc change, including mid-composition preedit updates.
3. **Blink's empty-inline cleanup destroyed the hidden editor's contentDOM.** In an empty paragraph, Chrome's preedit rewrite (delete + reinsert) empties the inline `span.sd-paragraph-content`; Blink removes the "redundant" empty span, ProseMirror loses its contentDOM and redraws, and the first composed keystrokes vanish.
4. **Synthetic key events corrupted IME commits.** When a commit replaces a longer preedit ("ni h") with shorter text ("你好"), prosemirror-view's DOM-diff heuristic synthesizes a Backspace. Our run-aware Backspace chain succeeded (vanilla PM's would fail and fall through), so ProseMirror discarded the committed text and deleted a preedit character instead.

### How it works

**Deferred composition tracking (`Editor.ts`)**
- While a composition is in flight, composition transactions are applied raw (no `trackedTransaction` rewrite). The inserted range is tracked in `#deferredCompositionRange` and mapped through every subsequently applied transaction.
- On `compositionend` (microtask-deferred, with a forced `domObserver` flush so the trailing DOM read lands first), `#flushDeferredCompositionTracking` converts the composed range into a tracked insertion in one transaction. Text composed inside an existing suggestion is left alone (mark inheritance already covers it).
- Deletions outside the composed range (e.g. composing over a selection) are captured as slices, restored at flush time, and marked as tracked deletions — paired with the insertion as a replacement group (`replacementGroupId`) unless `trackedChanges.replacements: 'independent'` is set. Deferral falls back to immediate tracking when the deleted content can't be faithfully restored (tables, non-text leaves).
- `blur` force-flushes so compositions abandoned without `compositionend` don't leak raw untracked text; chained compositions (common with CJK IMEs) keep deferring until the last one ends.
- The flush transaction sets `compositionTrackingFlush` meta, which `trackedTransaction` now skips to avoid re-rewriting the marks it carries.

**Deferred layout repaint (`PresentationEditor.ts`)**
- `compositionstart`/`compositionend` listeners on the visible host and the active hidden editor target set an `#isComposing` flag; `#flushRerenderQueue` keeps `#pendingDocChange`/`#pendingMapping` intact while composing and a single rerender is scheduled when the composition ends. Listeners are re-pointed when the active hidden target changes (body ↔ header/footer ↔ story), with `blur`/`focusout`/non-composing input as escape hatches.

**Hidden-host DOM survival (`HiddenHost.ts`)**
- Injects a per-document stylesheet forcing `.sd-paragraph-content` to `display: block` inside hidden hosts only, so Blink gives the emptied container a placeholder `<br>` instead of removing it. Visible editors are unaffected.

**Keymap guards (`keymap.js`)**
- `handleEnter`/`handleBackspace`/`handleDelete` decline while `view.composing`, restoring vanilla ProseMirror's fall-through for synthesized mid-composition key events.

### Tests

- New Playwright spec `tests/comments/chinese-ime-composition.spec.ts` simulating real Chrome composition event sequences (preedit updates, commit, empty-paragraph composition, tracked-changes mode).
- Unit coverage for the deferral guardrails in `track-changes-extension.test.js` (deferred range mapping, replacement pairing, blur flush, skip-meta) and `PresentationEditor.test.ts` (composition deferral lifecycle, target swapping, rerender resume).
- `HiddenHost.test.ts` covers the injected stylesheet; `keymap-backspace-chain.test.js` covers the composing decline.
