### PR TITLE
fix(document-api): allow Document API to update contentLocked SDTs

### DIFF
--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/content-controls/index.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/content-controls/index.ts
@@ -26,7 +26,13 @@ export {
   readChoiceListData,
 } from './sdt-info-builder.js';
 
-export { assertNotSdtLocked, assertNotContentLocked, assertControlType } from './lock-enforcement.js';
+export {
+  assertNotSdtLocked,
+  assertNotContentLocked,
+  assertNotFullyLocked,
+  assertControlType,
+  requiresWholeNodeReplacement,
+} from './lock-enforcement.js';
 
 export { buildMutationSuccess, buildMutationFailure, applyPagination } from './result-builders.js';
 

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/content-controls/lock-enforcement.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/content-controls/lock-enforcement.ts
@@ -4,6 +4,31 @@
  * Centralized lock-check logic used by all mutation wrappers.
  * The plan mandates that lock checks happen pre-apply (before PM dispatch),
  * throwing LOCK_VIOLATION for locks and TYPE_MISMATCH for type guards.
+ *
+ * ## Lock Mode Semantics
+ *
+ * The ECMA-376 lock modes define restrictions for interactive (UI) editing:
+ * - `unlocked` — no restrictions
+ * - `sdtLocked` — cannot delete the wrapper (content editable)
+ * - `contentLocked` — cannot edit content interactively (can delete wrapper)
+ * - `sdtContentLocked` — cannot delete wrapper OR edit content
+ *
+ * ## Document API Bypass for contentLocked (SD-3429)
+ *
+ * The Document API allows programmatic updates to `contentLocked` SDTs via
+ * whole-node replacement. This is an intentional asymmetry:
+ *
+ * - **Interactive editing** — blocked by the lock plugin's `filterTransaction`
+ *   which rejects inner-content modifications
+ * - **Programmatic (Document API)** — allowed via `replaceEntireSdt` which
+ *   replaces the entire SDT node (wrapper + content). The lock plugin permits
+ *   this because the step covers the full node range (wrapper-level, not content-level).
+ *
+ * This enables use cases where template authors lock fields to prevent user typing
+ * but still need automated systems to populate values programmatically.
+ *
+ * `sdtContentLocked` remains fully blocked for both interactive and programmatic
+ * mutations via `assertNotFullyLocked`.
  */
 
 import type { ContentControlType } from '@superdoc/document-api';
@@ -47,8 +72,13 @@ export function assertNotContentLocked(sdt: ResolvedSdt, operation: string): voi
 
 /**
  * Assert that the SDT is not fully locked (sdtContentLocked).
- * Used before operations that modify content — allows `contentLocked` SDTs
- * to be updated via whole-node replacement (which the lock plugin permits).
+ *
+ * This is the check for Document API content mutations. It intentionally allows
+ * `contentLocked` SDTs to be updated programmatically via whole-node replacement
+ * (see file-level docs for SD-3429 rationale).
+ *
+ * Only `sdtContentLocked` is blocked — this mode indicates the author explicitly
+ * prohibited all modifications, including programmatic ones.
  */
 export function assertNotFullyLocked(sdt: ResolvedSdt, operation: string): void {
   const mode = resolveLockMode(sdt.node.attrs as Record<string, unknown>);

--- a/packages/super-editor/src/editors/v1/document-api-adapters/helpers/content-controls/lock-enforcement.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/helpers/content-controls/lock-enforcement.ts
@@ -45,6 +45,32 @@ export function assertNotContentLocked(sdt: ResolvedSdt, operation: string): voi
   }
 }
 
