### PR TITLE
fix(release): publish GitHub releases for stable versions only

### DIFF
--- a/.github/workflows/release-vscode-ext.yml
+++ b/.github/workflows/release-vscode-ext.yml
@@ -2,7 +2,7 @@
 # Stable releases are orchestrated centrally by release-stable.yml so that
 # every stable release shares one concurrency slot and one git push lane.
 # Note: VS Code Marketplace doesn't support semver prerelease versions, so
-# main pushes only build a .vsix and attach it to the GitHub release.
+# main pushes create prerelease tags without publishing a .vsix.
 name: 📦 Release vscode-ext
 
 on:

--- a/apps/cli/.releaserc.cjs
+++ b/apps/cli/.releaserc.cjs
@@ -33,12 +33,10 @@ const branches = [
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
-// stable -> main syncs (real merges) re-attribute prereleases to PRs already shipped on @latest.
-// Gate per-PR/issue success comments off on prereleases to avoid duplicate "shipped" comments.
-const shouldCommentOnRelease = !isPrerelease;
-// Linear release comments are the shipped-version breadcrumb inside Linear
-// itself, so keep them on for prereleases even while GitHub PR comments stay
-// gated separately.
+// GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
+const shouldPublishGitHubRelease = !isPrerelease;
+// Linear release comments remain the shipped-version breadcrumb, so
+// prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;
 
 // Use AI-powered notes for stable releases, conventional generator for prereleases
@@ -89,13 +87,14 @@ config.plugins.push([
   },
 ]);
 
-config.plugins.push([
-  '@semantic-release/github',
-  {
-    successComment:
-      ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **superdoc-cli** v${nextRelease.version}\n\nThe release is available on [GitHub release](${releases.find(release => release.pluginName === "@semantic-release/github").url})',
-    successCommentCondition: shouldCommentOnRelease ? undefined : false,
-  },
-]);
+if (shouldPublishGitHubRelease) {
+  config.plugins.push([
+    '@semantic-release/github',
+    {
+      successComment:
+        ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **superdoc-cli** v${nextRelease.version}\n\nThe release is available on [GitHub release](${releases.find(release => release.pluginName === "@semantic-release/github").url})',
+    },
+  ]);
+}
 
 module.exports = config;

