### PR TITLE
feat(super-editor): visual-only loading overlay toggle (IT-1365)

### DIFF
--- a/packages/super-editor/src/editors/v1/components/EditorSkeleton.vue
+++ b/packages/super-editor/src/editors/v1/components/EditorSkeleton.vue
@@ -1,28 +1,51 @@
+<script setup>
+/**
+ * Loading placeholder shown while the editor is not ready.
+ *
+ * The root element is always rendered, because it doubles as the interaction
+ * barrier: it covers the editable surface underneath and, having no
+ * `pointer-events: none`, stops clicks and edits from reaching a document that
+ * has not finished loading (or, in collaboration, synchronizing).
+ *
+ * `visible` therefore controls only the painted placeholder. When false the
+ * barrier stays in place but becomes transparent, so an integrator can render
+ * their own loading UI without also unlocking a half-loaded document.
+ */
+defineProps({
+  visible: {
+    type: Boolean,
+    default: true,
+  },
+});
+</script>
+
 <template>
-  <div class="placeholder-editor">
-    <div class="placeholder-title">
-      <div class="placeholder-line placeholder-line--60"></div>
-    </div>
+  <div class="placeholder-editor" :class="{ 'placeholder-editor--transparent': !visible }">
+    <template v-if="visible">
+      <div class="placeholder-title">
+        <div class="placeholder-line placeholder-line--60"></div>
+      </div>
 
-    <div class="placeholder-block">
-      <div v-for="n in 7" :key="`p-1-${n}`" class="placeholder-line"></div>
-      <div class="placeholder-line placeholder-line--60"></div>
-    </div>
+      <div class="placeholder-block">
+        <div v-for="n in 7" :key="`p-1-${n}`" class="placeholder-line"></div>
+        <div class="placeholder-line placeholder-line--60"></div>
+      </div>
 
-    <div class="placeholder-block placeholder-block--narrow">
-      <div v-for="n in 6" :key="`p-2-${n}`" class="placeholder-line placeholder-line--30"></div>
-    </div>
+      <div class="placeholder-block placeholder-block--narrow">
+        <div v-for="n in 6" :key="`p-2-${n}`" class="placeholder-line placeholder-line--30"></div>
+      </div>
 
-    <div class="placeholder-block">
-      <div class="placeholder-line placeholder-line--60"></div>
-      <div v-for="n in 7" :key="`p-3-${n}`" class="placeholder-line"></div>
-      <div class="placeholder-line placeholder-line--30"></div>
-    </div>
+      <div class="placeholder-block">
+        <div class="placeholder-line placeholder-line--60"></div>
+        <div v-for="n in 7" :key="`p-3-${n}`" class="placeholder-line"></div>
+        <div class="placeholder-line placeholder-line--30"></div>
+      </div>
 
-    <div class="placeholder-block placeholder-block--tail">
-      <div v-for="n in 8" :key="`p-4-${n}`" class="placeholder-line"></div>
-      <div class="placeholder-line placeholder-line--70"></div>
-    </div>
+      <div class="placeholder-block placeholder-block--tail">
+        <div v-for="n in 8" :key="`p-4-${n}`" class="placeholder-line"></div>
+        <div class="placeholder-line placeholder-line--70"></div>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -41,6 +64,11 @@
   flex-direction: column;
   gap: 28px;
   padding: 1in;
