### PR TITLE
fix(super-editor): verify comment selection feedback settles (IT-1278)

### DIFF
--- a/packages/super-editor/src/editors/v1/extensions/comment/comments-plugin.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/comment/comments-plugin.test.js
@@ -766,6 +766,30 @@ describe('CommentsPlugin state', () => {
       expect(editor.emit).not.toHaveBeenCalled();
     });
 
+    it('settles when the selected event is echoed back to the plugin', () => {
+      const { view, editor } = createPluginStateEnvironment();
+
+      editor.emit.mockImplementation((event, update) => {
+        if (event === 'commentsUpdate' && update.type === comments_module_events.SELECTED) {
+          setActiveComment(view, update.activeCommentId);
+        }
+      });
+
+      setActiveComment(view, 'comment-1');
+      setActiveComment(view, 'comment-2');
+      setActiveComment(view, 'comment-3');
+
+      vi.runAllTimers();
+
+      expect(editor.emit).toHaveBeenCalledTimes(1);
+      expect(editor.emit).toHaveBeenCalledWith('commentsUpdate', {
+        type: comments_module_events.SELECTED,
+        activeCommentId: 'comment-3',
+      });
+      expect(CommentsPluginKey.getState(view.state).activeThreadId).toBe('comment-3');
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
     it('does not emit when the editor is destroyed before a deferred notification runs', () => {
       const { view, editor } = createPluginStateEnvironment();
 


### PR DESCRIPTION
Adds a focused regression check for the IT-1278 comment-selection feedback loop. The previous stable promotion was squash-merged, so semantic-release could not see a release-worthy commit; this conventional fix commit allows the existing production fix to publish as a patch.

- Verifies an echoed selection settles after one event with no timer left behind.
- Leaves production code unchanged because `stable` already contains the fix.
- Merge with a regular merge commit. Squashing would hide the conventional commit again.