### PR TITLE
feat: textbox object interaction

### DIFF
--- a/packages/layout-engine/layout-bridge/src/cacheInvalidation.ts
+++ b/packages/layout-engine/layout-bridge/src/cacheInvalidation.ts
@@ -11,7 +11,7 @@
  * 4. Body measure cache for affected block IDs after token resolution
  */
 
-import type { FlowBlock, SectionMetadata } from '@superdoc/contracts';
+import type { DrawingBlock, FlowBlock, SectionMetadata } from '@superdoc/contracts';
 import type { HeaderFooterConstraints } from '@superdoc/layout-engine';
 import type { MeasureCache } from './cache';
 import type { HeaderFooterLayoutCache } from './layoutHeaderFooter';
@@ -57,9 +57,14 @@ export function computeHeaderFooterContentHash(blocks: FlowBlock[]): string {
       }
     }
 
-    if (block.kind === 'drawing' && 'geometry' in block) {
-      const g = (block as { geometry?: { width?: number; height?: number } }).geometry;
-      if (g) parts.push(`g:${g.width ?? 0}x${g.height ?? 0}`);
+    if (block.kind === 'drawing') {
+      const drawing = block as DrawingBlock;
+      if ('geometry' in drawing && drawing.geometry) {
+        parts.push(`g:${drawing.geometry.width ?? 0}x${drawing.geometry.height ?? 0}`);
+      }
+      if (drawing.anchor) {
+        parts.push(`a:${drawing.anchor.offsetH ?? 0},${drawing.anchor.offsetV ?? 0}`);
+      }
     }
   }
 

--- a/packages/layout-engine/layout-bridge/src/cacheInvalidation.ts
+++ b/packages/layout-engine/layout-bridge/src/cacheInvalidation.ts
@@ -56,6 +56,11 @@ export function computeHeaderFooterContentHash(blocks: FlowBlock[]): string {
         }
       }
     }
+
+    if (block.kind === 'drawing' && 'geometry' in block) {
+      const g = (block as { geometry?: { width?: number; height?: number } }).geometry;
+      if (g) parts.push(`g:${g.width ?? 0}x${g.height ?? 0}`);
+    }
   }
 
   return parts.join('|');

