### PR TITLE
fix(cli): build SDK before native release artifacts

### DIFF
--- a/apps/cli/scripts/__tests__/ensure-superdoc-build.test.ts
+++ b/apps/cli/scripts/__tests__/ensure-superdoc-build.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { ensureDocumentApiBuild, ensureSuperdocBuild } from '../ensure-superdoc-build.js';
+import { ensureDocumentApiBuild, ensureNodeSdkBuild, ensureSuperdocBuild } from '../ensure-superdoc-build.js';
 
 type CommandCall = {
   command: string;
@@ -30,8 +30,31 @@ describe('ensureDocumentApiBuild', () => {
   });
 });
 
+describe('ensureNodeSdkBuild', () => {
+  test('generates SDK artifacts and rebuilds the Node SDK package', () => {
+    const calls: CommandCall[] = [];
+
+    ensureNodeSdkBuild((command, args, label) => {
+      calls.push({ command, args, label });
+    });
+
+    expect(calls).toEqual([
+      {
+        command: 'pnpm',
+        args: ['--prefix', expect.stringContaining('/packages/sdk'), 'run', 'generate'],
+        label: 'Generate SDK artifacts for CLI runtime',
+      },
+      {
+        command: 'pnpm',
+        args: ['--prefix', expect.stringContaining('/packages/sdk/langs/node'), 'run', 'build'],
+        label: 'Build Node SDK for CLI runtime',
+      },
+    ]);
+  });
+});
+
 describe('ensureSuperdocBuild', () => {
-  test('builds document-api first, then the fast packaged superdoc build by default', () => {
+  test('builds SDK first, then the fast packaged superdoc build by default', () => {
     const calls: CommandCall[] = [];
 
     ensureSuperdocBuild({}, (command, args, label) => {
@@ -41,13 +64,13 @@ describe('ensureSuperdocBuild', () => {
     expect(calls).toEqual([
       {
         command: 'pnpm',
-        args: ['exec', 'tsc', '-b', '--clean', 'packages/document-api'],
-        label: 'Clean document-api dist for CLI runtime',
+        args: ['--prefix', expect.stringContaining('/packages/sdk'), 'run', 'generate'],
+        label: 'Generate SDK artifacts for CLI runtime',
       },
       {
         command: 'pnpm',
-        args: ['exec', 'tsc', '-b', 'packages/document-api'],
-        label: 'Build document-api dist for CLI runtime',
+        args: ['--prefix', expect.stringContaining('/packages/sdk/langs/node'), 'run', 'build'],
+        label: 'Build Node SDK for CLI runtime',
       },
       {
         command: 'pnpm',

--- a/apps/cli/scripts/ensure-superdoc-build.js
+++ b/apps/cli/scripts/ensure-superdoc-build.js
@@ -4,6 +4,8 @@ import { ensureNoUnknownFlags, isDirectExecution, repoRoot, runCommand } from '.
 const allowedFlags = new Set(['--types']);
 const superdocRoot = path.join(repoRoot, 'packages/superdoc');
 const documentApiRoot = path.join(repoRoot, 'packages/document-api');
+const sdkWorkspaceRoot = path.join(repoRoot, 'packages/sdk');
+const nodeSdkRoot = path.join(sdkWorkspaceRoot, 'langs/node');
 const documentApiProject = path.relative(repoRoot, documentApiRoot);
 
 /**
@@ -17,8 +19,24 @@ export function ensureDocumentApiBuild(run = runCommand) {
 }
 
 /**
+ * Ensures the Node SDK package resolves for CLI builds.
+ *
+ * The CLI imports `@superdoc-dev/sdk` for `doc.preset.*`; Bun resolves that
+ * package through its dist export while compiling native binaries. SDK
+ * generation exports the CLI contract first, which builds document-api dist
+ * for clean checkouts.
+ *
+ * @returns {void}
+ */
+export function ensureNodeSdkBuild(run = runCommand) {
+  run('pnpm', ['--prefix', sdkWorkspaceRoot, 'run', 'generate'], 'Generate SDK artifacts for CLI runtime');
+  run('pnpm', ['--prefix', nodeSdkRoot, 'run', 'build'], 'Build Node SDK for CLI runtime');
+}
+
+/**
  * Ensures the CLI's runtime dependencies are freshly built:
- * - document-api contract/catalog dist consumed by CLI + SDK generation
+ * - document-api contract/catalog dist consumed by CLI metadata export
+ * - Node SDK dist consumed by `doc.preset.*`
  * - packaged `superdoc` for the v1 runtime path
  *
  * `--types` performs the full published build so package type exports exist.
@@ -32,7 +50,7 @@ export function ensureSuperdocBuild(options = {}, run = runCommand) {
   const scriptName = includeTypes ? 'build:es' : 'build:dev';
   const label = includeTypes ? 'Build packaged SuperDoc runtime and types' : 'Build packaged SuperDoc runtime';
 
-  ensureDocumentApiBuild(run);
+  ensureNodeSdkBuild(run);
   run('pnpm', ['--prefix', superdocRoot, 'run', scriptName], label);
 }
 


### PR DESCRIPTION
The CLI native release build now prepares the Node SDK before Bun compiles CLI binaries. `doc.preset.*` imports SDK preset code, so a fresh release checkout needs generated SDK sources and the SDK dist package before `bun build --compile`.

- Adds SDK artifact generation and Node SDK build to the CLI runtime prep helper.
- Keeps the existing packaged SuperDoc runtime prep in the same release path.
- Verified with the focused CLI script test and a host native CLI build.