### PR TITLE
feat(mcp): make tracked-change author configurable, clarify save/close

### DIFF
--- a/apps/mcp/src/__tests__/session-manager.test.ts
+++ b/apps/mcp/src/__tests__/session-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'bun:test';
 import { resolve } from 'node:path';
-import { SessionManager } from '../session-manager.js';
+import { SessionManager, DEFAULT_MCP_USER } from '../session-manager.js';
 
 const BLANK_DOCX = resolve(import.meta.dir, '../../../../shared/common/data/blank.docx');
 
@@ -73,5 +73,24 @@ describe('SessionManager', () => {
 
     // Should contain part of the filename
     expect(session.id).toMatch(/^blank-[a-f0-9]{6}$/);
+  });
+
+  it('attributes edits to the default author when none is configured', async () => {
+    const session = await manager.open(BLANK_DOCX);
+
+    // The opened editor carries the author tracked changes/comments are recorded under.
+    expect(session.editor.options.user).toEqual(DEFAULT_MCP_USER);
+    expect(session.editor.options.user.name).toBe('MCP Server');
+  });
+
+  it('attributes edits to a configured author (tracked-change w:author)', async () => {
+    const scoped = new SessionManager({ id: 'agent', name: 'Agent' });
+    try {
+      const session = await scoped.open(BLANK_DOCX);
+      expect(session.editor.options.user).toEqual({ id: 'agent', name: 'Agent' });
+      expect(session.editor.options.user.name).toBe('Agent');
+    } finally {
+      await scoped.closeAll();
+    }
   });
 });

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { MCP_SYSTEM_PROMPT } from './generated/mcp-prompt.js';
-import { SessionManager } from './session-manager.js';
+import { SessionManager, DEFAULT_MCP_USER, type McpUser } from './session-manager.js';
 import { registerAllTools } from './tools/index.js';
 
 const require = createRequire(import.meta.url);
@@ -21,6 +21,18 @@ if (!PRESETS_SUPPORTED.has(requestedPreset)) {
   process.exit(2);
 }
 
+// The author that tracked changes and comments are attributed to. Defaults to "MCP Server"
+// (unchanged behaviour); set SUPERDOC_AUTHOR_NAME so an agent records edits under the identity
+// it is acting as (the .docx w:author/comment author), and optionally SUPERDOC_AUTHOR_ID.
+function resolveAuthor(): McpUser {
+  const name = process.env.SUPERDOC_AUTHOR_NAME?.trim();
+  const id = process.env.SUPERDOC_AUTHOR_ID?.trim();
+  return {
+    id: id || DEFAULT_MCP_USER.id,
+    name: name || DEFAULT_MCP_USER.name,
+  };
+}
+
 const server = new McpServer(
   {
     name: 'superdoc',
@@ -31,7 +43,7 @@ const server = new McpServer(
   },
 );
 
-const sessions = new SessionManager();
+const sessions = new SessionManager(resolveAuthor());
 
 registerAllTools(server, sessions);
 

--- a/apps/mcp/src/session-manager.ts
+++ b/apps/mcp/src/session-manager.ts
@@ -14,8 +14,27 @@ export interface Session {
   openedAt: number;
 }
 
+/** The author every tracked change and comment made in a session is attributed to. */
+export interface McpUser {
+  id: string;
+  name: string;
+}
+
+/** Used when no author is configured (preserves the original MCP behaviour). */
+export const DEFAULT_MCP_USER: McpUser = { id: 'mcp', name: 'MCP Server' };
+
 export class SessionManager {
   private sessions = new Map<string, Session>();
+  private readonly user: McpUser;
+
+  /**
+   * @param user The author tracked changes and comments are attributed to. Defaults to
+   * {@link DEFAULT_MCP_USER}. The server wires this from `SUPERDOC_AUTHOR_NAME` /
+   * `SUPERDOC_AUTHOR_ID` so an agent can record edits under the identity it is acting as.
+   */
+  constructor(user: McpUser = DEFAULT_MCP_USER) {
+    this.user = user;
+  }
 
   async open(filePath: string): Promise<Session> {
     const absolutePath = resolve(filePath);
@@ -32,7 +51,7 @@ export class SessionManager {
 
     const editor = await Editor.open(bytes, {
       documentId: absolutePath,
-      user: { id: 'mcp', name: 'MCP Server' },
+      user: this.user,
       telemetry: {
         metadata: {
           source: 'superdoc-mcp',

--- a/apps/mcp/src/tools/lifecycle.ts
+++ b/apps/mcp/src/tools/lifecycle.ts
@@ -38,7 +38,8 @@ export function registerLifecycleTools(server: McpServer, sessions: SessionManag
     'superdoc_save',
     {
       title: 'Save Document',
-      description: 'Save the document to disk. Writes to the original path unless "out" is specified.',
+      description:
+        'Save the document to disk, writing all edits (including tracked changes and comments) to the .docx. Edits from the other tools are held in memory only until you call this — you MUST call superdoc_save to persist them, and before superdoc_close (which discards unsaved changes). Writes to the original path unless "out" is specified.',
       inputSchema: {
         session_id: z.string().describe('Session ID from superdoc_open.'),
         out: z.string().optional().describe('Save to a different file path instead of the original.'),
@@ -64,7 +65,8 @@ export function registerLifecycleTools(server: McpServer, sessions: SessionManag
     'superdoc_close',
     {
       title: 'Close Document',
-      description: 'Close a document session and release memory. Unsaved changes will be lost.',
+      description:
+        'Close a document session and release memory. Unsaved changes are discarded — call superdoc_save FIRST if you want to keep your edits.',
       inputSchema: {
         session_id: z.string().describe('Session ID to close.'),
       },


### PR DESCRIPTION
The MCP server opened every document as the fixed user `MCP Server`, so every tracked change and comment an agent made was attributed to `MCP Server` with no way to change it. An agent acting as a named user, or any tool that needs edits attributed to a specific author, had no knob for it.

`SessionManager` now takes the author as a constructor argument, and the server reads it from `SUPERDOC_AUTHOR_NAME` (plus optional `SUPERDOC_AUTHOR_ID`), defaulting to the previous `MCP Server` so existing behaviour is unchanged. The configured author flows to `Editor.open`'s `user`, so saved `.docx` tracked changes and comments carry that `w:author`.

Also tightens two tool descriptions to match the real lifecycle: edits live in memory until `superdoc_save`, and `superdoc_close` discards anything unsaved. Agents frequently edited and then closed without saving, so the edits never reached the output file; the sharper wording steers them to save first.

- `SUPERDOC_AUTHOR_NAME=Agent npx @superdoc-dev/mcp` -> tracked changes authored `Agent`.
- Default (no env) is unchanged: author `MCP Server`.

**Review**: confirm the default path is untouched (no env -> `MCP Server`) and the author flows to `editor.options.user`. 
**Verified**: `bun test` in apps/mcp -> 39 pass / 0 fail (adds 2 SessionManager author cases); end-to-end, driving the built server with `SUPERDOC_AUTHOR_NAME=Agent` through open -> tracked replace -> save produces `w:author="Agent"` while preserving a pre-existing reviewer revision.