--- a/packages/layout-engine/layout-bridge/src/index.ts
+++ b/packages/layout-engine/layout-bridge/src/index.ts
@@ -60,6 +60,7 @@ export type {
 } from './headerFooterUtils';
 export {
   layoutHeaderFooterWithCache,
+  invalidateHeaderFooterMeasureCache,
   type HeaderFooterBatchResult,
   getBucketForPageNumber,
   getBucketRepresentative,

--- a/packages/layout-engine/layout-bridge/src/layoutHeaderFooter.ts
+++ b/packages/layout-engine/layout-bridge/src/layoutHeaderFooter.ts
@@ -465,6 +465,11 @@ export class HeaderFooterLayoutCache {
 
 const sharedHeaderFooterCache = new HeaderFooterLayoutCache();
 
+/** Invalidate header/footer measure cache entries for the given block IDs. */
+export function invalidateHeaderFooterMeasureCache(blockIds: string[]): void {
+  sharedHeaderFooterCache.invalidate(blockIds);
+}
+
 /**
  * Layouts header/footer variants with intelligent caching and page number resolution.
  *

--- a/packages/layout-engine/layout-resolved/src/versionSignature.ts
+++ b/packages/layout-engine/layout-resolved/src/versionSignature.ts
@@ -471,6 +471,8 @@ export const deriveBlockVersion = (block: FlowBlock): string => {
         vector.geometry.flipH ? 1 : 0,
         vector.geometry.flipV ? 1 : 0,
         drawingTextVersion(vector),
+        block.anchor?.offsetH ?? '',
+        block.anchor?.offsetV ?? '',
       ].join('|');
     }
     if (block.drawingKind === 'shapeGroup') {

--- a/packages/layout-engine/measuring/dom/src/index.ts
+++ b/packages/layout-engine/measuring/dom/src/index.ts
@@ -3408,9 +3408,9 @@ async function measureDrawingBlock(block: DrawingBlock, constraints: MeasureCons
   const naturalWidth = Math.max(1, rotatedBounds.width);
   const naturalHeight = Math.max(1, rotatedBounds.height);
 
-  // For floating drawings (wrapNone), don't constrain to the content area width.
-  // These drawings are positioned independently and can extend to page edges.
-  const isFloating = block.wrap?.type === 'None';
+  // Anchored and floating drawings are positioned independently — don't constrain
+  // to the content area width (they can extend past margins/page edges).
+  const isFloating = block.wrap?.type === 'None' || block.anchor?.isAnchored === true;
   const maxWidth = fullWidthMax ?? (constraints.maxWidth > 0 && !isFloating ? constraints.maxWidth : naturalWidth);
 
   // For anchored drawings with negative vertical positioning (designed to overflow their container),

--- a/packages/layout-engine/painters/dom/src/styles.ts
+++ b/packages/layout-engine/painters/dom/src/styles.ts
@@ -1080,6 +1080,13 @@ const IMAGE_SELECTION_STYLES = `
 .${DOM_CLASS_NAMES.INLINE_IMAGE_CLIP_WRAPPER}.superdoc-image-selected {
   outline-offset: 2px;
 }
+
+.superdoc-textbox-selected {
+  outline: 2px solid #4a90e2;
+  outline-offset: 2px;
+  border-radius: 2px;
+  box-shadow: 0 0 0 1px rgba(74, 144, 226, 0.35);
+}
 `;
 
 const MATH_MENCLOSE_STYLES = `

--- a/packages/super-editor/src/editors/v1/components/SuperEditor.test.js
+++ b/packages/super-editor/src/editors/v1/components/SuperEditor.test.js
@@ -1606,6 +1606,35 @@ describe('SuperEditor.vue', () => {
         wrapper.unmount();
         vi.useRealTimers();
       });
+
+      it('should clear textbox selection state', async () => {
+        vi.useFakeTimers();
+        EditorConstructor.loadXmlData.mockResolvedValueOnce(['<docx />', {}, {}, {}]);
+
+        const wrapper = mount(SuperEditor, {
+          props: {
+            documentId: 'doc-textbox-selection',
+            options: {},
+          },
+        });
+
+        await flushPromises();
+        await flushPromises();
+
+        const textboxEl = document.createElement('div');
+        textboxEl.classList.add('superdoc-textbox-selected');
+        wrapper.vm.selectedTextboxState.element = textboxEl;
+        wrapper.vm.selectedTextboxState.blockId = 'textbox-1';
+
+        wrapper.vm.clearSelectedTextbox();
+
+        expect(textboxEl.classList.contains('superdoc-textbox-selected')).toBe(false);
+        expect(wrapper.vm.selectedTextboxState.element).toBe(null);
+        expect(wrapper.vm.selectedTextboxState.blockId).toBe(null);
+
+        wrapper.unmount();
+        vi.useRealTimers();
+      });
     });
   });
 });

--- a/packages/super-editor/src/editors/v1/components/SuperEditor.vue
+++ b/packages/super-editor/src/editors/v1/components/SuperEditor.vue
@@ -348,6 +348,7 @@ const cleanupViewingModeUi = () => {
   hideTableResizeOverlay();
   hideImageResizeOverlay();
   clearSelectedImage();
+  clearSelectedTextbox();
 };
 
 /**
@@ -358,6 +359,11 @@ const selectedImageState = reactive({
   element: null,
   blockId: null,
   pmStart: null,
+});
+
+const selectedTextboxState = reactive({
+  element: null,
+  blockId: null,
 });
 
 /**
@@ -781,6 +787,14 @@ const clearSelectedImage = () => {
   selectedImageState.pmStart = null;
 };
 
+const clearSelectedTextbox = () => {
+  if (selectedTextboxState.element?.classList?.contains('superdoc-textbox-selected')) {
+    selectedTextboxState.element.classList.remove('superdoc-textbox-selected');
+  }
+  selectedTextboxState.element = null;
+  selectedTextboxState.blockId = null;
+};
+
 /**
  * Apply visual selection to the provided image fragment element
  * @param {HTMLElement | null} element - DOM element for the image fragment
@@ -821,6 +835,25 @@ const cleanupInactiveHeaderFooterOwnedImageUi = () => {
   }
   if (selectedImageState.element && !canInteractWithHeaderFooterOwnedMedia(selectedImageState.element)) {
     clearSelectedImage();
+  }
+};
+
+const setSelectedTextbox = (element, blockId) => {
+  if (isViewingMode() || !activeEditor.value?.isEditable) {
+    clearSelectedTextbox();
+    return;
+  }
+
+  if (selectedTextboxState.element && selectedTextboxState.element !== element) {
+    selectedTextboxState.element.classList.remove('superdoc-textbox-selected');
+  }
+
+  if (element && element.classList) {
+    element.classList.add('superdoc-textbox-selected');
+    selectedTextboxState.element = element;
+    selectedTextboxState.blockId = blockId ?? null;
+  } else {
+    clearSelectedTextbox();
   }
 };
 
@@ -1078,6 +1111,12 @@ const initEditor = async ({ content, media = {}, mediaFiles = {}, fonts = {} } =
       cleanupInactiveHeaderFooterOwnedImageUi();
     };
     presentationEditor.on('headerFooterModeChanged', headerFooterModeChangeHandler);
+    presentationEditor.on('textboxSelected', ({ element, blockId }) => {
+      setSelectedTextbox(element, blockId ?? null);
+    });
+    presentationEditor.on('textboxDeselected', () => {
+      clearSelectedTextbox();
+    });
 
     layoutUpdatedHandler = () => {
       if (imageResizeState.visible && imageResizeState.blockId) {
@@ -1121,6 +1160,16 @@ const initEditor = async ({ content, media = {}, mediaFiles = {}, fonts = {} } =
           }
 
           clearSelectedImage();
+        }
+      }
+
+      if (selectedTextboxState.blockId) {
+        const escapedBlockId = CSS.escape(selectedTextboxState.blockId);
+        const refreshed = editorElem.value?.querySelector(`[data-block-id="${escapedBlockId}"]`);
+        if (refreshed) {
+          setSelectedTextbox(refreshed, selectedTextboxState.blockId);
+        } else {
+          clearSelectedTextbox();
         }
       }
 

--- a/packages/super-editor/src/editors/v1/components/SuperEditor.vue
+++ b/packages/super-editor/src/editors/v1/components/SuperEditor.vue
@@ -13,6 +13,7 @@ import EditorSkeleton from './EditorSkeleton.vue';
 import LinkInput from './toolbar/LinkInput.vue';
 import TableResizeOverlay from './TableResizeOverlay.vue';
 import ImageResizeOverlay from './ImageResizeOverlay.vue';
+import TextboxResizeOverlay from './TextboxResizeOverlay.vue';
 import LinkClickHandler from './link-click/LinkClickHandler.vue';
 import { checkNodeSpecificClicks } from './cursor-helpers.js';
 import { adjustPaginationBreaks } from './pagination-helpers.js';
@@ -1451,6 +1452,12 @@ onBeforeUnmount(() => {
         :editor="contextMenuEditor"
         :visible="imageResizeState.visible"
         :imageElement="imageResizeState.imageElement"
+      />
+      <TextboxResizeOverlay
+        v-if="editorReady && activeEditor"
+        :editor="editor"
+        :visible="Boolean(selectedTextboxState.element)"
+        :textboxElement="selectedTextboxState.element"
       />
     </div>
 

--- a/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.test.js
+++ b/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.test.js
@@ -130,6 +130,100 @@ describe('TextboxResizeOverlay', () => {
     remove();
   });
 
+  it('NW resize: shifts marginOffset origin up-left by the same delta as the size growth', async () => {
+    const editor = createMockEditor();
+    const { textboxEl, remove } = createTextboxElement();
+
+    const wrapper = mount(TextboxResizeOverlay, {
+      attachTo: document.body,
+      props: { editor, visible: true, textboxElement: textboxEl },
+    });
+
+    // textboxEl is 120×60 at clientRect (10,20). NW handle is top-left corner.
+    // Drag NW by (-30, -20): cursor moves upper-left → shape grows to 150×80.
+    const handle = wrapper.find('.resize-handle--nw');
+    await handle.trigger('mousedown', { clientX: 10, clientY: 20 });
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: -20, clientY: 0 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: -20, clientY: 0 }));
+
+    // width grows by 30 → horizontal shifts left by 30: 50 - 30 = 20
+    // height grows by 20 → top shifts up by 20: 80 - 20 = 60
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'width', 150);
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'height', 80);
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'marginOffset', { horizontal: 20, top: 60 });
+
+    wrapper.unmount();
+    remove();
+  });
+
+  it('SW resize: shifts only horizontal origin, top stays fixed', async () => {
+    const editor = createMockEditor();
+    const { textboxEl, remove } = createTextboxElement();
+
+    const wrapper = mount(TextboxResizeOverlay, {
+      attachTo: document.body,
+      props: { editor, visible: true, textboxElement: textboxEl },
+    });
+
+    // SW handle: drag left by 20, down by 15 → width grows 20, height grows 15.
+    const handle = wrapper.find('.resize-handle--sw');
+    await handle.trigger('mousedown', { clientX: 10, clientY: 80 });
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: -10, clientY: 95 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: -10, clientY: 95 }));
+
+    // horizontal: 50 - 20 = 30, top stays 80
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'width', 140);
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'height', 75);
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'marginOffset', { horizontal: 30, top: 80 });
+
+    wrapper.unmount();
+    remove();
+  });
+
+  it('NE resize: shifts only top origin, horizontal stays fixed', async () => {
+    const editor = createMockEditor();
+    const { textboxEl, remove } = createTextboxElement();
+
+    const wrapper = mount(TextboxResizeOverlay, {
+      attachTo: document.body,
+      props: { editor, visible: true, textboxElement: textboxEl },
+    });
+
+    // NE handle: drag right by 25, up by 10 → width grows 25, height grows 10.
+    const handle = wrapper.find('.resize-handle--ne');
+    await handle.trigger('mousedown', { clientX: 130, clientY: 20 });
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 155, clientY: 10 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 155, clientY: 10 }));
+
+    // horizontal stays 50, top: 80 - 10 = 70
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'width', 145);
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'height', 70);
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'marginOffset', { horizontal: 50, top: 70 });
+
+    wrapper.unmount();
+    remove();
+  });
+
+  it('SE resize: does not modify marginOffset', async () => {
+    const editor = createMockEditor();
+    const { textboxEl, remove } = createTextboxElement();
+
+    const wrapper = mount(TextboxResizeOverlay, {
+      attachTo: document.body,
+      props: { editor, visible: true, textboxElement: textboxEl },
+    });
+
+    const handle = wrapper.find('.resize-handle--se');
+    await handle.trigger('mousedown', { clientX: 130, clientY: 80 });
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 190, clientY: 120 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 190, clientY: 120 }));
+
+    expect(editor.state.tr.setNodeAttribute).not.toHaveBeenCalledWith(10, 'marginOffset', expect.anything());
+
+    wrapper.unmount();
+    remove();
+  });
+
   it('dispatches marginOffset update when dragging overlay body', async () => {
     const editor = createMockEditor();
     const { textboxEl, remove } = createTextboxElement();

--- a/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.test.js
+++ b/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.test.js
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import TextboxResizeOverlay from './TextboxResizeOverlay.vue';
+
+vi.mock('@superdoc/layout-bridge', () => ({
+  measureCache: {
+    invalidate: vi.fn(),
+  },
+  invalidateHeaderFooterMeasureCache: vi.fn(),
+}));
+
+function createMockEditor(overrides = {}) {
+  const shapeNode = {
+    type: { name: 'shapeContainer' },
+    attrs: { width: 120, height: 60 },
+    marks: [],
+  };
+  const paragraphNode = {
+    isBlock: true,
+    type: { name: 'paragraph', spec: { attrs: { sdBlockId: {}, sdBlockRev: {} } } },
+    attrs: { sdBlockRev: 3 },
+  };
+
+  const tr = {
+    setNodeAttribute: vi.fn().mockReturnThis(),
+  };
+
+  return {
+    options: { documentMode: 'editing' },
+    isEditable: true,
+    state: {
+      doc: {
+        resolve: vi.fn(() => ({
+          depth: 1,
+          node: () => paragraphNode,
+          before: () => 0,
+        })),
+      },
+      selection: {
+        from: 10,
+        node: shapeNode,
+      },
+      tr,
+    },
+    view: {
+      dom: document.createElement('div'),
+      dispatch: vi.fn(),
+    },
+    ...overrides,
+  };
+}
+
+function createTextboxElement() {
+  const editorShell = document.createElement('div');
+  editorShell.className = 'super-editor';
+  const textboxEl = document.createElement('div');
+  textboxEl.setAttribute('data-block-id', 'textbox-block');
+  const contentSpan = document.createElement('span');
+  contentSpan.setAttribute('data-pm-start', '10');
+  textboxEl.appendChild(contentSpan);
+  editorShell.appendChild(textboxEl);
+  document.body.appendChild(editorShell);
+
+  textboxEl.getBoundingClientRect = vi.fn(() => ({
+    left: 10,
+    top: 20,
+    width: 120,
+    height: 60,
+    right: 130,
+    bottom: 80,
+    x: 10,
+    y: 20,
+    toJSON: () => {},
+  }));
+
+  editorShell.getBoundingClientRect = vi.fn(() => ({
+    left: 0,
+    top: 0,
+    width: 400,
+    height: 300,
+    right: 400,
+    bottom: 300,
+    x: 0,
+    y: 0,
+    toJSON: () => {},
+  }));
+
+  return {
+    textboxEl,
+    remove: () => editorShell.remove(),
+  };
+}
+
+describe('TextboxResizeOverlay', () => {
+  it('renders four resize handles for a visible textbox selection', () => {
+    const editor = createMockEditor();
+    const { textboxEl, remove } = createTextboxElement();
+
+    const wrapper = mount(TextboxResizeOverlay, {
+      attachTo: document.body,
+      props: { editor, visible: true, textboxElement: textboxEl },
+    });
+
+    expect(wrapper.findAll('.resize-handle')).toHaveLength(4);
+
+    wrapper.unmount();
+    remove();
+  });
+
+  it('dispatches width and height updates for shapeContainer resize', async () => {
+    const editor = createMockEditor();
+    const { textboxEl, remove } = createTextboxElement();
+
+    const wrapper = mount(TextboxResizeOverlay, {
+      attachTo: document.body,
+      props: { editor, visible: true, textboxElement: textboxEl },
+    });
+
+    const handle = wrapper.find('.resize-handle--se');
+    await handle.trigger('mousedown', { clientX: 130, clientY: 80 });
+
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 190, clientY: 120 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 190, clientY: 120 }));
+
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'width', 180);
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'height', 100);
+    expect(editor.view.dispatch).toHaveBeenCalledWith(editor.state.tr);
+
+    wrapper.unmount();
+    remove();
+  });
+
+  it('falls back to DOM position markers when NodeSelection is unavailable on mouseup', async () => {
+    const editor = createMockEditor({
+      state: {
+        doc: {
+          resolve: vi.fn(() => ({
+            depth: 2,
+            node: (depth) =>
+              depth === 2
+                ? { type: { name: 'shapeContainer' }, attrs: { width: 120, height: 60 } }
+                : {
+                    isBlock: true,
+                    type: { name: 'paragraph', spec: { attrs: { sdBlockId: {}, sdBlockRev: {} } } },
+                    attrs: { sdBlockRev: 7 },
+                  },
+            before: (depth) => (depth === 2 ? 24 : 5),
+          })),
+        },
+        selection: {
+          from: 10,
+          node: { type: { name: 'shapeContainer' }, attrs: { width: 120, height: 60 } },
+        },
+        tr: {
+          setNodeAttribute: vi.fn().mockReturnThis(),
+        },
+      },
+    });
+    const { textboxEl, remove } = createTextboxElement();
+
+    const wrapper = mount(TextboxResizeOverlay, {
+      attachTo: document.body,
+      props: { editor, visible: true, textboxElement: textboxEl },
+    });
+
+    const handle = wrapper.find('.resize-handle--se');
+    await handle.trigger('mousedown', { clientX: 130, clientY: 80 });
+
+    editor.state.selection = { from: 1, node: null };
+
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 170, clientY: 110 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 170, clientY: 110 }));
+
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(24, 'width', 160);
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(24, 'height', 90);
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(5, 'sdBlockRev', 8);
+    expect(editor.view.dispatch).toHaveBeenCalledWith(editor.state.tr);
+
+    wrapper.unmount();
+    remove();
+  });
+});

--- a/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.test.js
+++ b/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.test.js
@@ -12,7 +12,7 @@ vi.mock('@superdoc/layout-bridge', () => ({
 function createMockEditor(overrides = {}) {
   const shapeNode = {
     type: { name: 'shapeContainer' },
-    attrs: { width: 120, height: 60 },
+    attrs: { width: 120, height: 60, marginOffset: { horizontal: 50, top: 80 } },
     marks: [],
   };
   const paragraphNode = {
@@ -125,6 +125,47 @@ describe('TextboxResizeOverlay', () => {
     expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'width', 180);
     expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'height', 100);
     expect(editor.view.dispatch).toHaveBeenCalledWith(editor.state.tr);
+
+    wrapper.unmount();
+    remove();
+  });
+
+  it('dispatches marginOffset update when dragging overlay body', async () => {
+    const editor = createMockEditor();
+    const { textboxEl, remove } = createTextboxElement();
+
+    const wrapper = mount(TextboxResizeOverlay, {
+      attachTo: document.body,
+      props: { editor, visible: true, textboxElement: textboxEl },
+    });
+
+    // Mousedown on overlay body (not a handle)
+    await wrapper.trigger('mousedown', { clientX: 50, clientY: 50 });
+
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 80, clientY: 60 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 80, clientY: 60 }));
+
+    // marginOffset.horizontal += 30, marginOffset.top += 10
+    expect(editor.state.tr.setNodeAttribute).toHaveBeenCalledWith(10, 'marginOffset', { horizontal: 80, top: 90 });
+    expect(editor.view.dispatch).toHaveBeenCalledWith(editor.state.tr);
+
+    wrapper.unmount();
+    remove();
+  });
+
+  it('skips move dispatch when drag delta is below threshold', async () => {
+    const editor = createMockEditor();
+    const { textboxEl, remove } = createTextboxElement();
+
+    const wrapper = mount(TextboxResizeOverlay, {
+      attachTo: document.body,
+      props: { editor, visible: true, textboxElement: textboxEl },
+    });
+
+    await wrapper.trigger('mousedown', { clientX: 50, clientY: 50 });
+    document.dispatchEvent(new MouseEvent('mouseup', { clientX: 51, clientY: 51 }));
+
+    expect(editor.state.tr.setNodeAttribute).not.toHaveBeenCalledWith(10, 'marginOffset', expect.anything());
 
     wrapper.unmount();
     remove();

--- a/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.vue
+++ b/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.vue
@@ -1,0 +1,375 @@
+<template>
+  <div
+    v-if="visible && textboxElement"
+    class="superdoc-textbox-resize-overlay"
+    :style="overlayStyle"
+    @pointerdown.stop
+    @mousedown.stop
+  >
+    <div
+      v-for="handle in resizeHandles"
+      :key="handle.position"
+      class="resize-handle"
+      :class="{
+        'resize-handle--active': dragState && dragState.handle === handle.position,
+        [`resize-handle--${handle.position}`]: true,
+      }"
+      :style="handle.style"
+      @mousedown="onHandleMouseDown($event, handle.position)"
+    ></div>
+
+    <div v-if="dragState" class="resize-guideline" :style="guidelineStyle"></div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onBeforeUnmount, ref, watch } from 'vue';
+import { measureCache, invalidateHeaderFooterMeasureCache } from '@superdoc/layout-bridge';
+import { nodeAllowsSdBlockRevAttr } from '../extensions/block-node/block-node.js';
+
+const OVERLAY_EXPANSION_PX = 2000;
+const RESIZE_HANDLE_SIZE_PX = 12;
+const DIMENSION_CHANGE_THRESHOLD_PX = 1;
+const Z_INDEX_OVERLAY = 10;
+const Z_INDEX_GUIDELINE = 20;
+
+const props = defineProps({
+  editor: {
+    type: Object,
+    required: true,
+  },
+  visible: {
+    type: Boolean,
+    default: false,
+  },
+  textboxElement: {
+    type: Object,
+    default: null,
+  },
+});
+
+// Always evaluated fresh — getActiveEditor() is not reactive, so computed() would
+// cache a stale body editor and never update when header/footer mode activates.
+function getResizeEditor() {
+  const editor = props.editor;
+  return typeof editor?.getActiveEditor === 'function' ? editor.getActiveEditor() : editor;
+}
+
+const isResizeDisabled = computed(
+  () => getResizeEditor()?.options?.documentMode === 'viewing' || !getResizeEditor()?.isEditable,
+);
+
+const dragState = ref(null);
+const forcedCleanup = ref(false);
+
+function resolveEditorState(editor) {
+  return editor?.view?.state ?? editor?.state ?? null;
+}
+
+function resolveTextboxBlockId(textboxElement) {
+  return (
+    textboxElement?.dataset?.blockId ??
+    textboxElement?.getAttribute?.('data-block-id') ??
+    textboxElement?.closest?.('[data-block-id]')?.getAttribute?.('data-block-id') ??
+    null
+  );
+}
+
+function resolveShapeContainerAtSelection(editor) {
+  const state = resolveEditorState(editor);
+  const selection = state?.selection;
+  const node = selection?.node;
+  const pos = selection?.from;
+  if (node?.type?.name !== 'shapeContainer' || !Number.isFinite(pos)) {
+    return null;
+  }
+
+  return { state, node, pos };
+}
+
+function resolveShapeContainerFromTextboxElement(editor, textboxElement) {
+  const state = resolveEditorState(editor);
+  const pmStart = textboxElement?.querySelector?.('[data-pm-start]')?.getAttribute?.('data-pm-start');
+  const contentPos = Number.parseInt(pmStart ?? '', 10);
+  if (!state?.doc || !Number.isFinite(contentPos) || contentPos < 0) {
+    return null;
+  }
+
+  const $contentPos = state.doc.resolve(contentPos);
+  for (let depth = $contentPos.depth; depth > 0; depth -= 1) {
+    const ancestor = $contentPos.node(depth);
+    if (ancestor?.type?.name !== 'shapeContainer') continue;
+
+    const pos = $contentPos.before(depth);
+    return { state, node: ancestor, pos };
+  }
+
+  return null;
+}
+
+function resolveShapeContainer(editor, textboxElement) {
+  return (
+    resolveShapeContainerAtSelection(editor) ?? resolveShapeContainerFromTextboxElement(editor, textboxElement) ?? null
+  );
+}
+
+const overlayStyle = computed(() => {
+  if (!props.textboxElement || !props.textboxElement.isConnected) return {};
+
+  const textboxRect = props.textboxElement.getBoundingClientRect();
+  const wrapper = props.textboxElement.closest('.super-editor');
+  if (!wrapper) {
+    return {
+      position: 'absolute',
+      left: `${props.textboxElement.offsetLeft}px`,
+      top: `${props.textboxElement.offsetTop}px`,
+      width: `${textboxRect.width}px`,
+      height: `${textboxRect.height}px`,
+      pointerEvents: dragState.value ? 'auto' : 'none',
+      zIndex: Z_INDEX_OVERLAY,
+    };
+  }
+
+  const wrapperRect = wrapper.getBoundingClientRect();
+  const scrollLeft = wrapper.scrollLeft || 0;
+  const scrollTop = wrapper.scrollTop || 0;
+  const relativeLeft = textboxRect.left - wrapperRect.left + scrollLeft;
+  const relativeTop = textboxRect.top - wrapperRect.top + scrollTop;
+
+  let overlayWidth = textboxRect.width;
+  let overlayHeight = textboxRect.height;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  if (dragState.value) {
+    overlayWidth = textboxRect.width + OVERLAY_EXPANSION_PX * 2;
+    overlayHeight = textboxRect.height + OVERLAY_EXPANSION_PX * 2;
+    offsetX = -OVERLAY_EXPANSION_PX;
+    offsetY = -OVERLAY_EXPANSION_PX;
+  }
+
+  return {
+    position: 'absolute',
+    left: `${relativeLeft + offsetX}px`,
+    top: `${relativeTop + offsetY}px`,
+    width: `${overlayWidth}px`,
+    height: `${overlayHeight}px`,
+    pointerEvents: dragState.value ? 'auto' : 'none',
+    zIndex: Z_INDEX_OVERLAY,
+  };
+});
+
+const resizeHandles = computed(() => {
+  if (!props.textboxElement) return [];
+
+  const rect = props.textboxElement.getBoundingClientRect();
+  const offset = RESIZE_HANDLE_SIZE_PX / 2;
+  const expansion = dragState.value ? OVERLAY_EXPANSION_PX : 0;
+
+  return [
+    {
+      position: 'nw',
+      style: { left: `${expansion - offset}px`, top: `${expansion - offset}px`, cursor: 'nwse-resize' },
+    },
+    {
+      position: 'ne',
+      style: { left: `${expansion + rect.width - offset}px`, top: `${expansion - offset}px`, cursor: 'nesw-resize' },
+    },
+    {
+      position: 'sw',
+      style: { left: `${expansion - offset}px`, top: `${expansion + rect.height - offset}px`, cursor: 'nesw-resize' },
+    },
+    {
+      position: 'se',
+      style: {
+        left: `${expansion + rect.width - offset}px`,
+        top: `${expansion + rect.height - offset}px`,
+        cursor: 'nwse-resize',
+      },
+    },
+  ];
+});
+
+const guidelineStyle = computed(() => {
+  if (!dragState.value) return { display: 'none' };
+
+  return {
+    position: 'absolute',
+    left: `${OVERLAY_EXPANSION_PX}px`,
+    top: `${OVERLAY_EXPANSION_PX}px`,
+    width: `${dragState.value.width}px`,
+    height: `${dragState.value.height}px`,
+    border: '2px solid #4A90E2',
+    backgroundColor: 'rgba(74, 144, 226, 0.1)',
+    pointerEvents: 'none',
+    zIndex: Z_INDEX_GUIDELINE,
+    boxSizing: 'border-box',
+  };
+});
+
+function onHandleMouseDown(event, handlePosition) {
+  event.preventDefault();
+  event.stopPropagation();
+
+  if (isResizeDisabled.value || !props.textboxElement) return;
+
+  const editor = getResizeEditor();
+  const resolvedShape = resolveShapeContainer(editor, props.textboxElement);
+  if (!editor?.view || !resolvedShape) {
+    return;
+  }
+
+  const rect = props.textboxElement.getBoundingClientRect();
+  dragState.value = {
+    handle: handlePosition,
+    initialX: event.clientX,
+    initialY: event.clientY,
+    initialWidth: rect.width,
+    initialHeight: rect.height,
+    width: rect.width,
+    height: rect.height,
+  };
+
+  editor.view.dom.style.pointerEvents = 'none';
+  document.addEventListener('mousemove', onDocumentMouseMove);
+  document.addEventListener('mouseup', onDocumentMouseUp);
+  document.addEventListener('keydown', onEscapeKey);
+}
+
+function onDocumentMouseMove(event) {
+  if (!dragState.value) return;
+
+  let deltaX = event.clientX - dragState.value.initialX;
+  let deltaY = event.clientY - dragState.value.initialY;
+  const handle = dragState.value.handle;
+
+  if (handle === 'nw') {
+    deltaX = -deltaX;
+    deltaY = -deltaY;
+  } else if (handle === 'ne') {
+    deltaY = -deltaY;
+  } else if (handle === 'sw') {
+    deltaX = -deltaX;
+  }
+
+  dragState.value.width = Math.max(20, dragState.value.initialWidth + deltaX);
+  dragState.value.height = Math.max(20, dragState.value.initialHeight + deltaY);
+}
+
+function onEscapeKey(event) {
+  if (event.key !== 'Escape' || !dragState.value) return;
+  forcedCleanup.value = true;
+  onDocumentMouseUp();
+  forcedCleanup.value = false;
+}
+
+function onDocumentMouseUp() {
+  if (!dragState.value) return;
+
+  const editor = getResizeEditor();
+  if (editor?.view?.dom) {
+    editor.view.dom.style.pointerEvents = 'auto';
+  }
+
+  document.removeEventListener('mousemove', onDocumentMouseMove);
+  document.removeEventListener('mouseup', onDocumentMouseUp);
+  document.removeEventListener('keydown', onEscapeKey);
+
+  const widthDelta = Math.abs(dragState.value.width - dragState.value.initialWidth);
+  const heightDelta = Math.abs(dragState.value.height - dragState.value.initialHeight);
+
+  if (
+    !forcedCleanup.value &&
+    (widthDelta > DIMENSION_CHANGE_THRESHOLD_PX || heightDelta > DIMENSION_CHANGE_THRESHOLD_PX)
+  ) {
+    dispatchResizeTransaction(Math.round(dragState.value.width), Math.round(dragState.value.height));
+  }
+
+  dragState.value = null;
+}
+
+function dispatchResizeTransaction(newWidth, newHeight) {
+  const editor = getResizeEditor();
+  const resolvedShape = resolveShapeContainer(editor, props.textboxElement);
+  if (!editor?.view || !resolvedShape) {
+    return;
+  }
+
+  const { state, pos } = resolvedShape;
+  const tr = state.tr;
+  tr.setNodeAttribute(pos, 'width', newWidth);
+  tr.setNodeAttribute(pos, 'height', newHeight);
+
+  const $shapePos = state.doc.resolve(pos);
+  for (let depth = $shapePos.depth; depth > 0; depth -= 1) {
+    const ancestor = $shapePos.node(depth);
+    if (!nodeAllowsSdBlockRevAttr(ancestor)) continue;
+
+    const currentRev = Number.parseInt(ancestor.attrs?.sdBlockRev, 10);
+    if (!Number.isFinite(currentRev)) continue;
+    tr.setNodeAttribute($shapePos.before(depth), 'sdBlockRev', currentRev + 1);
+  }
+
+  editor.view.dispatch(tr);
+
+  const blockId = resolveTextboxBlockId(props.textboxElement);
+  if (blockId) {
+    measureCache.invalidate([blockId]);
+    invalidateHeaderFooterMeasureCache([blockId]);
+  }
+}
+
+watch(
+  () => props.visible,
+  (visible) => {
+    if (!visible && dragState.value) {
+      forcedCleanup.value = true;
+      onDocumentMouseUp();
+      forcedCleanup.value = false;
+    }
+  },
+);
+
+onBeforeUnmount(() => {
+  if (!dragState.value) return;
+  document.removeEventListener('mousemove', onDocumentMouseMove);
+  document.removeEventListener('mouseup', onDocumentMouseUp);
+  document.removeEventListener('keydown', onEscapeKey);
+  const editor = getResizeEditor();
+  if (editor?.view?.dom) {
+    editor.view.dom.style.pointerEvents = 'auto';
+  }
+});
+</script>
+
+<style scoped>
+.superdoc-textbox-resize-overlay {
+  position: absolute;
+  pointer-events: none;
+  user-select: none;
+  overflow: visible;
+}
+
+.resize-handle {
+  position: absolute;
+  width: v-bind('RESIZE_HANDLE_SIZE_PX + "px"');
+  height: v-bind('RESIZE_HANDLE_SIZE_PX + "px"');
+  background-color: #ffffff;
+  border: 2px solid #4a90e2;
+  border-radius: 50%;
+  user-select: none;
+  pointer-events: auto;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.resize-handle--active {
+  background-color: #4a90e2;
+  border-color: #ffffff;
+}
+
+.resize-guideline {
+  position: absolute;
+  pointer-events: none;
+  box-shadow: 0 0 4px rgba(74, 144, 226, 0.5);
+}
+</style>

--- a/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.vue
+++ b/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.vue
@@ -4,7 +4,7 @@
     class="superdoc-textbox-resize-overlay"
     :style="overlayStyle"
     @pointerdown.stop
-    @mousedown.stop
+    @mousedown="onOverlayMouseDown"
   >
     <div
       v-for="handle in resizeHandles"
@@ -60,6 +60,7 @@ const isResizeDisabled = computed(
 );
 
 const dragState = ref(null);
+const moveState = ref(null);
 const forcedCleanup = ref(false);
 
 function resolveEditorState(editor) {
@@ -125,7 +126,7 @@ const overlayStyle = computed(() => {
       top: `${props.textboxElement.offsetTop}px`,
       width: `${textboxRect.width}px`,
       height: `${textboxRect.height}px`,
-      pointerEvents: dragState.value ? 'auto' : 'none',
+      pointerEvents: 'auto',
       zIndex: Z_INDEX_OVERLAY,
     };
   }
@@ -148,13 +149,19 @@ const overlayStyle = computed(() => {
     offsetY = -OVERLAY_EXPANSION_PX;
   }
 
+  // Read delta properties so the computed re-runs on each mousemove tick.
+  // getBoundingClientRect() includes CSS transforms, so once these deps fire
+  // the overlay and handles follow the element as it translates.
+  void moveState.value?.deltaX;
+  void moveState.value?.deltaY;
+
   return {
     position: 'absolute',
     left: `${relativeLeft + offsetX}px`,
     top: `${relativeTop + offsetY}px`,
     width: `${overlayWidth}px`,
     height: `${overlayHeight}px`,
-    pointerEvents: dragState.value ? 'auto' : 'none',
+    pointerEvents: 'auto',
     zIndex: Z_INDEX_OVERLAY,
   };
 });
@@ -165,6 +172,7 @@ const resizeHandles = computed(() => {
   const rect = props.textboxElement.getBoundingClientRect();
   const offset = RESIZE_HANDLE_SIZE_PX / 2;
   const expansion = dragState.value ? OVERLAY_EXPANSION_PX : 0;
+  void moveState.value; // re-run when move delta changes so handles follow the textbox
 
   return [
     {
@@ -288,6 +296,103 @@ function onDocumentMouseUp() {
   dragState.value = null;
 }
 
+function onOverlayMouseDown(event) {
+  event.stopPropagation();
+  // Resize handles call stopPropagation themselves, so this fires only on the overlay body.
+  if (event.target.closest('.resize-handle')) return;
+  if (isResizeDisabled.value || !props.textboxElement) return;
+
+  event.preventDefault();
+
+  const editor = getResizeEditor();
+  const resolvedShape = resolveShapeContainer(editor, props.textboxElement);
+  if (!editor?.view || !resolvedShape) return;
+
+  const existingOffset = resolvedShape.node.attrs?.marginOffset;
+  if (!existingOffset || (existingOffset.horizontal == null && existingOffset.top == null)) return;
+
+  moveState.value = {
+    initialX: event.clientX,
+    initialY: event.clientY,
+    initialHorizontal: existingOffset.horizontal ?? 0,
+    initialTop: existingOffset.top ?? 0,
+    deltaX: 0,
+    deltaY: 0,
+  };
+
+  document.addEventListener('mousemove', onDocumentMouseMoveForMove);
+  document.addEventListener('mouseup', onDocumentMouseUpForMove);
+  document.addEventListener('keydown', onEscapeKeyForMove);
+}
+
+function onDocumentMouseMoveForMove(event) {
+  if (!moveState.value) return;
+  moveState.value.deltaX = event.clientX - moveState.value.initialX;
+  moveState.value.deltaY = event.clientY - moveState.value.initialY;
+  if (props.textboxElement) {
+    props.textboxElement.style.transform = `translate(${moveState.value.deltaX}px, ${moveState.value.deltaY}px)`;
+  }
+}
+
+function onEscapeKeyForMove(event) {
+  if (event.key !== 'Escape' || !moveState.value) return;
+  if (props.textboxElement) props.textboxElement.style.transform = '';
+  cleanupMoveListeners();
+}
+
+function cleanupMoveListeners() {
+  document.removeEventListener('mousemove', onDocumentMouseMoveForMove);
+  document.removeEventListener('mouseup', onDocumentMouseUpForMove);
+  document.removeEventListener('keydown', onEscapeKeyForMove);
+  moveState.value = null;
+}
+
+function onDocumentMouseUpForMove() {
+  if (!moveState.value) return;
+
+  const { deltaX, deltaY, initialHorizontal, initialTop } = moveState.value;
+
+  if (props.textboxElement) props.textboxElement.style.transform = '';
+
+  const MOVE_THRESHOLD_PX = 2;
+  if (Math.abs(deltaX) > MOVE_THRESHOLD_PX || Math.abs(deltaY) > MOVE_THRESHOLD_PX) {
+    dispatchMoveTransaction(Math.round(initialHorizontal + deltaX), Math.round(initialTop + deltaY));
+  }
+
+  cleanupMoveListeners();
+}
+
+function dispatchMoveTransaction(newHorizontal, newTop) {
+  const editor = getResizeEditor();
+  const resolvedShape = resolveShapeContainer(editor, props.textboxElement);
+  if (!editor?.view || !resolvedShape) return;
+
+  const { state, node, pos } = resolvedShape;
+  const tr = state.tr;
+  tr.setNodeAttribute(pos, 'marginOffset', {
+    ...node.attrs.marginOffset,
+    horizontal: newHorizontal,
+    top: newTop,
+  });
+
+  const $shapePos = state.doc.resolve(pos);
+  for (let depth = $shapePos.depth; depth > 0; depth -= 1) {
+    const ancestor = $shapePos.node(depth);
+    if (!nodeAllowsSdBlockRevAttr(ancestor)) continue;
+    const currentRev = Number.parseInt(ancestor.attrs?.sdBlockRev, 10);
+    if (!Number.isFinite(currentRev)) continue;
+    tr.setNodeAttribute($shapePos.before(depth), 'sdBlockRev', currentRev + 1);
+  }
+
+  editor.view.dispatch(tr);
+
+  const blockId = resolveTextboxBlockId(props.textboxElement);
+  if (blockId) {
+    measureCache.invalidate([blockId]);
+    invalidateHeaderFooterMeasureCache([blockId]);
+  }
+}
+
 function dispatchResizeTransaction(newWidth, newHeight) {
   const editor = getResizeEditor();
   const resolvedShape = resolveShapeContainer(editor, props.textboxElement);
@@ -322,22 +427,35 @@ function dispatchResizeTransaction(newWidth, newHeight) {
 watch(
   () => props.visible,
   (visible) => {
-    if (!visible && dragState.value) {
-      forcedCleanup.value = true;
-      onDocumentMouseUp();
-      forcedCleanup.value = false;
+    if (!visible) {
+      if (dragState.value) {
+        forcedCleanup.value = true;
+        onDocumentMouseUp();
+        forcedCleanup.value = false;
+      }
+      if (moveState.value) {
+        if (props.textboxElement) props.textboxElement.style.transform = '';
+        cleanupMoveListeners();
+      }
     }
   },
 );
 
 onBeforeUnmount(() => {
-  if (!dragState.value) return;
-  document.removeEventListener('mousemove', onDocumentMouseMove);
-  document.removeEventListener('mouseup', onDocumentMouseUp);
-  document.removeEventListener('keydown', onEscapeKey);
-  const editor = getResizeEditor();
-  if (editor?.view?.dom) {
-    editor.view.dom.style.pointerEvents = 'auto';
+  if (dragState.value) {
+    document.removeEventListener('mousemove', onDocumentMouseMove);
+    document.removeEventListener('mouseup', onDocumentMouseUp);
+    document.removeEventListener('keydown', onEscapeKey);
+    const editor = getResizeEditor();
+    if (editor?.view?.dom) {
+      editor.view.dom.style.pointerEvents = 'auto';
+    }
+  }
+  if (moveState.value) {
+    document.removeEventListener('mousemove', onDocumentMouseMoveForMove);
+    document.removeEventListener('mouseup', onDocumentMouseUpForMove);
+    document.removeEventListener('keydown', onEscapeKeyForMove);
+    moveState.value = null;
   }
 });
 </script>
@@ -345,9 +463,10 @@ onBeforeUnmount(() => {
 <style scoped>
 .superdoc-textbox-resize-overlay {
   position: absolute;
-  pointer-events: none;
+  pointer-events: auto;
   user-select: none;
   overflow: visible;
+  cursor: move;
 }
 
 .resize-handle {

--- a/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.vue
+++ b/packages/super-editor/src/editors/v1/components/TextboxResizeOverlay.vue
@@ -201,12 +201,18 @@ const resizeHandles = computed(() => {
 const guidelineStyle = computed(() => {
   if (!dragState.value) return { display: 'none' };
 
+  const { handle, initialWidth, initialHeight, width, height } = dragState.value;
+  // For handles that anchor the bottom-right corner (NW, NE, SW), offset the
+  // guideline so the fixed corner stays visually pinned during drag.
+  const left = OVERLAY_EXPANSION_PX + (handle === 'nw' || handle === 'sw' ? initialWidth - width : 0);
+  const top = OVERLAY_EXPANSION_PX + (handle === 'nw' || handle === 'ne' ? initialHeight - height : 0);
+
   return {
     position: 'absolute',
-    left: `${OVERLAY_EXPANSION_PX}px`,
-    top: `${OVERLAY_EXPANSION_PX}px`,
-    width: `${dragState.value.width}px`,
-    height: `${dragState.value.height}px`,
+    left: `${left}px`,
+    top: `${top}px`,
+    width: `${width}px`,
+    height: `${height}px`,
     border: '2px solid #4A90E2',
     backgroundColor: 'rgba(74, 144, 226, 0.1)',
     pointerEvents: 'none',
@@ -228,6 +234,7 @@ function onHandleMouseDown(event, handlePosition) {
   }
 
   const rect = props.textboxElement.getBoundingClientRect();
+  const initialMarginOffset = resolvedShape.node.attrs?.marginOffset ?? null;
   dragState.value = {
     handle: handlePosition,
     initialX: event.clientX,
@@ -236,6 +243,7 @@ function onHandleMouseDown(event, handlePosition) {
     initialHeight: rect.height,
     width: rect.width,
     height: rect.height,
+    initialMarginOffset,
   };
 
   editor.view.dom.style.pointerEvents = 'none';
@@ -404,6 +412,28 @@ function dispatchResizeTransaction(newWidth, newHeight) {
   const tr = state.tr;
   tr.setNodeAttribute(pos, 'width', newWidth);
   tr.setNodeAttribute(pos, 'height', newHeight);
+
+  // NW/SW handles anchor the bottom-right corner: the origin must shift by the
+  // same amount the dimension grew, so the opposite corner stays fixed.
+  const handle = dragState.value?.handle;
+  const initialMarginOffset = dragState.value?.initialMarginOffset;
+  // NW/SW handles anchor the bottom-right corner; NE anchors the bottom-left.
+  // The origin must shift by the same amount the leading edge grew.
+  if (initialMarginOffset && (handle === 'nw' || handle === 'sw' || handle === 'ne')) {
+    const effectiveDeltaX = newWidth - (dragState.value?.initialWidth ?? newWidth);
+    const effectiveDeltaY = newHeight - (dragState.value?.initialHeight ?? newHeight);
+    tr.setNodeAttribute(pos, 'marginOffset', {
+      ...initialMarginOffset,
+      horizontal:
+        handle === 'nw' || handle === 'sw'
+          ? (initialMarginOffset.horizontal ?? 0) - effectiveDeltaX
+          : (initialMarginOffset.horizontal ?? 0),
+      top:
+        handle === 'nw' || handle === 'ne'
+          ? (initialMarginOffset.top ?? 0) - effectiveDeltaY
+          : (initialMarginOffset.top ?? 0),
+    });
+  }
 
   const $shapePos = state.doc.resolve(pos);
   for (let depth = $shapePos.depth; depth > 0; depth -= 1) {

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/PresentationEditor.ts
@@ -5939,13 +5939,15 @@ export class PresentationEditor extends EventEmitter {
       onSurfaceTransaction: ({ sourceEditor, surface, headerId, sectionType, transaction, duration }) => {
         const documentTransaction =
           transaction && typeof transaction === 'object' ? (transaction as { docChanged?: boolean }) : null;
-        if (documentTransaction?.docChanged && headerId) {
-          this.#invalidateTrackedChangesForStory({
-            kind: 'story',
-            storyType: 'headerFooterPart',
-            refId: headerId,
-          });
-          this.#headerFooterSession?.invalidateLayoutForRefs([headerId]);
+        if (documentTransaction?.docChanged) {
+          if (headerId) {
+            this.#invalidateTrackedChangesForStory({
+              kind: 'story',
+              storyType: 'headerFooterPart',
+              refId: headerId,
+            });
+            this.#headerFooterSession?.invalidateLayoutForRefs([headerId]);
+          }
           this.#flowBlockCache.setHasExternalChanges?.(true);
           this.#pendingDocChange = true;
           this.#selectionSync.onLayoutStart();

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/pointer-events/EditorInputManager.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/pointer-events/EditorInputManager.ts
@@ -2725,7 +2725,7 @@ export class EditorInputManager {
         ?.querySelector(`[data-page-index="${pageIndex}"]`) as HTMLElement | null;
       const pageCandidates = pageElement?.querySelectorAll<HTMLElement>('[data-block-id]');
       if (pageCandidates) {
-        for (const candidate of pageCandidates) {
+        for (const candidate of Array.from(pageCandidates)) {
           const rect = candidate.getBoundingClientRect();
           if (clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
             addCandidate(candidate);

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/pointer-events/EditorInputManager.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/pointer-events/EditorInputManager.ts
@@ -602,6 +602,7 @@ export class EditorInputManager {
 
   // Image selection state
   #lastSelectedImageBlockId: string | null = null;
+  #lastSelectedTextboxBlockId: string | null = null;
 
   // Focus suppression (for draggable annotations)
   #suppressFocusInFromDraggable = false;
@@ -1597,6 +1598,40 @@ export class EditorInputManager {
       event.preventDefault();
     }
 
+    const textboxBorderSelection = this.#resolveTextboxBorderSelection({
+      event,
+      editor,
+      doc,
+      hitPos: hit?.pos ?? null,
+      rawHitPos: rawHit?.pos ?? null,
+      pageIndex: normalizedPoint.pageIndex,
+    });
+    if (textboxBorderSelection) {
+      const { editor: selectionEditor, fragmentEl, shapeContainerPos, blockId } = textboxBorderSelection;
+      try {
+        const tr = selectionEditor.state.tr.setSelection(NodeSelection.create(doc, shapeContainerPos));
+        selectionEditor.view?.dispatch(tr);
+
+        if (this.#lastSelectedImageBlockId) {
+          this.#callbacks.emit?.('imageDeselected', { blockId: this.#lastSelectedImageBlockId });
+          this.#lastSelectedImageBlockId = null;
+        }
+        if (this.#lastSelectedTextboxBlockId && this.#lastSelectedTextboxBlockId !== blockId) {
+          this.#callbacks.emit?.('textboxDeselected', { blockId: this.#lastSelectedTextboxBlockId });
+        }
+
+        this.#callbacks.emit?.('textboxSelected', { element: fragmentEl, blockId });
+        this.#lastSelectedTextboxBlockId = blockId;
+      } catch (error) {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('[EditorInputManager] Failed to create NodeSelection for textbox container:', error);
+        }
+      }
+
+      this.#callbacks.focusEditorAfterImageSelection?.();
+      return;
+    }
+
     // Handle click outside text content — keep cursor and scroll position unchanged.
     if (!rawHit) {
       this.#focusEditor();
@@ -1647,6 +1682,10 @@ export class EditorInputManager {
     if (this.#lastSelectedImageBlockId) {
       this.#callbacks.emit?.('imageDeselected', { blockId: this.#lastSelectedImageBlockId });
       this.#lastSelectedImageBlockId = null;
+    }
+    if (this.#lastSelectedTextboxBlockId) {
+      this.#callbacks.emit?.('textboxDeselected', { blockId: this.#lastSelectedTextboxBlockId });
+      this.#lastSelectedTextboxBlockId = null;
     }
 
     // Handle shift+click to extend selection
@@ -2507,6 +2546,10 @@ export class EditorInputManager {
     if (this.#lastSelectedImageBlockId && this.#lastSelectedImageBlockId !== newSelectionId) {
       this.#callbacks.emit?.('imageDeselected', { blockId: this.#lastSelectedImageBlockId });
     }
+    if (this.#lastSelectedTextboxBlockId && this.#lastSelectedTextboxBlockId !== newSelectionId) {
+      this.#callbacks.emit?.('textboxDeselected', { blockId: this.#lastSelectedTextboxBlockId });
+      this.#lastSelectedTextboxBlockId = null;
+    }
 
     const editor = this.#deps?.getEditor();
     try {
@@ -2555,6 +2598,10 @@ export class EditorInputManager {
       if (this.#lastSelectedImageBlockId && this.#lastSelectedImageBlockId !== fragmentHit.fragment.blockId) {
         this.#callbacks.emit?.('imageDeselected', { blockId: this.#lastSelectedImageBlockId });
       }
+      if (this.#lastSelectedTextboxBlockId) {
+        this.#callbacks.emit?.('textboxDeselected', { blockId: this.#lastSelectedTextboxBlockId });
+        this.#lastSelectedTextboxBlockId = null;
+      }
 
       if (fragmentHit.fragment.kind === 'image') {
         const targetElement =
@@ -2578,6 +2625,164 @@ export class EditorInputManager {
 
     this.#callbacks.focusEditorAfterImageSelection?.();
     return true;
+  }
+
+  #resolveTextboxBorderSelection({
+    event,
+    editor,
+    doc,
+    hitPos,
+    rawHitPos,
+    pageIndex,
+  }: {
+    event: PointerEvent;
+    editor: Editor;
+    doc: ProseMirrorNode | null | undefined;
+    hitPos: number | null;
+    rawHitPos: number | null;
+    pageIndex?: number;
+  }): { editor: Editor; fragmentEl: HTMLElement; shapeContainerPos: number; blockId: string | null } | null {
+    if (!doc) {
+      return null;
+    }
+
+    const fragmentEl = this.#resolveTextboxFragmentElement(event.target, event.clientX, event.clientY, pageIndex);
+    if (!fragmentEl) {
+      return null;
+    }
+
+    const BORDER_HIT_MARGIN = 6;
+    const rect = fragmentEl.getBoundingClientRect();
+    const isNearBorder =
+      event.clientX - rect.left <= BORDER_HIT_MARGIN ||
+      rect.right - event.clientX <= BORDER_HIT_MARGIN ||
+      event.clientY - rect.top <= BORDER_HIT_MARGIN ||
+      rect.bottom - event.clientY <= BORDER_HIT_MARGIN;
+    if (!isNearBorder) {
+      return null;
+    }
+
+    const shapeContainerPos = this.#resolveShapeContainerPos(doc, fragmentEl, [hitPos, rawHitPos]);
+    if (shapeContainerPos == null) {
+      return null;
+    }
+
+    return {
+      editor,
+      fragmentEl,
+      shapeContainerPos,
+      blockId: fragmentEl.dataset.blockId ?? null,
+    };
+  }
+
+  #resolveTextboxFragmentElement(
+    target: EventTarget | null,
+    clientX: number,
+    clientY: number,
+    pageIndex?: number,
+  ): HTMLElement | null {
+    const candidates: HTMLElement[] = [];
+    const seen = new Set<HTMLElement>();
+    const addCandidate = (element: HTMLElement | null): void => {
+      if (!element || seen.has(element)) {
+        return;
+      }
+      seen.add(element);
+      candidates.push(element);
+    };
+
+    const resolveCandidate = (element: Element | null): HTMLElement | null => {
+      if (!(element instanceof HTMLElement)) {
+        return null;
+      }
+
+      const pageLevelFragment = element.closest<HTMLElement>('.superdoc-drawing-fragment');
+      if (pageLevelFragment) {
+        return pageLevelFragment;
+      }
+
+      const tableDrawing = element.closest<HTMLElement>('.superdoc-table-drawing');
+      if (tableDrawing?.parentElement instanceof HTMLElement && tableDrawing.parentElement.dataset.blockId) {
+        return tableDrawing.parentElement;
+      }
+
+      const blockWrapper = element.closest<HTMLElement>('[data-block-id]');
+      return blockWrapper ?? null;
+    };
+
+    addCandidate(resolveCandidate(target as Element | null));
+
+    const ownerDocument = target instanceof Element ? target.ownerDocument : document;
+    if (typeof ownerDocument.elementsFromPoint === 'function') {
+      for (const element of ownerDocument.elementsFromPoint(clientX, clientY)) {
+        addCandidate(resolveCandidate(element));
+      }
+    }
+
+    if (Number.isFinite(pageIndex)) {
+      const pageElement = this.#deps
+        ?.getViewportHost()
+        ?.querySelector(`[data-page-index="${pageIndex}"]`) as HTMLElement | null;
+      const pageCandidates = pageElement?.querySelectorAll<HTMLElement>('[data-block-id]');
+      if (pageCandidates) {
+        for (const candidate of pageCandidates) {
+          const rect = candidate.getBoundingClientRect();
+          if (clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
+            addCandidate(candidate);
+          }
+        }
+      }
+    }
+
+    for (const candidate of candidates) {
+      if (
+        candidate.classList.contains('superdoc-textbox-shape') ||
+        candidate.querySelector('.superdoc-textbox-shape') != null
+      ) {
+        return candidate;
+      }
+    }
+
+    return null;
+  }
+
+  #resolveShapeContainerPos(
+    doc: ProseMirrorNode,
+    fragmentEl: HTMLElement,
+    candidatePositions: Array<number | null | undefined>,
+  ): number | null {
+    const fragmentPmStart = fragmentEl.querySelector<HTMLElement>('[data-pm-start]')?.dataset.pmStart;
+    const positions = [...candidatePositions];
+    if (fragmentPmStart != null) {
+      positions.push(Number(fragmentPmStart));
+    }
+
+    for (const pos of positions) {
+      if (!Number.isFinite(pos)) {
+        continue;
+      }
+      const resolvedPos = this.#findAncestorShapeContainerPos(doc, Number(pos));
+      if (resolvedPos != null) {
+        return resolvedPos;
+      }
+    }
+
+    return null;
+  }
+
+  #findAncestorShapeContainerPos(doc: ProseMirrorNode, pos: number): number | null {
+    try {
+      const $pos = doc.resolve(pos);
+      for (let depth = $pos.depth; depth >= 0; depth -= 1) {
+        if ($pos.node(depth).type.name === 'shapeContainer') {
+          return $pos.before(depth);
+        }
+      }
+    } catch {
+      return null;
+    }
+
+    return null;
   }
 
   #handleShiftClick(event: PointerEvent, headPos: number): void {

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/EditorInputManager.structuredContent.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/EditorInputManager.structuredContent.test.ts
@@ -191,6 +191,7 @@ describe('EditorInputManager structured content clicks', () => {
   let getEditor: Mock;
   let mockHitTestTable: Mock;
   let scheduleSelectionUpdate: Mock;
+  let emitMock: Mock;
 
   function mountWithDoc(
     mode: 'tableInSdt' | 'plainSdt' | 'inlineSdtAfterBoundary' | 'emptyInlineSdt' | 'nestedInlineInBlock',
@@ -283,6 +284,7 @@ describe('EditorInputManager structured content clicks', () => {
       scheduleSelectionUpdate: (scheduleSelectionUpdate = vi.fn()),
       updateSelectionDebugHud: vi.fn(),
       hitTestTable: (mockHitTestTable = vi.fn(() => null)),
+      emit: (emitMock = vi.fn()),
     });
     manager.bind();
   });
@@ -348,8 +350,26 @@ describe('EditorInputManager structured content clicks', () => {
 
   it('keeps textboxShape clicks on TextSelection instead of NodeSelection', () => {
     mountWithDoc('plainSdt');
+    const fragment = document.createElement('div');
+    fragment.className = 'superdoc-drawing-fragment';
+    const textbox = document.createElement('div');
+    textbox.className = 'superdoc-textbox-shape';
     const target = document.createElement('span');
-    viewportHost.appendChild(target);
+    textbox.appendChild(target);
+    fragment.appendChild(textbox);
+    viewportHost.appendChild(fragment);
+
+    vi.spyOn(fragment, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 120,
+      bottom: 80,
+      width: 120,
+      height: 80,
+      toJSON: () => ({}),
+    } as DOMRect);
 
     (getFragmentAtPosition as unknown as Mock).mockReturnValueOnce({
       fragment: {
@@ -383,6 +403,139 @@ describe('EditorInputManager structured content clicks', () => {
     expect(resolvePointerPositionHit as unknown as Mock).toHaveBeenCalled();
     expect(mockTextSelectionCreate).toHaveBeenCalledWith(mockEditor.state.doc, 12);
     expect(mockNodeSelectionCreate).not.toHaveBeenCalled();
+  });
+
+  it('uses NodeSelection when click lands on textboxShape border inside a table cell wrapper', () => {
+    mountWithDoc('plainSdt');
+    mockEditor.state.doc.resolve = vi.fn((pos: number) => ({
+      depth: pos === 14 ? 2 : 0,
+      node: (depth: number) => {
+        if (pos === 14) {
+          if (depth === 2) return { type: { name: 'paragraph' } };
+          if (depth === 1) return { type: { name: 'shapeTextbox' } };
+          return { type: { name: 'shapeContainer' } };
+        }
+        return { type: { name: 'doc' } };
+      },
+      before: (depth: number) => (depth === 0 ? 8 : 9),
+    }));
+
+    const wrapper = document.createElement('div');
+    wrapper.dataset.blockId = 'textbox-table-1';
+    const tableDrawing = document.createElement('div');
+    tableDrawing.className = 'superdoc-table-drawing';
+    const textbox = document.createElement('div');
+    textbox.className = 'superdoc-textbox-shape';
+    const line = document.createElement('div');
+    line.dataset.pmStart = '14';
+    textbox.appendChild(line);
+    tableDrawing.appendChild(textbox);
+    wrapper.appendChild(tableDrawing);
+    viewportHost.appendChild(wrapper);
+
+    vi.spyOn(wrapper, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 120,
+      bottom: 80,
+      width: 120,
+      height: 80,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const PointerEventImpl = getPointerEventImpl();
+    tableDrawing.dispatchEvent(
+      new PointerEventImpl('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 1,
+        clientX: 3,
+        clientY: 24,
+      } as PointerEventInit),
+    );
+
+    expect(mockNodeSelectionCreate).toHaveBeenCalledWith(mockEditor.state.doc, 8);
+    expect(mockTextSelectionCreate).not.toHaveBeenCalled();
+    expect(emitMock).toHaveBeenCalledWith('textboxSelected', {
+      element: wrapper,
+      blockId: 'textbox-table-1',
+    });
+  });
+
+  it('uses NodeSelection for textbox border clicks even when rawHit is missing', () => {
+    mountWithDoc('plainSdt');
+    (resolvePointerPositionHit as unknown as Mock).mockReturnValueOnce(null);
+    mockEditor.state.doc.resolve = vi.fn((pos: number) => ({
+      depth: pos === 14 ? 2 : 0,
+      node: (depth: number) => {
+        if (pos === 14) {
+          if (depth === 2) return { type: { name: 'paragraph' } };
+          if (depth === 1) return { type: { name: 'shapeTextbox' } };
+          return { type: { name: 'shapeContainer' } };
+        }
+        return { type: { name: 'doc' } };
+      },
+      before: (depth: number) => (depth === 0 ? 8 : 9),
+    }));
+
+    const page = document.createElement('div');
+    page.dataset.pageIndex = '0';
+    const fragment = document.createElement('div');
+    fragment.className = 'superdoc-drawing-fragment';
+    fragment.dataset.blockId = 'textbox-header-1';
+    fragment.dataset.behindDocSection = 'footer';
+    const textbox = document.createElement('div');
+    textbox.className = 'superdoc-textbox-shape';
+    const line = document.createElement('div');
+    line.dataset.pmStart = '14';
+    textbox.appendChild(line);
+    fragment.appendChild(textbox);
+    page.appendChild(fragment);
+    viewportHost.appendChild(page);
+
+    vi.spyOn(fragment, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 120,
+      bottom: 80,
+      width: 120,
+      height: 80,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const originalElementsFromPoint = document.elementsFromPoint;
+    Object.defineProperty(document, 'elementsFromPoint', {
+      configurable: true,
+      value: vi.fn(() => [page, document.body] as unknown as Element[]),
+    });
+
+    const PointerEventImpl = getPointerEventImpl();
+    page.dispatchEvent(
+      new PointerEventImpl('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 1,
+        clientX: 4,
+        clientY: 24,
+      } as PointerEventInit),
+    );
+
+    expect(mockNodeSelectionCreate).toHaveBeenCalledWith(mockEditor.state.doc, 8);
+    expect(emitMock).toHaveBeenCalledWith('textboxSelected', {
+      element: fragment,
+      blockId: 'textbox-header-1',
+    });
+
+    Object.defineProperty(document, 'elementsFromPoint', {
+      configurable: true,
+      value: originalElementsFromPoint,
+    });
   });
 
   it('resolves nested inline structured content before an ancestor block', () => {

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/pict/helpers/translate-shape-container.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/w/pict/helpers/translate-shape-container.js
@@ -106,6 +106,14 @@ function buildShapeStyle(attrs) {
     style['mso-position-vertical-relative'] = attrs.anchorData.vRelativeFrom;
   }
 
+  // User-driven resize: override width/height from live attrs (px → pt).
+  if (attrs.width != null) {
+    style['width'] = `${convertToPt(attrs.width)}pt`;
+  }
+  if (attrs.height != null) {
+    style['height'] = `${convertToPt(attrs.height)}pt`;
+  }
+
   const entries = Object.entries(style);
   if (entries.length === 0) return undefined;
 

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.js
@@ -12,6 +12,19 @@ export function translateDrawingMLTextbox(params) {
   }
 
   const drawing = carbonCopy(drawingContent);
+
+  // Patch geometry when the user resized the textbox (attrs.width/height are in px).
+  // Two elements carry the size in EMU (1 px = 9525 EMU at 96 DPI):
+  //   <wp:extent cx cy>  — anchor bounding box (child of wp:anchor)
+  //   <a:ext cx cy>      — shape transform geometry (inside wps:spPr/a:xfrm)
+  const { width: pxWidth, height: pxHeight } = node.attrs ?? {};
+  if (pxWidth != null || pxHeight != null) {
+    const emuCx = pxWidth != null ? String(Math.round(pxWidth * 9525)) : null;
+    const emuCy = pxHeight != null ? String(Math.round(pxHeight * 9525)) : null;
+    patchNodeAttributes(drawing, 'wp:extent', emuCx, emuCy);
+    patchNodeAttributes(drawing, 'a:ext', emuCx, emuCy);
+  }
+
   const liveParagraphs = translateChildNodes({
     ...params,
     node: shapeTextbox,
@@ -49,4 +62,19 @@ function findTextboxContentNode(node) {
   }
 
   return null;
+}
+
+// Patches cx/cy on the first element matching targetName found anywhere in the tree.
+function patchNodeAttributes(node, targetName, cx, cy) {
+  if (!node || typeof node !== 'object') return false;
+  if (node.name === targetName && node.attributes) {
+    if (cx != null) node.attributes.cx = cx;
+    if (cy != null) node.attributes.cy = cy;
+    return true;
+  }
+  if (!Array.isArray(node.elements)) return false;
+  for (const child of node.elements) {
+    if (patchNodeAttributes(child, targetName, cx, cy)) return true;
+  }
+  return false;
 }

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.js
@@ -17,12 +17,21 @@ export function translateDrawingMLTextbox(params) {
   // Two elements carry the size in EMU (1 px = 9525 EMU at 96 DPI):
   //   <wp:extent cx cy>  — anchor bounding box (child of wp:anchor)
   //   <a:ext cx cy>      — shape transform geometry (inside wps:spPr/a:xfrm)
-  const { width: pxWidth, height: pxHeight } = node.attrs ?? {};
+  const { width: pxWidth, height: pxHeight, marginOffset } = node.attrs ?? {};
   if (pxWidth != null || pxHeight != null) {
     const emuCx = pxWidth != null ? String(Math.round(pxWidth * 9525)) : null;
     const emuCy = pxHeight != null ? String(Math.round(pxHeight * 9525)) : null;
     patchNodeAttributes(drawing, 'wp:extent', emuCx, emuCy);
     patchNodeAttributes(drawing, 'a:ext', emuCx, emuCy);
+  }
+
+  // Patch position when the user moved the textbox (marginOffset.horizontal/top are in px).
+  // wp:positionH > wp:posOffset and wp:positionV > wp:posOffset carry the offset in EMU.
+  if (marginOffset?.horizontal != null) {
+    patchPositionOffset(drawing, 'wp:positionH', String(Math.round(marginOffset.horizontal * 9525)));
+  }
+  if (marginOffset?.top != null) {
+    patchPositionOffset(drawing, 'wp:positionV', String(Math.round(marginOffset.top * 9525)));
   }
 
   const liveParagraphs = translateChildNodes({
@@ -62,6 +71,25 @@ function findTextboxContentNode(node) {
   }
 
   return null;
+}
+
+// Patches the text content of wp:posOffset inside the first posNodeName element found in the tree.
+// Only patches when wp:posOffset already exists (i.e. the shape uses absolute, not align, positioning).
+function patchPositionOffset(node, posNodeName, emuValue) {
+  if (!node || typeof node !== 'object') return false;
+  if (node.name === posNodeName && Array.isArray(node.elements)) {
+    const offsetEl = node.elements.find((el) => el.name === 'wp:posOffset');
+    if (offsetEl && Array.isArray(offsetEl.elements) && offsetEl.elements.length > 0) {
+      offsetEl.elements[0].text = emuValue;
+      return true;
+    }
+    return false;
+  }
+  if (!Array.isArray(node.elements)) return false;
+  for (const child of node.elements) {
+    if (patchPositionOffset(child, posNodeName, emuValue)) return true;
+  }
+  return false;
 }
 
 // Patches cx/cy on the first element matching targetName found anywhere in the tree.

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.js
@@ -1,6 +1,7 @@
 import { translateChildNodes } from '@converter/v2/exporter/helpers/translateChildNodes';
 import { wrapTextInRun } from '@converter/exporter.js';
 import { carbonCopy } from '@core/utilities/carbonCopy.js';
+import { pixelsToEmu } from '@converter/helpers.js';
 
 export function translateDrawingMLTextbox(params) {
   const { node } = params;
@@ -19,19 +20,19 @@ export function translateDrawingMLTextbox(params) {
   //   <a:ext cx cy>      — shape transform geometry (inside wps:spPr/a:xfrm)
   const { width: pxWidth, height: pxHeight, marginOffset } = node.attrs ?? {};
   if (pxWidth != null || pxHeight != null) {
-    const emuCx = pxWidth != null ? String(Math.round(pxWidth * 9525)) : null;
-    const emuCy = pxHeight != null ? String(Math.round(pxHeight * 9525)) : null;
+    const emuCx = pxWidth != null ? String(pixelsToEmu(pxWidth)) : null;
+    const emuCy = pxHeight != null ? String(pixelsToEmu(pxHeight)) : null;
     patchNodeAttributes(drawing, 'wp:extent', emuCx, emuCy);
-    patchNodeAttributes(drawing, 'a:ext', emuCx, emuCy);
+    patchShapeGeometryExt(drawing, emuCx, emuCy);
   }
 
   // Patch position when the user moved the textbox (marginOffset.horizontal/top are in px).
   // wp:positionH > wp:posOffset and wp:positionV > wp:posOffset carry the offset in EMU.
   if (marginOffset?.horizontal != null) {
-    patchPositionOffset(drawing, 'wp:positionH', String(Math.round(marginOffset.horizontal * 9525)));
+    patchPositionOffset(drawing, 'wp:positionH', String(pixelsToEmu(marginOffset.horizontal)));
   }
   if (marginOffset?.top != null) {
-    patchPositionOffset(drawing, 'wp:positionV', String(Math.round(marginOffset.top * 9525)));
+    patchPositionOffset(drawing, 'wp:positionV', String(pixelsToEmu(marginOffset.top)));
   }
 
   const liveParagraphs = translateChildNodes({
@@ -90,6 +91,22 @@ function patchPositionOffset(node, posNodeName, emuValue) {
     if (patchPositionOffset(child, posNodeName, emuValue)) return true;
   }
   return false;
+}
+
+// Navigates directly to wps:spPr > a:xfrm > a:ext to patch cx/cy.
+// Avoids DFS first-match hitting a:ext elements in extension lists (which carry a uri attribute, not cx/cy).
+function patchShapeGeometryExt(root, cx, cy) {
+  const PATH = ['wp:anchor', 'a:graphic', 'a:graphicData', 'wps:wsp', 'wps:spPr', 'a:xfrm', 'a:ext'];
+  let node = root;
+  for (const name of PATH) {
+    if (!node || !Array.isArray(node.elements)) return false;
+    node = node.elements.find((el) => el.name === name) ?? null;
+    if (!node) return false;
+  }
+  if (!node.attributes) node.attributes = {};
+  if (cx != null) node.attributes.cx = cx;
+  if (cy != null) node.attributes.cy = cy;
+  return true;
 }
 
 // Patches cx/cy on the first element matching targetName found anywhere in the tree.

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.test.js
@@ -94,6 +94,64 @@ describe('translateDrawingMLTextbox', () => {
     });
   });
 
+  it('patches wp:posOffset EMU values when marginOffset is present', () => {
+    translateChildNodes.mockReturnValue([]);
+
+    const drawingContent = {
+      name: 'w:drawing',
+      elements: [
+        {
+          name: 'wp:anchor',
+          elements: [
+            {
+              name: 'wp:positionH',
+              attributes: { relativeFrom: 'margin' },
+              elements: [{ name: 'wp:posOffset', elements: [{ type: 'text', text: '457200' }] }],
+            },
+            {
+              name: 'wp:positionV',
+              attributes: { relativeFrom: 'margin' },
+              elements: [{ name: 'wp:posOffset', elements: [{ type: 'text', text: '914400' }] }],
+            },
+            {
+              name: 'a:graphic',
+              elements: [
+                {
+                  name: 'a:graphicData',
+                  elements: [
+                    {
+                      name: 'wps:wsp',
+                      elements: [{ name: 'wps:txbx', elements: [{ name: 'w:txbxContent', elements: [] }] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = translateDrawingMLTextbox({
+      node: {
+        type: 'shapeContainer',
+        attrs: {
+          drawingContent,
+          marginOffset: { horizontal: 100, top: 200 },
+        },
+        content: [{ type: 'shapeTextbox', attrs: {}, content: [] }],
+      },
+    });
+
+    // carbonCopy makes a deep copy — check the patched copy in the result, not the original.
+    const resultDrawing = result?.elements?.[0]?.elements?.[0]?.elements?.[0];
+    const posH = findNodeByName(resultDrawing, 'wp:positionH');
+    const posV = findNodeByName(resultDrawing, 'wp:positionV');
+    // 100px * 9525 = 952500, 200px * 9525 = 1905000
+    expect(posH.elements[0].elements[0].text).toBe('952500');
+    expect(posV.elements[0].elements[0].text).toBe('1905000');
+  });
+
   it('returns null when drawingContent is missing', () => {
     const result = translateDrawingMLTextbox({
       node: {

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.test.js
@@ -310,6 +310,84 @@ describe('translateDrawingMLTextbox', () => {
     expect(posH.elements[0].elements[0].text).toBe('123456');
   });
 
+  it('does not patch a:ext elements in extension lists — only patches wps:spPr > a:xfrm > a:ext', () => {
+    translateChildNodes.mockReturnValue([]);
+
+    // In real Word documents, wp:cNvGraphicFramePr > a:extLst > a:ext appears earlier in
+    // DFS order than wps:spPr > a:xfrm > a:ext. The old patchNodeAttributes DFS would
+    // wrongly add cx/cy to the extension-list a:ext. patchShapeGeometryExt uses a direct path.
+    const drawingContent = {
+      name: 'w:drawing',
+      elements: [
+        {
+          name: 'wp:anchor',
+          elements: [
+            { name: 'wp:extent', attributes: { cx: '457200', cy: '914400' } },
+            // Extension-list a:ext with uri appears BEFORE the shape geometry a:ext in DFS order
+            {
+              name: 'wp:cNvGraphicFramePr',
+              elements: [
+                {
+                  name: 'a:extLst',
+                  elements: [
+                    { name: 'a:ext', attributes: { uri: '{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}' }, elements: [] },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'a:graphic',
+              elements: [
+                {
+                  name: 'a:graphicData',
+                  elements: [
+                    {
+                      name: 'wps:wsp',
+                      elements: [
+                        {
+                          name: 'wps:spPr',
+                          elements: [
+                            {
+                              name: 'a:xfrm',
+                              elements: [{ name: 'a:ext', attributes: { cx: '457200', cy: '914400' } }],
+                            },
+                          ],
+                        },
+                        { name: 'wps:txbx', elements: [{ name: 'w:txbxContent', elements: [] }] },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = translateDrawingMLTextbox({
+      node: {
+        type: 'shapeContainer',
+        attrs: { drawingContent, width: 200, height: 100 },
+        content: [{ type: 'shapeTextbox', attrs: {}, content: [] }],
+      },
+    });
+
+    // carbonCopy creates a deep copy — inspect the output, not the inputs.
+    const resultDrawing = result?.elements?.[0]?.elements?.[0]?.elements?.[0];
+
+    // DFS first match is the extension-list a:ext — it must NOT have cx/cy added.
+    const firstExt = findNodeByName(resultDrawing, 'a:ext');
+    expect(firstExt.attributes).toEqual({ uri: '{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}' });
+
+    // The shape geometry a:ext (inside wps:spPr > a:xfrm) must be patched.
+    // 200px * 9525 = 1905000, 100px * 9525 = 952500
+    const spPr = findNodeByName(resultDrawing, 'wps:spPr');
+    const shapeExt = findNodeByName(spPr, 'a:ext');
+    expect(shapeExt.attributes.cx).toBe('1905000');
+    expect(shapeExt.attributes.cy).toBe('952500');
+  });
+
   it('returns null when drawingContent is missing', () => {
     const result = translateDrawingMLTextbox({
       node: {

--- a/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v3/handlers/wp/helpers/translate-drawingml-textbox.test.js
@@ -152,6 +152,164 @@ describe('translateDrawingMLTextbox', () => {
     expect(posV.elements[0].elements[0].text).toBe('1905000');
   });
 
+  it('patches wp:extent and a:ext EMU values when width and height attrs are present', () => {
+    translateChildNodes.mockReturnValue([]);
+
+    const drawingContent = {
+      name: 'w:drawing',
+      elements: [
+        {
+          name: 'wp:anchor',
+          elements: [
+            { name: 'wp:extent', attributes: { cx: '457200', cy: '914400' } },
+            {
+              name: 'a:graphic',
+              elements: [
+                {
+                  name: 'a:graphicData',
+                  elements: [
+                    {
+                      name: 'wps:wsp',
+                      elements: [
+                        {
+                          name: 'wps:spPr',
+                          elements: [
+                            {
+                              name: 'a:xfrm',
+                              elements: [{ name: 'a:ext', attributes: { cx: '457200', cy: '914400' } }],
+                            },
+                          ],
+                        },
+                        { name: 'wps:txbx', elements: [{ name: 'w:txbxContent', elements: [] }] },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = translateDrawingMLTextbox({
+      node: {
+        type: 'shapeContainer',
+        attrs: { drawingContent, width: 200, height: 100 },
+        content: [{ type: 'shapeTextbox', attrs: {}, content: [] }],
+      },
+    });
+
+    // 200px * 9525 = 1905000, 100px * 9525 = 952500
+    const resultDrawing = result?.elements?.[0]?.elements?.[0]?.elements?.[0];
+    const extent = findNodeByName(resultDrawing, 'wp:extent');
+    const ext = findNodeByName(resultDrawing, 'a:ext');
+    expect(extent.attributes.cx).toBe('1905000');
+    expect(extent.attributes.cy).toBe('952500');
+    expect(ext.attributes.cx).toBe('1905000');
+    expect(ext.attributes.cy).toBe('952500');
+  });
+
+  it('patches only cx when only width is changed', () => {
+    translateChildNodes.mockReturnValue([]);
+
+    const drawingContent = {
+      name: 'w:drawing',
+      elements: [
+        {
+          name: 'wp:anchor',
+          elements: [
+            { name: 'wp:extent', attributes: { cx: '457200', cy: '914400' } },
+            {
+              name: 'a:graphic',
+              elements: [
+                {
+                  name: 'a:graphicData',
+                  elements: [
+                    {
+                      name: 'wps:wsp',
+                      elements: [
+                        {
+                          name: 'wps:spPr',
+                          elements: [
+                            {
+                              name: 'a:xfrm',
+                              elements: [{ name: 'a:ext', attributes: { cx: '457200', cy: '914400' } }],
+                            },
+                          ],
+                        },
+                        { name: 'wps:txbx', elements: [{ name: 'w:txbxContent', elements: [] }] },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = translateDrawingMLTextbox({
+      node: {
+        type: 'shapeContainer',
+        attrs: { drawingContent, width: 300, height: null },
+        content: [{ type: 'shapeTextbox', attrs: {}, content: [] }],
+      },
+    });
+
+    // 300px * 9525 = 2857500; cy must be unchanged
+    const resultDrawing = result?.elements?.[0]?.elements?.[0]?.elements?.[0];
+    const extent = findNodeByName(resultDrawing, 'wp:extent');
+    expect(extent.attributes.cx).toBe('2857500');
+    expect(extent.attributes.cy).toBe('914400');
+  });
+
+  it('does not patch posOffset when marginOffset is absent', () => {
+    translateChildNodes.mockReturnValue([]);
+
+    const drawingContent = {
+      name: 'w:drawing',
+      elements: [
+        {
+          name: 'wp:anchor',
+          elements: [
+            {
+              name: 'wp:positionH',
+              elements: [{ name: 'wp:posOffset', elements: [{ type: 'text', text: '123456' }] }],
+            },
+            {
+              name: 'a:graphic',
+              elements: [
+                {
+                  name: 'a:graphicData',
+                  elements: [
+                    {
+                      name: 'wps:wsp',
+                      elements: [{ name: 'wps:txbx', elements: [{ name: 'w:txbxContent', elements: [] }] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = translateDrawingMLTextbox({
+      node: {
+        type: 'shapeContainer',
+        attrs: { drawingContent },
+        content: [{ type: 'shapeTextbox', attrs: {}, content: [] }],
+      },
+    });
+
+    const resultDrawing = result?.elements?.[0]?.elements?.[0]?.elements?.[0];
+    const posH = findNodeByName(resultDrawing, 'wp:positionH');
+    expect(posH.elements[0].elements[0].text).toBe('123456');
+  });
+
   it('returns null when drawingContent is missing', () => {
     const result = translateDrawingMLTextbox({
       node: {

--- a/tests/behavior/tests/textboxes/textbox-header-footer.spec.ts
+++ b/tests/behavior/tests/textboxes/textbox-header-footer.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect } from '../../fixtures/superdoc.js';
+import { activateHeader, activateFooter } from '../../helpers/story-surfaces.js';
+import path from 'node:path';
+
+const HF_TEXTBOX = path.resolve(import.meta.dirname, 'fixtures/header_footer_textbox.docx');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the bounding box of the first drawing fragment containing a textbox shape
+ * for the given story kind ('header' | 'footer').
+ *
+ * behindDoc fragments are rendered on the page element (data-behind-doc-section),
+ * not inside .superdoc-page-header/footer, so we search both locations.
+ */
+async function getTextboxFragmentBoxForStory(page: any, kind: 'header' | 'footer') {
+  const handle = await page.evaluateHandle((storyKind: string) => {
+    // 1. Look inside the surface container
+    const surface = document.querySelector(`.superdoc-page-${storyKind}`);
+    const inSurface = surface
+      ?.querySelector('.superdoc-drawing-fragment .superdoc-textbox-shape')
+      ?.closest('.superdoc-drawing-fragment') as HTMLElement | null;
+    if (inSurface) return inSurface;
+
+    // 2. behindDoc fragments are on the page element with data-behind-doc-section
+    const behindDoc = document
+      .querySelector(`[data-behind-doc-section="${storyKind}"] .superdoc-textbox-shape`)
+      ?.closest('[data-behind-doc-section]') as HTMLElement | null;
+    return behindDoc ?? null;
+  }, kind);
+  const el = handle.asElement();
+  if (!el) throw new Error(`No textbox drawing fragment found for ${kind}`);
+  const box = await el.boundingBox();
+  if (!box) throw new Error(`Textbox fragment for ${kind} not visible`);
+  return box;
+}
+
+/** Click the border of a textbox fragment (within 6px BORDER_HIT_MARGIN). */
+async function clickTextboxBorderAt(page: any, box: { x: number; y: number }) {
+  await page.mouse.click(box.x + 3, box.y + 3);
+}
+
+/** Returns true if the active editor has a NodeSelection on shapeContainer. */
+async function hasShapeContainerNodeSelection(page: any): Promise<boolean> {
+  return page.evaluate(() => {
+    function resolveActiveState() {
+      const active = (window as any).editor?.presentationEditor?.getActiveEditor?.();
+      return active?.state ?? active?.view?.state ?? null;
+    }
+    const state = resolveActiveState();
+    const sel = state?.selection;
+    return sel?.constructor?.name === 'NodeSelection' && sel?.node?.type?.name === 'shapeContainer';
+  });
+}
+
+/** Returns attrs of the first shapeContainer in the active editor's document. */
+async function getFirstShapeContainerAttrs(page: any): Promise<Record<string, any>> {
+  return page.evaluate(() => {
+    function resolveActiveState() {
+      const active = (window as any).editor?.presentationEditor?.getActiveEditor?.();
+      return active?.state ?? active?.view?.state ?? null;
+    }
+    const state = resolveActiveState();
+    if (!state) throw new Error('No active editor state');
+    let attrs: any = null;
+    state.doc.descendants((node: any) => {
+      if (!attrs && node.type?.name === 'shapeContainer') {
+        attrs = { ...node.attrs };
+        return false;
+      }
+    });
+    if (!attrs) throw new Error('No shapeContainer found in active editor document');
+    return attrs;
+  });
+}
+
+async function dragSeResizeHandle(superdoc: any, dx: number, dy: number) {
+  const handle = superdoc.page.locator('.superdoc-textbox-resize-overlay .resize-handle--se');
+  await expect(handle).toBeAttached({ timeout: 5000 });
+  const handleBox = await handle.boundingBox();
+  if (!handleBox) throw new Error('SE resize handle not visible');
+  const startX = handleBox.x + handleBox.width / 2;
+  const startY = handleBox.y + handleBox.height / 2;
+  await superdoc.page.mouse.move(startX, startY);
+  await superdoc.page.mouse.down();
+  await superdoc.page.mouse.move(startX + dx, startY + dy, { steps: 10 });
+  await superdoc.page.mouse.up();
+  await superdoc.waitForStable();
+}
+
+async function dragTextboxOverlayBody(superdoc: any, dx: number, dy: number) {
+  const overlay = superdoc.page.locator('.superdoc-textbox-resize-overlay');
+  await expect(overlay).toBeAttached({ timeout: 5000 });
+  const overlayBox = await overlay.boundingBox();
+  if (!overlayBox) throw new Error('Textbox overlay not visible');
+  const startX = overlayBox.x + overlayBox.width / 2;
+  const startY = overlayBox.y + overlayBox.height / 2;
+  await superdoc.page.mouse.move(startX, startY);
+  await superdoc.page.mouse.down();
+  await superdoc.page.mouse.move(startX + dx, startY + dy, { steps: 10 });
+  await superdoc.page.mouse.up();
+  await superdoc.waitForStable();
+}
+
+// ---------------------------------------------------------------------------
+// Tests: header textbox
+// ---------------------------------------------------------------------------
+
+test.describe('Textbox object interaction — header/footer', () => {
+  test.beforeEach(async ({ superdoc }) => {
+    await superdoc.loadDocument(HF_TEXTBOX);
+  });
+
+  test('@behavior textbox header: clicking textbox border produces NodeSelection on shapeContainer', async ({
+    superdoc,
+  }) => {
+    await activateHeader(superdoc);
+
+    const box = await getTextboxFragmentBoxForStory(superdoc.page, 'header');
+    await clickTextboxBorderAt(superdoc.page, box);
+    await superdoc.waitForStable();
+
+    expect(await hasShapeContainerNodeSelection(superdoc.page)).toBe(true);
+  });
+
+  test('@behavior textbox header: clicking textbox border shows selection ring', async ({ superdoc }) => {
+    await activateHeader(superdoc);
+
+    const box = await getTextboxFragmentBoxForStory(superdoc.page, 'header');
+    await clickTextboxBorderAt(superdoc.page, box);
+    await superdoc.waitForStable();
+
+    const hasRing = await superdoc.page.evaluate(() => {
+      return !!document.querySelector('.superdoc-textbox-selected');
+    });
+    expect(hasRing).toBe(true);
+  });
+
+  test('@behavior textbox header: TextboxResizeOverlay renders with 4 handles', async ({ superdoc }) => {
+    await activateHeader(superdoc);
+
+    const box = await getTextboxFragmentBoxForStory(superdoc.page, 'header');
+    await clickTextboxBorderAt(superdoc.page, box);
+    await superdoc.waitForStable();
+
+    const overlay = superdoc.page.locator('.superdoc-textbox-resize-overlay');
+    await expect(overlay).toBeAttached({ timeout: 3000 });
+    await expect(superdoc.page.locator('.superdoc-textbox-resize-overlay .resize-handle')).toHaveCount(4);
+  });
+
+  test('@behavior textbox header: dragging SE resize handle updates shapeContainer width and height', async ({
+    superdoc,
+  }) => {
+    await activateHeader(superdoc);
+
+    const box = await getTextboxFragmentBoxForStory(superdoc.page, 'header');
+    await clickTextboxBorderAt(superdoc.page, box);
+    await superdoc.waitForStable();
+
+    const before = await getFirstShapeContainerAttrs(superdoc.page);
+    await dragSeResizeHandle(superdoc, 30, 20);
+
+    const after = await getFirstShapeContainerAttrs(superdoc.page);
+    expect(after.width).toBeGreaterThan(before.width ?? 0);
+    expect(after.height).toBeGreaterThan(before.height ?? 0);
+  });
+
+  test('@behavior textbox header: dragging overlay body updates shapeContainer marginOffset', async ({ superdoc }) => {
+    await activateHeader(superdoc);
+
+    const initialAttrs = await getFirstShapeContainerAttrs(superdoc.page);
+    if (initialAttrs.marginOffset?.horizontal == null && initialAttrs.marginOffset?.top == null) {
+      test.skip();
+      return;
+    }
+
+    const box = await getTextboxFragmentBoxForStory(superdoc.page, 'header');
+    await clickTextboxBorderAt(superdoc.page, box);
+    await superdoc.waitForStable();
+
+    await dragTextboxOverlayBody(superdoc, 25, 15);
+
+    const after = await getFirstShapeContainerAttrs(superdoc.page);
+    expect(
+      Math.abs((after.marginOffset?.horizontal ?? 0) - (initialAttrs.marginOffset.horizontal ?? 0)),
+    ).toBeGreaterThan(2);
+    expect(Math.abs((after.marginOffset?.top ?? 0) - (initialAttrs.marginOffset.top ?? 0))).toBeGreaterThan(2);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tests: footer textbox
+  // ---------------------------------------------------------------------------
+
+  test('@behavior textbox footer: clicking textbox border produces NodeSelection on shapeContainer', async ({
+    superdoc,
+  }) => {
+    await activateFooter(superdoc);
+
+    const box = await getTextboxFragmentBoxForStory(superdoc.page, 'footer');
+    await clickTextboxBorderAt(superdoc.page, box);
+    await superdoc.waitForStable();
+
+    expect(await hasShapeContainerNodeSelection(superdoc.page)).toBe(true);
+  });
+
+  test('@behavior textbox footer: resize handle updates shapeContainer width and height', async ({ superdoc }) => {
+    await activateFooter(superdoc);
+
+    const box = await getTextboxFragmentBoxForStory(superdoc.page, 'footer');
+    await clickTextboxBorderAt(superdoc.page, box);
+    await superdoc.waitForStable();
+
+    const before = await getFirstShapeContainerAttrs(superdoc.page);
+    await dragSeResizeHandle(superdoc, 30, 20);
+
+    const after = await getFirstShapeContainerAttrs(superdoc.page);
+    expect(after.width).toBeGreaterThan(before.width ?? 0);
+    expect(after.height).toBeGreaterThan(before.height ?? 0);
+  });
+});

--- a/tests/behavior/tests/textboxes/textbox-object-interaction.spec.ts
+++ b/tests/behavior/tests/textboxes/textbox-object-interaction.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../../fixtures/superdoc.js';
 import path from 'node:path';
 
 const TEXT_BOXES = path.resolve(import.meta.dirname, 'fixtures/text-boxes.docx');
+const TABLE_TEXTBOX = path.resolve(import.meta.dirname, 'fixtures/contract-acc-tbl-padding.docx');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -256,5 +257,66 @@ test.describe('Textbox object interaction — text-boxes', () => {
       return found;
     });
     expect(hasContent).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: table cell textbox — regression for versionSignature fix
+//
+// Drawings inside table cells are rendered inside the table fragment (not as
+// standalone DrawingFragment elements). Before the versionSignature fix, moving
+// a table-cell textbox did not bust the table fragment paint cache, so the
+// visual position only updated after a subsequent resize. This suite guards
+// against that regression.
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the bounding box of the first textbox shape rendered inside a table
+ * (i.e. NOT inside a standalone .superdoc-drawing-fragment).
+ */
+async function getTableCellTextboxBox(page: any) {
+  const handle = await page.evaluateHandle(() => {
+    const all = Array.from(document.querySelectorAll<HTMLElement>('.superdoc-textbox-shape'));
+    return all.find((el) => !el.closest('.superdoc-drawing-fragment')) ?? null;
+  });
+  const el = handle.asElement();
+  if (!el) throw new Error('No table-cell textbox found');
+  const box = await el.boundingBox();
+  if (!box) throw new Error('Table-cell textbox not visible');
+  return box;
+}
+
+test.describe('Textbox object interaction — table cell', () => {
+  test.beforeEach(async ({ superdoc }) => {
+    await superdoc.loadDocument(TABLE_TEXTBOX);
+  });
+
+  test('@behavior textbox table-cell: move updates visual position immediately without requiring resize', async ({
+    superdoc,
+  }) => {
+    const before = await getTableCellTextboxBox(superdoc.page);
+
+    // Click the border of the table-cell textbox to get NodeSelection
+    await superdoc.page.mouse.click(before.x + 3, before.y + 3);
+    await superdoc.waitForStable();
+
+    const overlay = superdoc.page.locator('.superdoc-textbox-resize-overlay');
+    await expect(overlay).toBeAttached({ timeout: 5000 });
+
+    // Drag the overlay body to move the textbox
+    const overlayBox = await overlay.boundingBox();
+    if (!overlayBox) throw new Error('Overlay not visible');
+    const startX = overlayBox.x + overlayBox.width / 2;
+    const startY = overlayBox.y + overlayBox.height / 2;
+    await superdoc.page.mouse.move(startX, startY);
+    await superdoc.page.mouse.down();
+    await superdoc.page.mouse.move(startX + 30, startY + 20, { steps: 10 });
+    await superdoc.page.mouse.up();
+    await superdoc.waitForStable();
+
+    // Visual position must update without an additional resize
+    const after = await getTableCellTextboxBox(superdoc.page);
+    const moved = Math.abs(after.x - before.x) > 2 || Math.abs(after.y - before.y) > 2;
+    expect(moved).toBe(true);
   });
 });

--- a/tests/behavior/tests/textboxes/textbox-object-interaction.spec.ts
+++ b/tests/behavior/tests/textboxes/textbox-object-interaction.spec.ts
@@ -1,0 +1,260 @@
+import { test, expect } from '../../fixtures/superdoc.js';
+import path from 'node:path';
+
+const TEXT_BOXES = path.resolve(import.meta.dirname, 'fixtures/text-boxes.docx');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the bounding box of the first body drawing fragment that contains a
+ * textbox shape (excludes header/footer fragments).
+ */
+async function getBodyTextboxFragmentBox(page: any) {
+  const handle = await page.evaluateHandle(() => {
+    const frags = Array.from(document.querySelectorAll<HTMLElement>('.superdoc-drawing-fragment'));
+    for (const frag of frags) {
+      const story = frag.dataset.layoutStory ?? '';
+      if (story.startsWith('header:') || story.startsWith('footer:')) continue;
+      if (frag.querySelector('.superdoc-textbox-shape')) return frag;
+    }
+    return null;
+  });
+  const el = handle.asElement();
+  if (!el) throw new Error('No body textbox drawing fragment found');
+  const box = await el.boundingBox();
+  if (!box) throw new Error('Body textbox fragment not visible');
+  return box;
+}
+
+/**
+ * Click the top-left border of the first body textbox (within 6px BORDER_HIT_MARGIN).
+ * This triggers NodeSelection on the shapeContainer, not a content caret.
+ */
+async function clickTextboxBorder(superdoc: any) {
+  const box = await getBodyTextboxFragmentBox(superdoc.page);
+  // Click 3px inside from top-left — within the 6px border hit margin
+  await superdoc.page.mouse.click(box.x + 3, box.y + 3);
+}
+
+/** Returns true if a shapeContainer NodeSelection is active on the body editor. */
+async function hasShapeContainerNodeSelection(page: any): Promise<boolean> {
+  return page.evaluate(() => {
+    const { state } = (window as any).editor;
+    const sel = state.selection;
+    return sel.constructor.name === 'NodeSelection' && sel.node?.type?.name === 'shapeContainer';
+  });
+}
+
+/** Returns the attrs of the first shapeContainer in the body document. */
+async function getFirstShapeContainerAttrs(page: any): Promise<Record<string, any>> {
+  return page.evaluate(() => {
+    const { state } = (window as any).editor;
+    let attrs: any = null;
+    state.doc.descendants((node: any) => {
+      if (!attrs && node.type?.name === 'shapeContainer') {
+        attrs = { ...node.attrs };
+        return false;
+      }
+    });
+    if (!attrs) throw new Error('No shapeContainer found in document');
+    return attrs;
+  });
+}
+
+/**
+ * Drag the SE resize handle of the TextboxResizeOverlay by (dx, dy).
+ * Assumes the textbox is already selected (NodeSelection).
+ */
+async function dragSeResizeHandle(superdoc: any, dx: number, dy: number) {
+  const handle = superdoc.page.locator('.superdoc-textbox-resize-overlay .resize-handle--se');
+  await expect(handle).toBeAttached({ timeout: 5000 });
+
+  const handleBox = await handle.boundingBox();
+  if (!handleBox) throw new Error('SE resize handle not visible');
+
+  const startX = handleBox.x + handleBox.width / 2;
+  const startY = handleBox.y + handleBox.height / 2;
+
+  await superdoc.page.mouse.move(startX, startY);
+  await superdoc.page.mouse.down();
+  await superdoc.page.mouse.move(startX + dx, startY + dy, { steps: 10 });
+  await superdoc.page.mouse.up();
+  await superdoc.waitForStable();
+}
+
+/**
+ * Drag the overlay body (not a handle) to trigger a move.
+ * Assumes the textbox is already selected (NodeSelection).
+ */
+async function dragTextboxOverlayBody(superdoc: any, dx: number, dy: number) {
+  const overlay = superdoc.page.locator('.superdoc-textbox-resize-overlay');
+  await expect(overlay).toBeAttached({ timeout: 5000 });
+
+  const overlayBox = await overlay.boundingBox();
+  if (!overlayBox) throw new Error('Textbox overlay not visible');
+
+  // Click in the center of the overlay — far from the corner handles
+  const startX = overlayBox.x + overlayBox.width / 2;
+  const startY = overlayBox.y + overlayBox.height / 2;
+
+  await superdoc.page.mouse.move(startX, startY);
+  await superdoc.page.mouse.down();
+  await superdoc.page.mouse.move(startX + dx, startY + dy, { steps: 10 });
+  await superdoc.page.mouse.up();
+  await superdoc.waitForStable();
+}
+
+// ---------------------------------------------------------------------------
+// Tests: object selection
+// ---------------------------------------------------------------------------
+
+test.describe('Textbox object interaction — text-boxes', () => {
+  test.beforeEach(async ({ superdoc }) => {
+    await superdoc.loadDocument(TEXT_BOXES);
+  });
+
+  test('@behavior textbox: clicking textbox border produces NodeSelection on shapeContainer', async ({ superdoc }) => {
+    await clickTextboxBorder(superdoc);
+    await superdoc.waitForStable();
+
+    expect(await hasShapeContainerNodeSelection(superdoc.page)).toBe(true);
+  });
+
+  test('@behavior textbox: clicking textbox border adds selection ring CSS class', async ({ superdoc }) => {
+    await clickTextboxBorder(superdoc);
+    await superdoc.waitForStable();
+
+    const hasRing = await superdoc.page.evaluate(() => {
+      return !!document.querySelector('.superdoc-textbox-selected');
+    });
+    expect(hasRing).toBe(true);
+  });
+
+  test('@behavior textbox: clicking outside selected textbox removes selection ring', async ({ superdoc }) => {
+    await clickTextboxBorder(superdoc);
+    await superdoc.waitForStable();
+    expect(await hasShapeContainerNodeSelection(superdoc.page)).toBe(true);
+
+    // Click on a body paragraph line that is outside any drawing fragment
+    const bodyLineBox = await superdoc.page.evaluateHandle(() => {
+      return (
+        Array.from(document.querySelectorAll<HTMLElement>('.superdoc-line')).find(
+          (el) => !el.closest('.superdoc-drawing-fragment') && !el.closest('.superdoc-table-drawing'),
+        ) ?? null
+      );
+    });
+    const bodyLineEl = bodyLineBox.asElement();
+    if (!bodyLineEl) throw new Error('No body paragraph line found outside drawing fragments');
+    const lineBox = await bodyLineEl.boundingBox();
+    if (!lineBox) throw new Error('Body line not visible');
+    await superdoc.page.mouse.click(lineBox.x + lineBox.width / 2, lineBox.y + lineBox.height / 2);
+    await superdoc.waitForStable();
+
+    const hasRing = await superdoc.page.evaluate(() => {
+      return !!document.querySelector('.superdoc-textbox-selected');
+    });
+    expect(hasRing).toBe(false);
+  });
+
+  test('@behavior textbox: TextboxResizeOverlay renders when textbox is border-selected', async ({ superdoc }) => {
+    await clickTextboxBorder(superdoc);
+    await superdoc.waitForStable();
+
+    const overlay = superdoc.page.locator('.superdoc-textbox-resize-overlay');
+    await expect(overlay).toBeAttached({ timeout: 3000 });
+
+    // All four corner handles are present
+    const handles = superdoc.page.locator('.superdoc-textbox-resize-overlay .resize-handle');
+    await expect(handles).toHaveCount(4);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tests: resize
+  // ---------------------------------------------------------------------------
+
+  test('@behavior textbox: dragging SE resize handle updates shapeContainer width and height', async ({ superdoc }) => {
+    await clickTextboxBorder(superdoc);
+    await superdoc.waitForStable();
+
+    const before = await getFirstShapeContainerAttrs(superdoc.page);
+    await dragSeResizeHandle(superdoc, 40, 30);
+
+    const after = await getFirstShapeContainerAttrs(superdoc.page);
+    expect(after.width).toBeGreaterThan(before.width ?? 0);
+    expect(after.height).toBeGreaterThan(before.height ?? 0);
+  });
+
+  test('@behavior textbox: resize does not delete or flatten textbox content', async ({ superdoc }) => {
+    await clickTextboxBorder(superdoc);
+    await superdoc.waitForStable();
+
+    await dragSeResizeHandle(superdoc, 40, 30);
+
+    // shapeTextbox with paragraph content must still exist in the PM document
+    const hasContent = await superdoc.page.evaluate(() => {
+      const { state } = (window as any).editor;
+      let found = false;
+      state.doc.descendants((node: any) => {
+        if (node.type?.name === 'shapeTextbox') {
+          found = node.content?.childCount > 0;
+          return false;
+        }
+      });
+      return found;
+    });
+    expect(hasContent).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tests: move
+  // ---------------------------------------------------------------------------
+
+  test('@behavior textbox: dragging overlay body updates shapeContainer marginOffset', async ({ superdoc }) => {
+    const initialAttrs = await getFirstShapeContainerAttrs(superdoc.page);
+
+    // Skip if the textbox uses align-based positioning (no marginOffset)
+    if (initialAttrs.marginOffset?.horizontal == null && initialAttrs.marginOffset?.top == null) {
+      test.skip();
+      return;
+    }
+
+    await clickTextboxBorder(superdoc);
+    await superdoc.waitForStable();
+
+    await dragTextboxOverlayBody(superdoc, 30, 20);
+
+    const after = await getFirstShapeContainerAttrs(superdoc.page);
+    const hBefore = initialAttrs.marginOffset.horizontal ?? 0;
+    const tBefore = initialAttrs.marginOffset.top ?? 0;
+    expect(Math.abs((after.marginOffset?.horizontal ?? 0) - hBefore)).toBeGreaterThan(2);
+    expect(Math.abs((after.marginOffset?.top ?? 0) - tBefore)).toBeGreaterThan(2);
+  });
+
+  test('@behavior textbox: move does not delete or flatten textbox content', async ({ superdoc }) => {
+    const initialAttrs = await getFirstShapeContainerAttrs(superdoc.page);
+    if (initialAttrs.marginOffset?.horizontal == null && initialAttrs.marginOffset?.top == null) {
+      test.skip();
+      return;
+    }
+
+    await clickTextboxBorder(superdoc);
+    await superdoc.waitForStable();
+
+    await dragTextboxOverlayBody(superdoc, 30, 20);
+
+    const hasContent = await superdoc.page.evaluate(() => {
+      const { state } = (window as any).editor;
+      let found = false;
+      state.doc.descendants((node: any) => {
+        if (node.type?.name === 'shapeTextbox') {
+          found = node.content?.childCount > 0;
+          return false;
+        }
+      });
+      return found;
+    });
+    expect(hasContent).toBe(true);
+  });
+});


### PR DESCRIPTION
Main task: SD-3395.

Sub-tasks (phases): SD-3405, SD-3406.

Textbox object interaction — selection, resize, and move (Phase 2 and 3).

## Summary

Adds object-level interaction for floating DrawingML textboxes represented as
`shapeContainer` nodes: border selection, resize handles, and drag-to-move.

### Selection

- Border clicks within a 6 px hit margin create a ProseMirror `NodeSelection`
  on the textbox instead of placing a caret in its text content.
- Selected textboxes get a `superdoc-textbox-selected` ring; clicking outside
  clears it.
- Works in both body and header/footer contexts.

### Resize

- `TextboxResizeOverlay` renders four corner handles for selected textboxes.
- Dragging a handle updates `width`/`height` on the `shapeContainer`.
- Leading-edge handles also adjust `marginOffset` so the opposite corner
  remains fixed.
- Export patches both `wp:extent` and `wps:spPr > a:xfrm > a:ext` in EMU.
  The `a:ext` update now targets the shape geometry path directly instead of
  relying on DFS first-match.

### Move

- Dragging the overlay body updates `marginOffset` on the `shapeContainer`.
- A temporary CSS `transform: translate(…)` provides live drag feedback.
- Textbox moves now invalidate the right caches for table-cell and
  header/footer relayout.
- Export patches `wp:positionH/V > wp:posOffset` in EMU.

<img width="514" height="363" alt="Screenshot" src="https://github.com/user-attachments/assets/d5a74cb1-2634-41d5-897c-11cb9d042478" />
