### PR TITLE
chore(pnpm): consolidate workspace settings into pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,56 +123,5 @@
   },
   "optionalDependencies": {
     "canvas": "catalog:"
-  },
-  "pnpm": {
-    "overrides": {
-      "canvas": "3.2.3",
-      "happy-dom": "20.4.0",
-      "jsdom": "27.3.0",
-      "vue": "3.5.32",
-      "@vue/compiler-core": "3.5.32",
-      "@vue/compiler-dom": "3.5.32",
-      "@vue/compiler-sfc": "3.5.32",
-      "@vue/runtime-core": "3.5.32",
-      "@vue/runtime-dom": "3.5.32",
-      "@vue/server-renderer": "3.5.32",
-      "@vue/shared": "3.5.32",
-      "vite": "npm:rolldown-vite@7.3.1",
-      "axios": "1.18.0",
-      "protobufjs@7": "7.6.4",
-      "protobufjs@8": "8.6.4",
-      "superdoc": "workspace:*",
-      "@superdoc-dev/react": "workspace:*",
-      "@superdoc-dev/superdoc-yjs-collaboration": "workspace:*",
-      "@superdoc-dev/sdk": "workspace:*",
-      "openapi-types": "12.1.3",
-      "@types/minimatch": "5.1.2"
-    },
-    "ignoredBuiltDependencies": [
-      "@parcel/watcher",
-      "@playwright/browser-chromium",
-      "@swc/core",
-      "lmdb",
-      "msgpackr-extract",
-      "msw",
-      "onnxruntime-node",
-      "protobufjs"
-    ],
-    "onlyBuiltDependencies": [
-      "@vscode/vsce-sign",
-      "better-sqlite3",
-      "canvas",
-      "esbuild",
-      "keytar",
-      "lefthook",
-      "puppeteer",
-      "sharp",
-      "unrs-resolver",
-      "vue-demi"
-    ],
-    "patchedDependencies": {
-      "readable-stream@3.6.2": "patches/readable-stream@3.6.2.patch",
-      "openapi-types@12.1.3": "patches/openapi-types@12.1.3.patch"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -131,8 +131,35 @@ catalog:
   y-websocket: ^3.0.0
   yjs: ^13.6.19 # range allows consumers to use newer patch versions
 
+# AIDEV-NOTE: This file is the single source for pnpm settings. Do not
+# reintroduce a `pnpm` object in package.json. pnpm 10.6.2+ reads settings
+# from here, and pnpm 11 stops reading package.json#pnpm entirely.
+overrides:
+  canvas: 3.2.3
+  happy-dom: 20.4.0
+  jsdom: 27.3.0
+  vue: 3.5.32
+  '@vue/compiler-core': 3.5.32
+  '@vue/compiler-dom': 3.5.32
+  '@vue/compiler-sfc': 3.5.32
+  '@vue/runtime-core': 3.5.32
+  '@vue/runtime-dom': 3.5.32
+  '@vue/server-renderer': 3.5.32
+  '@vue/shared': 3.5.32
+  vite: 'npm:rolldown-vite@7.3.1'
+  axios: 1.18.0
+  protobufjs@7: 7.6.4
+  protobufjs@8: 8.6.4
+  superdoc: 'workspace:*'
+  '@superdoc-dev/react': 'workspace:*'
+  '@superdoc-dev/superdoc-yjs-collaboration': 'workspace:*'
+  '@superdoc-dev/sdk': 'workspace:*'
+  openapi-types: 12.1.3
+  '@types/minimatch': 5.1.2
+
 onlyBuiltDependencies:
   - '@vscode/vsce-sign'
+  - better-sqlite3
   - canvas
   - esbuild
   - keytar
@@ -142,5 +169,16 @@ onlyBuiltDependencies:
   - unrs-resolver
   - vue-demi
 
+ignoredBuiltDependencies:
+  - '@parcel/watcher'
+  - '@playwright/browser-chromium'
+  - '@swc/core'
+  - lmdb
+  - msgpackr-extract
+  - msw
+  - onnxruntime-node
+  - protobufjs
+
 patchedDependencies:
   readable-stream@3.6.2: patches/readable-stream@3.6.2.patch
+  openapi-types@12.1.3: patches/openapi-types@12.1.3.patch


### PR DESCRIPTION
Moves the pnpm settings still living in `package.json#pnpm` into `pnpm-workspace.yaml`, which is where pnpm has read them since 10.6.2 and the only place pnpm 11 will read them at all.

Keeping both locations had already let them drift, which is the real reason to do this now. `better-sqlite3` was allowed to run build scripts only via `package.json`, and the `openapi-types` patch was declared only there, so the workspace file was quietly incomplete.

Resolution is deliberately untouched, and that is the thing worth checking:

- `pnpm-lock.yaml` is byte-identical before and after
- `pnpm install --frozen-lockfile` succeeds, and both patches are applied on disk afterwards
- no dependency version moves; only two files change

Landing it separately also shrinks the diff of the Vite and Vitest upgrades stacked behind it, since a Vite+ migration would relocate these same keys anyway.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

