### PR TITLE
fix(cli): reject missing option values before following flags

### DIFF
--- a/apps/cli/.releaserc.cjs
+++ b/apps/cli/.releaserc.cjs
@@ -12,7 +12,7 @@ const {
  *
  * Keep in sync with .github/workflows/release-cli.yml paths: trigger.
  */
-require('../../scripts/semantic-release/patch-commit-filter.cjs')([
+const RELEASE_PATHS = [
   'apps/cli',
   'packages/document-api',
   'packages/superdoc',
@@ -22,7 +22,9 @@ require('../../scripts/semantic-release/patch-commit-filter.cjs')([
   'packages/preset-geometry',
   'shared',
   'pnpm-workspace.yaml',
-]);
+];
+
+require('../../scripts/semantic-release/patch-commit-filter.cjs')(RELEASE_PATHS);
 
 const branch = process.env.GITHUB_REF_NAME || process.env.CI_COMMIT_BRANCH;
 
@@ -42,7 +44,21 @@ const shouldCommentOnRelease = !isPrerelease;
 const shouldCommentOnLinearRelease = true;
 
 // Use AI-powered notes for stable releases, conventional generator for prereleases
-const notesPlugin = isPrerelease ? createReleaseNotesGenerator() : ['semantic-release-ai-notes', { style: 'concise' }];
+const notesPlugin = isPrerelease
+  ? createReleaseNotesGenerator()
+  : [
+      'semantic-release-ai-notes',
+      {
+        style: 'concise',
+        scope: {
+          name: 'SuperDoc CLI',
+          paths: RELEASE_PATHS,
+          audience: 'Developers using the SuperDoc CLI to convert and process documents from the command line',
+          instructions:
+            'This CLI wraps the document engine. Only mention engine changes when they change CLI commands, output, or supported document operations.',
+        },
+      },
+    ];
 
 const config = {
   branches,

--- a/apps/cli/src/__tests__/lib/args.test.ts
+++ b/apps/cli/src/__tests__/lib/args.test.ts
@@ -121,6 +121,21 @@ describe('parseCommandArgs', () => {
     expect(result.options.name).toBe('bob');
   });
 
+  test('reports a missing value without consuming the following option', () => {
+    const result = parseCommandArgs(['--name', '--verbose'], specs);
+
+    expect(result.errors).toEqual(['--name requires a value.']);
+    expect(result.options.name).toBeUndefined();
+    expect(result.options.verbose).toBe(true);
+  });
+
+  test('accepts an option-like string when provided inline', () => {
+    const result = parseCommandArgs(['--name=--verbose'], specs);
+
+    expect(result.errors).toEqual([]);
+    expect(result.options.name).toBe('--verbose');
+  });
+
   test('parses number options', () => {
     const result = parseCommandArgs(['--count', '42'], specs);
     expect(result.options.count).toBe(42);

--- a/apps/cli/src/lib/args.ts
+++ b/apps/cli/src/lib/args.ts
@@ -227,7 +227,7 @@ export function parseCommandArgs(tokens: string[], specs: OptionSpec[]): ParsedA
       }
     } else {
       const valueToken = inlineValue ?? tokens[i + 1];
-      if (valueToken == null) {
+      if (valueToken == null || (inlineValue == null && valueToken.startsWith('--'))) {
         errors.push(`--${rawName} requires a value.`);
         i += 1;
         continue;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,8 +238,8 @@ catalogs:
       specifier: ^24.2.7
       version: 24.2.9
     semantic-release-ai-notes:
-      specifier: ^0.2.3
-      version: 0.2.3
+      specifier: ^0.4.0
+      version: 0.4.0
     semantic-release-commit-filter:
       specifier: ^1.0.2
       version: 1.0.2
@@ -413,7 +413,7 @@ importers:
         version: 24.2.9(typescript@5.9.3)
       semantic-release-ai-notes:
         specifier: 'catalog:'
-        version: 0.2.3(semantic-release@24.2.9(typescript@5.9.3))(zod@4.3.6)
+        version: 0.4.0(semantic-release@24.2.9(typescript@5.9.3))(zod@4.3.6)
       semantic-release-commit-filter:
         specifier: 'catalog:'
         version: 1.0.2
@@ -543,7 +543,7 @@ importers:
         version: 24.2.9(typescript@5.9.3)
       semantic-release-ai-notes:
         specifier: 'catalog:'
-        version: 0.2.3(semantic-release@24.2.9(typescript@5.9.3))(zod@4.3.6)
+        version: 0.4.0(semantic-release@24.2.9(typescript@5.9.3))(zod@4.3.6)
       semantic-release-commit-filter:
         specifier: 'catalog:'
         version: 1.0.2
@@ -3779,21 +3779,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
-
-  '@anthropic-ai/claude-agent-sdk@0.2.86':
-    resolution: {integrity: sha512-Vynvs18smLzPSeSYk2/k/75IeiSa8AmrhkWgcwaVpZhLZOCuye5GYRv6uMZea0We/3N82c0udI5+hf2aOLiwMg==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^4.0.0
-
-  '@anthropic-ai/sdk@0.74.0':
-    resolution: {integrity: sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@anthropic-ai/sdk@0.80.0':
     resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
@@ -20474,8 +20459,8 @@ packages:
     resolution: {integrity: sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==}
     engines: {node: '>=18'}
 
-  semantic-release-ai-notes@0.2.3:
-    resolution: {integrity: sha512-xVcvNroQZbfKKlM3jepJFdxtMhzoXSnNQ6C37gNRUc20r15wlOe9nLj6bOroGFId5GIVhJU7wevFw7bEk8TzZw==}
+  semantic-release-ai-notes@0.4.0:
+    resolution: {integrity: sha512-4xqORLBAB8ILr3SkUcZTXyH6r1zgjlKrPokQEHOPC9hG9u7Dt+n2uOcEMnBNc0yQC6Ohphp30gFdjUKfQ8mz9w==}
     engines: {node: '>=18'}
     peerDependencies:
       semantic-release: '>=20.0.0'
@@ -23509,31 +23494,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
-
-  '@anthropic-ai/claude-agent-sdk@0.2.86(zod@4.3.6)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.74.0(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.28.0(zod@4.3.6)
-      zod: 4.3.6
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@anthropic-ai/sdk@0.74.0(zod@4.3.6)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 4.3.6
 
   '@anthropic-ai/sdk@0.80.0(zod@4.3.6)':
     dependencies:
@@ -45522,9 +45482,9 @@ snapshots:
       '@peculiar/x509': 1.14.3
       pkijs: 3.4.0
 
-  semantic-release-ai-notes@0.2.3(semantic-release@24.2.9(typescript@5.9.3))(zod@4.3.6):
+  semantic-release-ai-notes@0.4.0(semantic-release@24.2.9(typescript@5.9.3))(zod@4.3.6):
     dependencies:
-      '@anthropic-ai/claude-agent-sdk': 0.2.86(zod@4.3.6)
+      '@anthropic-ai/claude-agent-sdk': 0.2.105(zod@4.3.6)
       '@semantic-release/error': 4.0.0
       semantic-release: 24.2.9(typescript@5.9.3)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -107,7 +107,7 @@ catalog:
   rollup-plugin-copy: ^3.5.0
   rollup-plugin-visualizer: ^5.12.0
   semantic-release: ^24.2.7
-  semantic-release-ai-notes: ^0.2.3
+  semantic-release-ai-notes: ^0.4.0
   semantic-release-commit-filter: ^1.0.2
   sirv: ^3.0.2
   tippy.js: ^6.3.7


### PR DESCRIPTION
The CLI parser now reports a missing option value without hiding the flag that follows it. This also backports package-scoped AI release notes to stable so the resulting patch exercises the intended CLI-only release flow.

- Keeps option-like string values available through the inline --name=--value form.
- Separates the shared release configuration from the CLI fix so unrelated packages do not receive a version bump.
- Merge with a merge commit, not squash, to preserve that release isolation.