--- a/apps/cli/.releaserc.cjs
+++ b/apps/cli/.releaserc.cjs
@@ -34,7 +34,7 @@ const branches = [
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
 // GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
-const shouldPublishGitHubRelease = !isPrerelease;
+const shouldPublishGitHubRelease = Boolean(branch) && !isPrerelease;
 // Linear release comments remain the shipped-version breadcrumb, so
 // prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;

--- a/apps/create/.releaserc.cjs
+++ b/apps/create/.releaserc.cjs
@@ -13,12 +13,10 @@ const branches = [
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
-// stable -> main syncs (real merges) re-attribute prereleases to PRs already shipped on @latest.
-// Gate per-PR/issue success comments off on prereleases to avoid duplicate "shipped" comments.
-const shouldCommentOnRelease = !isPrerelease;
-// Linear release comments are the shipped-version breadcrumb inside Linear
-// itself, so keep them on for prereleases even while GitHub PR comments stay
-// gated separately.
+// GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
+const shouldPublishGitHubRelease = !isPrerelease;
+// Linear release comments remain the shipped-version breadcrumb, so
+// prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;
 
 const notesPlugin = isPrerelease ? createReleaseNotesGenerator() : ['semantic-release-ai-notes', { style: 'concise' }];
@@ -49,13 +47,14 @@ config.plugins.push([
   },
 ]);
 
-config.plugins.push([
-  '@semantic-release/github',
-  {
-    successComment:
-      ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **@superdoc-dev/create** v${nextRelease.version}\n\nThe release is available on [GitHub release](${releases.find(release => release.pluginName === "@semantic-release/github").url})',
-    successCommentCondition: shouldCommentOnRelease ? undefined : false,
-  },
-]);
+if (shouldPublishGitHubRelease) {
+  config.plugins.push([
+    '@semantic-release/github',
+    {
+      successComment:
+        ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **@superdoc-dev/create** v${nextRelease.version}\n\nThe release is available on [GitHub release](${releases.find(release => release.pluginName === "@semantic-release/github").url})',
+    },
+  ]);
+}
 
 module.exports = config;

--- a/apps/create/.releaserc.cjs
+++ b/apps/create/.releaserc.cjs
@@ -14,7 +14,7 @@ const branches = [
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
 // GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
-const shouldPublishGitHubRelease = !isPrerelease;
+const shouldPublishGitHubRelease = Boolean(branch) && !isPrerelease;
 // Linear release comments remain the shipped-version breadcrumb, so
 // prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;

--- a/apps/mcp/.releaserc.cjs
+++ b/apps/mcp/.releaserc.cjs
@@ -38,7 +38,7 @@ const branches = [
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
 // GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
-const shouldPublishGitHubRelease = !isPrerelease;
+const shouldPublishGitHubRelease = Boolean(branch) && !isPrerelease;
 // Linear release comments remain the shipped-version breadcrumb, so
 // prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;

--- a/apps/mcp/.releaserc.cjs
+++ b/apps/mcp/.releaserc.cjs
@@ -37,12 +37,10 @@ const branches = [
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
-// stable -> main syncs (real merges) re-attribute prereleases to PRs already shipped on @latest.
-// Gate per-PR/issue success comments off on prereleases to avoid duplicate "shipped" comments.
-const shouldCommentOnRelease = !isPrerelease;
-// Linear release comments are the shipped-version breadcrumb inside Linear
-// itself, so keep them on for prereleases even while GitHub PR comments stay
-// gated separately.
+// GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
+const shouldPublishGitHubRelease = !isPrerelease;
+// Linear release comments remain the shipped-version breadcrumb, so
+// prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;
 
 // Use AI-powered notes for stable releases, conventional generator for prereleases
@@ -92,13 +90,14 @@ config.plugins.push([
   },
 ]);
 
-config.plugins.push([
-  '@semantic-release/github',
-  {
-    successComment:
-      ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **@superdoc-dev/mcp** v${nextRelease.version}\n\nThe release is available on [GitHub release](${releases.find(release => release.pluginName === "@semantic-release/github").url})',
-    successCommentCondition: shouldCommentOnRelease ? undefined : false,
-  },
-]);
+if (shouldPublishGitHubRelease) {
+  config.plugins.push([
+    '@semantic-release/github',
+    {
+      successComment:
+        ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **@superdoc-dev/mcp** v${nextRelease.version}\n\nThe release is available on [GitHub release](${releases.find(release => release.pluginName === "@semantic-release/github").url})',
+    },
+  ]);
+}
 
 module.exports = config;

--- a/apps/vscode-ext/.releaserc.cjs
+++ b/apps/vscode-ext/.releaserc.cjs
@@ -33,12 +33,10 @@ const branches = [
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
-// stable -> main syncs (real merges) re-attribute prereleases to PRs already shipped on @latest.
-// Gate per-PR/issue success comments off on prereleases to avoid duplicate "shipped" comments.
-const shouldCommentOnRelease = !isPrerelease;
-// Linear release comments are the shipped-version breadcrumb inside Linear
-// itself, so keep them on for prereleases even while GitHub PR comments stay
-// gated separately.
+// GitHub Releases are stable-only; prerelease tags still proceed on main.
+const shouldPublishGitHubRelease = !isPrerelease;
+// Linear release comments remain the shipped-version breadcrumb, so
+// prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;
 
 // Use AI-powered notes for stable releases, conventional generator for prereleases
@@ -65,16 +63,9 @@ const config = {
   ],
 };
 
-// VS Code Marketplace doesn't support semver prerelease versions (e.g., 0.0.1-next.1)
-// Only publish stable releases to marketplace; prereleases get GitHub release with .vsix attached
-if (isPrerelease) {
-  config.plugins.push([
-    '@semantic-release/exec',
-    {
-      prepareCmd: 'pnpm run package', // Creates .vsix file only
-    },
-  ]);
-} else {
+// VS Code Marketplace doesn't support semver prerelease versions, so only
+// stable releases build and publish a .vsix.
+if (!isPrerelease) {
   config.plugins.push([
     '@semantic-release/exec',
     {
@@ -103,14 +94,15 @@ config.plugins.push([
   },
 ]);
 
-config.plugins.push([
-  '@semantic-release/github',
-  {
-    assets: [{ path: '*.vsix', label: 'VS Code Extension' }],
-    successComment:
-      ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **vscode-ext** v${nextRelease.version}',
-    successCommentCondition: shouldCommentOnRelease ? undefined : false,
-  },
-]);
+if (shouldPublishGitHubRelease) {
+  config.plugins.push([
+    '@semantic-release/github',
+    {
+      assets: [{ path: '*.vsix', label: 'VS Code Extension' }],
+      successComment:
+        ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **vscode-ext** v${nextRelease.version}',
+    },
+  ]);
+}
 
 module.exports = config;

--- a/apps/vscode-ext/.releaserc.cjs
+++ b/apps/vscode-ext/.releaserc.cjs
@@ -34,7 +34,7 @@ const branches = [
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
 // GitHub Releases are stable-only; prerelease tags still proceed on main.
-const shouldPublishGitHubRelease = !isPrerelease;
+const shouldPublishGitHubRelease = Boolean(branch) && !isPrerelease;
 // Linear release comments remain the shipped-version breadcrumb, so
 // prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;

--- a/packages/esign/.releaserc.cjs
+++ b/packages/esign/.releaserc.cjs
@@ -22,7 +22,7 @@ const branches = [
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
 // GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
-const shouldPublishGitHubRelease = !isPrerelease;
+const shouldPublishGitHubRelease = Boolean(branch) && !isPrerelease;
 // Linear release comments remain the shipped-version breadcrumb, so
 // prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;

--- a/packages/esign/.releaserc.cjs
+++ b/packages/esign/.releaserc.cjs
@@ -21,12 +21,10 @@ const branches = [
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
-// stable -> main syncs (real merges) re-attribute prereleases to PRs already shipped on @latest.
-// Gate per-PR/issue success comments off on prereleases to avoid duplicate "shipped" comments.
-const shouldCommentOnRelease = !isPrerelease;
-// Linear release comments are the shipped-version breadcrumb inside Linear
-// itself, so keep them on for prereleases even while GitHub PR comments stay
-// gated separately.
+// GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
+const shouldPublishGitHubRelease = !isPrerelease;
+// Linear release comments remain the shipped-version breadcrumb, so
+// prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;
 
 // Use AI-powered notes for stable releases, conventional generator for prereleases
@@ -64,13 +62,14 @@ config.plugins.push([
   },
 ]);
 
-config.plugins.push([
-  '@semantic-release/github',
-  {
-    successComment:
-      ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **esign** v${nextRelease.version}\n\nThe release is available on [GitHub release](https://github.com/superdoc-dev/superdoc/releases/tag/${nextRelease.gitTag})',
-    successCommentCondition: shouldCommentOnRelease ? undefined : false,
-  },
-]);
+if (shouldPublishGitHubRelease) {
+  config.plugins.push([
+    '@semantic-release/github',
+    {
+      successComment:
+        ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **esign** v${nextRelease.version}\n\nThe release is available on [GitHub release](https://github.com/superdoc-dev/superdoc/releases/tag/${nextRelease.gitTag})',
+    },
+  ]);
+}
 
 module.exports = config;

--- a/packages/fonts/.releaserc.cjs
+++ b/packages/fonts/.releaserc.cjs
@@ -15,7 +15,7 @@ const branches = [
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 // GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
-const shouldPublishGitHubRelease = !isPrerelease;
+const shouldPublishGitHubRelease = Boolean(branch) && !isPrerelease;
 const shouldCommentOnLinearRelease = true;
 const notesPlugin = isPrerelease ? createReleaseNotesGenerator() : ['semantic-release-ai-notes', { style: 'concise' }];
 

--- a/packages/fonts/.releaserc.cjs
+++ b/packages/fonts/.releaserc.cjs
@@ -14,7 +14,8 @@ const branches = [
 ];
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
-const shouldCommentOnRelease = !isPrerelease;
+// GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
+const shouldPublishGitHubRelease = !isPrerelease;
 const shouldCommentOnLinearRelease = true;
 const notesPlugin = isPrerelease ? createReleaseNotesGenerator() : ['semantic-release-ai-notes', { style: 'concise' }];
 
@@ -49,13 +50,14 @@ config.plugins.push([
   },
 ]);
 
-config.plugins.push([
-  '@semantic-release/github',
-  {
-    successComment:
-      ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **@superdoc-dev/fonts** v${nextRelease.version}\n\nThe release is available on [GitHub release](https://github.com/superdoc-dev/superdoc/releases/tag/${nextRelease.gitTag})',
-    successCommentCondition: shouldCommentOnRelease ? undefined : false,
-  },
-]);
+if (shouldPublishGitHubRelease) {
+  config.plugins.push([
+    '@semantic-release/github',
+    {
+      successComment:
+        ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **@superdoc-dev/fonts** v${nextRelease.version}\n\nThe release is available on [GitHub release](https://github.com/superdoc-dev/superdoc/releases/tag/${nextRelease.gitTag})',
+    },
+  ]);
+}
 
 module.exports = config;

--- a/packages/react/.releaserc.cjs
+++ b/packages/react/.releaserc.cjs
@@ -33,12 +33,10 @@ const branches = [
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
-// stable -> main syncs (real merges) re-attribute prereleases to PRs already shipped on @latest.
-// Gate per-PR/issue success comments off on prereleases to avoid duplicate "shipped" comments.
-const shouldCommentOnRelease = !isPrerelease;
-// Linear release comments are the shipped-version breadcrumb inside Linear
-// itself, so keep them on for prereleases even while GitHub PR comments stay
-// gated separately.
+// GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
+const shouldPublishGitHubRelease = !isPrerelease;
+// Linear release comments remain the shipped-version breadcrumb, so
+// prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;
 
 // Use AI-powered notes for stable releases, conventional generator for prereleases
@@ -82,13 +80,14 @@ config.plugins.push([
   { teamKeys: ['SD'], addComment: shouldCommentOnLinearRelease, packageName: 'react' },
 ]);
 
-config.plugins.push([
-  '@semantic-release/github',
-  {
-    successComment:
-      ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **@superdoc-dev/react** v${nextRelease.version}\n\nThe release is available on [GitHub release](https://github.com/superdoc-dev/superdoc/releases/tag/${nextRelease.gitTag})',
-    successCommentCondition: shouldCommentOnRelease ? undefined : false,
-  },
-]);
+if (shouldPublishGitHubRelease) {
+  config.plugins.push([
+    '@semantic-release/github',
+    {
+      successComment:
+        ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **@superdoc-dev/react** v${nextRelease.version}\n\nThe release is available on [GitHub release](https://github.com/superdoc-dev/superdoc/releases/tag/${nextRelease.gitTag})',
+    },
+  ]);
+}
 
 module.exports = config;

--- a/packages/react/.releaserc.cjs
+++ b/packages/react/.releaserc.cjs
@@ -34,7 +34,7 @@ const branches = [
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
 // GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
-const shouldPublishGitHubRelease = !isPrerelease;
+const shouldPublishGitHubRelease = Boolean(branch) && !isPrerelease;
 // Linear release comments remain the shipped-version breadcrumb, so
 // prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;

--- a/packages/sdk/.releaserc.cjs
+++ b/packages/sdk/.releaserc.cjs
@@ -33,12 +33,10 @@ const branches = [
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
-// stable -> main syncs (real merges) re-attribute prereleases to PRs already shipped on @latest.
-// Gate per-PR/issue success comments off on prereleases to avoid duplicate "shipped" comments.
-const shouldCommentOnRelease = !isPrerelease;
-// Linear release comments are the shipped-version breadcrumb inside Linear
-// itself, so keep them on for prereleases even while GitHub PR comments stay
-// gated separately.
+// GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
+const shouldPublishGitHubRelease = !isPrerelease;
+// Linear release comments remain the shipped-version breadcrumb, so
+// prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;
 
 // Use AI-powered notes for stable releases, conventional generator for prereleases
@@ -116,13 +114,14 @@ config.plugins.push([
   },
 ]);
 
-config.plugins.push([
-  '@semantic-release/github',
-  {
-    successComment:
-      ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **superdoc-sdk** v${nextRelease.version}',
-    successCommentCondition: shouldCommentOnRelease ? undefined : false,
-  },
-]);
+if (shouldPublishGitHubRelease) {
+  config.plugins.push([
+    '@semantic-release/github',
+    {
+      successComment:
+        ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **superdoc-sdk** v${nextRelease.version}',
+    },
+  ]);
+}
 
 module.exports = config;

--- a/packages/sdk/.releaserc.cjs
+++ b/packages/sdk/.releaserc.cjs
@@ -34,7 +34,7 @@ const branches = [
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
 // GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
-const shouldPublishGitHubRelease = !isPrerelease;
+const shouldPublishGitHubRelease = Boolean(branch) && !isPrerelease;
 // Linear release comments remain the shipped-version breadcrumb, so
 // prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;

--- a/packages/superdoc/.releaserc.cjs
+++ b/packages/superdoc/.releaserc.cjs
@@ -61,12 +61,10 @@ const branches = [
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
-// stable -> main syncs (real merges) re-attribute prereleases to PRs already shipped on @latest.
-// Gate per-PR/issue success comments off on prereleases to avoid duplicate "shipped" comments.
-const shouldCommentOnRelease = !isPrerelease;
-// Linear release comments are the shipped-version breadcrumb inside Linear
-// itself, so keep them on for prereleases even while GitHub PR comments stay
-// gated separately.
+// GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
+const shouldPublishGitHubRelease = !isLocalPreview && !isPrerelease;
+// Linear release comments remain the shipped-version breadcrumb, so
+// prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;
 
 // Use AI-powered notes for stable releases, conventional generator for prereleases
@@ -120,13 +118,12 @@ if (!isLocalPreview) {
 }
 
 // GitHub plugin comes last
-if (!isLocalPreview) {
+if (shouldPublishGitHubRelease) {
   config.plugins.push([
     '@semantic-release/github',
     {
       successComment:
         ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **superdoc** v${nextRelease.version}\n\nThe release is available on [GitHub release](https://github.com/superdoc-dev/superdoc/releases/tag/${nextRelease.gitTag})',
-      successCommentCondition: shouldCommentOnRelease ? undefined : false,
     },
   ]);
 }

--- a/packages/superdoc/.releaserc.cjs
+++ b/packages/superdoc/.releaserc.cjs
@@ -62,7 +62,7 @@ const branches = [
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
 // GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
-const shouldPublishGitHubRelease = !isLocalPreview && !isPrerelease;
+const shouldPublishGitHubRelease = !isLocalPreview && Boolean(branch) && !isPrerelease;
 // Linear release comments remain the shipped-version breadcrumb, so
 // prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;

--- a/packages/template-builder/.releaserc.cjs
+++ b/packages/template-builder/.releaserc.cjs
@@ -23,7 +23,7 @@ const branches = [
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
 // GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
-const shouldPublishGitHubRelease = !isPrerelease;
+const shouldPublishGitHubRelease = Boolean(branch) && !isPrerelease;
 // Linear release comments remain the shipped-version breadcrumb, so
 // prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;

--- a/packages/template-builder/.releaserc.cjs
+++ b/packages/template-builder/.releaserc.cjs
@@ -22,12 +22,10 @@ const branches = [
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);
 
-// stable -> main syncs (real merges) re-attribute prereleases to PRs already shipped on @latest.
-// Gate per-PR/issue success comments off on prereleases to avoid duplicate "shipped" comments.
-const shouldCommentOnRelease = !isPrerelease;
-// Linear release comments are the shipped-version breadcrumb inside Linear
-// itself, so keep them on for prereleases even while GitHub PR comments stay
-// gated separately.
+// GitHub Releases are stable-only; prerelease tags and package publishing still proceed.
+const shouldPublishGitHubRelease = !isPrerelease;
+// Linear release comments remain the shipped-version breadcrumb, so
+// prereleases link to their Git tags when no GitHub Release exists.
 const shouldCommentOnLinearRelease = true;
 
 // Use AI-powered notes for stable releases, conventional generator for prereleases
@@ -65,13 +63,14 @@ config.plugins.push([
   },
 ]);
 
-config.plugins.push([
-  '@semantic-release/github',
-  {
-    successComment:
-      ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **template-builder** v${nextRelease.version}\n\nThe release is available on [GitHub release](https://github.com/superdoc-dev/superdoc/releases/tag/${nextRelease.gitTag})',
-    successCommentCondition: shouldCommentOnRelease ? undefined : false,
-  },
-]);
+if (shouldPublishGitHubRelease) {
+  config.plugins.push([
+    '@semantic-release/github',
+    {
+      successComment:
+        ':tada: This ${issue.pull_request ? "PR" : "issue"} is included in **template-builder** v${nextRelease.version}\n\nThe release is available on [GitHub release](https://github.com/superdoc-dev/superdoc/releases/tag/${nextRelease.gitTag})',
+    },
+  ]);
+}
 
 module.exports = config;

--- a/scripts/__tests__/release-local.test.mjs
+++ b/scripts/__tests__/release-local.test.mjs
@@ -540,7 +540,7 @@ test('stable recovery tracks PyPI gaps when SDK PyPI publishing is enabled', asy
   );
 });
 
-test('release configs keep GitHub prerelease comments gated while Linear uses the dedicated release-comment policy', async () => {
+test('release configs publish GitHub releases only for stable versions while Linear keeps prerelease breadcrumbs', async () => {
   const releasercPaths = [
     'packages/superdoc/.releaserc.cjs',
     'packages/fonts/.releaserc.cjs',
@@ -568,15 +568,19 @@ test('release configs keep GitHub prerelease comments gated while Linear uses th
       `${releasercPath}: must use the commit-message Linear sync plugin, not the PR-branch-based external plugin`,
     );
 
-    assert.ok(
-      content.includes('const shouldCommentOnRelease = !isPrerelease'),
-      `${releasercPath}: must define shouldCommentOnRelease = !isPrerelease so the prerelease comment gate is consistent across configs`,
-    );
-
     if (usesGithubPlugin) {
       assert.ok(
-        content.includes('successCommentCondition: shouldCommentOnRelease ? undefined : false'),
-        `${releasercPath}: @semantic-release/github must gate successCommentCondition through shouldCommentOnRelease so prereleases don't re-comment on every PR after a stable -> main sync`,
+        content.includes('const shouldPublishGitHubRelease =') && content.includes('!isPrerelease'),
+        `${releasercPath}: must make GitHub release publication stable-only`,
+      );
+      assert.ok(
+        content.includes('if (shouldPublishGitHubRelease)'),
+        `${releasercPath}: must gate @semantic-release/github behind shouldPublishGitHubRelease`,
+      );
+      assert.equal(
+        content.includes('successCommentCondition:'),
+        false,
+        `${releasercPath}: prereleases must omit the GitHub plugin instead of configuring its success hook`,
       );
     }
 
@@ -587,7 +591,7 @@ test('release configs keep GitHub prerelease comments gated while Linear uses th
       );
       assert.ok(
         content.includes('addComment: shouldCommentOnLinearRelease'),
-        `${releasercPath}: Linear addComment must use the dedicated Linear comment gate so prerelease Linear breadcrumbs stay on while GitHub PR comments remain gated`,
+        `${releasercPath}: Linear addComment must use the dedicated Linear comment gate so prerelease breadcrumbs remain available without GitHub Releases`,
       );
       assert.equal(
         content.includes('addComment: true'),

--- a/scripts/__tests__/release-local.test.mjs
+++ b/scripts/__tests__/release-local.test.mjs
@@ -570,8 +570,10 @@ test('release configs publish GitHub releases only for stable versions while Lin
 
     if (usesGithubPlugin) {
       assert.ok(
-        content.includes('const shouldPublishGitHubRelease =') && content.includes('!isPrerelease'),
-        `${releasercPath}: must make GitHub release publication stable-only`,
+        content.includes('const shouldPublishGitHubRelease =') &&
+          content.includes('Boolean(branch)') &&
+          content.includes('!isPrerelease'),
+        `${releasercPath}: must fail closed when the release branch is unknown and publish GitHub releases only for stable versions`,
       );
       assert.ok(
         content.includes('if (shouldPublishGitHubRelease)'),

--- a/scripts/semantic-release/linear-commit-sync.cjs
+++ b/scripts/semantic-release/linear-commit-sync.cjs
@@ -266,7 +266,7 @@ function getLabelColor(releaseType) {
   return colors[releaseType] || '#4752C4';
 }
 
-function buildReleaseUrl(repositoryUrl, gitTag) {
+function buildReleaseUrl(repositoryUrl, gitTag, channel) {
   if (!repositoryUrl || !gitTag) {
     return '';
   }
@@ -274,13 +274,14 @@ function buildReleaseUrl(repositoryUrl, gitTag) {
   if (!match) {
     return '';
   }
-  return `https://github.com/${match[1]}/${match[2]}/releases/tag/${gitTag}`;
+  const tagPath = channel === 'next' ? 'tree' : 'releases/tag';
+  return `https://github.com/${match[1]}/${match[2]}/${tagPath}/${gitTag}`;
 }
 
 function formatComment(template, version, channel, packageName, gitTag, repositoryUrl) {
   const channelText = channel ? `(${channel} channel)` : '';
   const packageText = packageName ? `**${packageName}**` : '';
-  const releaseUrl = buildReleaseUrl(repositoryUrl, gitTag);
+  const releaseUrl = buildReleaseUrl(repositoryUrl, gitTag, channel);
   const releaseLink = releaseUrl ? `[${version}](${releaseUrl})` : version;
   const tpl = template || 'Released in {package} v{releaseLink} {channel}';
   return tpl

--- a/scripts/semantic-release/linear-commit-sync.test.cjs
+++ b/scripts/semantic-release/linear-commit-sync.test.cjs
@@ -89,7 +89,7 @@ test('collectIssueIdsFromCommits ignores generated release commits with old note
 });
 
 
-test('formatComment keeps the existing release comment template behavior', () => {
+test('formatComment links prerelease comments to the Git tag', () => {
   assert.equal(
     formatComment(
       'shipped in {package} {releaseLink} {channel}',
@@ -99,7 +99,21 @@ test('formatComment keeps the existing release comment template behavior', () =>
       'v1.2.3',
       'https://github.com/superdoc-dev/superdoc.git',
     ),
-    'shipped in **superdoc** [1.2.3](https://github.com/superdoc-dev/superdoc/releases/tag/v1.2.3) (next channel)',
+    'shipped in **superdoc** [1.2.3](https://github.com/superdoc-dev/superdoc/tree/v1.2.3) (next channel)',
+  );
+});
+
+test('formatComment links stable comments to the GitHub release', () => {
+  assert.equal(
+    formatComment(
+      'shipped in {package} {releaseLink} {channel}',
+      '1.2.3',
+      'latest',
+      'superdoc',
+      'v1.2.3',
+      'https://github.com/superdoc-dev/superdoc.git',
+    ),
+    'shipped in **superdoc** [1.2.3](https://github.com/superdoc-dev/superdoc/releases/tag/v1.2.3) (latest channel)',
   );
 });
 


### PR DESCRIPTION
Keeps the GitHub Releases page focused on stable package history by omitting the GitHub publishing plugin from `next` releases. Version calculation and prerelease distribution continue through Git tags and package registry dist-tags without creating a public release entry for every merge.

- preserves prerelease Git tags and npm `next` publishing
- keeps stable release notes, comments, and assets unchanged
- stops packaging prerelease VS Code `.vsix` files that had no destination outside GitHub Releases
- links Linear prerelease breadcrumbs to Git tags instead of missing Release pages