+/**
+ * Assert that the SDT is not fully locked (sdtContentLocked).
+ * Used before operations that modify content — allows `contentLocked` SDTs
+ * to be updated via whole-node replacement (which the lock plugin permits).
+ */
+export function assertNotFullyLocked(sdt: ResolvedSdt, operation: string): void {
+  const mode = resolveLockMode(sdt.node.attrs as Record<string, unknown>);
+  if (mode === 'sdtContentLocked') {
+    throw new DocumentApiAdapterError(
+      'LOCK_VIOLATION',
+      `Content control "${sdt.node.attrs.id}" has lock mode "${mode}" which prevents ${operation}.`,
+      { lockMode: mode, operation },
+    );
+  }
+}
+
+/**
+ * Check if the SDT requires whole-node replacement for content updates.
+ * `contentLocked` SDTs block inner-content modifications but allow replacing
+ * the entire node (wrapper + content), which preserves attrs including id.
+ */
+export function requiresWholeNodeReplacement(sdt: ResolvedSdt): boolean {
+  const mode = resolveLockMode(sdt.node.attrs as Record<string, unknown>);
+  return mode === 'contentLocked';
+}
+
 // ---------------------------------------------------------------------------
 // Type guard
 // ---------------------------------------------------------------------------

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.test.ts
@@ -1315,3 +1315,135 @@ describe('contentControls.setType default sdtPr seeding', () => {
     expect(checkbox?.elements?.some((el) => el.name === 'w14:uncheckedState')).toBe(true);
   });
 });
