### PR TITLE
fix(ci): install SDK Python test deps in release workflows

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -129,8 +129,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Python build tools
-        run: pip install build
+      - name: Install Python build and test tools
+        run: python3 -m pip install build pytest pytest-asyncio
 
       - name: Build packages
         run: pnpm run build
@@ -304,8 +304,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Python build tools
-        run: pip install build
+      - name: Install Python build and test tools
+        run: python3 -m pip install build pytest pytest-asyncio
 
       - name: Show current version
         run: |
@@ -425,8 +425,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Python build tools
-        run: pip install build
+      - name: Install Python build and test tools
+        run: python3 -m pip install build pytest pytest-asyncio
 
       - name: Compute smoke version
         id: smoke_version

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -95,8 +95,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Python build tools
-        run: pip install build
+      - name: Install Python build and test tools
+        run: python3 -m pip install build pytest pytest-asyncio
 
       - name: Build packages
         run: pnpm run build

--- a/packages/sdk/scripts/__tests__/release-order.test.mjs
+++ b/packages/sdk/scripts/__tests__/release-order.test.mjs
@@ -19,6 +19,14 @@ function assertOrder(content, first, second, context) {
   assert.ok(firstIndex < secondIndex, `${context}: expected "${first}" before "${second}"`);
 }
 
+function sectionBetween(content, start, end, context) {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end, startIndex + start.length);
+  assert.notEqual(startIndex, -1, `${context}: missing section start "${start}"`);
+  assert.notEqual(endIndex, -1, `${context}: missing section end "${end}"`);
+  return content.slice(startIndex, endIndex);
+}
+
 test('sdk-release.mjs builds Node SDK before validate', async () => {
   const content = await readRepoFile('packages/sdk/scripts/sdk-release.mjs');
   assertOrder(
@@ -37,6 +45,45 @@ test('ci-sdk workflow builds Node SDK before validate', async () => {
 test('release-sdk fallback workflow builds Node SDK before validate', async () => {
   const content = await readRepoFile('.github/workflows/release-sdk.yml');
   assertOrder(content, '- name: Build Node SDK', '- name: Validate SDK', '.github/workflows/release-sdk.yml');
+});
+
+test('release workflows install Python SDK test dependencies before validation', async () => {
+  const installCommand = 'python3 -m pip install build pytest pytest-asyncio';
+
+  const releaseSdk = await readRepoFile('.github/workflows/release-sdk.yml');
+  const autoRelease = sectionBetween(
+    releaseSdk,
+    '  auto-release:',
+    '  sync-labs-agent:',
+    '.github/workflows/release-sdk.yml',
+  );
+  assertOrder(
+    autoRelease,
+    installCommand,
+    '- name: Run semantic-release',
+    '.github/workflows/release-sdk.yml auto-release',
+  );
+
+  const manualRelease = sectionBetween(
+    releaseSdk,
+    '  manual-release:',
+    '  testpypi-smoke:',
+    '.github/workflows/release-sdk.yml',
+  );
+  assertOrder(
+    manualRelease,
+    installCommand,
+    '- name: Validate SDK',
+    '.github/workflows/release-sdk.yml manual-release',
+  );
+
+  const stableRelease = await readRepoFile('.github/workflows/release-stable.yml');
+  assertOrder(
+    stableRelease,
+    installCommand,
+    '- name: Release stable packages (orchestrator)',
+    '.github/workflows/release-stable.yml',
+  );
 });
 
 test('release-sdk fallback workflow publishes Node SDK via sdk-release-publish', async () => {


### PR DESCRIPTION
The stable tooling release and SDK fallback release now install the Python test dependencies required by `sdk-validate.mjs` before SDK validation runs. The failed stable release had `pytest` missing, then fell through to the local `uv` fallback even though `uv` is not installed in the runner.

- Installs `build`, `pytest`, and `pytest-asyncio` through `python3 -m pip` in release-stable and release-sdk Python setup, matching the interpreter used by `python3 -m pytest`.
- Adds a workflow regression test that checks the dependencies are installed before the SDK validation paths.
- PR CI validates the script/test surface, but it does not execute the stable release workflows themselves. The release-path proof here is workflow inspection, the new ordering test, and the existing green `ci-sdk.yml` pattern that already installs `pytest pytest-asyncio` before `sdk-validate.mjs`.
- Current stable release state is half-complete: CLI `0.21.0` is already published and tagged, while SDK `1.20.0` has no tag or package. After this merges, rerun the stable tooling release so the orchestrator can skip the complete CLI release and retry SDK validation/publish with the Python test deps installed.