### PR TITLE
fix(super-converter): keep user comments anchored to tracked changes on export

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/SuperConverter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/SuperConverter.js
@@ -17,6 +17,7 @@ import { baseNumbering } from './v2/exporter/helpers/base-list.definitions.js';
 import { DEFAULT_CUSTOM_XML, DEFAULT_DOCX_DEFS } from './exporter-docx-defs.js';
 import {
   getCommentDefinition,
+  isSyntheticTrackedChangeComment,
   prepareCommentParaIds,
   prepareCommentsXmlFilesForExport,
 } from './v2/exporter/commentsExporter.js';
@@ -1245,8 +1246,12 @@ class SuperConverter {
     // Reset export warnings for this export cycle
     this.exportWarnings = [];
 
-    // Filter out synthetic tracked change comments - they shouldn't be exported to comments.xml
-    const exportableComments = comments.filter((c) => !c.trackedChange);
+    // Exclude only SYNTHETIC tracked-change projection rows: the sidebar entries
+    // SuperDoc auto-generates for each tracked change carry `trackedChange: true` but have
+    // no authored body. Genuine user comments anchored to (or overlapping) a tracked change
+    // also carry `trackedChange: true`; those MUST still be exported, otherwise an
+    // accept-and-comment redline review loses every comment placed on a tracked change.
+    const exportableComments = comments.filter((c) => !isSyntheticTrackedChangeComment(c));
     const commentsWithParaIds = exportableComments.map((c) => prepareCommentParaIds(c));
     const commentDefinitions = commentsWithParaIds.map((c, index) =>
       getCommentDefinition(c, index, commentsWithParaIds, editor),

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/exporter/commentsExporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/exporter/commentsExporter.js
@@ -18,6 +18,26 @@ export const prepareCommentParaIds = (comment) => {
   return newComment;
 };
 
+/**
+ * Detect a SYNTHETIC tracked-change projection row.
+ *
+ * SuperDoc seeds the comments array with one auto-generated entry per tracked change so the
+ * sidebar can render it; these carry `trackedChange: true` but no authored body and must not
+ * be written to comments.xml. A genuine user comment anchored to (or overlapping) a tracked
+ * change ALSO carries `trackedChange: true`, so it must NOT be treated as synthetic. Only rows
+ * that are flagged tracked-change AND have no comment body AND are not a thread reply are
+ * synthetic. Mirrors `isSyntheticTrackedChangeProjection` in the document-api comment store.
+ *
+ * @param {Object} comment The export comment record
+ * @returns {boolean} True only for body-less tracked-change projection rows
+ */
+export const isSyntheticTrackedChangeComment = (comment) => {
+  if (!comment || comment.trackedChange !== true) return false;
+  const has = (key) => Object.prototype.hasOwnProperty.call(comment, key);
+  const hasBody = has('commentText') || has('text') || has('commentJSON') || has('elements');
+  return !hasBody && !has('parentCommentId');
+};
+
 const getCommentIds = (comment) => {
   if (!comment) return [];
   return [comment.commentId, comment.importedId, comment.internalId].filter((id) => id != null).map((id) => String(id));

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/exporter/commentsExporter.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/exporter/commentsExporter.test.js
@@ -1,6 +1,7 @@
 import {
   getCommentDefinition,
   isCommentResolvedInThread,
+  isSyntheticTrackedChangeComment,
   updateCommentsExtendedXml,
   updateCommentsIdsAndExtensible,
   updateCommentsXml,
@@ -810,5 +811,39 @@ describe('updateCommentsXml', () => {
 
     expect(updatedComment.attributes['w:email']).toBeUndefined();
     expect(updatedComment.attributes['custom:email']).toBe('author@example.com');
+  });
+});
+
+describe('isSyntheticTrackedChangeComment', () => {
+  it('keeps a plain comment that is not linked to a tracked change', () => {
+    expect(isSyntheticTrackedChangeComment(makeComment())).toBe(false);
+  });
+
+  it('drops a body-less synthetic tracked-change projection row', () => {
+    expect(isSyntheticTrackedChangeComment({ commentId: 'tc-1', trackedChange: true })).toBe(true);
+  });
+
+  it('keeps a genuine user comment that is anchored to a tracked change', () => {
+    // The regression: these carry trackedChange:true but have an authored body, so they
+    // must still be exported — otherwise accept-and-comment redline reviews lose them.
+    const linkedComment = makeComment({ commentId: 'c-on-tc', trackedChange: true });
+    expect(isSyntheticTrackedChangeComment(linkedComment)).toBe(false);
+  });
+
+  it.each(['commentText', 'text', 'commentJSON', 'elements'])(
+    'treats a tracked-change comment carrying a "%s" body as a real comment',
+    (bodyKey) => {
+      expect(isSyntheticTrackedChangeComment({ commentId: 'c', trackedChange: true, [bodyKey]: 'x' })).toBe(false);
+    },
+  );
+
+  it('keeps a tracked-change reply (has parentCommentId) even without its own body', () => {
+    expect(isSyntheticTrackedChangeComment({ commentId: 'r', trackedChange: true, parentCommentId: 'p' })).toBe(false);
+  });
+
+  it('keeps the comment whenever trackedChange is falsy or the input is nullish', () => {
+    expect(isSyntheticTrackedChangeComment({ commentId: 'c', trackedChange: false })).toBe(false);
+    expect(isSyntheticTrackedChangeComment({ commentId: 'c' })).toBe(false);
+    expect(isSyntheticTrackedChangeComment(null)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
`exportToDocx` drops genuine user comments that are anchored to (or overlap) a tracked change. Only SuperDoc's *synthetic* tracked-change projection rows should be excluded from `comments.xml`.

## Root cause
The export filter `comments.filter((c) => !c.trackedChange)` excludes **every** comment flagged `trackedChange: true`. That flag is set both on synthetic projection rows (no authored body) **and** on real user comments linked to / overlapping a tracked change. Excluded comments also lose their `commentRangeStart/End` + `commentReference` anchors, because the body translator skips comments missing from the export list. Result: any comment placed on a redline is silently lost on export, while plain comments survive.

## Fix
Add `isSyntheticTrackedChangeComment` (mirrors the `isSyntheticTrackedChangeProjection` discriminator in the document-api comment store) and narrow the filter to drop only synthetic rows: `trackedChange === true` **and** no body (`commentText`/`text`/`commentJSON`/`elements`) **and** no `parentCommentId`. Genuine comments stay in the export list and their anchors are re-emitted.

## Tests
Adds unit coverage in `commentsExporter.test.js` for `isSyntheticTrackedChangeComment` (keeps body-bearing tracked-change comments and replies; drops body-less projections).

Made with [Cursor](https://cursor.com)