### PR TITLE
fix(document-api): handle JSON-encoded tags in SDT query operations

### DIFF
--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.test.ts
@@ -1315,3 +1315,81 @@ describe('contentControls.setType default sdtPr seeding', () => {
     expect(checkbox?.elements?.some((el) => el.name === 'w14:uncheckedState')).toBe(true);
   });
 });
+
+// SD-3428 regression: SDTs created via the StructuredContent extension store their
+// tag in JSON format {"group":"tagValue"} while the Document API stores plain strings.
+// Before the fix, list({tag}) and selectByTag({tag}) used strict equality and would
+// miss JSON-encoded tags. The fix introduces matchesTag() which handles both formats.
+describe('SD-3428: JSON-encoded tag matching in list and selectByTag', () => {
+  it('list({tag}) matches SDTs with JSON-encoded tags from StructuredContent extension', () => {
+    // Simulate an SDT created via insertStructuredContentInline which stores
+    // tags as JSON: {"group":"my-tag"}
+    const editor = makeSdtEditor({ tag: '{"group":"my-tag"}' });
+    const adapter = createContentControlsAdapter(editor);
+
+    const result = adapter.list({ tag: 'my-tag' });
+
+    expect(result.items.length).toBe(1);
+    expect(result.items[0].id).toBe('sdt-1');
+  });
+
+  it('list({tag}) still matches SDTs with plain string tags from Document API', () => {
+    // SDTs created via Document API store tags as plain strings
+    const editor = makeSdtEditor({ tag: 'plain-tag' });
+    const adapter = createContentControlsAdapter(editor);
+
+    const result = adapter.list({ tag: 'plain-tag' });
+
+    expect(result.items.length).toBe(1);
+    expect(result.items[0].id).toBe('sdt-1');
+  });
+
+  it('selectByTag matches SDTs with JSON-encoded tags', () => {
+    const editor = makeSdtEditor({ tag: '{"group":"json-tag"}' });
+    const adapter = createContentControlsAdapter(editor);
+
+    const result = adapter.selectByTag({ tag: 'json-tag' });
+
+    expect(result.items.length).toBe(1);
+    expect(result.items[0].id).toBe('sdt-1');
+  });
+
+  it('selectByTag still matches SDTs with plain string tags', () => {
+    const editor = makeSdtEditor({ tag: 'plain-tag' });
+    const adapter = createContentControlsAdapter(editor);
+
+    const result = adapter.selectByTag({ tag: 'plain-tag' });
+
+    expect(result.items.length).toBe(1);
+    expect(result.items[0].id).toBe('sdt-1');
+  });
+
+  it('list({tag}) excludes SDTs when JSON group does not match', () => {
+    const editor = makeSdtEditor({ tag: '{"group":"other-tag"}' });
+    const adapter = createContentControlsAdapter(editor);
+
+    const result = adapter.list({ tag: 'my-tag' });
+
+    expect(result.items.length).toBe(0);
+  });
+
+  it('handles malformed JSON tags gracefully (no match, no throw)', () => {
+    // If someone stores invalid JSON starting with '{', it should not throw
+    const editor = makeSdtEditor({ tag: '{invalid-json' });
+    const adapter = createContentControlsAdapter(editor);
+
+    const result = adapter.list({ tag: 'some-tag' });
+
+    expect(result.items.length).toBe(0);
+  });
+
+  it('handles JSON without group property (no match)', () => {
+    // Valid JSON but missing the 'group' property
+    const editor = makeSdtEditor({ tag: '{"other":"value"}' });
+    const adapter = createContentControlsAdapter(editor);
+
+    const result = adapter.list({ tag: 'value' });
+
+    expect(result.items.length).toBe(0);
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.ts
@@ -385,6 +385,30 @@ function replaceSdtTextContent(editor: Editor, target: ContentControlTarget, tex
 }
 
 // ---------------------------------------------------------------------------
+// Tag matching helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Match a tag value against a query, handling both plain strings and JSON-encoded
+ * tags from the StructuredContent extension (which stores `{group: "..."}` format).
+ */
+function matchesTag(storedTag: string | undefined, queryTag: string): boolean {
+  if (!storedTag) return false;
+  // Direct match (Document API style)
+  if (storedTag === queryTag) return true;
+  // JSON fallback (StructuredContent extension style)
+  if (storedTag.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(storedTag) as Record<string, unknown>;
+      return parsed?.group === queryTag;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 // A. Core CRUD + Discovery — Read operations
 // ---------------------------------------------------------------------------
 
@@ -396,7 +420,7 @@ function listWrapper(editor: Editor, query?: ContentControlsListQuery): ContentC
     infos = infos.filter((info) => info.controlType === query.controlType);
   }
   if (query?.tag) {
-    infos = infos.filter((info) => info.properties.tag === query.tag);
+    infos = infos.filter((info) => matchesTag(info.properties.tag, query.tag!));
   }
 
   return applyPagination(infos, query);
@@ -438,7 +462,9 @@ function listInRangeWrapper(editor: Editor, input: ContentControlsListInRangeInp
 
 function selectByTagWrapper(editor: Editor, input: ContentControlsSelectByTagInput): ContentControlsListResult {
   const allSdts = findAllSdtNodes(editor.state.doc);
-  const infos = allSdts.map(buildContentControlInfoFromNode).filter((info) => info.properties.tag === input.tag);
+  const infos = allSdts
+    .map(buildContentControlInfoFromNode)
+    .filter((info) => matchesTag(info.properties.tag, input.tag));
   return applyPagination(infos, input);
 }
 

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.ts
@@ -92,6 +92,7 @@ import { executeDomainCommand } from './plan-wrappers.js';
 import { clearIndexCache } from '../helpers/index-cache.js';
 import { buildTextWithTabs, parentAllowsNodeAt } from '../helpers/text-with-tabs.js';
 import { resolveSelectionTarget } from '../helpers/selection-target-resolver.js';
+import { getGroup } from '../../extensions/structured-content/structuredContentHelpers/tagUtils.js';
 
 // Shared helpers — single source of truth for SDT logic
 import {
@@ -391,21 +392,15 @@ function replaceSdtTextContent(editor: Editor, target: ContentControlTarget, tex
 /**
  * Match a tag value against a query, handling both plain strings and JSON-encoded
  * tags from the StructuredContent extension (which stores `{group: "..."}` format).
+ * Uses the canonical getGroup() helper from tagUtils to avoid duplicating decode logic.
  */
 function matchesTag(storedTag: string | undefined, queryTag: string): boolean {
   if (!storedTag) return false;
   // Direct match (Document API style)
   if (storedTag === queryTag) return true;
-  // JSON fallback (StructuredContent extension style)
-  if (storedTag.startsWith('{')) {
-    try {
-      const parsed = JSON.parse(storedTag) as Record<string, unknown>;
-      return parsed?.group === queryTag;
-    } catch {
-      return false;
-    }
-  }
-  return false;
+  // JSON fallback (StructuredContent extension style) - use canonical helper
+  const group = getGroup(storedTag);
+  return group === queryTag;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `matchesTag()` helper to handle both plain string and JSON-encoded tag formats
- Fix `selectByTag` and `list` queries to find SDTs created via the StructuredContent extension
- The extension stores tags as `{"group":"tag"}` while Document API stores plain `"tag"`

## Test plan
- [ ] Create SDT via Document API with a tag
- [ ] Create SDT via editor command with same tag
- [ ] Verify `selectByTag` returns both SDTs
- [ ] Verify `list({ tag: '...' })` returns both SDTs

Fixes SD-3428

🤖 Generated with [Claude Code](https://claude.ai/code)