### PR TITLE
Respect localized built-in DOCX styles

### DIFF
--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.js
@@ -786,7 +786,7 @@ export function addDefaultStylesIfMissing(styles) {
   const { elements } = updatedStyles.elements[0];
 
   Object.keys(DEFAULT_LINKED_STYLES).forEach((styleId) => {
-    const existsOnDoc = elements.some((el) => el.attributes?.['w:styleId'] === styleId);
+    const existsOnDoc = elements.some((el) => isEquivalentBuiltInStyle(el, styleId));
     if (!existsOnDoc) {
       const missingStyle = DEFAULT_LINKED_STYLES[styleId];
       updatedStyles.elements[0].elements.push(missingStyle);
@@ -794,6 +794,40 @@ export function addDefaultStylesIfMissing(styles) {
   });
 
   return updatedStyles;
+}
+
+const BUILT_IN_STYLE_ALIASES = {
+  Title: ['title', 'titulo', 'ttulo'],
+  Subtitle: ['subtitle', 'subtitulo', 'subttulo'],
+  Heading1: ['heading1', 'titulo1', 'ttulo1', 'kop1'],
+  Heading2: ['heading2', 'titulo2', 'ttulo2', 'kop2'],
+  Heading3: ['heading3', 'titulo3', 'ttulo3', 'kop3'],
+  Normal: ['normal'],
+};
+
+function normalizeBuiltInStyleName(value) {
+  return String(value ?? '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .toLowerCase();
+}
+
+function getStyleDisplayName(styleElement) {
+  return styleElement.elements?.find((el) => el.name === 'w:name')?.attributes?.['w:val'];
+}
+
+function isEquivalentBuiltInStyle(styleElement, canonicalStyleId) {
+  if (styleElement.attributes?.['w:styleId'] === canonicalStyleId) return true;
+  if (styleElement.attributes?.['w:type'] !== 'paragraph') return false;
+
+  const aliases = BUILT_IN_STYLE_ALIASES[canonicalStyleId];
+  if (!aliases) return false;
+
+  const normalizedStyleId = normalizeBuiltInStyleName(styleElement.attributes?.['w:styleId']);
+  const normalizedName = normalizeBuiltInStyleName(getStyleDisplayName(styleElement));
+
+  return aliases.includes(normalizedStyleId) || aliases.includes(normalizedName);
 }
 
 /**

--- a/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  addDefaultStylesIfMissing,
   createDocumentJson,
   collapseWhitespaceNextToInlinePassthrough,
   defaultNodeListHandler,
@@ -10,6 +11,31 @@ import {
 } from './docxImporter.js';
 
 const n = (type, attrs = {}) => ({ type, attrs, marks: [] });
+
+const makeStylesXml = (styleElements) => ({
+  elements: [
+    {
+      name: 'w:styles',
+      elements: styleElements,
+    },
+  ],
+});
+
+const style = (styleId, name, type = 'paragraph') => ({
+  name: 'w:style',
+  attributes: {
+    'w:type': type,
+    'w:styleId': styleId,
+  },
+  elements: [
+    {
+      name: 'w:name',
+      attributes: { 'w:val': name },
+    },
+  ],
+});
+
+const getStyleIds = (styles) => styles.elements[0].elements.map((element) => element.attributes?.['w:styleId']);
 
 const makeCustomPropertyDocx = (propertyName, textValue) => ({
   'word/document.xml': {
@@ -95,6 +121,36 @@ const makeGoogleDocsLikeDocx = () => ({
       },
     ],
   },
+});
+
+describe('addDefaultStylesIfMissing', () => {
+  it('recognizes localized title and heading styles before adding defaults', () => {
+    const styles = makeStylesXml([
+      style('Normal', 'Normal'),
+      style('Ttulo', 'Título'),
+      style('Ttulo1', 'Título 1'),
+      style('BodyText', 'Body Text'),
+    ]);
+
+    const result = addDefaultStylesIfMissing(styles);
+    const styleIds = getStyleIds(result);
+
+    expect(styleIds.filter((styleId) => styleId === 'Title')).toHaveLength(0);
+    expect(styleIds.filter((styleId) => styleId === 'Heading1')).toHaveLength(0);
+    expect(styleIds).toContain('Ttulo');
+    expect(styleIds).toContain('Ttulo1');
+    expect(getStyleIds(styles)).toEqual(['Normal', 'Ttulo', 'Ttulo1', 'BodyText']);
+  });
+
+  it('still adds defaults that have no canonical or localized equivalent', () => {
+    const styles = makeStylesXml([style('Normal', 'Normal')]);
+
+    const result = addDefaultStylesIfMissing(styles);
+    const styleIds = getStyleIds(result);
+
+    expect(styleIds).toContain('Title');
+    expect(styleIds).toContain('Heading1');
+  });
 });
 
 describe('filterOutRootInlineNodes', () => {


### PR DESCRIPTION
## Summary

Updates DOCX default-style injection so SuperDoc recognizes localized built-in style equivalents before adding the built-in defaults.

## Why

`addDefaultStylesIfMissing` previously checked only for exact canonical style IDs such as `Title` and `Heading1`. Some Word-authored DOCX files, especially localized documents, can contain built-in title/heading styles with localized or sanitized IDs/names, for example:

- `Ttulo` / `Título`
- `Ttulo1` / `Título 1`
- `Kop1`

Those styles should count as existing built-in title/heading styles. Without that recognition, SuperDoc appends its default `Title`/`Heading1` definitions and consumers can see the default styling take precedence over the imported template's own heading/title styling.

## What changed

- Adds built-in style alias detection for the default style insertion path.
- Normalizes style IDs and `w:name` values by stripping diacritics, spacing, and punctuation before matching.
- Recognizes Portuguese title aliases (`Título`, `Título 1`) and existing localized heading examples such as `Kop1`.
- Adds regression coverage for localized title/heading styles and for the normal missing-default case.

## Validation

Passed:

```bash
node_modules/.bin/vitest.cmd run packages/super-editor/src/editors/v1/core/super-converter/v2/importer/docxImporter.test.js --root packages/super-editor
```

Result: `1 passed`, `41 tests passed`.

Note: running through `pnpm --filter @superdoc/super-editor test -- ...` on Windows triggered the monorepo `prepare` lifecycle with Unix shell syntax (`if [ -z "$CI" ]`), so the targeted test was run directly with the local Vitest binary after dependencies were installed.
