### PR TITLE
fix: release pipeline v1/v2

### DIFF
--- a/apps/cli/.releaserc.cjs
+++ b/apps/cli/.releaserc.cjs
@@ -28,9 +28,22 @@ require('../../scripts/semantic-release/patch-commit-filter.cjs')(RELEASE_PATHS)
 
 const branch = process.env.GITHUB_REF_NAME || process.env.CI_COMMIT_BRANCH;
 
+// Tag ownership: `@superdoc-dev/cli` on npm is published by two release lines. V2 owns
+// the default channels — `latest` for stable, `next` for previews — and V1 is
+// maintenance-only under `legacy`. V1 must never claim `latest` or `next`: both
+// lines publish the same package name, so a V1 release that claimed a V2 channel
+// would silently take it over (last write wins). That is what happened here —
+// V1 kept moving `next` while V2's releases were left untagged.
+//
+// `main` is deliberately absent. It was the only branch that could produce a
+// `next` release, so removing it is what stops V1 claiming the channel.
+//
+// Matches packages/superdoc, which established this split.
 const branches = [
-  { name: 'stable', channel: 'latest' },
-  { name: 'main', prerelease: 'next', channel: 'next' },
+  {
+    name: 'stable',
+    channel: 'legacy', // V1 maintenance line; V2 owns `latest`
+  },
 ];
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);

--- a/packages/react/.releaserc.cjs
+++ b/packages/react/.releaserc.cjs
@@ -28,9 +28,22 @@ require('../../scripts/semantic-release/patch-commit-filter.cjs')(RELEASE_PATHS)
 
 const branch = process.env.GITHUB_REF_NAME || process.env.CI_COMMIT_BRANCH;
 
+// Tag ownership: `@superdoc-dev/react` on npm is published by two release lines. V2 owns
+// the default channels — `latest` for stable, `next` for previews — and V1 is
+// maintenance-only under `legacy`. V1 must never claim `latest` or `next`: both
+// lines publish the same package name, so a V1 release that claimed a V2 channel
+// would silently take it over (last write wins). That is what happened here —
+// V1 kept moving `next` while V2's releases were left untagged.
+//
+// `main` is deliberately absent. It was the only branch that could produce a
+// `next` release, so removing it is what stops V1 claiming the channel.
+//
+// Matches packages/superdoc, which established this split.
 const branches = [
-  { name: 'stable', channel: 'latest' },
-  { name: 'main', prerelease: 'next', channel: 'next' },
+  {
+    name: 'stable',
+    channel: 'legacy', // V1 maintenance line; V2 owns `latest`
+  },
 ];
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);

--- a/packages/sdk/.releaserc.cjs
+++ b/packages/sdk/.releaserc.cjs
@@ -28,9 +28,22 @@ require('../../scripts/semantic-release/patch-commit-filter.cjs')(RELEASE_PATHS)
 const branch = process.env.GITHUB_REF_NAME || process.env.CI_COMMIT_BRANCH;
 const isCiRelease = Boolean(process.env.CI);
 
+// Tag ownership: `@superdoc-dev/sdk` on npm is published by two release lines. V2 owns
+// the default channels — `latest` for stable, `next` for previews — and V1 is
+// maintenance-only under `legacy`. V1 must never claim `latest` or `next`: both
+// lines publish the same package name, so a V1 release that claimed a V2 channel
+// would silently take it over (last write wins). That is what happened here —
+// V1 kept moving `next` while V2's releases were left untagged.
+//
+// `main` is deliberately absent. It was the only branch that could produce a
+// `next` release, so removing it is what stops V1 claiming the channel.
+//
+// Matches packages/superdoc, which established this split.
 const branches = [
-  { name: 'stable', channel: 'latest' },
-  { name: 'main', prerelease: 'next', channel: 'next' },
+  {
+    name: 'stable',
+    channel: 'legacy', // V1 maintenance line; V2 owns `latest`
+  },
 ];
 
 const isPrerelease = branches.some((b) => typeof b === 'object' && b.name === branch && b.prerelease);

--- a/scripts/release-local-stable.mjs
+++ b/scripts/release-local-stable.mjs
@@ -906,6 +906,10 @@ const packages = [
     tagPrefix: 'cli-v',
     tagPattern: 'cli-v*',
     npmPackages: CLI_NPM_PACKAGES,
+    // V1 is the maintenance line for this package; V2 owns `latest` and `next`.
+    // Mirrors the `legacy` channel in its .releaserc.cjs so a recovered publish
+    // lands on the same tag the release itself would use.
+    stableDistTag: 'legacy',
     resumePublish: resumeCliPublish,
   },
   {
@@ -915,6 +919,10 @@ const packages = [
     tagPrefix: 'sdk-v',
     tagPattern: 'sdk-v*',
     npmPackages: SDK_NODE_NPM_PACKAGES,
+    // V1 is the maintenance line for this package; V2 owns `latest` and `next`.
+    // Mirrors the `legacy` channel in its .releaserc.cjs so a recovered publish
+    // lands on the same tag the release itself would use.
+    stableDistTag: 'legacy',
     resumePublish: resumeSdkPublish,
     ...(SDK_PYPI_ENABLED
       ? {
@@ -961,6 +969,10 @@ const packages = [
     tagPrefix: 'react-v',
     tagPattern: 'react-v*',
     npmPackages: ['@superdoc-dev/react'],
+    // V1 is the maintenance line for this package; V2 owns `latest` and `next`.
+    // Mirrors the `legacy` channel in its .releaserc.cjs so a recovered publish
+    // lands on the same tag the release itself would use.
+    stableDistTag: 'legacy',
     resumePublish: resumeReactPublish,
   },
   {


### PR DESCRIPTION
### Issue

`superdoc`, `@superdoc-dev/react`, `@superdoc-dev/cli` and `@superdoc-dev/sdk` are each published to one npm name by two release lines. #1207 stopped V1 claiming V2's channels for `superdoc` only — the other three still published prereleases from `main` to `next` and stables to `latest`. V1's `react@1.16.1-next.4` took `next`, leaving V2's `2.0.0-next.4` untagged.

`scripts/release-local-stable.mjs` had the same gap: only `superdoc` declared `stableDistTag`, so a recovered V1 stable for the others would land on `latest`.

### Proposed solution

Apply #1207's rule to the remaining three: `stable` → `legacy`, and drop the `main` entry so no branch can produce a `next` release. Mirror it with `stableDistTag: 'legacy'` in their `release-local-stable.mjs` descriptors. `mcp`, `fonts` and `vscode-ext` keep `latest` — V2 doesn't publish those.

Note: nothing claims `react`/`cli`/`sdk` `next` until V2's lanes are enabled, so those tags go stale rather than wrong.
