### PR TITLE
fix(passthrough): ensure inline passthrough nodes do not attach content

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/passthroughNodeImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/passthroughNodeImporter.js
@@ -37,14 +37,18 @@ export const handlePassthroughNode = (params) => {
     originalXml.elements = originalElements;
   }
 
+  const inline = isInlineContext(params.path, node.name);
   const passthroughNode = {
-    type: isInlineContext(params.path, node.name) ? 'passthroughInline' : 'passthroughBlock',
+    type: inline ? 'passthroughInline' : 'passthroughBlock',
     attrs: {
       originalName: node.name,
       originalXml,
     },
     marks: [],
-    content: childContent,
+    // passthroughInline is atom: true with no content expression. Child text (e.g.
+    // w:instrText for MERGEFIELD) must live only in attrs.originalXml; attaching
+    // content makes y-prosemirror drop the node during collab hydration.
+    content: inline ? undefined : childContent,
   };
 
   return {

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/passthroughNodeImporter.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/passthroughNodeImporter.test.js
@@ -54,4 +54,22 @@ describe('passthrough node importer', () => {
     const { nodes } = handlePassthroughNode(createParams(node, { path: [{ name: 'w:p' }] }));
     expect(nodes[0].type).toBe('passthroughInline');
   });
+
+  it('does not attach content to inline passthrough with child text (w:instrText MERGEFIELD)', () => {
+    const node = {
+      name: 'w:instrText',
+      attributes: { 'xml:space': 'preserve' },
+      elements: [{ type: 'text', text: ' MERGEFIELD System_Date ' }],
+    };
+    const handler = vi.fn(() => [{ type: 'text', text: ' MERGEFIELD System_Date ' }]);
+    const params = createParams(node, {
+      path: [{ name: 'w:p' }, { name: 'w:r' }],
+      nodeListHandler: { handler, handlerEntities: [] },
+    });
+    const { nodes } = handlePassthroughNode(params);
+    expect(nodes[0].type).toBe('passthroughInline');
+    expect(nodes[0].attrs.originalName).toBe('w:instrText');
+    expect(nodes[0].attrs.originalXml.elements).toEqual(node.elements);
+    expect(nodes[0].content).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Fix collaboration export of unrecognized Word fields (e.g. MERGEFIELD) by stopping the passthrough importer from attaching content to passthroughInline nodes; instruction text now lives only in attrs.originalXml, which export already uses.

Root cause: w:instrText was imported as an inline atom with child text nodes, and y-prosemirror’s schema-checked hydration dropped that node on sync—leaving a broken field shell (fldChar begin/separate/end) without MERGEFIELD in exported DOCX.

Added a regression test for w:instrText in inline context and verified TDD (red → green); block passthrough behavior is unchanged.