+}
+
+/* Keeps the barrier (and its pointer handling) while hiding the placeholder. */
+.placeholder-editor--transparent {
+  background-color: transparent;
 }
 
 .placeholder-title {

--- a/packages/super-editor/src/editors/v1/components/SuperEditor.loading-overlay.test.js
+++ b/packages/super-editor/src/editors/v1/components/SuperEditor.loading-overlay.test.js
@@ -1,0 +1,157 @@
+/**
+ * Built-in loading overlay (EditorSkeleton) visibility.
+ *
+ * The `showLoadingOverlay` option is visual-only. It must hide the skeleton
+ * WITHOUT advancing `editorReady`, because `editorReady` also gates the
+ * interactive chrome (context menu, table/image/textbox resize overlays).
+ * The legacy internal `suppressSkeletonLoader` does advance `editorReady`;
+ * these tests pin down that the two options stay distinct.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const getFileObjectMock = vi.hoisted(() =>
+  vi.fn(async () => new Blob([], { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' })),
+);
+const getStarterExtensionsMock = vi.hoisted(() => vi.fn(() => [{ name: 'core' }]));
+
+const EditorConstructor = vi.hoisted(() => {
+  const MockEditor = vi.fn(function (options) {
+    this.options = options;
+    this.listeners = {};
+    this.on = vi.fn((event, handler) => {
+      this.listeners[event] = handler;
+    });
+    this.off = vi.fn();
+    this.view = { focus: vi.fn() };
+    this.setDocumentMode = vi.fn();
+    this.destroy = vi.fn();
+  });
+  MockEditor.loadXmlData = vi.fn();
+  return MockEditor;
+});
+
+vi.mock('./cursor-helpers.js', () => ({
+  onMarginClickCursorChange: vi.fn(),
+  checkNodeSpecificClicks: vi.fn(),
+}));
+vi.mock('./context-menu/ContextMenu.vue', () => ({ default: { name: 'ContextMenu', render: () => null } }));
+vi.mock('./rulers/Ruler.vue', () => ({ default: { name: 'Ruler', render: () => null } }));
+vi.mock('./popovers/GenericPopover.vue', () => ({ default: { name: 'GenericPopover', render: () => null } }));
+vi.mock('./toolbar/LinkInput.vue', () => ({ default: { name: 'LinkInput', render: () => null } }));
+vi.mock('./TableResizeOverlay.vue', () => ({ default: { name: 'TableResizeOverlay', render: () => null } }));
+vi.mock('@superdoc/common', () => ({ getFileObject: getFileObjectMock }));
+vi.mock('@superdoc/common/data/blank.docx?url', () => ({ default: 'blank-docx-url' }), { virtual: true });
+vi.mock('@extensions/index.js', () => ({ getStarterExtensions: getStarterExtensionsMock }));
+vi.mock('@superdoc/super-editor', () => ({ Editor: EditorConstructor }));
+
+import SuperEditor from './SuperEditor.vue';
+
+const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+const OVERLAY = '.placeholder-editor';
+
+/** Fake y-doc + provider, mirroring the shape SuperEditor.vue probes on mount. */
+const makeCollabOptions = () => {
+  const metaMap = { has: vi.fn((key) => key === 'docx'), get: vi.fn(() => undefined) };
+  return {
+    ydoc: {
+      getMap: vi.fn((name) => (name === 'parts' ? { size: 0 } : metaMap)),
+      getXmlFragment: vi.fn(() => ({ length: 0 })),
+    },
+    collaborationProvider: { on: vi.fn(), off: vi.fn() },
+  };
+};
+
+const mountEditor = async (options) => {
+  EditorConstructor.loadXmlData.mockResolvedValue(['<docx />', {}, {}, {}]);
+  const wrapper = mount(SuperEditor, {
+    props: {
+      documentId: 'doc-loading-overlay',
+      fileSource: new Blob([], { type: DOCX_MIME }),
+      options: { externalExtensions: [], ...options },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+};
+
+describe('SuperEditor built-in loading overlay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the overlay by default while collaboration is pending', async () => {
+    const wrapper = await mountEditor(makeCollabOptions());
+
+    expect(wrapper.find(OVERLAY).exists()).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it('renders the overlay when showLoadingOverlay is explicitly true', async () => {
+    const wrapper = await mountEditor({ ...makeCollabOptions(), showLoadingOverlay: true });
+
+    expect(wrapper.find(OVERLAY).exists()).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it('hides the overlay when showLoadingOverlay is false', async () => {
+    const wrapper = await mountEditor({ ...makeCollabOptions(), showLoadingOverlay: false });
+
+    expect(wrapper.find(OVERLAY).exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it('is visual-only: showLoadingOverlay false does not advance editorReady or arm interactive chrome', async () => {
+    const wrapper = await mountEditor({ ...makeCollabOptions(), showLoadingOverlay: false });
+
+    // Readiness is untouched, so collaboration timing is unchanged...
+    expect(wrapper.vm.editorReady).toBe(false);
+    // ...and the chrome gated on it stays unmounted.
+    expect(wrapper.findComponent({ name: 'TableResizeOverlay' }).exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it('keeps the legacy suppressSkeletonLoader behaviour of advancing editorReady', async () => {
+    const wrapper = await mountEditor({ ...makeCollabOptions(), suppressSkeletonLoader: true });
+
+    expect(wrapper.vm.editorReady).toBe(true);
+    expect(wrapper.find(OVERLAY).exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it('still hides the overlay once the editor becomes ready', async () => {
+    vi.useFakeTimers();
+    const wrapper = await mountEditor(makeCollabOptions());
+
+    expect(wrapper.find(OVERLAY).exists()).toBe(true);
+
+    EditorConstructor.mock.results.at(-1).value.listeners.collaborationReady();
+    vi.advanceTimersByTime(150);
+    await flushPromises();
+
+    expect(wrapper.vm.editorReady).toBe(true);
+    expect(wrapper.find(OVERLAY).exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it('does not render the overlay without a collaboration provider', async () => {
+    const wrapper = await mountEditor({});
+
+    expect(wrapper.find(OVERLAY).exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+});

--- a/packages/super-editor/src/editors/v1/components/SuperEditor.loading-overlay.test.js
+++ b/packages/super-editor/src/editors/v1/components/SuperEditor.loading-overlay.test.js
@@ -1,11 +1,16 @@
 /**
  * Built-in loading overlay (EditorSkeleton) visibility.
  *
- * The `showLoadingOverlay` option is visual-only. It must hide the skeleton
- * WITHOUT advancing `editorReady`, because `editorReady` also gates the
- * interactive chrome (context menu, table/image/textbox resize overlays).
- * The legacy internal `suppressSkeletonLoader` does advance `editorReady`;
- * these tests pin down that the two options stay distinct.
+ * `.placeholder-editor` is both the visible placeholder and the interaction
+ * barrier over the editable surface underneath, so the two concerns are tested
+ * separately:
+ *
+ *   - the barrier element is mounted whenever `editorReady` is false;
+ *   - `showLoadingOverlay` only decides whether that barrier paints.
+ *
+ * The legacy internal `suppressSkeletonLoader` is different in kind: it forces
+ * `editorReady` true, which removes the barrier and arms the chrome gated on
+ * readiness (context menu, table/image/textbox resize overlays).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
@@ -48,32 +53,38 @@ vi.mock('@superdoc/super-editor', () => ({ Editor: EditorConstructor }));
 import SuperEditor from './SuperEditor.vue';
 
 const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-const OVERLAY = '.placeholder-editor';
+/** Full-surface element: placeholder when painted, interaction barrier either way. */
+const BARRIER = '.placeholder-editor';
+/** Only present when the placeholder actually paints. */
+const PLACEHOLDER_LINE = '.placeholder-line';
 
-/** Fake y-doc + provider, mirroring the shape SuperEditor.vue probes on mount. */
-const makeCollabOptions = () => {
-  const metaMap = { has: vi.fn((key) => key === 'docx'), get: vi.fn(() => undefined) };
+const makeYdoc = () => {
+  const metaMap = { has: vi.fn(() => true), get: vi.fn(() => undefined) };
   return {
-    ydoc: {
-      getMap: vi.fn((name) => (name === 'parts' ? { size: 0 } : metaMap)),
-      getXmlFragment: vi.fn(() => ({ length: 0 })),
-    },
-    collaborationProvider: { on: vi.fn(), off: vi.fn() },
+    getMap: vi.fn((name) => (name === 'parts' ? { size: 0 } : metaMap)),
+    getXmlFragment: vi.fn(() => ({ length: 0 })),
   };
 };
 
-const mountEditor = async (options) => {
+const makeProvider = () => ({ on: vi.fn(), off: vi.fn() });
+
+/** Collaboration options alongside a file source (the file-source init path). */
+const makeCollabOptions = () => ({ ydoc: makeYdoc(), collaborationProvider: makeProvider() });
+
+const mountEditor = async (options, { withFileSource = true } = {}) => {
   EditorConstructor.loadXmlData.mockResolvedValue(['<docx />', {}, {}, {}]);
   const wrapper = mount(SuperEditor, {
     props: {
       documentId: 'doc-loading-overlay',
-      fileSource: new Blob([], { type: DOCX_MIME }),
+      ...(withFileSource ? { fileSource: new Blob([], { type: DOCX_MIME }) } : {}),
       options: { externalExtensions: [], ...options },
     },
   });
   await flushPromises();
   return wrapper;
 };
+
+const latestEditor = () => EditorConstructor.mock.results.at(-1)?.value;
 
 describe('SuperEditor built-in loading overlay', () => {
   beforeEach(() => {
@@ -87,70 +98,137 @@ describe('SuperEditor built-in loading overlay', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders the overlay by default while collaboration is pending', async () => {
-    const wrapper = await mountEditor(makeCollabOptions());
+  describe('with a file source and a collaboration provider', () => {
+    it('paints the placeholder by default while the editor is not ready', async () => {
+      const wrapper = await mountEditor(makeCollabOptions());
 
-    expect(wrapper.find(OVERLAY).exists()).toBe(true);
+      expect(wrapper.find(BARRIER).exists()).toBe(true);
+      expect(wrapper.find(PLACEHOLDER_LINE).exists()).toBe(true);
 
-    wrapper.unmount();
+      wrapper.unmount();
+    });
+
+    it('paints the placeholder when showLoadingOverlay is explicitly true', async () => {
+      const wrapper = await mountEditor({ ...makeCollabOptions(), showLoadingOverlay: true });
+
+      expect(wrapper.find(PLACEHOLDER_LINE).exists()).toBe(true);
+
+      wrapper.unmount();
+    });
+
+    it('stops painting the placeholder when showLoadingOverlay is false', async () => {
+      const wrapper = await mountEditor({ ...makeCollabOptions(), showLoadingOverlay: false });
+
+      expect(wrapper.find(PLACEHOLDER_LINE).exists()).toBe(false);
+
+      wrapper.unmount();
+    });
+
+    it('keeps the interaction barrier mounted when showLoadingOverlay is false', async () => {
+      const wrapper = await mountEditor({ ...makeCollabOptions(), showLoadingOverlay: false });
+
+      // The barrier still covers the editable surface, it is just transparent.
+      const barrier = wrapper.find(BARRIER);
+      expect(barrier.exists()).toBe(true);
+      expect(barrier.classes()).toContain('placeholder-editor--transparent');
+
+      wrapper.unmount();
+    });
+
+    it('is visual-only: showLoadingOverlay false does not advance editorReady or arm interactive chrome', async () => {
+      const wrapper = await mountEditor({ ...makeCollabOptions(), showLoadingOverlay: false });
+
+      expect(wrapper.vm.editorReady).toBe(false);
+      expect(wrapper.findComponent({ name: 'TableResizeOverlay' }).exists()).toBe(false);
+
+      wrapper.unmount();
+    });
+
+    it('removes the barrier entirely once the editor becomes ready', async () => {
+      vi.useFakeTimers();
+      const wrapper = await mountEditor(makeCollabOptions());
+
+      expect(wrapper.find(BARRIER).exists()).toBe(true);
+
+      latestEditor().listeners.collaborationReady();
+      vi.advanceTimersByTime(150);
+      await flushPromises();
+
+      expect(wrapper.vm.editorReady).toBe(true);
+      expect(wrapper.find(BARRIER).exists()).toBe(false);
+
+      wrapper.unmount();
+    });
+
+    it('keeps the legacy suppressSkeletonLoader behaviour of advancing editorReady', async () => {
+      const wrapper = await mountEditor({ ...makeCollabOptions(), suppressSkeletonLoader: true });
+
+      // Broader than showLoadingOverlay: readiness advances, so the barrier goes too.
+      expect(wrapper.vm.editorReady).toBe(true);
+      expect(wrapper.find(BARRIER).exists()).toBe(false);
+
+      wrapper.unmount();
+    });
   });
 
-  it('renders the overlay when showLoadingOverlay is explicitly true', async () => {
-    const wrapper = await mountEditor({ ...makeCollabOptions(), showLoadingOverlay: true });
+  describe('through the collaboration init path (no file source)', () => {
+    /** Drives provider `synced`, which is what creates the editor on this path. */
+    const syncProvider = async (provider) => {
+      const syncedHandler = provider.on.mock.calls.find(([event]) => event === 'synced')?.[1];
+      expect(syncedHandler).toBeTypeOf('function');
+      syncedHandler();
+      await flushPromises();
+    };
 
-    expect(wrapper.find(OVERLAY).exists()).toBe(true);
+    it('holds the barrier across provider sync until collaborationReady', async () => {
+      vi.useFakeTimers();
+      const provider = makeProvider();
+      const wrapper = await mountEditor(
+        { ydoc: makeYdoc(), collaborationProvider: provider },
+        { withFileSource: false },
+      );
 
-    wrapper.unmount();
+      expect(wrapper.find(BARRIER).exists()).toBe(true);
+      expect(wrapper.find(PLACEHOLDER_LINE).exists()).toBe(true);
+
+      await syncProvider(provider);
+
+      // Synced is not ready: the document still must not be editable.
+      expect(wrapper.vm.editorReady).toBe(false);
+      expect(wrapper.find(BARRIER).exists()).toBe(true);
+
+      latestEditor().listeners.collaborationReady();
+      vi.advanceTimersByTime(150);
+      await flushPromises();
+
+      expect(wrapper.vm.editorReady).toBe(true);
+      expect(wrapper.find(BARRIER).exists()).toBe(false);
+
+      wrapper.unmount();
+    });
+
+    it('keeps the barrier unpainted but present when showLoadingOverlay is false', async () => {
+      const provider = makeProvider();
+      const wrapper = await mountEditor(
+        { ydoc: makeYdoc(), collaborationProvider: provider, showLoadingOverlay: false },
+        { withFileSource: false },
+      );
+
+      await syncProvider(provider);
+
+      expect(wrapper.vm.editorReady).toBe(false);
+      expect(wrapper.find(BARRIER).exists()).toBe(true);
+      expect(wrapper.find(PLACEHOLDER_LINE).exists()).toBe(false);
+
+      wrapper.unmount();
+    });
   });
 
-  it('hides the overlay when showLoadingOverlay is false', async () => {
-    const wrapper = await mountEditor({ ...makeCollabOptions(), showLoadingOverlay: false });
-
-    expect(wrapper.find(OVERLAY).exists()).toBe(false);
-
-    wrapper.unmount();
-  });
-
-  it('is visual-only: showLoadingOverlay false does not advance editorReady or arm interactive chrome', async () => {
-    const wrapper = await mountEditor({ ...makeCollabOptions(), showLoadingOverlay: false });
-
-    // Readiness is untouched, so collaboration timing is unchanged...
-    expect(wrapper.vm.editorReady).toBe(false);
-    // ...and the chrome gated on it stays unmounted.
-    expect(wrapper.findComponent({ name: 'TableResizeOverlay' }).exists()).toBe(false);
-
-    wrapper.unmount();
-  });
-
-  it('keeps the legacy suppressSkeletonLoader behaviour of advancing editorReady', async () => {
-    const wrapper = await mountEditor({ ...makeCollabOptions(), suppressSkeletonLoader: true });
-
-    expect(wrapper.vm.editorReady).toBe(true);
-    expect(wrapper.find(OVERLAY).exists()).toBe(false);
-
-    wrapper.unmount();
-  });
-
-  it('still hides the overlay once the editor becomes ready', async () => {
-    vi.useFakeTimers();
-    const wrapper = await mountEditor(makeCollabOptions());
-
-    expect(wrapper.find(OVERLAY).exists()).toBe(true);
-
-    EditorConstructor.mock.results.at(-1).value.listeners.collaborationReady();
-    vi.advanceTimersByTime(150);
-    await flushPromises();
-
-    expect(wrapper.vm.editorReady).toBe(true);
-    expect(wrapper.find(OVERLAY).exists()).toBe(false);
-
-    wrapper.unmount();
-  });
-
-  it('does not render the overlay without a collaboration provider', async () => {
+  it('does not render the barrier without a collaboration provider', async () => {
     const wrapper = await mountEditor({});
 
-    expect(wrapper.find(OVERLAY).exists()).toBe(false);
+    expect(wrapper.vm.editorReady).toBe(true);
+    expect(wrapper.find(BARRIER).exists()).toBe(false);
 
     wrapper.unmount();
   });

--- a/packages/super-editor/src/editors/v1/components/SuperEditor.vue
+++ b/packages/super-editor/src/editors/v1/components/SuperEditor.vue
@@ -73,6 +73,22 @@ const contextMenuDisabled = computed(() => {
 });
 
 /**
+ * Whether the built-in loading skeleton may render.
+ *
+ * This is deliberately visual-only: it gates <EditorSkeleton> and nothing else.
+ * `editorReady` keeps its existing meaning and timing, so turning the overlay
+ * off does not mount the interactive chrome (context menu, table/image/textbox
+ * resize overlays) any earlier than it would otherwise.
+ *
+ * That is the difference from the legacy internal `suppressSkeletonLoader`
+ * option, which forces `editorReady` true and therefore also arms that chrome
+ * before collaboration has synced.
+ *
+ * @returns {boolean} True when the skeleton should be rendered.
+ */
+const showLoadingOverlay = computed(() => props.options?.showLoadingOverlay !== false && !editorReady.value);
+
+/**
  * Computed property that determines if web layout mode is active (OOXML ST_View 'web').
  * @returns {boolean} True if viewOptions.layout is 'web'
  */
@@ -1461,7 +1477,7 @@ onBeforeUnmount(() => {
       />
     </div>
 
-    <EditorSkeleton v-if="!editorReady" />
+    <EditorSkeleton v-if="showLoadingOverlay" />
 
     <GenericPopover
       v-if="activeEditor"

--- a/packages/super-editor/src/editors/v1/components/SuperEditor.vue
+++ b/packages/super-editor/src/editors/v1/components/SuperEditor.vue
@@ -73,20 +73,23 @@ const contextMenuDisabled = computed(() => {
 });
 
 /**
- * Whether the built-in loading skeleton may render.
+ * Whether the built-in loading placeholder is painted.
  *
- * This is deliberately visual-only: it gates <EditorSkeleton> and nothing else.
- * `editorReady` keeps its existing meaning and timing, so turning the overlay
- * off does not mount the interactive chrome (context menu, table/image/textbox
- * resize overlays) any earlier than it would otherwise.
+ * This is deliberately visual-only. Whether the skeleton is *mounted* stays
+ * tied to `editorReady`, because that element is also the interaction barrier
+ * over the editable surface underneath; this flag only decides whether it
+ * paints. So turning the overlay off changes pixels and nothing else:
+ * readiness, collaboration timing, and the chrome gated on `editorReady`
+ * (context menu, table/image/textbox resize overlays) are all untouched, and
+ * a half-loaded document still cannot be edited.
  *
  * That is the difference from the legacy internal `suppressSkeletonLoader`
- * option, which forces `editorReady` true and therefore also arms that chrome
- * before collaboration has synced.
+ * option, which forces `editorReady` true and therefore also drops the barrier
+ * and arms that chrome before collaboration has synced.
  *
- * @returns {boolean} True when the skeleton should be rendered.
+ * @returns {boolean} True when the placeholder should be painted.
  */
-const showLoadingOverlay = computed(() => props.options?.showLoadingOverlay !== false && !editorReady.value);
+const showLoadingOverlay = computed(() => props.options?.showLoadingOverlay !== false);
 
 /**
  * Computed property that determines if web layout mode is active (OOXML ST_View 'web').
@@ -1477,7 +1480,7 @@ onBeforeUnmount(() => {
       />
     </div>
 
-    <EditorSkeleton v-if="showLoadingOverlay" />
+    <EditorSkeleton v-if="!editorReady" :visible="showLoadingOverlay" />
 
     <GenericPopover
       v-if="activeEditor"


### PR DESCRIPTION
Stack 1/2 — internal only, no public API change. Public surface is #3881.

## Problem

The built-in loading skeleton (`EditorSkeleton`) was gated solely on `editorReady`, so the only way to hide it was the internal `suppressSkeletonLoader` option — which works by forcing `editorReady = true`.

That is too blunt. `editorReady` also gates the interactive chrome: `ContextMenu`, `LinkClickHandler`, `TableResizeOverlay`, `ImageResizeOverlay`, `TextboxResizeOverlay`.

## Change

Adds an internal `showLoadingOverlay` option (default `true`) that controls **only whether the placeholder paints**.

`.placeholder-editor` is not just a visual: it is a full-surface, z-indexed element with no `pointer-events: none`, so it is also the only thing stopping pointer input reaching the editable surface underneath while `editorReady` is false (the editor is mounted, and `editable` defaults to `true` in `Editor.ts:793`). So the element stays mounted whenever `editorReady` is false and merely goes transparent when the overlay is off.

Result: hiding the overlay changes pixels and nothing else. Readiness, collaboration timing, the five chrome gates, and the interaction barrier are all untouched — a half-loaded document still cannot be edited.

`suppressSkeletonLoader` keeps its broader legacy semantics and is unchanged.

## Review feedback addressed

- **Codex + cubic (P2), interaction barrier**: valid, confirmed in source, fixed in `8eab403`. The first revision unmounted the barrier along with the visual.
- **cubic (P3), test coverage**: valid. Every test passed a `fileSource`, so the collaboration init path was never exercised. Added a lane that mounts without a file source and drives provider `synced`.

## Tests

`SuperEditor.loading-overlay.test.js` — 10/10, split into barrier vs. paint assertions, plus the real collaboration path. Existing `SuperEditor.test.js` 36/36 unchanged.

Refs IT-1365

🤖 Generated with [Claude Code](https://claude.com/claude-code)