### PR TITLE
test(vitest): upgrade Vitest 3.2 to 4.1

### DIFF
--- a/packages/ai/src/ai-actions/__tests__/core/ai-planner.test.ts
+++ b/packages/ai/src/ai-actions/__tests__/core/ai-planner.test.ts
@@ -20,7 +20,7 @@ const createActionInstance = () => ({
 });
 
 vi.mock('../../services/ai-actions-service', () => {
-  const factory = vi.fn(() => {
+  const factory = vi.fn(function () {
     const instance = createActionInstance();
     actionInstances.push(instance);
     return instance;

--- a/packages/collaboration-yjs/src/shared-doc/shared-doc.test.ts
+++ b/packages/collaboration-yjs/src/shared-doc/shared-doc.test.ts
@@ -269,9 +269,14 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  vi.unmock('../shared-doc/constants.js');
-  vi.unmock('../shared-doc/callback.js');
-  vi.unmock('../shared-doc/utils.js');
+  // AIDEV-NOTE: These modules are registered with `vi.doMock`, so they must be
+  // released with the runtime counterpart. `vi.unmock` is hoisted to the top of
+  // the module regardless of where it appears, so it ran before any test and
+  // never undid the `doMock` registrations. Vitest 4 warns about that hoisting
+  // and will make it an error.
+  vi.doUnmock('../shared-doc/constants.js');
+  vi.doUnmock('../shared-doc/callback.js');
+  vi.doUnmock('../shared-doc/utils.js');
 });
 
 describe('shared-doc constants and utils', () => {

--- a/packages/collaboration-yjs/src/tests/collaboration-service.test.ts
+++ b/packages/collaboration-yjs/src/tests/collaboration-service.test.ts
@@ -50,11 +50,13 @@ describe('SuperDocCollaboration', () => {
       this.has = vi.fn();
     });
 
-    connectionHandlerCtor.mockImplementation(({ documentManager, hooks }) => ({
-      handle: handleSpy,
-      documentManager,
-      hooks,
-    }));
+    connectionHandlerCtor.mockImplementation(function ({ documentManager, hooks }) {
+      return {
+        handle: handleSpy,
+        documentManager,
+        hooks,
+      };
+    });
 
     generateParamsFn.mockImplementation(() => ({
       documentId: 'doc-123',

--- a/packages/collaboration-yjs/src/tests/document-manager.test.ts
+++ b/packages/collaboration-yjs/src/tests/document-manager.test.ts
@@ -14,7 +14,7 @@ vi.mock('../internal-logger/logger.js', () => ({
 }));
 
 vi.mock('../shared-doc/index.js', () => {
-  const SharedSuperDoc = vi.fn((documentId: string) => {
+  const SharedSuperDoc = vi.fn(function (documentId: string) {
     const doc = {
       name: documentId,
       conns: new Map<CollaborationWebSocket, Set<number>>(),

--- a/packages/super-editor/src/editors/v1/components/toolbar/Toolbar.test.js
+++ b/packages/super-editor/src/editors/v1/components/toolbar/Toolbar.test.js
@@ -149,7 +149,9 @@ describe('Toolbar', () => {
   it('does not attach ResizeObserver when responsiveToContainer is disabled', () => {
     const observe = vi.fn();
     const disconnect = vi.fn();
-    const ResizeObserverMock = vi.fn(() => ({ observe, disconnect }));
+    const ResizeObserverMock = vi.fn(function () {
+      return { observe, disconnect };
+    });
     vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 
     const mockToolbar = {
@@ -177,7 +179,9 @@ describe('Toolbar', () => {
   it('attaches ResizeObserver to the container when responsiveToContainer is enabled', () => {
     const observe = vi.fn();
     const disconnect = vi.fn();
-    const ResizeObserverMock = vi.fn(() => ({ observe, disconnect }));
+    const ResizeObserverMock = vi.fn(function () {
+      return { observe, disconnect };
+    });
     vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 
     const container = document.createElement('div');

--- a/packages/super-editor/src/editors/v1/core/Editor.telemetry.test.ts
+++ b/packages/super-editor/src/editors/v1/core/Editor.telemetry.test.ts
@@ -3,9 +3,11 @@ import { Telemetry, COMMUNITY_LICENSE_KEY } from '@superdoc/common';
 
 // Mock the Telemetry class to verify it's called correctly
 vi.mock('@superdoc/common', () => ({
-  Telemetry: vi.fn().mockImplementation(() => ({
-    trackDocumentOpen: vi.fn(),
-  })),
+  Telemetry: vi.fn().mockImplementation(function () {
+    return {
+      trackDocumentOpen: vi.fn(),
+    };
+  }),
   COMMUNITY_LICENSE_KEY: 'community-and-eval-agplv3',
 }));
 

--- a/packages/super-editor/src/editors/v1/core/commands/continueNumbering.headless.test.js
+++ b/packages/super-editor/src/editors/v1/core/commands/continueNumbering.headless.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+// @vitest-environment node
+// AIDEV-NOTE: This suite asserts the no-view (headless) dispatch path, so it
+// must run without a DOM. It relied on the package's environmentMatchGlobs
+// node rule, which Vitest 4 removed; the docblock now states it locally.
 /**
  * Headless dispatch regression for `continueNumbering`.
  *

--- a/packages/super-editor/src/editors/v1/core/commands/restartNumbering.headless.test.js
+++ b/packages/super-editor/src/editors/v1/core/commands/restartNumbering.headless.test.js
@@ -1,4 +1,8 @@
 // @ts-check
+// @vitest-environment node
+// AIDEV-NOTE: This suite asserts the no-view (headless) dispatch path, so it
+// must run without a DOM. It relied on the package's environmentMatchGlobs
+// node rule, which Vitest 4 removed; the docblock now states it locally.
 /**
  * Headless dispatch regression for `restartNumbering` (first-item branch).
  *

--- a/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.test.ts
+++ b/packages/super-editor/src/editors/v1/core/header-footer/HeaderFooterRegistry.test.ts
@@ -71,23 +71,24 @@ const { mockCreateHeaderFooterEditor, mockOnHeaderFooterDataUpdate, mockToFlowBl
       return editorStub;
     };
 
-    const mockCreateHeaderFooterEditor = vi.fn(
-      (input?: { editorContainer?: HTMLElement; editorHost?: HTMLElement }) => {
-        const editor = createSectionEditor();
-        if (input?.editorContainer instanceof HTMLElement) {
-          if (input.editorHost instanceof HTMLElement) {
-            input.editorHost.appendChild(input.editorContainer);
-          } else {
-            document.body.appendChild(input.editorContainer);
-          }
+    const mockCreateHeaderFooterEditor = vi.fn(function (input?: {
+      editorContainer?: HTMLElement;
+      editorHost?: HTMLElement;
+    }) {
+      const editor = createSectionEditor();
+      if (input?.editorContainer instanceof HTMLElement) {
+        if (input.editorHost instanceof HTMLElement) {
+          input.editorHost.appendChild(input.editorContainer);
+        } else {
+          document.body.appendChild(input.editorContainer);
         }
-        editors.push({ editor, emit: editor.emit });
-        queueMicrotask(() => {
-          editor.emit('create');
-        });
-        return editor;
-      },
-    );
+      }
+      editors.push({ editor, emit: editor.emit });
+      queueMicrotask(() => {
+        editor.emit('create');
+      });
+      return editor;
+    });
 
     return {
       mockCreateHeaderFooterEditor,

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.collaboration.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.collaboration.test.ts
@@ -56,39 +56,41 @@ const {
 
 // Mock Editor class
 vi.mock('../../Editor', () => ({
-  Editor: vi.fn().mockImplementation(() => ({
-    setDocumentMode: vi.fn(),
-    setOptions: vi.fn(),
-    on: vi.fn(),
-    off: vi.fn(),
-    destroy: vi.fn(),
-    getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
-    isEditable: true,
-    state: {
-      selection: { from: 0, to: 0, anchor: 0, head: 0, empty: true },
-      doc: {
-        nodeSize: 100,
-        content: {
-          size: 100,
+  Editor: vi.fn().mockImplementation(function () {
+    return {
+      setDocumentMode: vi.fn(),
+      setOptions: vi.fn(),
+      on: vi.fn(),
+      off: vi.fn(),
+      destroy: vi.fn(),
+      getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
+      isEditable: true,
+      state: {
+        selection: { from: 0, to: 0, anchor: 0, head: 0, empty: true },
+        doc: {
+          nodeSize: 100,
+          content: {
+            size: 100,
+          },
+          descendants: vi.fn(),
         },
-        descendants: vi.fn(),
       },
-    },
-    view: {
-      dom: document.createElement('div'),
-      hasFocus: vi.fn(() => false),
-    },
-    options: {
-      documentId: 'test-doc',
-      element: document.createElement('div'),
-    },
-    converter: mockEditorConverterStore.current,
-    storage: {
-      image: {
-        media: mockEditorConverterStore.mediaFiles,
+      view: {
+        dom: document.createElement('div'),
+        hasFocus: vi.fn(() => false),
       },
-    },
-  })),
+      options: {
+        documentId: 'test-doc',
+        element: document.createElement('div'),
+      },
+      converter: mockEditorConverterStore.current,
+      storage: {
+        image: {
+          media: mockEditorConverterStore.mediaFiles,
+        },
+      },
+    };
+  }),
 }));
 
 // Mock dependencies
@@ -111,14 +113,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
   findWordBoundaries: vi.fn(),
   findParagraphBoundaries: vi.fn(),
   createDragHandler: vi.fn(),
-  PageGeometryHelper: vi.fn().mockImplementation(({ layout, pageGap }) => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => pageGap ?? 0),
-    getLayout: vi.fn(() => layout),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function ({ layout, pageGap }) {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => pageGap ?? 0),
+      getLayout: vi.fn(() => layout),
+    };
+  }),
 }));
 
 vi.mock('@superdoc/painter-dom', () => ({
@@ -149,38 +153,44 @@ vi.mock('@superdoc/measuring-dom', () => ({
 }));
 
 vi.mock('../../header-footer/HeaderFooterRegistry', () => ({
-  HeaderFooterEditorManager: vi.fn(() => ({
-    createEditor: vi.fn(),
-    destroyEditor: vi.fn(),
-    getEditor: vi.fn(),
-    refresh: mockHeaderFooterRefresh,
-    on: vi.fn(),
-    off: vi.fn(),
-    destroy: vi.fn(),
-  })),
-  HeaderFooterLayoutAdapter: vi.fn(() => ({
-    clear: vi.fn(),
-    getBatch: vi.fn(() => []),
-    getBlocksByRId: vi.fn(() => new Map()),
-    invalidateAll: mockHeaderFooterInvalidateAll,
-    setTrackedChangesRenderConfig: vi.fn(),
-  })),
+  HeaderFooterEditorManager: vi.fn(function () {
+    return {
+      createEditor: vi.fn(),
+      destroyEditor: vi.fn(),
+      getEditor: vi.fn(),
+      refresh: mockHeaderFooterRefresh,
+      on: vi.fn(),
+      off: vi.fn(),
+      destroy: vi.fn(),
+    };
+  }),
+  HeaderFooterLayoutAdapter: vi.fn(function () {
+    return {
+      clear: vi.fn(),
+      getBatch: vi.fn(() => []),
+      getBlocksByRId: vi.fn(() => new Map()),
+      invalidateAll: mockHeaderFooterInvalidateAll,
+      setTrackedChangesRenderConfig: vi.fn(),
+    };
+  }),
 }));
 
 vi.mock('../../header-footer/EditorOverlayManager', () => ({
-  EditorOverlayManager: vi.fn(() => ({
-    showEditingOverlay: vi.fn(() => ({
-      success: true,
-      editorHost: document.createElement('div'),
-      reason: null,
-    })),
-    hideEditingOverlay: vi.fn(),
-    showSelectionOverlay: vi.fn(),
-    hideSelectionOverlay: vi.fn(),
-    setOnDimmingClick: vi.fn(),
-    getActiveEditorHost: vi.fn(() => null),
-    destroy: vi.fn(),
-  })),
+  EditorOverlayManager: vi.fn(function () {
+    return {
+      showEditingOverlay: vi.fn(() => ({
+        success: true,
+        editorHost: document.createElement('div'),
+        reason: null,
+      })),
+      hideEditingOverlay: vi.fn(),
+      showSelectionOverlay: vi.fn(),
+      hideSelectionOverlay: vi.fn(),
+      setOnDimmingClick: vi.fn(),
+      getActiveEditorHost: vi.fn(() => null),
+      destroy: vi.fn(),
+    };
+  }),
 }));
 
 vi.mock('y-prosemirror', () => ({

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.decorationSync.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.decorationSync.test.ts
@@ -144,19 +144,21 @@ const {
       setShowFormattingMarks: vi.fn(),
     })),
     mockEditorConverterStore: converterStore,
-    mockEditorOverlayManager: vi.fn().mockImplementation(() => ({
-      showEditingOverlay: vi.fn(() => ({
-        success: true,
-        editorHost: document.createElement('div'),
-        reason: null,
-      })),
-      hideEditingOverlay: vi.fn(),
-      showSelectionOverlay: vi.fn(),
-      hideSelectionOverlay: vi.fn(),
-      setOnDimmingClick: vi.fn(),
-      getActiveEditorHost: vi.fn(() => null),
-      destroy: vi.fn(),
-    })),
+    mockEditorOverlayManager: vi.fn().mockImplementation(function () {
+      return {
+        showEditingOverlay: vi.fn(() => ({
+          success: true,
+          editorHost: document.createElement('div'),
+          reason: null,
+        })),
+        hideEditingOverlay: vi.fn(),
+        showSelectionOverlay: vi.fn(),
+        hideSelectionOverlay: vi.fn(),
+        setOnDimmingClick: vi.fn(),
+        getActiveEditorHost: vi.fn(() => null),
+        destroy: vi.fn(),
+      };
+    }),
     mockPlugins: plugins,
     mockEditorOn: editorOn,
   };
@@ -169,7 +171,7 @@ vi.mock('../input/PositionHitResolver.js', () => ({
 
 vi.mock('../../Editor.js', () => {
   return {
-    Editor: vi.fn().mockImplementation(() => {
+    Editor: vi.fn().mockImplementation(function () {
       const domElement = document.createElement('div');
 
       const mockState = {
@@ -250,14 +252,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
   computeDisplayPageNumber: vi.fn((pages: Array<{ number?: number }>) =>
     pages.map((p) => ({ displayText: String(p.number ?? 1) })),
   ),
-  PageGeometryHelper: vi.fn().mockImplementation(() => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => 0),
-    getLayout: vi.fn(() => ({ pages: [] })),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function () {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => 0),
+      getLayout: vi.fn(() => ({ pages: [] })),
+    };
+  }),
 }));
 
 vi.mock('@superdoc/painter-dom', () => ({

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.draggableFocus.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.draggableFocus.test.ts
@@ -68,26 +68,28 @@ const {
       setShowFormattingMarks: vi.fn(),
     })),
     mockEditorConverterStore: converterStore,
-    mockEditorOverlayManager: vi.fn().mockImplementation(() => ({
-      showEditingOverlay: vi.fn(() => ({
-        success: true,
-        editorHost: document.createElement('div'),
-        reason: null,
-      })),
-      hideEditingOverlay: vi.fn(),
-      showSelectionOverlay: vi.fn(),
-      hideSelectionOverlay: vi.fn(),
-      setOnDimmingClick: vi.fn(),
-      getActiveEditorHost: vi.fn(() => null),
-      destroy: vi.fn(),
-    })),
+    mockEditorOverlayManager: vi.fn().mockImplementation(function () {
+      return {
+        showEditingOverlay: vi.fn(() => ({
+          success: true,
+          editorHost: document.createElement('div'),
+          reason: null,
+        })),
+        hideEditingOverlay: vi.fn(),
+        showSelectionOverlay: vi.fn(),
+        hideSelectionOverlay: vi.fn(),
+        setOnDimmingClick: vi.fn(),
+        getActiveEditorHost: vi.fn(() => null),
+        destroy: vi.fn(),
+      };
+    }),
   };
 });
 
 // Mock Editor class
 vi.mock('../../Editor.js', () => {
   return {
-    Editor: vi.fn().mockImplementation(() => {
+    Editor: vi.fn().mockImplementation(function () {
       const domElement = document.createElement('div');
 
       return {
@@ -170,14 +172,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
   computeDisplayPageNumber: vi.fn((pages) =>
     pages.map((p: { number?: number }) => ({ displayText: String(p.number ?? 1) })),
   ),
-  PageGeometryHelper: vi.fn().mockImplementation(() => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => 0),
-    getLayout: vi.fn(() => ({ pages: [] })),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function () {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => 0),
+      getLayout: vi.fn(() => ({ pages: [] })),
+    };
+  }),
 }));
 
 // Mock painter-dom

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.focusWrapping.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.focusWrapping.test.ts
@@ -81,26 +81,28 @@ const {
       setShowFormattingMarks: vi.fn(),
     })),
     mockEditorConverterStore: converterStore,
-    mockEditorOverlayManager: vi.fn().mockImplementation(() => ({
-      showEditingOverlay: vi.fn(() => ({
-        success: true,
-        editorHost: document.createElement('div'),
-        reason: null,
-      })),
-      hideEditingOverlay: vi.fn(),
-      showSelectionOverlay: vi.fn(),
-      hideSelectionOverlay: vi.fn(),
-      setOnDimmingClick: vi.fn(),
-      getActiveEditorHost: vi.fn(() => null),
-      destroy: vi.fn(),
-    })),
+    mockEditorOverlayManager: vi.fn().mockImplementation(function () {
+      return {
+        showEditingOverlay: vi.fn(() => ({
+          success: true,
+          editorHost: document.createElement('div'),
+          reason: null,
+        })),
+        hideEditingOverlay: vi.fn(),
+        showSelectionOverlay: vi.fn(),
+        hideSelectionOverlay: vi.fn(),
+        setOnDimmingClick: vi.fn(),
+        getActiveEditorHost: vi.fn(() => null),
+        destroy: vi.fn(),
+      };
+    }),
   };
 });
 
 // Mock Editor class
 vi.mock('../../Editor.js', () => {
   return {
-    Editor: vi.fn().mockImplementation(() => {
+    Editor: vi.fn().mockImplementation(function () {
       const domElement = document.createElement('div');
 
       return {
@@ -185,14 +187,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
   computeDisplayPageNumber: vi.fn((pages) =>
     pages.map((p: { number?: number }) => ({ displayText: String(p.number ?? 1) })),
   ),
-  PageGeometryHelper: vi.fn().mockImplementation(() => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => 0),
-    getLayout: vi.fn(() => ({ pages: [] })),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function () {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => 0),
+      getLayout: vi.fn(() => ({ pages: [] })),
+    };
+  }),
 }));
 
 // Mock painter-dom

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.footnotesPmMarkers.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.footnotesPmMarkers.test.ts
@@ -14,36 +14,38 @@ const { mockIncrementalLayout, mockResolveLayout } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../Editor', () => ({
-  Editor: vi.fn().mockImplementation(() => ({
-    on: vi.fn(),
-    off: vi.fn(),
-    destroy: vi.fn(),
-    setDocumentMode: vi.fn(),
-    setOptions: vi.fn(),
-    getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
-    isEditable: true,
-    schema: {},
-    state: {
-      selection: { from: 0, to: 0 },
-      doc: {
-        nodeSize: 100,
-        content: { size: 100 },
-        descendants: vi.fn((cb: (node: any, pos: number) => void) => {
-          cb({ type: { name: 'footnoteReference' }, attrs: { id: '1' }, nodeSize: 1 }, 10);
-        }),
+  Editor: vi.fn().mockImplementation(function () {
+    return {
+      on: vi.fn(),
+      off: vi.fn(),
+      destroy: vi.fn(),
+      setDocumentMode: vi.fn(),
+      setOptions: vi.fn(),
+      getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
+      isEditable: true,
+      schema: {},
+      state: {
+        selection: { from: 0, to: 0 },
+        doc: {
+          nodeSize: 100,
+          content: { size: 100 },
+          descendants: vi.fn((cb: (node: any, pos: number) => void) => {
+            cb({ type: { name: 'footnoteReference' }, attrs: { id: '1' }, nodeSize: 1 }, 10);
+          }),
+        },
       },
-    },
-    view: { dom: document.createElement('div'), hasFocus: vi.fn(() => false) },
-    options: { documentId: 'test', element: document.createElement('div'), mediaFiles: {} },
-    converter: {
-      headers: {},
-      footers: {},
-      headerIds: { default: null, ids: [] },
-      footerIds: { default: null, ids: [] },
-      footnotes: [{ id: '1', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'x' }] }] }],
-    },
-    storage: { image: { media: {} } },
-  })),
+      view: { dom: document.createElement('div'), hasFocus: vi.fn(() => false) },
+      options: { documentId: 'test', element: document.createElement('div'), mediaFiles: {} },
+      converter: {
+        headers: {},
+        footers: {},
+        headerIds: { default: null, ids: [] },
+        footerIds: { default: null, ids: [] },
+        footnotes: [{ id: '1', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'x' }] }] }],
+      },
+      storage: { image: { media: {} } },
+    };
+  }),
 }));
 
 vi.mock('@core/layout-adapter', async (importOriginal) => {
@@ -89,14 +91,16 @@ vi.mock('@superdoc/layout-bridge', async (importOriginal) => {
     findWordBoundaries: vi.fn(),
     findParagraphBoundaries: vi.fn(),
     createDragHandler: vi.fn(),
-    PageGeometryHelper: vi.fn(() => ({
-      updateLayout: vi.fn(),
-      getPageIndexAtY: vi.fn(() => 0),
-      getNearestPageIndex: vi.fn(() => 0),
-      getPageTop: vi.fn(() => 0),
-      getPageGap: vi.fn(() => 0),
-      getLayout: vi.fn(() => ({ pages: [] })),
-    })),
+    PageGeometryHelper: vi.fn(function () {
+      return {
+        updateLayout: vi.fn(),
+        getPageIndexAtY: vi.fn(() => 0),
+        getNearestPageIndex: vi.fn(() => 0),
+        getPageTop: vi.fn(() => 0),
+        getPageGap: vi.fn(() => 0),
+        getLayout: vi.fn(() => ({ pages: [] })),
+      };
+    }),
   };
 });
 
@@ -124,32 +128,38 @@ vi.mock('@superdoc/layout-resolved', () => ({
 }));
 
 vi.mock('../../header-footer/HeaderFooterRegistry', () => ({
-  HeaderFooterEditorManager: vi.fn(() => ({
-    createEditor: vi.fn(),
-    destroyEditor: vi.fn(),
-    getEditor: vi.fn(),
-    on: vi.fn(),
-    off: vi.fn(),
-    destroy: vi.fn(),
-  })),
-  HeaderFooterLayoutAdapter: vi.fn(() => ({
-    clear: vi.fn(),
-    getBatch: vi.fn(() => []),
-    getBlocksByRId: vi.fn(() => new Map()),
-    setTrackedChangesRenderConfig: vi.fn(),
-  })),
+  HeaderFooterEditorManager: vi.fn(function () {
+    return {
+      createEditor: vi.fn(),
+      destroyEditor: vi.fn(),
+      getEditor: vi.fn(),
+      on: vi.fn(),
+      off: vi.fn(),
+      destroy: vi.fn(),
+    };
+  }),
+  HeaderFooterLayoutAdapter: vi.fn(function () {
+    return {
+      clear: vi.fn(),
+      getBatch: vi.fn(() => []),
+      getBlocksByRId: vi.fn(() => new Map()),
+      setTrackedChangesRenderConfig: vi.fn(),
+    };
+  }),
 }));
 
 vi.mock('../../header-footer/EditorOverlayManager', () => ({
-  EditorOverlayManager: vi.fn(() => ({
-    showEditingOverlay: vi.fn(() => ({ success: true, editorHost: document.createElement('div') })),
-    hideEditingOverlay: vi.fn(),
-    showSelectionOverlay: vi.fn(),
-    hideSelectionOverlay: vi.fn(),
-    setOnDimmingClick: vi.fn(),
-    getActiveEditorHost: vi.fn(() => null),
-    destroy: vi.fn(),
-  })),
+  EditorOverlayManager: vi.fn(function () {
+    return {
+      showEditingOverlay: vi.fn(() => ({ success: true, editorHost: document.createElement('div') })),
+      hideEditingOverlay: vi.fn(),
+      showSelectionOverlay: vi.fn(),
+      hideSelectionOverlay: vi.fn(),
+      setOnDimmingClick: vi.fn(),
+      getActiveEditorHost: vi.fn(() => null),
+      destroy: vi.fn(),
+    };
+  }),
 }));
 
 vi.mock('y-prosemirror', () => ({

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.getCurrentPageIndex.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.getCurrentPageIndex.test.ts
@@ -70,7 +70,7 @@ const {
     })),
     mockMeasureBlock: vi.fn(() => ({ width: 100, height: 100 })),
     mockEditorConverterStore: converterStore,
-    mockCreateHeaderFooterEditor: vi.fn(() => {
+    mockCreateHeaderFooterEditor: vi.fn(function () {
       const createEmitter = () => {
         const listeners = new Map<string, Set<(payload?: unknown) => void>>();
         const on = (event: string, handler: (payload?: unknown) => void) => {
@@ -122,78 +122,82 @@ const {
     }),
     mockOnHeaderFooterDataUpdate: vi.fn(),
     mockUpdateYdocDocxData: vi.fn(() => Promise.resolve()),
-    mockEditorOverlayManager: vi.fn().mockImplementation(() => ({
-      showEditingOverlay: vi.fn(() => ({
-        success: true,
-        editorHost: document.createElement('div'),
-        reason: null,
-      })),
-      hideEditingOverlay: vi.fn(),
-      showSelectionOverlay: vi.fn(),
-      hideSelectionOverlay: vi.fn(),
-      setOnDimmingClick: vi.fn(),
-      getActiveEditorHost: vi.fn(() => null),
-      destroy: vi.fn(),
-    })),
+    mockEditorOverlayManager: vi.fn().mockImplementation(function () {
+      return {
+        showEditingOverlay: vi.fn(() => ({
+          success: true,
+          editorHost: document.createElement('div'),
+          reason: null,
+        })),
+        hideEditingOverlay: vi.fn(),
+        showSelectionOverlay: vi.fn(),
+        hideSelectionOverlay: vi.fn(),
+        setOnDimmingClick: vi.fn(),
+        getActiveEditorHost: vi.fn(() => null),
+        destroy: vi.fn(),
+      };
+    }),
   };
 });
 
 // Mock Editor class
 vi.mock('../../Editor', () => {
   return {
-    Editor: vi.fn().mockImplementation(() => ({
-      setDocumentMode: vi.fn(),
-      setOptions: vi.fn(),
-      on: vi.fn(),
-      off: vi.fn(),
-      destroy: vi.fn(),
-      getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
-      isEditable: true,
-      state: {
-        selection: { from: 0, to: 0 },
-        doc: {
-          nodeSize: 100,
-          content: {
-            size: 100,
+    Editor: vi.fn().mockImplementation(function () {
+      return {
+        setDocumentMode: vi.fn(),
+        setOptions: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        destroy: vi.fn(),
+        getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
+        isEditable: true,
+        state: {
+          selection: { from: 0, to: 0 },
+          doc: {
+            nodeSize: 100,
+            content: {
+              size: 100,
+            },
+            descendants: vi.fn(),
+            nodesBetween: vi.fn((_from: number, _to: number, callback: (node: unknown, pos: number) => void) => {
+              callback({ isTextblock: true }, 0);
+            }),
+            resolve: vi.fn((pos: number) => ({
+              pos,
+              depth: 0,
+              parent: { inlineContent: true },
+              node: vi.fn(),
+              min: vi.fn((other: { pos: number }) => Math.min(pos, other.pos)),
+              max: vi.fn((other: { pos: number }) => Math.max(pos, other.pos)),
+            })),
           },
-          descendants: vi.fn(),
-          nodesBetween: vi.fn((_from: number, _to: number, callback: (node: unknown, pos: number) => void) => {
-            callback({ isTextblock: true }, 0);
+          tr: {
+            setSelection: vi.fn().mockReturnThis(),
+          },
+        },
+        view: {
+          // Real element so listener-based wiring (e.g. SD-2368 composition
+          // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+          dom: Object.assign(document.createElement('div'), {
+            dispatchEvent: vi.fn(() => true),
+            focus: vi.fn(),
           }),
-          resolve: vi.fn((pos: number) => ({
-            pos,
-            depth: 0,
-            parent: { inlineContent: true },
-            node: vi.fn(),
-            min: vi.fn((other: { pos: number }) => Math.min(pos, other.pos)),
-            max: vi.fn((other: { pos: number }) => Math.max(pos, other.pos)),
-          })),
-        },
-        tr: {
-          setSelection: vi.fn().mockReturnThis(),
-        },
-      },
-      view: {
-        // Real element so listener-based wiring (e.g. SD-2368 composition
-        // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
-        dom: Object.assign(document.createElement('div'), {
-          dispatchEvent: vi.fn(() => true),
           focus: vi.fn(),
-        }),
-        focus: vi.fn(),
-        dispatch: vi.fn(),
-      },
-      options: {
-        documentId: 'test-doc',
-        element: document.createElement('div'),
-      },
-      converter: mockEditorConverterStore.current,
-      storage: {
-        image: {
-          media: mockEditorConverterStore.mediaFiles,
+          dispatch: vi.fn(),
         },
-      },
-    })),
+        options: {
+          documentId: 'test-doc',
+          element: document.createElement('div'),
+        },
+        converter: mockEditorConverterStore.current,
+        storage: {
+          image: {
+            media: mockEditorConverterStore.mediaFiles,
+          },
+        },
+      };
+    }),
   };
 });
 
@@ -231,14 +235,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
     },
   })),
   computeDisplayPageNumber: vi.fn((pages) => pages.map((p) => ({ displayText: String(p.number ?? 1) }))),
-  PageGeometryHelper: vi.fn().mockImplementation(({ layout, pageGap }) => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => pageGap ?? 0),
-    getLayout: vi.fn(() => layout),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function ({ layout, pageGap }) {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => pageGap ?? 0),
+      getLayout: vi.fn(() => layout),
+    };
+  }),
 }));
 
 // Mock painter-dom

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.getElementAtPos.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.getElementAtPos.test.ts
@@ -54,19 +54,21 @@ const {
       setShowFormattingMarks: vi.fn(),
     })),
     mockEditorConverterStore: converterStore,
-    mockEditorOverlayManager: vi.fn().mockImplementation(() => ({
-      showEditingOverlay: vi.fn(() => ({
-        success: true,
-        editorHost: document.createElement('div'),
-        reason: null,
-      })),
-      hideEditingOverlay: vi.fn(),
-      showSelectionOverlay: vi.fn(),
-      hideSelectionOverlay: vi.fn(),
-      setOnDimmingClick: vi.fn(),
-      getActiveEditorHost: vi.fn(() => null),
-      destroy: vi.fn(),
-    })),
+    mockEditorOverlayManager: vi.fn().mockImplementation(function () {
+      return {
+        showEditingOverlay: vi.fn(() => ({
+          success: true,
+          editorHost: document.createElement('div'),
+          reason: null,
+        })),
+        hideEditingOverlay: vi.fn(),
+        showSelectionOverlay: vi.fn(),
+        hideSelectionOverlay: vi.fn(),
+        setOnDimmingClick: vi.fn(),
+        getActiveEditorHost: vi.fn(() => null),
+        destroy: vi.fn(),
+      };
+    }),
   };
 });
 
@@ -77,7 +79,7 @@ vi.mock('../input/PositionHitResolver.js', () => ({
 
 vi.mock('../../Editor.js', () => {
   return {
-    Editor: vi.fn().mockImplementation(() => {
+    Editor: vi.fn().mockImplementation(function () {
       const domElement = document.createElement('div');
 
       return {
@@ -154,14 +156,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
   computeDisplayPageNumber: vi.fn((pages: Array<{ number?: number }>) =>
     pages.map((p) => ({ displayText: String(p.number ?? 1) })),
   ),
-  PageGeometryHelper: vi.fn().mockImplementation(() => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => 0),
-    getLayout: vi.fn(() => ({ pages: [] })),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function () {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => 0),
+      getLayout: vi.fn(() => ({ pages: [] })),
+    };
+  }),
 }));
 
 vi.mock('@superdoc/painter-dom', () => ({

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.goToAnchor.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.goToAnchor.test.ts
@@ -70,7 +70,7 @@ const {
     })),
     mockMeasureBlock: vi.fn(() => ({ width: 100, height: 100 })),
     mockEditorConverterStore: converterStore,
-    mockCreateHeaderFooterEditor: vi.fn(() => {
+    mockCreateHeaderFooterEditor: vi.fn(function () {
       const createEmitter = () => {
         const listeners = new Map<string, Set<(payload?: unknown) => void>>();
         const on = (event: string, handler: (payload?: unknown) => void) => {
@@ -122,70 +122,74 @@ const {
     }),
     mockOnHeaderFooterDataUpdate: vi.fn(),
     mockUpdateYdocDocxData: vi.fn(() => Promise.resolve()),
-    mockEditorOverlayManager: vi.fn().mockImplementation(() => ({
-      showEditingOverlay: vi.fn(() => ({
-        success: true,
-        editorHost: document.createElement('div'),
-        reason: null,
-      })),
-      hideEditingOverlay: vi.fn(),
-      showSelectionOverlay: vi.fn(),
-      hideSelectionOverlay: vi.fn(),
-      setOnDimmingClick: vi.fn(),
-      getActiveEditorHost: vi.fn(() => null),
-      destroy: vi.fn(),
-    })),
+    mockEditorOverlayManager: vi.fn().mockImplementation(function () {
+      return {
+        showEditingOverlay: vi.fn(() => ({
+          success: true,
+          editorHost: document.createElement('div'),
+          reason: null,
+        })),
+        hideEditingOverlay: vi.fn(),
+        showSelectionOverlay: vi.fn(),
+        hideSelectionOverlay: vi.fn(),
+        setOnDimmingClick: vi.fn(),
+        getActiveEditorHost: vi.fn(() => null),
+        destroy: vi.fn(),
+      };
+    }),
   };
 });
 
 // Mock Editor class
 vi.mock('../../Editor', () => {
   return {
-    Editor: vi.fn().mockImplementation(() => ({
-      setDocumentMode: vi.fn(),
-      setOptions: vi.fn(),
-      on: vi.fn(),
-      off: vi.fn(),
-      destroy: vi.fn(),
-      getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
-      isEditable: true,
-      state: {
-        selection: { from: 0, to: 0 },
-        doc: {
-          nodeSize: 100,
-          content: {
-            size: 100,
+    Editor: vi.fn().mockImplementation(function () {
+      return {
+        setDocumentMode: vi.fn(),
+        setOptions: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        destroy: vi.fn(),
+        getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
+        isEditable: true,
+        state: {
+          selection: { from: 0, to: 0 },
+          doc: {
+            nodeSize: 100,
+            content: {
+              size: 100,
+            },
+            // Mock ProseMirror document methods
+            descendants: vi.fn(),
+            resolve: vi.fn(() => ({
+              node: vi.fn(),
+              parent: null,
+              depth: 0,
+            })),
           },
-          // Mock ProseMirror document methods
-          descendants: vi.fn(),
-          resolve: vi.fn(() => ({
-            node: vi.fn(),
-            parent: null,
-            depth: 0,
-          })),
         },
-      },
-      view: {
-        // Real element so listener-based wiring (e.g. SD-2368 composition
-        // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
-        dom: Object.assign(document.createElement('div'), {
-          dispatchEvent: vi.fn(() => true),
+        view: {
+          // Real element so listener-based wiring (e.g. SD-2368 composition
+          // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+          dom: Object.assign(document.createElement('div'), {
+            dispatchEvent: vi.fn(() => true),
+            focus: vi.fn(),
+          }),
           focus: vi.fn(),
-        }),
-        focus: vi.fn(),
-        dispatch: vi.fn(),
-      },
-      options: {
-        documentId: 'test-doc',
-        element: document.createElement('div'),
-      },
-      converter: mockEditorConverterStore.current,
-      storage: {
-        image: {
-          media: mockEditorConverterStore.mediaFiles,
+          dispatch: vi.fn(),
         },
-      },
-    })),
+        options: {
+          documentId: 'test-doc',
+          element: document.createElement('div'),
+        },
+        converter: mockEditorConverterStore.current,
+        storage: {
+          image: {
+            media: mockEditorConverterStore.mediaFiles,
+          },
+        },
+      };
+    }),
   };
 });
 
@@ -219,14 +223,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
     },
   })),
   computeDisplayPageNumber: vi.fn((pages) => pages.map((p) => ({ displayText: String(p.number ?? 1) }))),
-  PageGeometryHelper: vi.fn().mockImplementation(({ layout, pageGap }) => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => pageGap ?? 0),
-    getLayout: vi.fn(() => layout),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function ({ layout, pageGap }) {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => pageGap ?? 0),
+      getLayout: vi.fn(() => layout),
+    };
+  }),
 }));
 
 // Mock painter-dom

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.media.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.media.test.ts
@@ -15,25 +15,27 @@ const { mockStorage } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../Editor', () => ({
-  Editor: vi.fn().mockImplementation(() => ({
-    on: vi.fn(),
-    off: vi.fn(),
-    destroy: vi.fn(),
-    setDocumentMode: vi.fn(),
-    setOptions: vi.fn(),
-    getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
-    isEditable: true,
-    state: { selection: { from: 0, to: 0 }, doc: { nodeSize: 100, content: { size: 100 }, descendants: vi.fn() } },
-    view: { dom: document.createElement('div'), hasFocus: vi.fn(() => false) },
-    options: { documentId: 'test', element: document.createElement('div'), mediaFiles: {} },
-    converter: {
-      headers: {},
-      footers: {},
-      headerIds: { default: null, ids: [] },
-      footerIds: { default: null, ids: [] },
-    },
-    storage: { image: mockStorage },
-  })),
+  Editor: vi.fn().mockImplementation(function () {
+    return {
+      on: vi.fn(),
+      off: vi.fn(),
+      destroy: vi.fn(),
+      setDocumentMode: vi.fn(),
+      setOptions: vi.fn(),
+      getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
+      isEditable: true,
+      state: { selection: { from: 0, to: 0 }, doc: { nodeSize: 100, content: { size: 100 }, descendants: vi.fn() } },
+      view: { dom: document.createElement('div'), hasFocus: vi.fn(() => false) },
+      options: { documentId: 'test', element: document.createElement('div'), mediaFiles: {} },
+      converter: {
+        headers: {},
+        footers: {},
+        headerIds: { default: null, ids: [] },
+        footerIds: { default: null, ids: [] },
+      },
+      storage: { image: mockStorage },
+    };
+  }),
 }));
 
 vi.mock('@core/layout-adapter', async (importOriginal) => {
@@ -64,14 +66,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
   findWordBoundaries: vi.fn(),
   findParagraphBoundaries: vi.fn(),
   createDragHandler: vi.fn(),
-  PageGeometryHelper: vi.fn(() => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => 0),
-    getLayout: vi.fn(() => ({ pages: [] })),
-  })),
+  PageGeometryHelper: vi.fn(function () {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => 0),
+      getLayout: vi.fn(() => ({ pages: [] })),
+    };
+  }),
 }));
 
 vi.mock('@superdoc/painter-dom', () => ({
@@ -93,32 +97,38 @@ vi.mock('@superdoc/painter-dom', () => ({
 vi.mock('@superdoc/measuring-dom', () => ({ measureBlock: vi.fn(() => ({ width: 100, height: 100 })) }));
 
 vi.mock('../../header-footer/HeaderFooterRegistry', () => ({
-  HeaderFooterEditorManager: vi.fn(() => ({
-    createEditor: vi.fn(),
-    destroyEditor: vi.fn(),
-    getEditor: vi.fn(),
-    on: vi.fn(),
-    off: vi.fn(),
-    destroy: vi.fn(),
-  })),
-  HeaderFooterLayoutAdapter: vi.fn(() => ({
-    clear: vi.fn(),
-    getBatch: vi.fn(() => []),
-    getBlocksByRId: vi.fn(() => new Map()),
-    setTrackedChangesRenderConfig: vi.fn(),
-  })),
+  HeaderFooterEditorManager: vi.fn(function () {
+    return {
+      createEditor: vi.fn(),
+      destroyEditor: vi.fn(),
+      getEditor: vi.fn(),
+      on: vi.fn(),
+      off: vi.fn(),
+      destroy: vi.fn(),
+    };
+  }),
+  HeaderFooterLayoutAdapter: vi.fn(function () {
+    return {
+      clear: vi.fn(),
+      getBatch: vi.fn(() => []),
+      getBlocksByRId: vi.fn(() => new Map()),
+      setTrackedChangesRenderConfig: vi.fn(),
+    };
+  }),
 }));
 
 vi.mock('../../header-footer/EditorOverlayManager', () => ({
-  EditorOverlayManager: vi.fn(() => ({
-    showEditingOverlay: vi.fn(() => ({ success: true, editorHost: document.createElement('div') })),
-    hideEditingOverlay: vi.fn(),
-    showSelectionOverlay: vi.fn(),
-    hideSelectionOverlay: vi.fn(),
-    setOnDimmingClick: vi.fn(),
-    getActiveEditorHost: vi.fn(() => null),
-    destroy: vi.fn(),
-  })),
+  EditorOverlayManager: vi.fn(function () {
+    return {
+      showEditingOverlay: vi.fn(() => ({ success: true, editorHost: document.createElement('div') })),
+      hideEditingOverlay: vi.fn(),
+      showSelectionOverlay: vi.fn(),
+      hideSelectionOverlay: vi.fn(),
+      setOnDimmingClick: vi.fn(),
+      getActiveEditorHost: vi.fn(() => null),
+      destroy: vi.fn(),
+    };
+  }),
 }));
 
 vi.mock('y-prosemirror', () => ({

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.scrollToPosition.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.scrollToPosition.test.ts
@@ -89,7 +89,7 @@ const {
     })),
     mockMeasureBlock: vi.fn(() => ({ width: 100, height: 100 })),
     mockEditorConverterStore: converterStore,
-    mockCreateHeaderFooterEditor: vi.fn(() => {
+    mockCreateHeaderFooterEditor: vi.fn(function () {
       const createEmitter = () => {
         const listeners = new Map<string, Set<(payload?: unknown) => void>>();
         const on = (event: string, handler: (payload?: unknown) => void) => {
@@ -141,69 +141,73 @@ const {
     }),
     mockOnHeaderFooterDataUpdate: vi.fn(),
     mockUpdateYdocDocxData: vi.fn(() => Promise.resolve()),
-    mockEditorOverlayManager: vi.fn().mockImplementation(() => ({
-      showEditingOverlay: vi.fn(() => ({
-        success: true,
-        editorHost: document.createElement('div'),
-        reason: null,
-      })),
-      hideEditingOverlay: vi.fn(),
-      showSelectionOverlay: vi.fn(),
-      hideSelectionOverlay: vi.fn(),
-      setOnDimmingClick: vi.fn(),
-      getActiveEditorHost: vi.fn(() => null),
-      destroy: vi.fn(),
-    })),
+    mockEditorOverlayManager: vi.fn().mockImplementation(function () {
+      return {
+        showEditingOverlay: vi.fn(() => ({
+          success: true,
+          editorHost: document.createElement('div'),
+          reason: null,
+        })),
+        hideEditingOverlay: vi.fn(),
+        showSelectionOverlay: vi.fn(),
+        hideSelectionOverlay: vi.fn(),
+        setOnDimmingClick: vi.fn(),
+        getActiveEditorHost: vi.fn(() => null),
+        destroy: vi.fn(),
+      };
+    }),
   };
 });
 
 // Mock Editor class
 vi.mock('../../Editor', () => {
   return {
-    Editor: vi.fn().mockImplementation(() => ({
-      setDocumentMode: vi.fn(),
-      setOptions: vi.fn(),
-      on: vi.fn(),
-      off: vi.fn(),
-      destroy: vi.fn(),
-      getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
-      isEditable: true,
-      state: {
-        selection: { from: 0, to: 0 },
-        doc: {
-          nodeSize: 200,
-          content: {
-            size: 200,
+    Editor: vi.fn().mockImplementation(function () {
+      return {
+        setDocumentMode: vi.fn(),
+        setOptions: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        destroy: vi.fn(),
+        getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
+        isEditable: true,
+        state: {
+          selection: { from: 0, to: 0 },
+          doc: {
+            nodeSize: 200,
+            content: {
+              size: 200,
+            },
+            descendants: vi.fn(),
+            resolve: vi.fn(() => ({
+              node: vi.fn(),
+              parent: null,
+              depth: 0,
+            })),
           },
-          descendants: vi.fn(),
-          resolve: vi.fn(() => ({
-            node: vi.fn(),
-            parent: null,
-            depth: 0,
-          })),
         },
-      },
-      view: {
-        // Real element so listener-based wiring (e.g. SD-2368 composition
-        // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
-        dom: Object.assign(document.createElement('div'), {
-          dispatchEvent: vi.fn(() => true),
+        view: {
+          // Real element so listener-based wiring (e.g. SD-2368 composition
+          // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+          dom: Object.assign(document.createElement('div'), {
+            dispatchEvent: vi.fn(() => true),
+            focus: vi.fn(),
+          }),
           focus: vi.fn(),
-        }),
-        focus: vi.fn(),
-        dispatch: vi.fn(),
-      },
-      options: {
-        documentId: 'test-doc',
-        element: document.createElement('div'),
-      },
-      converter: mockEditorConverterStore.current,
-      storage: {
-        image: {
-          media: mockEditorConverterStore.mediaFiles,
+          dispatch: vi.fn(),
         },
-      },
-    })),
+        options: {
+          documentId: 'test-doc',
+          element: document.createElement('div'),
+        },
+        converter: mockEditorConverterStore.current,
+        storage: {
+          image: {
+            media: mockEditorConverterStore.mediaFiles,
+          },
+        },
+      };
+    }),
   };
 });
 
@@ -237,14 +241,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
     },
   })),
   computeDisplayPageNumber: vi.fn((pages) => pages.map((p) => ({ displayText: String(p.number ?? 1) }))),
-  PageGeometryHelper: vi.fn().mockImplementation(({ layout, pageGap }) => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => pageGap ?? 0),
-    getLayout: vi.fn(() => layout),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function ({ layout, pageGap }) {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => pageGap ?? 0),
+      getLayout: vi.fn(() => layout),
+    };
+  }),
 }));
 
 // Mock painter-dom

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.sectionPageStyles.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.sectionPageStyles.test.ts
@@ -70,7 +70,7 @@ const {
     })),
     mockMeasureBlock: vi.fn(() => ({ width: 100, height: 100 })),
     mockEditorConverterStore: converterStore,
-    mockCreateHeaderFooterEditor: vi.fn(() => {
+    mockCreateHeaderFooterEditor: vi.fn(function () {
       const createEmitter = () => {
         const listeners = new Map<string, Set<(payload?: unknown) => void>>();
         const on = (event: string, handler: (payload?: unknown) => void) => {
@@ -122,78 +122,82 @@ const {
     }),
     mockOnHeaderFooterDataUpdate: vi.fn(),
     mockUpdateYdocDocxData: vi.fn(() => Promise.resolve()),
-    mockEditorOverlayManager: vi.fn().mockImplementation(() => ({
-      showEditingOverlay: vi.fn(() => ({
-        success: true,
-        editorHost: document.createElement('div'),
-        reason: null,
-      })),
-      hideEditingOverlay: vi.fn(),
-      showSelectionOverlay: vi.fn(),
-      hideSelectionOverlay: vi.fn(),
-      setOnDimmingClick: vi.fn(),
-      getActiveEditorHost: vi.fn(() => null),
-      destroy: vi.fn(),
-    })),
+    mockEditorOverlayManager: vi.fn().mockImplementation(function () {
+      return {
+        showEditingOverlay: vi.fn(() => ({
+          success: true,
+          editorHost: document.createElement('div'),
+          reason: null,
+        })),
+        hideEditingOverlay: vi.fn(),
+        showSelectionOverlay: vi.fn(),
+        hideSelectionOverlay: vi.fn(),
+        setOnDimmingClick: vi.fn(),
+        getActiveEditorHost: vi.fn(() => null),
+        destroy: vi.fn(),
+      };
+    }),
   };
 });
 
 // Mock Editor class
 vi.mock('../../Editor', () => {
   return {
-    Editor: vi.fn().mockImplementation(() => ({
-      setDocumentMode: vi.fn(),
-      setOptions: vi.fn(),
-      on: vi.fn(),
-      off: vi.fn(),
-      destroy: vi.fn(),
-      getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
-      isEditable: true,
-      state: {
-        selection: { from: 0, to: 0 },
-        doc: {
-          nodeSize: 100,
-          content: {
-            size: 100,
+    Editor: vi.fn().mockImplementation(function () {
+      return {
+        setDocumentMode: vi.fn(),
+        setOptions: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        destroy: vi.fn(),
+        getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
+        isEditable: true,
+        state: {
+          selection: { from: 0, to: 0 },
+          doc: {
+            nodeSize: 100,
+            content: {
+              size: 100,
+            },
+            descendants: vi.fn(),
+            nodesBetween: vi.fn((_from: number, _to: number, callback: (node: unknown, pos: number) => void) => {
+              callback({ isTextblock: true }, 0);
+            }),
+            resolve: vi.fn((pos: number) => ({
+              pos,
+              depth: 0,
+              parent: { inlineContent: true },
+              node: vi.fn(),
+              min: vi.fn((other: { pos: number }) => Math.min(pos, other.pos)),
+              max: vi.fn((other: { pos: number }) => Math.max(pos, other.pos)),
+            })),
           },
-          descendants: vi.fn(),
-          nodesBetween: vi.fn((_from: number, _to: number, callback: (node: unknown, pos: number) => void) => {
-            callback({ isTextblock: true }, 0);
+          tr: {
+            setSelection: vi.fn().mockReturnThis(),
+          },
+        },
+        view: {
+          // Real element so listener-based wiring (e.g. SD-2368 composition
+          // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+          dom: Object.assign(document.createElement('div'), {
+            dispatchEvent: vi.fn(() => true),
+            focus: vi.fn(),
           }),
-          resolve: vi.fn((pos: number) => ({
-            pos,
-            depth: 0,
-            parent: { inlineContent: true },
-            node: vi.fn(),
-            min: vi.fn((other: { pos: number }) => Math.min(pos, other.pos)),
-            max: vi.fn((other: { pos: number }) => Math.max(pos, other.pos)),
-          })),
-        },
-        tr: {
-          setSelection: vi.fn().mockReturnThis(),
-        },
-      },
-      view: {
-        // Real element so listener-based wiring (e.g. SD-2368 composition
-        // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
-        dom: Object.assign(document.createElement('div'), {
-          dispatchEvent: vi.fn(() => true),
           focus: vi.fn(),
-        }),
-        focus: vi.fn(),
-        dispatch: vi.fn(),
-      },
-      options: {
-        documentId: 'test-doc',
-        element: document.createElement('div'),
-      },
-      converter: mockEditorConverterStore.current,
-      storage: {
-        image: {
-          media: mockEditorConverterStore.mediaFiles,
+          dispatch: vi.fn(),
         },
-      },
-    })),
+        options: {
+          documentId: 'test-doc',
+          element: document.createElement('div'),
+        },
+        converter: mockEditorConverterStore.current,
+        storage: {
+          image: {
+            media: mockEditorConverterStore.mediaFiles,
+          },
+        },
+      };
+    }),
   };
 });
 
@@ -230,14 +234,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
     },
   })),
   computeDisplayPageNumber: vi.fn((pages) => pages.map((p) => ({ displayText: String(p.number ?? 1) }))),
-  PageGeometryHelper: vi.fn().mockImplementation(({ layout, pageGap }) => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => pageGap ?? 0),
-    getLayout: vi.fn(() => layout),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function ({ layout, pageGap }) {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => pageGap ?? 0),
+      getLayout: vi.fn(() => layout),
+    };
+  }),
 }));
 
 // Mock painter-dom

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.test.ts
@@ -165,7 +165,7 @@ const {
     })),
     mockMeasureBlock: vi.fn(() => ({ width: 100, height: 100 })),
     mockEditorConverterStore: converterStore,
-    mockCreateHeaderFooterEditor: vi.fn(() => {
+    mockCreateHeaderFooterEditor: vi.fn(function () {
       const editor = createSectionEditor();
       editors.push({ editor });
       return editor;
@@ -180,19 +180,21 @@ const {
     createdStoryEditors: storyEditors,
     mockOnHeaderFooterDataUpdate: vi.fn(),
     mockUpdateYdocDocxData: vi.fn(() => Promise.resolve()),
-    mockEditorOverlayManager: vi.fn().mockImplementation(() => ({
-      showEditingOverlay: vi.fn(() => ({
-        success: true,
-        editorHost: document.createElement('div'),
-        reason: null,
-      })),
-      hideEditingOverlay: vi.fn(),
-      showSelectionOverlay: vi.fn(),
-      hideSelectionOverlay: vi.fn(),
-      setOnDimmingClick: vi.fn(),
-      getActiveEditorHost: vi.fn(() => null),
-      destroy: vi.fn(),
-    })),
+    mockEditorOverlayManager: vi.fn().mockImplementation(function () {
+      return {
+        showEditingOverlay: vi.fn(() => ({
+          success: true,
+          editorHost: document.createElement('div'),
+          reason: null,
+        })),
+        hideEditingOverlay: vi.fn(),
+        showSelectionOverlay: vi.fn(),
+        hideSelectionOverlay: vi.fn(),
+        setOnDimmingClick: vi.fn(),
+        getActiveEditorHost: vi.fn(() => null),
+        destroy: vi.fn(),
+      };
+    }),
     // SD-2836: rebuildRegions now iterates resolvedLayout.pages, so the mock
     // must synthesize a ResolvedPage per source Layout page to keep header/footer
     // region tests from going empty.
@@ -245,7 +247,7 @@ vi.mock('../input/PositionHitResolver.js', () => ({
 // Mock Editor class
 vi.mock('../../Editor', () => {
   return {
-    Editor: vi.fn().mockImplementation((options: { content?: unknown } = {}) => {
+    Editor: vi.fn().mockImplementation(function (options: { content?: unknown } = {}) {
       const contentAttrs =
         options.content && typeof options.content === 'object' && !Array.isArray(options.content)
           ? (((options.content as { attrs?: Record<string, unknown> }).attrs ?? {}) as Record<string, unknown>)
@@ -370,14 +372,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
     },
   })),
   computeDisplayPageNumber: vi.fn((pages) => pages.map((p) => ({ displayText: String(p.number ?? 1) }))),
-  PageGeometryHelper: vi.fn().mockImplementation(({ layout, pageGap }) => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => pageGap ?? 0),
-    getLayout: vi.fn(() => layout),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function ({ layout, pageGap }) {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => pageGap ?? 0),
+      getLayout: vi.fn(() => layout),
+    };
+  }),
 }));
 
 // Mock painter-dom

--- a/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.zoom.test.ts
+++ b/packages/super-editor/src/editors/v1/core/presentation-editor/tests/PresentationEditor.zoom.test.ts
@@ -127,7 +127,7 @@ const {
     })),
     mockMeasureBlock: vi.fn(() => ({ width: 100, height: 100 })),
     mockEditorConverterStore: converterStore,
-    mockCreateHeaderFooterEditor: vi.fn(() => {
+    mockCreateHeaderFooterEditor: vi.fn(function () {
       const editor = createSectionEditor();
       editors.push({ editor });
       return editor;
@@ -135,19 +135,21 @@ const {
     createdSectionEditors: editors,
     mockOnHeaderFooterDataUpdate: vi.fn(),
     mockUpdateYdocDocxData: vi.fn(() => Promise.resolve()),
-    mockEditorOverlayManager: vi.fn().mockImplementation(() => ({
-      showEditingOverlay: vi.fn(() => ({
-        success: true,
-        editorHost: document.createElement('div'),
-        reason: null,
-      })),
-      hideEditingOverlay: vi.fn(),
-      showSelectionOverlay: vi.fn(),
-      hideSelectionOverlay: vi.fn(),
-      setOnDimmingClick: vi.fn(),
-      getActiveEditorHost: vi.fn(() => null),
-      destroy: vi.fn(),
-    })),
+    mockEditorOverlayManager: vi.fn().mockImplementation(function () {
+      return {
+        showEditingOverlay: vi.fn(() => ({
+          success: true,
+          editorHost: document.createElement('div'),
+          reason: null,
+        })),
+        hideEditingOverlay: vi.fn(),
+        showSelectionOverlay: vi.fn(),
+        hideSelectionOverlay: vi.fn(),
+        setOnDimmingClick: vi.fn(),
+        getActiveEditorHost: vi.fn(() => null),
+        destroy: vi.fn(),
+      };
+    }),
   };
 });
 
@@ -159,59 +161,61 @@ vi.mock('../input/PositionHitResolver.js', () => ({
 // Mock Editor class
 vi.mock('../../Editor', () => {
   return {
-    Editor: vi.fn().mockImplementation(() => ({
-      setDocumentMode: vi.fn(),
-      setOptions: vi.fn(),
-      on: vi.fn(),
-      off: vi.fn(),
-      destroy: vi.fn(),
-      getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
-      isEditable: true,
-      state: {
-        selection: { from: 0, to: 0 },
-        doc: {
-          nodeSize: 100,
-          content: {
-            size: 100,
+    Editor: vi.fn().mockImplementation(function () {
+      return {
+        setDocumentMode: vi.fn(),
+        setOptions: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        destroy: vi.fn(),
+        getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
+        isEditable: true,
+        state: {
+          selection: { from: 0, to: 0 },
+          doc: {
+            nodeSize: 100,
+            content: {
+              size: 100,
+            },
+            descendants: vi.fn(),
+            nodesBetween: vi.fn((_from: number, _to: number, callback: (node: unknown, pos: number) => void) => {
+              callback({ isTextblock: true }, 0);
+            }),
+            resolve: vi.fn((pos: number) => ({
+              pos,
+              depth: 0,
+              parent: { inlineContent: true },
+              node: vi.fn(),
+              min: vi.fn((other: { pos: number }) => Math.min(pos, other.pos)),
+              max: vi.fn((other: { pos: number }) => Math.max(pos, other.pos)),
+            })),
           },
-          descendants: vi.fn(),
-          nodesBetween: vi.fn((_from: number, _to: number, callback: (node: unknown, pos: number) => void) => {
-            callback({ isTextblock: true }, 0);
+          tr: {
+            setSelection: vi.fn().mockReturnThis(),
+          },
+        },
+        view: {
+          // Real element so listener-based wiring (e.g. SD-2368 composition
+          // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+          dom: Object.assign(document.createElement('div'), {
+            dispatchEvent: vi.fn(() => true),
+            focus: vi.fn(),
           }),
-          resolve: vi.fn((pos: number) => ({
-            pos,
-            depth: 0,
-            parent: { inlineContent: true },
-            node: vi.fn(),
-            min: vi.fn((other: { pos: number }) => Math.min(pos, other.pos)),
-            max: vi.fn((other: { pos: number }) => Math.max(pos, other.pos)),
-          })),
-        },
-        tr: {
-          setSelection: vi.fn().mockReturnThis(),
-        },
-      },
-      view: {
-        // Real element so listener-based wiring (e.g. SD-2368 composition
-        // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
-        dom: Object.assign(document.createElement('div'), {
-          dispatchEvent: vi.fn(() => true),
           focus: vi.fn(),
-        }),
-        focus: vi.fn(),
-        dispatch: vi.fn(),
-      },
-      options: {
-        documentId: 'test-doc',
-        element: document.createElement('div'),
-      },
-      converter: mockEditorConverterStore.current,
-      storage: {
-        image: {
-          media: mockEditorConverterStore.mediaFiles,
+          dispatch: vi.fn(),
         },
-      },
-    })),
+        options: {
+          documentId: 'test-doc',
+          element: document.createElement('div'),
+        },
+        converter: mockEditorConverterStore.current,
+        storage: {
+          image: {
+            media: mockEditorConverterStore.mediaFiles,
+          },
+        },
+      };
+    }),
   };
 });
 
@@ -250,14 +254,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
     },
   })),
   computeDisplayPageNumber: vi.fn((pages) => pages.map((p) => ({ displayText: String(p.number ?? 1) }))),
-  PageGeometryHelper: vi.fn().mockImplementation(({ layout, pageGap }) => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => pageGap ?? 0),
-    getLayout: vi.fn(() => layout),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function ({ layout, pageGap }) {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => pageGap ?? 0),
+      getLayout: vi.fn(() => layout),
+    };
+  }),
 }));
 
 // Mock painter-dom

--- a/packages/super-editor/src/editors/v1/core/super-converter/image-dimensions.test.js
+++ b/packages/super-editor/src/editors/v1/core/super-converter/image-dimensions.test.js
@@ -227,7 +227,9 @@ describe('readImageDimensionsFromDataUri', () => {
   });
 
   it('rejects non-base64 raster data URIs without encoding payload text as bytes', () => {
-    const textEncoderConstructor = vi.fn(() => ({ encode: vi.fn(() => new Uint8Array()) }));
+    const textEncoderConstructor = vi.fn(function () {
+      return { encode: vi.fn(() => new Uint8Array()) };
+    });
     vi.stubGlobal('TextEncoder', textEncoderConstructor);
 
     expect(readImageDimensionsFromDataUri('data:image/png,not-base64')).toBeNull();

--- a/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/lists-formatting-wrappers.test.ts
+++ b/packages/super-editor/src/editors/v1/document-api-adapters/plan-engine/lists-formatting-wrappers.test.ts
@@ -224,11 +224,16 @@ function mockSetLevelTextChanged(editorRef: Editor): void {
 let editor: ReturnType<typeof makeEditor>;
 
 beforeEach(() => {
+  // AIDEV-NOTE: `restoreAllMocks` only restores `vi.spyOn` spies as of Vitest
+  // 4; it no longer resets implementations set on `vi.fn()` module mocks. Every
+  // default a test overrides must therefore be re-established here by hand.
   vi.restoreAllMocks();
   registerPartDescriptor(numberingPartDescriptor);
   editor = makeEditor();
   // Default: getPresetTemplate returns a valid template
   vi.mocked(LevelFormattingHelpers.getPresetTemplate).mockReturnValue(MOCK_TEMPLATE);
+  // Default: the abstract is owned by this sequence, so no clone-on-write
+  vi.mocked(LevelFormattingHelpers.isAbstractShared).mockReturnValue(false);
   // Default: no adjacent sequences
   vi.mocked(findAdjacentSequence).mockReturnValue(null);
   vi.mocked(getContiguousSequence).mockReturnValue([]);

--- a/packages/super-editor/src/editors/v1/extensions/image/imageHelpers/basicHelpers.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/image/imageHelpers/basicHelpers.test.js
@@ -54,7 +54,9 @@ describe('image helper utilities', () => {
     };
     vi.stubGlobal(
       'FileReader',
-      vi.fn(() => mockReader),
+      vi.fn(function () {
+        return mockReader;
+      }),
     );
 
     const file = new File(['data'], 'image.png', { type: 'image/png' });

--- a/packages/super-editor/src/editors/v1/extensions/image/imageHelpers/imageRegistrationPlugin.browser.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/image/imageHelpers/imageRegistrationPlugin.browser.test.js
@@ -23,7 +23,9 @@ const { mockDecoSet, mockPluginKeyInstance } = vi.hoisted(() => {
 // ── ProseMirror mocks ─────────────────────────────────────────────────
 vi.mock('prosemirror-state', () => ({
   Plugin: vi.fn(),
-  PluginKey: vi.fn(() => mockPluginKeyInstance),
+  PluginKey: vi.fn(function () {
+    return mockPluginKeyInstance;
+  }),
 }));
 
 vi.mock('prosemirror-view', () => ({

--- a/packages/super-editor/src/editors/v1/extensions/pagination/pagination-helpers.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/pagination/pagination-helpers.test.js
@@ -22,7 +22,9 @@ const { MockEditor, getStarterExtensions, applyStyleIsolationClass } = vi.hoiste
   }
 
   return {
-    MockEditor: vi.fn((options) => new MockEditor(options)),
+    MockEditor: vi.fn(function (options) {
+      return new MockEditor(options);
+    }),
     getStarterExtensions: vi.fn(() => []),
     applyStyleIsolationClass: vi.fn(),
   };

--- a/packages/super-editor/src/editors/v1/extensions/search/search.scrollBehavior.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/search/search.scrollBehavior.test.js
@@ -40,9 +40,11 @@ vi.mock('prosemirror-state', async (importOriginal) => {
 });
 
 vi.mock('@core/PositionTracker.js', () => ({
-  PositionTracker: vi.fn(() => ({
-    resolve: vi.fn(() => null),
-  })),
+  PositionTracker: vi.fn(function () {
+    return {
+      resolve: vi.fn(() => null),
+    };
+  }),
 }));
 
 // We import the extension so we can extract the command factory

--- a/packages/super-editor/src/editors/v1/extensions/search/search.session.test.js
+++ b/packages/super-editor/src/editors/v1/extensions/search/search.session.test.js
@@ -38,11 +38,13 @@ vi.mock('prosemirror-state', async (importOriginal) => {
 });
 
 vi.mock('@core/PositionTracker.js', () => ({
-  PositionTracker: vi.fn(() => ({
-    resolve: vi.fn(() => null),
-    trackMany: vi.fn((ranges) => ranges.map((_, i) => `tracker-${i}`)),
-    untrackByType: vi.fn(),
-  })),
+  PositionTracker: vi.fn(function () {
+    return {
+      resolve: vi.fn(() => null),
+      trackMany: vi.fn((ranges) => ranges.map((_, i) => `tracker-${i}`)),
+      untrackByType: vi.fn(),
+    };
+  }),
 }));
 
 const { Search } = await import('./search.js');

--- a/packages/super-editor/src/index.types.test.ts
+++ b/packages/super-editor/src/index.types.test.ts
@@ -559,7 +559,7 @@ const {
     })),
     mockMeasureBlock: vi.fn(() => ({ width: 100, height: 100 })),
     mockEditorConverterStore: converterStore,
-    mockCreateHeaderFooterEditor: vi.fn(() => {
+    mockCreateHeaderFooterEditor: vi.fn(function () {
       const listeners = new Map<string, Set<(payload?: unknown) => void>>();
       const on = (event: string, handler: (payload?: unknown) => void) => {
         if (!listeners.has(event)) listeners.set(event, new Set());
@@ -593,15 +593,17 @@ const {
       return editorStub;
     }),
     mockOnHeaderFooterDataUpdate: vi.fn(),
-    mockEditorOverlayManager: vi.fn().mockImplementation(() => ({
-      showEditingOverlay: vi.fn(() => ({ success: true, editorHost: document.createElement('div'), reason: null })),
-      hideEditingOverlay: vi.fn(),
-      showSelectionOverlay: vi.fn(),
-      hideSelectionOverlay: vi.fn(),
-      setOnDimmingClick: vi.fn(),
-      getActiveEditorHost: vi.fn(() => null),
-      destroy: vi.fn(),
-    })),
+    mockEditorOverlayManager: vi.fn().mockImplementation(function () {
+      return {
+        showEditingOverlay: vi.fn(() => ({ success: true, editorHost: document.createElement('div'), reason: null })),
+        hideEditingOverlay: vi.fn(),
+        showSelectionOverlay: vi.fn(),
+        hideSelectionOverlay: vi.fn(),
+        setOnDimmingClick: vi.fn(),
+        getActiveEditorHost: vi.fn(() => null),
+        destroy: vi.fn(),
+      };
+    }),
     // Return EXACTLY the PositionHit shape - no more, no less
     mockClickToPosition: vi.fn(() => ({
       pos: 5,
@@ -615,43 +617,45 @@ const {
 });
 
 vi.mock('./editors/v1/core/Editor', () => ({
-  Editor: vi.fn().mockImplementation(() => ({
-    setDocumentMode: vi.fn(),
-    setOptions: vi.fn(),
-    on: vi.fn(),
-    off: vi.fn(),
-    destroy: vi.fn(),
-    getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
-    isEditable: true,
-    state: {
-      selection: { from: 0, to: 0 },
-      doc: {
-        nodeSize: 100,
-        content: { size: 100 },
-        descendants: vi.fn(),
-        nodesBetween: vi.fn(),
-        resolve: vi.fn((pos: number) => ({
-          pos,
-          depth: 0,
-          parent: { inlineContent: true },
-          node: vi.fn(),
-          min: vi.fn((other: { pos: number }) => Math.min(pos, other.pos)),
-          max: vi.fn((other: { pos: number }) => Math.max(pos, other.pos)),
-        })),
+  Editor: vi.fn().mockImplementation(function () {
+    return {
+      setDocumentMode: vi.fn(),
+      setOptions: vi.fn(),
+      on: vi.fn(),
+      off: vi.fn(),
+      destroy: vi.fn(),
+      getJSON: vi.fn(() => ({ type: 'doc', content: [] })),
+      isEditable: true,
+      state: {
+        selection: { from: 0, to: 0 },
+        doc: {
+          nodeSize: 100,
+          content: { size: 100 },
+          descendants: vi.fn(),
+          nodesBetween: vi.fn(),
+          resolve: vi.fn((pos: number) => ({
+            pos,
+            depth: 0,
+            parent: { inlineContent: true },
+            node: vi.fn(),
+            min: vi.fn((other: { pos: number }) => Math.min(pos, other.pos)),
+            max: vi.fn((other: { pos: number }) => Math.max(pos, other.pos)),
+          })),
+        },
+        tr: { setSelection: vi.fn().mockReturnThis() },
       },
-      tr: { setSelection: vi.fn().mockReturnThis() },
-    },
-    view: {
-      // Real element so listener-based wiring (e.g. SD-2368 composition
-      // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
-      dom: Object.assign(document.createElement('div'), { dispatchEvent: vi.fn(() => true), focus: vi.fn() }),
-      focus: vi.fn(),
-      dispatch: vi.fn(),
-    },
-    options: { documentId: 'test-doc', element: document.createElement('div') },
-    converter: mockEditorConverterStore.current,
-    storage: { image: { media: mockEditorConverterStore.mediaFiles } },
-  })),
+      view: {
+        // Real element so listener-based wiring (e.g. SD-2368 composition
+        // deferral) can attach; dispatchEvent/focus stay non-dispatching stubs.
+        dom: Object.assign(document.createElement('div'), { dispatchEvent: vi.fn(() => true), focus: vi.fn() }),
+        focus: vi.fn(),
+        dispatch: vi.fn(),
+      },
+      options: { documentId: 'test-doc', element: document.createElement('div') },
+      converter: mockEditorConverterStore.current,
+      storage: { image: { media: mockEditorConverterStore.mediaFiles } },
+    };
+  }),
 }));
 
 vi.mock('@core/layout-adapter', async (importOriginal) => {
@@ -687,14 +691,16 @@ vi.mock('@superdoc/layout-bridge', () => ({
   computeDisplayPageNumber: vi.fn((pages) =>
     pages.map((p: { number?: number }) => ({ displayText: String(p.number ?? 1) })),
   ),
-  PageGeometryHelper: vi.fn().mockImplementation(({ layout, pageGap }) => ({
-    updateLayout: vi.fn(),
-    getPageIndexAtY: vi.fn(() => 0),
-    getNearestPageIndex: vi.fn(() => 0),
-    getPageTop: vi.fn(() => 0),
-    getPageGap: vi.fn(() => pageGap ?? 0),
-    getLayout: vi.fn(() => layout),
-  })),
+  PageGeometryHelper: vi.fn().mockImplementation(function ({ layout, pageGap }) {
+    return {
+      updateLayout: vi.fn(),
+      getPageIndexAtY: vi.fn(() => 0),
+      getNearestPageIndex: vi.fn(() => 0),
+      getPageTop: vi.fn(() => 0),
+      getPageGap: vi.fn(() => pageGap ?? 0),
+      getLayout: vi.fn(() => layout),
+    };
+  }),
 }));
 
 vi.mock('@superdoc/painter-dom', () => ({

--- a/packages/super-editor/tsconfig.build.json
+++ b/packages/super-editor/tsconfig.build.json
@@ -6,5 +6,18 @@
     "noImplicitAny": false,
     "strict": false
   },
-  "exclude": ["**/*.test.js", "**/*.test.ts", "**/*.spec.js", "**/*.spec.ts"]
+  // AIDEV-NOTE: Test support files must stay out of declaration emit. They
+  // import from vitest, so emitting them leaks `@vitest/spy` into inferred
+  // return types (TS2742) and leaves stale outputs behind (TS6305). Excluding
+  // `*.test.*` alone is not enough: helpers live beside the tests they serve.
+  // No production module imports anything under these directories.
+  "exclude": [
+    "**/*.test.js",
+    "**/*.test.ts",
+    "**/*.spec.js",
+    "**/*.spec.ts",
+    "**/tests/**",
+    "**/__tests__/**",
+    "**/__mocks__/**"
+  ]
 }

--- a/packages/super-editor/vite.config.js
+++ b/packages/super-editor/vite.config.js
@@ -46,6 +46,12 @@ export default defineConfig(({ mode }) => {
       // This avoids the cost of setting up happy-dom for pure logic tests.
       // Override to 'node' for directories that don't need DOM, with
       // explicit happy-dom exceptions for files that do (first match wins).
+      // AIDEV-NOTE: Vitest 4 removed `environmentMatchGlobs`, so every rule
+      // below is currently inert and these files run in the default
+      // environment. Two headless command tests assert node-only behavior and
+      // fail because of it. Replacing this with per-environment `projects` (or
+      // per-file `@vitest-environment` docblocks) is tracked as the remaining
+      // step of the Vitest 4 migration. Do not assume these globs take effect.
       environmentMatchGlobs: [
         // super-converter: all pure logic except tiff-converter (uses document.createElement)
         ['src/editors/v1/core/super-converter/**/tiff-converter.test.*', 'happy-dom'],
@@ -71,6 +77,11 @@ export default defineConfig(({ mode }) => {
         ['src/editors/v1/utils/**', 'node'],
       ],
       retry: 2,
+      // Vitest 4 no longer clears mock history between retry attempts,
+      // so any call-count assertion under `retry` accumulates calls
+      // across attempts. Clearing before each test keeps attempts
+      // independent.
+      clearMocks: true,
       testTimeout: 20000,
       hookTimeout: 10000,
       exclude: [

--- a/packages/super-editor/vite.config.js
+++ b/packages/super-editor/vite.config.js
@@ -42,40 +42,16 @@ export default defineConfig(({ mode }) => {
       globals: true,
       // Use happy-dom for faster tests (set VITEST_DOM=jsdom to use jsdom)
       environment: process.env.VITEST_DOM || 'happy-dom',
-      // Override environment to 'node' for directories that don't need DOM.
-      // This avoids the cost of setting up happy-dom for pure logic tests.
-      // Override to 'node' for directories that don't need DOM, with
-      // explicit happy-dom exceptions for files that do (first match wins).
-      // AIDEV-NOTE: Vitest 4 removed `environmentMatchGlobs`, so every rule
-      // below is currently inert and these files run in the default
-      // environment. Two headless command tests assert node-only behavior and
-      // fail because of it. Replacing this with per-environment `projects` (or
-      // per-file `@vitest-environment` docblocks) is tracked as the remaining
-      // step of the Vitest 4 migration. Do not assume these globs take effect.
-      environmentMatchGlobs: [
-        // super-converter: all pure logic except tiff-converter (uses document.createElement)
-        ['src/editors/v1/core/super-converter/**/tiff-converter.test.*', 'happy-dom'],
-        ['src/editors/v1/core/super-converter/**', 'node'],
-        // commands: mostly pure, except deleteSelection (document.getSelection)
-        // and insertContent integration tests (Editor with DOM view)
-        ['src/editors/v1/core/commands/deleteSelection.test.*', 'happy-dom'],
-        ['src/editors/v1/core/commands/insertContent.test.*', 'happy-dom'],
-        ['src/editors/v1/core/commands/**', 'node'],
-        // helpers: several need DOM (HTML parsing, sanitizer, content processor)
-        ['src/editors/v1/core/helpers/updateDOMAttributes.test.*', 'happy-dom'],
-        ['src/editors/v1/core/helpers/catchAllSchema.test.*', 'happy-dom'],
-        ['src/editors/v1/core/helpers/contentProcessor.test.*', 'happy-dom'],
-        ['src/editors/v1/core/helpers/createNodeFromContent.test.*', 'happy-dom'],
-        ['src/editors/v1/core/helpers/getHTMLFromFragment.test.*', 'happy-dom'],
-        ['src/editors/v1/core/helpers/htmlSanitizer.test.*', 'happy-dom'],
-        ['src/editors/v1/core/helpers/**', 'node'],
-        ['src/editors/v1/core/parts/**', 'node'],
-        // document-api-adapters: insert-structured-wrapper needs DOM for HTML insert
-        ['src/editors/v1/document-api-adapters/**/insert-structured-wrapper.test.*', 'happy-dom'],
-        ['src/editors/v1/document-api-adapters/**', 'node'],
-        ['src/editors/v1/core/ooxml-encryption/**', 'node'],
-        ['src/editors/v1/utils/**', 'node'],
-      ],
+      // AIDEV-NOTE: `environmentMatchGlobs` used to route ~630 pure-logic tests
+      // in super-converter, commands, helpers, parts, document-api-adapters,
+      // ooxml-encryption and utils to the node environment, skipping happy-dom
+      // setup. Vitest 4 removed the option, so every test now runs in the
+      // environment above. Only the two headless command suites depended on
+      // node for correctness, and they declare it with a `@vitest-environment`
+      // docblock. What is left is the lost startup saving: restoring it needs
+      // node and DOM `projects`, which is a topology change (this package is
+      // itself a project of the root config) and is deliberately not bundled
+      // into the Vitest 4 upgrade.
       retry: 2,
       // Vitest 4 no longer clears mock history between retry attempts,
       // so any call-count assertion under `retry` accumulates calls

--- a/packages/superdoc/src/SuperDoc.test.js
+++ b/packages/superdoc/src/SuperDoc.test.js
@@ -323,6 +323,8 @@ const createCommentsStoreWithFloatingGetter = () => {
   return { store, floatingCommentsState };
 };
 
+const mountedWrappers = [];
+
 const mountComponent = async (
   superdocStub,
   { surfaceManager = null, superdocStore = null, commentsStore = null, attachTo = null } = {},
@@ -334,7 +336,7 @@ const mountComponent = async (
 
   const component = (await import('./SuperDoc.vue')).default;
 
-  return mount(component, {
+  const wrapper = mount(component, {
     ...(attachTo ? { attachTo } : {}),
     global: {
       components: {
@@ -364,7 +366,19 @@ const mountComponent = async (
       },
     },
   });
+
+  mountedWrappers.push(wrapper);
+  return wrapper;
 };
+
+// AIDEV-NOTE: SuperDoc.vue registers document-level keydown listeners, so a
+// wrapper left mounted keeps handling events during later tests. Most callers
+// here never unmount, which let an earlier wrapper swallow the Escape key the
+// compact-comment-popover test dispatches. Unmounting centrally keeps each test
+// owning only its own listeners; do not rely on per-test unmount calls.
+afterEach(() => {
+  while (mountedWrappers.length) mountedWrappers.pop()?.unmount();
+});
 
 const createSuperdocStub = () => {
   const toolbar = { config: { aiApiKey: 'abc' }, setActiveEditor: vi.fn(), updateToolbarState: vi.fn() };

--- a/packages/superdoc/src/composables/use-comment-small-screen.test.js
+++ b/packages/superdoc/src/composables/use-comment-small-screen.test.js
@@ -40,7 +40,7 @@ describe('useCommentSmallScreen', () => {
   const createMockResizeObserver = () => {
     const instances = [];
     const Original = window.ResizeObserver;
-    window.ResizeObserver = vi.fn((cb) => {
+    window.ResizeObserver = vi.fn(function (cb) {
       const instance = {
         observe: vi.fn(),
         disconnect: vi.fn(),
@@ -261,7 +261,9 @@ describe('useCommentSmallScreen', () => {
     const disconnect = vi.fn();
     const observe = vi.fn();
     const originalResizeObserver = window.ResizeObserver;
-    window.ResizeObserver = vi.fn(() => ({ observe, disconnect }));
+    window.ResizeObserver = vi.fn(function () {
+      return { observe, disconnect };
+    });
 
     const { api, wrapper } = mountComposable();
     api.ensureCompactMeasurementObserver();

--- a/packages/superdoc/src/core/upgrade-collaboration.test.js
+++ b/packages/superdoc/src/core/upgrade-collaboration.test.js
@@ -82,7 +82,9 @@ vi.mock('./collaboration/permissions.js', () => ({
 }));
 
 vi.mock('./whiteboard/Whiteboard', () => ({
-  Whiteboard: vi.fn(() => ({})),
+  Whiteboard: vi.fn(function () {
+    return {};
+  }),
 }));
 vi.mock('./whiteboard/WhiteboardRenderer', () => ({
   WhiteboardRenderer: vi.fn(),

--- a/packages/superdoc/tsconfig.build.json
+++ b/packages/superdoc/tsconfig.build.json
@@ -1,3 +1,12 @@
 {
+  // AIDEV-NOTE: The `exclude` list in ./tsconfig.json must keep its `tests/**`
+  // entries alongside the `*.test.*` ones. Test support files (fixtures, mock
+  // builders) sit beside the tests they serve and import from vitest, so
+  // compiling them leaks `@vitest/spy` into inferred return types (TS2742) and
+  // leaves stale declarations behind (TS6305). That project also includes
+  // ../super-editor/src, so super-editor's test directories are excluded there
+  // too, not only in that package's own config. This note lives here because
+  // scripts/check-tsconfig-type-surface.cjs reads tsconfig.json with strict
+  // JSON.parse, which rejects comments.
   "extends": "./tsconfig.json"
 }

--- a/packages/superdoc/tsconfig.json
+++ b/packages/superdoc/tsconfig.json
@@ -44,15 +44,22 @@
     "**/*.spec.ts",
     "**/*.spec.tsx",
     "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/tests/**",
     "src/dev/**",
     "../document-api/src/**/*.test.*",
     "../document-api/src/**/*.spec.*",
     "../document-api/src/**/__tests__/**",
+    "../document-api/src/**/tests/**",
     "../layout-engine/**/*.test.*",
     "../layout-engine/**/*.spec.*",
     "../layout-engine/**/__tests__/**",
+    "../layout-engine/**/tests/**",
     "../super-editor/src/**/*.test.*",
     "../super-editor/src/**/*.spec.*",
-    "../super-editor/src/**/__tests__/**"
+    "../super-editor/src/**/__tests__/**",
+    "../super-editor/src/**/__mocks__/**",
+    "../super-editor/src/**/tests/**",
+    "../word-layout/src/**/tests/**"
   ]
 }

--- a/packages/superdoc/vite.config.js
+++ b/packages/superdoc/vite.config.js
@@ -188,6 +188,11 @@ export default defineConfig(({ mode, command }) => {
       // Use happy-dom for faster tests (set VITEST_DOM=jsdom to use jsdom)
       environment: process.env.VITEST_DOM || 'happy-dom',
       retry: 2,
+      // Vitest 4 no longer clears mock history between retry attempts,
+      // so any call-count assertion under `retry` accumulates calls
+      // across attempts. Clearing before each test keeps attempts
+      // independent.
+      clearMocks: true,
       testTimeout: 20000,
       hookTimeout: 10000,
       exclude: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ catalogs:
       specifier: 6.0.8
       version: 6.0.8
     '@vitest/coverage-v8':
-      specifier: ^3.2.4
-      version: 3.2.4
+      specifier: ^4.1.10
+      version: 4.1.10
     '@vue/test-utils':
       specifier: ^2.4.6
       version: 2.4.6
@@ -280,8 +280,8 @@ catalogs:
       specifier: ^0.28.0
       version: 0.28.0
     vitest:
-      specifier: ^3.2.4
-      version: 3.2.4
+      specifier: ^4.1.10
+      version: 4.1.10
     ws:
       specifier: ^8.18.0
       version: 8.20.0
@@ -374,7 +374,7 @@ importers:
         version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.10(vitest@4.1.10)
       concurrently:
         specifier: 'catalog:'
         version: 9.2.1
@@ -437,7 +437,7 @@ importers:
         version: 0.28.0(rollup@4.60.2)(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       canvas:
         specifier: 3.2.3
@@ -626,7 +626,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.25.12)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.25.12)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   demos/__tests__:
     devDependencies:
@@ -2277,7 +2277,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^21.1.4
-        version: 21.2.5(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(chokidar@5.0.0)(html-webpack-plugin@5.6.6(webpack@5.105.2(esbuild@0.27.3)))(jiti@2.6.1)(tailwindcss@4.2.2)(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 21.2.5(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(chokidar@5.0.0)(html-webpack-plugin@5.6.6(webpack@5.105.2(esbuild@0.27.3)))(jiti@2.6.1)(tailwindcss@4.2.2)(tsx@4.21.0)(typescript@5.9.3)(vitest@4.1.10)(yaml@2.8.3)
       '@angular/cli':
         specifier: ^21.1.4
         version: 21.2.5(@types/node@25.6.0)(chokidar@5.0.0)
@@ -2488,7 +2488,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.4)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.4)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: 3.5.32
         version: 3.5.32(typescript@5.9.3)
@@ -2513,7 +2513,7 @@ importers:
         version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.10(vitest@4.1.10)
       concurrently:
         specifier: 'catalog:'
         version: 9.2.1
@@ -2537,7 +2537,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/document-api: {}
 
@@ -2565,7 +2565,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/esign:
     dependencies:
@@ -2617,7 +2617,7 @@ importers:
         version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/esign/demo:
     dependencies:
@@ -2691,7 +2691,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/layout-engine/geometry-utils:
     devDependencies:
@@ -2700,7 +2700,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/layout-engine/layout-bridge:
     dependencies:
@@ -2743,7 +2743,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/layout-engine/layout-engine:
     dependencies:
@@ -2774,7 +2774,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/layout-engine/measuring/dom:
     dependencies:
@@ -2829,7 +2829,7 @@ importers:
         version: link:../../layout-resolved
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/layout-engine/style-engine:
     dependencies:
@@ -2848,7 +2848,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/layout-engine/tests:
     dependencies:
@@ -2930,7 +2930,7 @@ importers:
         version: 4.5.4(@types/node@22.19.2)(rollup@4.60.2)(typescript@5.9.3)(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/sdk: {}
 
@@ -3177,7 +3177,7 @@ importers:
         version: 0.28.0(rollup@4.60.2)(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       y-protocols:
         specifier: 'catalog:'
         version: 1.0.7(yjs@13.6.30)
@@ -3325,7 +3325,7 @@ importers:
         version: 0.28.0(rollup@4.60.2)(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       ws:
         specifier: ^8.18.3
         version: 8.20.0
@@ -3392,7 +3392,7 @@ importers:
         version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/template-builder/demo:
     dependencies:
@@ -3433,7 +3433,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   shared/common:
     devDependencies:
@@ -3448,7 +3448,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vue:
         specifier: 3.5.32
         version: 3.5.32(typescript@5.9.3)
@@ -3467,7 +3467,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   shared/font-utils: {}
 
@@ -3483,7 +3483,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   tests/document-api-smoke:
     dependencies:
@@ -3493,7 +3493,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -11303,20 +11303,20 @@ packages:
       vite: ^8.0.0
       vue: 3.5.32
 
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^8.0.0
@@ -11326,20 +11326,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@volar/language-core@2.4.15':
     resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
@@ -12084,8 +12084,8 @@ packages:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
 
-  ast-v8-to-istanbul@0.3.12:
-    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   ast-walker-scope@0.8.3:
     resolution: {integrity: sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==}
@@ -12615,8 +12615,8 @@ packages:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
 
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk-template@0.4.0:
@@ -12674,10 +12674,6 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
-
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -13536,10 +13532,6 @@ packages:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
 
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
-
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -14074,9 +14066,6 @@ packages:
   es-iterator-helpers@1.3.1:
     resolution: {integrity: sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -16194,10 +16183,6 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
@@ -16991,9 +16976,6 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
   lowdb@1.0.0:
     resolution: {integrity: sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==}
     engines: {node: '>=4'}
@@ -17057,9 +17039,6 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
@@ -18914,10 +18893,6 @@ packages:
 
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   pbkdf2@3.1.5:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
@@ -21387,10 +21362,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  test-exclude@7.0.2:
-    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
-    engines: {node: '>=18'}
-
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
@@ -21476,24 +21447,12 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
   tippy.js@6.3.7:
@@ -22329,11 +22288,6 @@ packages:
     peerDependencies:
       vite: ^8.0.0
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite-node@5.3.0:
     resolution: {integrity: sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -22491,26 +22445,39 @@ packages:
       vite:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: 20.4.0
       jsdom: 27.3.0
+      vite: ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -23291,13 +23258,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@21.2.5(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(chokidar@5.0.0)(html-webpack-plugin@5.6.6(webpack@5.105.2(esbuild@0.27.3)))(jiti@2.6.1)(tailwindcss@4.2.2)(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)':
+  '@angular-devkit/build-angular@21.2.5(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(chokidar@5.0.0)(html-webpack-plugin@5.6.6(webpack@5.105.2(esbuild@0.27.3)))(jiti@2.6.1)(tailwindcss@4.2.2)(tsx@4.21.0)(typescript@5.9.3)(vitest@4.1.10)(yaml@2.8.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.5(chokidar@5.0.0)
       '@angular-devkit/build-webpack': 0.2102.5(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3)))(webpack@5.105.2(esbuild@0.27.3))
       '@angular-devkit/core': 21.2.5(chokidar@5.0.0)
-      '@angular/build': 21.2.5(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.6.1)(less@4.4.2)(postcss@8.5.6)(tailwindcss@4.2.2)(terser@5.46.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+      '@angular/build': 21.2.5(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.6.1)(less@4.4.2)(postcss@8.5.6)(tailwindcss@4.2.2)(terser@5.46.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.9.3)(vitest@4.1.10)(yaml@2.8.3)
       '@angular/compiler-cli': 21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3)
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -23409,7 +23376,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/build@21.2.5(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.6.1)(less@4.4.2)(postcss@8.5.6)(tailwindcss@4.2.2)(terser@5.46.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)':
+  '@angular/build@21.2.5(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.6.1)(less@4.4.2)(postcss@8.5.6)(tailwindcss@4.2.2)(terser@5.46.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.9.3)(vitest@4.1.10)(yaml@2.8.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.5(chokidar@5.0.0)
@@ -23449,7 +23416,7 @@ snapshots:
       lmdb: 3.5.1
       postcss: 8.5.6
       tailwindcss: 4.2.2
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -25585,7 +25552,7 @@ snapshots:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       chokidar: 5.0.0
       pathe: 2.0.3
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       typescript: 5.9.3
     transitivePeerDependencies:
       - magicast
@@ -28495,7 +28462,7 @@ snapshots:
       simple-git: 3.33.0
       sirv: 3.0.2
       structured-clone-es: 2.0.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       vite: 8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-vue-tracer: 1.3.0(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
@@ -28525,7 +28492,7 @@ snapshots:
       rc9: 3.0.0
       scule: 1.3.0
       semver: 7.7.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ufo: 1.6.3
       unctx: 2.5.0
       untyped: 2.0.0
@@ -29209,7 +29176,7 @@ snapshots:
   '@parcel/watcher-wasm@2.5.6':
     dependencies:
       is-glob: 4.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   '@parcel/watcher-win32-arm64@2.5.6':
     optional: true
@@ -29225,7 +29192,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -31177,10 +31144,10 @@ snapshots:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.4)
+      fdir: 6.5.0(picomatch@4.0.5)
       is-reference: 1.2.1
       magic-string: 0.30.21
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.60.2
 
@@ -31227,7 +31194,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.60.2
 
@@ -33200,7 +33167,7 @@ snapshots:
       glob: 13.0.6
       graceful-fs: 4.2.11
       node-gyp-build: 4.8.4
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - encoding
@@ -33461,74 +33428,93 @@ snapshots:
       vite: 8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
-      '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.12
-      debug: 4.4.3(supports-color@5.5.0)
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      std-env: 3.10.0
-      test-exclude: 7.0.2
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.1.10':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
 
-  '@vitest/mocker@3.2.4(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.4)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@22.19.2)(esbuild@0.25.12)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.0(@types/node@22.19.2)(esbuild@0.25.12)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.4)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.2.0(@types/node@22.19.2)(esbuild@0.27.4)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@3.2.4(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.0(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+    optional: true
 
-  '@vitest/runner@3.2.4':
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.1.10': {}
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@volar/language-core@2.4.15':
     dependencies:
@@ -34428,7 +34414,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ast-v8-to-istanbul@0.3.12:
+  ast-v8-to-istanbul@1.0.5:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -35057,13 +35043,7 @@ snapshots:
       pathval: 1.1.1
       type-detect: 4.1.0
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   chalk-template@0.4.0:
     dependencies:
@@ -35107,8 +35087,6 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
-
-  check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -35599,7 +35577,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       webpack: 5.105.2(esbuild@0.27.3)
 
   core-js-compat@3.49.0:
@@ -35982,8 +35960,6 @@ snapshots:
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.1.0
-
-  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -36568,8 +36544,6 @@ snapshots:
       math-intrinsics: 1.1.0
       safe-array-concat: 1.1.3
 
-  es-module-lexer@1.7.0: {}
-
   es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
@@ -36829,7 +36803,7 @@ snapshots:
       get-tsconfig: 4.13.7
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
@@ -36845,7 +36819,7 @@ snapshots:
       get-tsconfig: 4.13.7
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
@@ -39123,7 +39097,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.18.0)
+      retry-axios: 2.6.0(axios@1.18.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -39710,14 +39684,6 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
-
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@5.5.0)
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
 
   istanbul-reports@3.2.0:
     dependencies:
@@ -40512,8 +40478,6 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
-  loupe@3.2.1: {}
-
   lowdb@1.0.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -40584,12 +40548,6 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  magicast@0.3.5:
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      source-map-js: 1.2.1
 
   magicast@0.5.2:
     dependencies:
@@ -42186,7 +42144,7 @@ snapshots:
       proc-log: 6.1.0
       semver: 7.7.4
       tar: 7.5.13
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       which: 6.0.1
     transitivePeerDependencies:
       - supports-color
@@ -43340,8 +43298,6 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@1.1.1: {}
-
-  pathval@2.0.1: {}
 
   pbkdf2@3.1.5:
     dependencies:
@@ -45294,7 +45250,7 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
-  retry-axios@2.6.0(axios@1.18.0):
+  retry-axios@2.6.0(axios@1.18.0(debug@4.4.3)):
     dependencies:
       axios: 1.18.0(debug@4.4.3)
     optional: true
@@ -45401,7 +45357,7 @@ snapshots:
   rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.60.2):
     dependencies:
       open: 11.0.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       source-map: 0.7.6
       yargs: 18.0.0
     optionalDependencies:
@@ -46547,7 +46503,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   super-regex@1.1.0:
@@ -46860,12 +46816,6 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  test-exclude@7.0.2:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 10.5.0
-      minimatch: 10.2.4
-
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.0
@@ -46942,21 +46892,12 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.1: {}
 
   tippy.js@6.3.7:
     dependencies:
@@ -47463,11 +47404,11 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       pkg-types: 2.3.0
       scule: 1.3.0
       strip-literal: 3.1.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
 
@@ -47595,19 +47536,19 @@ snapshots:
   unplugin-utils@0.3.1:
     dependencies:
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
   unplugin@3.0.0:
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
   unrouting@0.1.7:
@@ -48011,94 +47952,6 @@ snapshots:
     dependencies:
       vite: 8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vite-node@3.2.4(@types/node@22.19.2)(esbuild@0.25.12)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3(supports-color@5.5.0)
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 8.2.0(@types/node@22.19.2)(esbuild@0.25.12)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite-node@3.2.4(@types/node@22.19.2)(esbuild@0.27.4)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3(supports-color@5.5.0)
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 8.2.0(@types/node@22.19.2)(esbuild@0.27.4)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite-node@3.2.4(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3(supports-color@5.5.0)
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite-node@3.2.4(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3(supports-color@5.5.0)
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-node@5.3.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
@@ -48126,9 +47979,9 @@ snapshots:
       chokidar: 4.0.3
       npm-run-path: 6.0.0
       picocolors: 1.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       tiny-invariant: 1.3.3
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       vite: 8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vscode-uri: 3.1.0
     optionalDependencies:
@@ -48380,185 +48233,161 @@ snapshots:
     optionalDependencies:
       vite: 8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.25.12)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.25.12)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@5.5.0)
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@22.19.2)(esbuild@0.25.12)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 3.10.0
+      picomatch: 4.0.5
+      std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.16
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
       vite: 8.2.0(@types/node@22.19.2)(esbuild@0.25.12)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@22.19.2)(esbuild@0.25.12)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/debug': 4.1.13
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.2
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       happy-dom: 20.4.0
       jsdom: 27.3.0(canvas@3.2.3)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.4)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.4)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.4)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@5.5.0)
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.4)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 3.10.0
+      picomatch: 4.0.5
+      std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.16
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
       vite: 8.2.0(@types/node@22.19.2)(esbuild@0.27.4)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@22.19.2)(esbuild@0.27.4)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/debug': 4.1.13
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.2
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       happy-dom: 20.4.0
       jsdom: 27.3.0(canvas@3.2.3)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.2)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@5.5.0)
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 3.10.0
+      picomatch: 4.0.5
+      std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.16
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
       vite: 8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/debug': 4.1.13
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.2
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       happy-dom: 20.4.0
       jsdom: 27.3.0(canvas@3.2.3)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.3.0(canvas@3.2.3))(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@8.2.0(@types/node@22.19.2)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@5.5.0)
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 3.10.0
+      picomatch: 4.0.5
+      std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.16
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/debug': 4.1.13
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       happy-dom: 20.4.0
       jsdom: 27.3.0(canvas@3.2.3)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
+    optional: true
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.4.0)(jsdom@27.3.0(canvas@3.2.3))(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.4.0
+      jsdom: 27.3.0(canvas@3.2.3)
+    transitivePeerDependencies:
+      - msw
 
   vm-browserify@1.1.2: {}
 
@@ -48599,9 +48428,9 @@ snapshots:
       mlly: 1.8.2
       muggle-string: 0.4.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       scule: 1.3.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
       vue: 3.5.32(typescript@5.9.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,7 +46,7 @@ catalog:
   '@typescript-eslint/parser': ^8.49.0
   '@vitejs/plugin-react': ^6.0.5
   '@vitejs/plugin-vue': 6.0.8
-  '@vitest/coverage-v8': ^3.2.4
+  '@vitest/coverage-v8': ^4.1.10
   '@vue/test-utils': ^2.4.6
   buffer-crc32: ^1.0.0
   canvas: ^3.2.0
@@ -122,7 +122,7 @@ catalog:
   vite: ^8.0.0
   vite-plugin-dts: ~4.5.4
   vite-plugin-node-polyfills: ^0.28.0
-  vitest: ^3.2.4
+  vitest: ^4.1.10
   vue: 3.5.32
   xml-js: 1.6.11
   ws: ^8.18.0


### PR DESCRIPTION
Takes Vitest to 4.1.10, which the rest of the toolchain now wants: Vite 8 pairs with it, and `@angular/build` in the Angular example already demanded `vitest@^4.0.8`.

Most of the diff is one mechanical change. Vitest 4 stopped wrapping mock implementations in a constructable function, so any mock that production code calls with `new` had to move from an arrow to a `function`. That was applied to 58 sites via a codemod scoped to class-like mock targets only, so arrows stay everywhere a mock is merely called. It is kept in the first commit so it stays separable from the behavioural fixes in the second.

Four behavioural differences needed real fixes:

- Mock history is no longer cleared between retry attempts. Both packages set `retry: 2`, so call-count assertions accumulated across attempts and reported 2, then 3, then 4 calls for a single expected call. `clearMocks: true` keeps attempts independent.
- `restoreAllMocks` now only restores `vi.spyOn` spies, so a `mockReturnValue` set on a module mock survived into later tests and sent one list wrapper down the clone-on-write path. That default is re-established explicitly alongside the ones the suite already re-established.
- Test support files were leaking vitest types into declaration emit. Excluding `*.test.*` was never enough because helpers sit beside the tests they serve, so `@vitest/spy` reached inferred return types and left stale outputs behind. Both super-editor and superdoc needed it, since the superdoc project also includes `../super-editor/src`. Nothing in production imports from those directories.
- `vi.unmock` in shared-doc was paired with `vi.doMock`. Being hoisted, it ran before any test and never released those registrations, so `vi.doUnmock` is the correct counterpart. Vitest warned about this and will make it an error.

`environmentMatchGlobs` was removed outright, so the rules routing about 630 pure-logic tests to the node environment are gone. Only the two headless command suites depended on node for correctness, and they now declare it with a `@vitest-environment` docblock. What is left is the lost startup saving, which needs node and DOM projects; that is a topology change, since this package is itself a project of the root config, and is deliberately not bundled in here. The dead config block is removed rather than left as the record.

Verified from a clean detached checkout in this order: `pnpm install --frozen-lockfile`, `pnpm run build:superdoc`, `pnpm run check:types`, `pnpm test` (1531 files, 22972 tests, 0 failures), `pnpm run check:public` (83 stages, 0 failed). No vitest warnings remain.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/superdoc/docx-editor/pull/3874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