+
+// SD-3429: contentLocked SDTs can be updated via whole-node replacement through the
+// Document API. The lock plugin allows replacing the entire SDT node (wrapper + content)
+// while blocking inner-content modifications. This enables programmatic updates to
+// contentLocked fields while still blocking interactive typing.
+//
+// The whole-node replacement path:
+// 1. assertNotFullyLocked allows contentLocked (blocks only sdtContentLocked)
+// 2. requiresWholeNodeReplacement returns true for contentLocked
+// 3. replaceEntireSdt creates a new node with the same attrs but new content
+// 4. The lock plugin sees this as wrapper-level replacement (allowed for contentLocked)
+//
+// Additionally, replaceEntireSdt detects when the lock plugin silently rejects the
+// transaction (e.g., for nested contentLocked SDTs inside a contentLocked ancestor)
+// by checking if the doc actually changed after dispatch.
+describe('SD-3429: contentLocked SDT whole-node replacement via Document API', () => {
+  it('text.setValue on a contentLocked SDT uses whole-node replacement (replaceWith)', () => {
+    // contentLocked should use replaceEntireSdt which calls tr.replaceWith on the whole SDT
+    const editor = makeSdtEditor({ lockMode: 'contentLocked' });
+    const adapter = createContentControlsAdapter(editor);
+
+    // The operation may return NO_OP in the mock due to doc comparison, but we can
+    // verify it took the whole-node replacement path by checking replaceWith was called
+    try {
+      adapter.text.setValue({ target: SDT_TARGET, value: 'New value' }, { changeMode: 'direct' });
+    } catch {
+      // Ignore - we're testing the code path, not the result
+    }
+
+    const replaceWith = (editor.state.tr as any).replaceWith as ReturnType<typeof vi.fn>;
+    expect(replaceWith).toHaveBeenCalled();
+    // Verify it replaced the whole SDT range (from pos 0 to nodeSize)
+    const [from, to] = replaceWith.mock.calls[0];
+    expect(from).toBe(0); // SDT starts at position 0 in the mock doc
+    expect(to).toBeGreaterThan(from); // SDT has non-zero size
+  });
+
+  it('replaceContent on a contentLocked SDT uses whole-node replacement (replaceWith)', () => {
+    const editor = makeSdtEditor({ lockMode: 'contentLocked' });
+    const adapter = createContentControlsAdapter(editor);
+
+    try {
+      adapter.replaceContent({ target: SDT_TARGET, content: 'Replaced' }, { changeMode: 'direct' });
+    } catch {
+      // Ignore
+    }
+
+    const replaceWith = (editor.state.tr as any).replaceWith as ReturnType<typeof vi.fn>;
+    expect(replaceWith).toHaveBeenCalled();
+  });
+
+  it('clearContent on a contentLocked SDT uses whole-node replacement (replaceWith)', () => {
+    const editor = makeSdtEditor({ lockMode: 'contentLocked' });
+    const adapter = createContentControlsAdapter(editor);
+
+    try {
+      adapter.clearContent({ target: SDT_TARGET }, { changeMode: 'direct' });
+    } catch {
+      // Ignore
+    }
+
+    const replaceWith = (editor.state.tr as any).replaceWith as ReturnType<typeof vi.fn>;
+    expect(replaceWith).toHaveBeenCalled();
+  });
+
+  it('appendContent on a contentLocked SDT uses whole-node replacement (replaceWith)', () => {
+    const editor = makeSdtEditor({ lockMode: 'contentLocked' });
+    const adapter = createContentControlsAdapter(editor);
+
+    try {
+      adapter.appendContent({ target: SDT_TARGET, content: ' appended' }, { changeMode: 'direct' });
+    } catch {
+      // Ignore
+    }
+
+    const replaceWith = (editor.state.tr as any).replaceWith as ReturnType<typeof vi.fn>;
+    expect(replaceWith).toHaveBeenCalled();
+  });
+
+  it('prependContent on a contentLocked SDT uses whole-node replacement (replaceWith)', () => {
+    const editor = makeSdtEditor({ lockMode: 'contentLocked' });
+    const adapter = createContentControlsAdapter(editor);
+
+    try {
+      adapter.prependContent({ target: SDT_TARGET, content: 'prepended ' }, { changeMode: 'direct' });
+    } catch {
+      // Ignore
+    }
+
+    const replaceWith = (editor.state.tr as any).replaceWith as ReturnType<typeof vi.fn>;
+    expect(replaceWith).toHaveBeenCalled();
+  });
+
+  it('sdtLocked SDT uses inner-range replacement (not whole-node)', () => {
+    // sdtLocked should use replaceSdtTextContent which replaces inner content only
+    const editor = makeSdtEditor({ lockMode: 'sdtLocked' });
+    const adapter = createContentControlsAdapter(editor);
+
+    adapter.text.setValue({ target: SDT_TARGET, value: 'New value' }, { changeMode: 'direct' });
+
+    const replaceWith = (editor.state.tr as any).replaceWith as ReturnType<typeof vi.fn>;
+    expect(replaceWith).toHaveBeenCalled();
+    // For sdtLocked, the replaceWith should be on the inner range (pos+1, pos+nodeSize-1)
+    // not the whole node. The findSdtPos helper from SD-3123 tests shows this.
+    const [from, to] = replaceWith.mock.calls[0];
+    // Inner range excludes the wrapper boundaries
+    expect(from).toBeGreaterThan(0);
+  });
+
+  it('sdtContentLocked SDT rejects content mutations with LOCK_VIOLATION', () => {
+    // sdtContentLocked should still be blocked entirely by assertNotFullyLocked
+    const editor = makeSdtEditor({ lockMode: 'sdtContentLocked' });
+    const adapter = createContentControlsAdapter(editor);
+
+    expect(() => {
+      adapter.text.setValue({ target: SDT_TARGET, value: 'blocked' }, { changeMode: 'direct' });
+    }).toThrow(/sdtContentLocked.*prevents/);
+  });
+
+  it('unlocked SDT does not use whole-node replacement', () => {
+    const editor = makeSdtEditor({ lockMode: 'unlocked' });
+    const adapter = createContentControlsAdapter(editor);
+
+    adapter.text.setValue({ target: SDT_TARGET, value: 'New value' }, { changeMode: 'direct' });
+
+    const replaceWith = (editor.state.tr as any).replaceWith as ReturnType<typeof vi.fn>;
+    expect(replaceWith).toHaveBeenCalled();
+    // For unlocked, uses inner-range replacement
+    const [from] = replaceWith.mock.calls[0];
+    expect(from).toBeGreaterThan(0);
+  });
+});

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.ts
@@ -107,7 +107,9 @@ import {
   buildContentControlInfoFromNode,
   assertNotSdtLocked,
   assertNotContentLocked,
+  assertNotFullyLocked,
   assertControlType,
+  requiresWholeNodeReplacement,
   buildMutationSuccess,
   buildMutationFailure,
   applyPagination,
@@ -382,6 +384,49 @@ function replaceSdtTextContent(editor: Editor, target: ContentControlTarget, tex
   tr.replaceWith(innerFrom, innerTo, updatedParagraph);
   dispatchTransaction(editor, tr);
   return true;
+}
+
+/**
+ * Replace the entire SDT node (wrapper + content) while preserving all attrs.
+ * Used for `contentLocked` SDTs where inner-content modification is blocked
+ * by the lock plugin, but whole-node replacement is allowed.
+ */
+function replaceEntireSdt(editor: Editor, target: ContentControlTarget, text: string): boolean {
+  const resolved = resolveSdtByTarget(editor.state.doc, target);
+
+  // 1. Capture original node state FIRST for potential recovery
+  const originalNode = resolved.node;
+  const originalPos = resolved.pos;
+  const originalAttrs = { ...resolved.node.attrs };
+
+  // 2. Build the new content
+  let newContent;
+  if (resolved.kind === 'inline') {
+    newContent = text.length > 0 ? editor.schema.text(text) : null;
+  } else {
+    const paragraph = buildEmptyBlockContent(editor, resolved.node);
+    if (!paragraph) return false;
+    const paragraphText = text.length > 0 ? buildTextWithTabs(editor.schema, text, undefined) : null;
+    newContent = paragraph.type.create(paragraph.attrs ?? null, paragraphText, paragraph.marks);
+  }
+
+  // 3. Create the replacement node preserving all original attributes (including id)
+  const updatedNode = originalNode.type.create(originalAttrs, newContent, originalNode.marks);
+
+  // 4. Perform the replacement - if this fails, original doc state is unchanged
+  //    (ProseMirror transactions are atomic - either fully applied or not at all)
+  try {
+    const { tr } = editor.state;
+    const from = originalPos;
+    const to = originalPos + originalNode.nodeSize;
+    tr.replaceWith(from, to, updatedNode);
+    dispatchTransaction(editor, tr);
+    return true;
+  } catch (err) {
+    // Transaction failed - document state is unchanged, original node still exists
+    console.error('[replaceEntireSdt] Replacement failed, original node preserved:', err);
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -920,14 +965,17 @@ function replaceContentWrapper(
   options?: MutationOptions,
 ): ContentControlMutationResult {
   const sdt = resolveSdtByTarget(editor.state.doc, input.target);
-  assertNotContentLocked(sdt, 'replaceContent');
+  assertNotFullyLocked(sdt, 'replaceContent');
   if ((input.format ?? 'text') === 'text' && alreadyMatchesPlainTextReplacement(sdt, input.content)) {
     return buildMutationFailure('NO_OP', 'Content control already contains the requested text.');
   }
   const target = buildTarget(sdt);
+  const useWholeNode = requiresWholeNodeReplacement(sdt);
 
   return executeSdtMutation(editor, target, options, () => {
-    return replaceSdtTextContent(editor, input.target, input.content);
+    return useWholeNode
+      ? replaceEntireSdt(editor, input.target, input.content)
+      : replaceSdtTextContent(editor, input.target, input.content);
   });
 }
 
@@ -937,14 +985,15 @@ function clearContentWrapper(
   options?: MutationOptions,
 ): ContentControlMutationResult {
   const sdt = resolveSdtByTarget(editor.state.doc, input.target);
-  assertNotContentLocked(sdt, 'clearContent');
+  assertNotFullyLocked(sdt, 'clearContent');
   if (alreadyMatchesPlainTextReplacement(sdt, '')) {
     return buildMutationFailure('NO_OP', 'Content control is already empty.');
   }
   const target = buildTarget(sdt);
+  const useWholeNode = requiresWholeNodeReplacement(sdt);
 
   return executeSdtMutation(editor, target, options, () => {
-    return replaceSdtTextContent(editor, input.target, '');
+    return useWholeNode ? replaceEntireSdt(editor, input.target, '') : replaceSdtTextContent(editor, input.target, '');
   });
 }
 
@@ -954,16 +1003,20 @@ function appendContentWrapper(
   options?: MutationOptions,
 ): ContentControlMutationResult {
   const sdt = resolveSdtByTarget(editor.state.doc, input.target);
-  assertNotContentLocked(sdt, 'appendContent');
+  assertNotFullyLocked(sdt, 'appendContent');
   if (input.content.length === 0) {
     return buildMutationFailure('NO_OP', 'Appended content is empty.');
   }
   const target = buildTarget(sdt);
+  const useWholeNode = requiresWholeNodeReplacement(sdt);
 
   return executeSdtMutation(editor, target, options, () => {
     const resolved = resolveSdtByTarget(editor.state.doc, input.target);
     const currentText = resolved.node.textContent;
-    return replaceSdtTextContent(editor, input.target, currentText + input.content);
+    const newText = currentText + input.content;
+    return useWholeNode
+      ? replaceEntireSdt(editor, input.target, newText)
+      : replaceSdtTextContent(editor, input.target, newText);
   });
 }
 
@@ -973,16 +1026,20 @@ function prependContentWrapper(
   options?: MutationOptions,
 ): ContentControlMutationResult {
   const sdt = resolveSdtByTarget(editor.state.doc, input.target);
-  assertNotContentLocked(sdt, 'prependContent');
+  assertNotFullyLocked(sdt, 'prependContent');
   if (input.content.length === 0) {
     return buildMutationFailure('NO_OP', 'Prepended content is empty.');
   }
   const target = buildTarget(sdt);
+  const useWholeNode = requiresWholeNodeReplacement(sdt);
 
   return executeSdtMutation(editor, target, options, () => {
     const resolved = resolveSdtByTarget(editor.state.doc, input.target);
     const currentText = resolved.node.textContent;
-    return replaceSdtTextContent(editor, input.target, input.content + currentText);
+    const newText = input.content + currentText;
+    return useWholeNode
+      ? replaceEntireSdt(editor, input.target, newText)
+      : replaceSdtTextContent(editor, input.target, newText);
   });
 }
 
@@ -1269,14 +1326,17 @@ function textSetValueWrapper(
 ): ContentControlMutationResult {
   const sdt = resolveSdtByTarget(editor.state.doc, input.target);
   assertControlType(sdt, 'text', 'text.setValue');
-  assertNotContentLocked(sdt, 'text.setValue');
+  assertNotFullyLocked(sdt, 'text.setValue');
   if (alreadyMatchesPlainTextReplacement(sdt, input.value)) {
     return buildMutationFailure('NO_OP', 'Content control text already matches the requested value.');
   }
   const target = buildTarget(sdt);
+  const useWholeNode = requiresWholeNodeReplacement(sdt);
 
   return executeSdtMutation(editor, target, options, () => {
-    return replaceSdtTextContent(editor, input.target, input.value);
+    return useWholeNode
+      ? replaceEntireSdt(editor, input.target, input.value)
+      : replaceSdtTextContent(editor, input.target, input.value);
   });
 }
 
@@ -1287,14 +1347,15 @@ function textClearValueWrapper(
 ): ContentControlMutationResult {
   const sdt = resolveSdtByTarget(editor.state.doc, input.target);
   assertControlType(sdt, 'text', 'text.clearValue');
-  assertNotContentLocked(sdt, 'text.clearValue');
+  assertNotFullyLocked(sdt, 'text.clearValue');
   if (alreadyMatchesPlainTextReplacement(sdt, '')) {
     return buildMutationFailure('NO_OP', 'Content control text is already empty.');
   }
   const target = buildTarget(sdt);
+  const useWholeNode = requiresWholeNodeReplacement(sdt);
 
   return executeSdtMutation(editor, target, options, () => {
-    return replaceSdtTextContent(editor, input.target, '');
+    return useWholeNode ? replaceEntireSdt(editor, input.target, '') : replaceSdtTextContent(editor, input.target, '');
   });
 }
 

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/content-controls-wrappers.ts
@@ -390,16 +390,18 @@ function replaceSdtTextContent(editor: Editor, target: ContentControlTarget, tex
  * Replace the entire SDT node (wrapper + content) while preserving all attrs.
  * Used for `contentLocked` SDTs where inner-content modification is blocked
  * by the lock plugin, but whole-node replacement is allowed.
+ *
+ * SD-3429: Returns false if the transaction was silently rejected by a plugin
+ * (e.g., lock plugin filterTransaction returning false for nested locked SDTs).
  */
 function replaceEntireSdt(editor: Editor, target: ContentControlTarget, text: string): boolean {
   const resolved = resolveSdtByTarget(editor.state.doc, target);
 
-  // 1. Capture original node state FIRST for potential recovery
   const originalNode = resolved.node;
   const originalPos = resolved.pos;
   const originalAttrs = { ...resolved.node.attrs };
 
-  // 2. Build the new content
+  // Build the new content
   let newContent;
   if (resolved.kind === 'inline') {
     newContent = text.length > 0 ? editor.schema.text(text) : null;
@@ -410,21 +412,31 @@ function replaceEntireSdt(editor: Editor, target: ContentControlTarget, text: st
     newContent = paragraph.type.create(paragraph.attrs ?? null, paragraphText, paragraph.marks);
   }
 
-  // 3. Create the replacement node preserving all original attributes (including id)
+  // Create the replacement node preserving all original attributes (including id)
   const updatedNode = originalNode.type.create(originalAttrs, newContent, originalNode.marks);
 
-  // 4. Perform the replacement - if this fails, original doc state is unchanged
-  //    (ProseMirror transactions are atomic - either fully applied or not at all)
+  // Capture doc reference before dispatch to detect silent rejection
+  const docBefore = editor.state.doc;
+
   try {
     const { tr } = editor.state;
     const from = originalPos;
     const to = originalPos + originalNode.nodeSize;
     tr.replaceWith(from, to, updatedNode);
     dispatchTransaction(editor, tr);
+
+    // Check if transaction was actually applied. filterTransaction can silently
+    // reject transactions (returning false) without throwing, e.g., when this
+    // SDT is nested inside a contentLocked ancestor. Detect this by comparing
+    // doc references - ProseMirror creates a new doc instance on change.
+    const docAfter = editor.state.doc;
+    if (docBefore === docAfter) {
+      // Transaction was silently dropped (likely by lock plugin)
+      return false;
+    }
     return true;
   } catch (err) {
-    // Transaction failed - document state is unchanged, original node still exists
-    console.error('[replaceEntireSdt] Replacement failed, original node preserved:', err);
+    console.error('[replaceEntireSdt] Replacement failed:', err);
     return false;
   }
 }

--- a/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.js
+++ b/packages/super-editor/src/editors/v1/extensions/structured-content/structured-content-lock-plugin.js
@@ -14,12 +14,17 @@ export const STRUCTURED_CONTENT_LOCK_KEY = new PluginKey('structuredContentLock'
  * Lock modes (ECMA-376 w:lock):
  * - unlocked: No restrictions
  * - sdtLocked: Cannot delete the SDT wrapper (content editable)
- * - contentLocked: Cannot edit content (can delete wrapper)
+ * - contentLocked: Cannot edit content interactively (can delete wrapper)
  * - sdtContentLocked: Cannot delete wrapper OR edit content
  *
  * Strategy:
  * 1. handleKeyDown - Intercept keys BEFORE transaction to prevent browser selection issues
- * 2. filterTransaction - Safety net to catch programmatic changes
+ * 2. filterTransaction - Block inner-content modifications for locked SDTs
+ *
+ * Note: The Document API can programmatically update `contentLocked` SDTs via
+ * whole-node replacement (replaceEntireSdt). This plugin allows such operations
+ * because the step covers the full node range, which is classified as wrapper-level
+ * replacement rather than content modification. See lock-enforcement.ts SD-3429 docs.
  */
 
 /**


### PR DESCRIPTION
## Summary
- `contentLocked` SDTs block inner-content modification via the lock plugin
- Document API should still be able to update them programmatically
- Use whole-node replacement: replace the entire SDT node instead of modifying inner positions
- This preserves all attributes (including ID) while bypassing lock plugin position checks

## Changes
- Add `assertNotFullyLocked()` - rejects only `sdtContentLocked` (fully locked)
- Add `requiresWholeNodeReplacement()` - returns true for `contentLocked`
- Add `replaceEntireSdt()` - atomic replacement preserving original attrs
- Update `text.setValue`, `text.clearValue`, `replaceContent`, `clearContent` to use whole-node replacement for `contentLocked` SDTs

## Lock mode behavior
| Lock Mode | Inner-content edit | Whole-node replace | Document API |
|-----------|-------------------|-------------------|--------------|
| `unlocked` | ✅ | ✅ | ✅ normal |
| `sdtLocked` | ✅ | ❌ | ✅ normal |
| `contentLocked` | ❌ | ✅ | ✅ whole-node |
| `sdtContentLocked` | ❌ | ❌ | ❌ rejected |

## Test plan
- [ ] Create `contentLocked` SDT
- [ ] Verify `text.setValue` updates it successfully
- [ ] Verify the SDT ID is preserved after update
- [ ] Verify `sdtContentLocked` SDTs are still rejected

Fixes SD-3429

🤖 Generated with [Claude Code](https://claude.ai/code)